### PR TITLE
Consolidate linting and type-checking with Trunk

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -200,10 +200,9 @@ pub.subscribe(on_receive, "meshtastic.receive")
 
 1. Install dependencies: `poetry install --all-extras --with dev`
 2. Make changes
-3. Run linting: `poetry run pylint meshtastic examples/`
-4. Run type checking: `poetry run mypy meshtastic/`
-5. Run tests: `poetry run pytest -m unit`
-6. Update documentation if needed
+3. Run unified lint/type checks: `TRUNK_INTERACTIVE=0 .trunk/trunk check --fix --show-existing`
+4. Run tests: `poetry run pytest -m unit`
+5. Update documentation if needed
 
 ## CLI Development
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   release_create:
@@ -129,6 +130,7 @@ jobs:
     environment: pypi-release
     permissions:
       contents: read
+      id-token: write
     needs:
       - release_create
       - build-and-publish-ubuntu
@@ -140,6 +142,4 @@ jobs:
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,4 +142,4 @@ jobs:
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -20,6 +20,55 @@ lint:
         # Ignore generated files
         - meshtastic/**/*_pb2.py
         - meshtastic/**/*_pb2.pyi
+    - linters: [mypy-poetry]
+      paths:
+        # Keep Trunk's mypy scope aligned with CI (meshtastic/ only).
+        - examples/**
+        - tests/**
+        - meshtastic/tests/**
+    - linters: [pylint-poetry]
+      paths:
+        # Keep Trunk's pylint scope aligned with CI (meshtastic/ + examples/).
+        - tests/**
+        - meshtastic/tests/**
+  definitions:
+    - name: mypy-poetry
+      description: Run mypy via Poetry using the project's pinned dependencies.
+      files: [python, python-interface]
+      suggest_if: files_present
+      direct_configs:
+        - pyproject.toml
+        - mypy.ini
+        - .mypy.ini
+      commands:
+        - name: lint
+          output: mypy
+          run: poetry run mypy meshtastic/ --strict
+          target: meshtastic
+          run_from: ${root_or_parent_with_any_config}
+          success_codes: [0, 1]
+          batch: true
+          cache_results: false
+          stdin: false
+    - name: pylint-poetry
+      description: Run pylint via Poetry with the project's CI arguments.
+      files: [python]
+      suggest_if: files_present
+      direct_configs:
+        - pyproject.toml
+        - pylintrc
+        - .pylintrc
+      commands:
+        - name: lint
+          output: pylint
+          run: poetry run pylint meshtastic examples/ --exit-zero --output ${tmpfile} --output-format json
+          target: meshtastic
+          read_output_from: tmp_file
+          run_from: ${root_or_parent_with_any_config}
+          success_codes: [0]
+          batch: true
+          cache_results: false
+          stdin: false
   enabled:
     - actionlint@1.7.10
     - black@26.1.0
@@ -37,6 +86,8 @@ lint:
     - trivy@0.69.1
     - trufflehog@3.93.3
     - yamllint@1.38.0
+    - mypy-poetry
+    - pylint-poetry
 runtimes:
   enabled:
     - go@1.21.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ canonical internal helpers (`_async_await`, `_async_run`, `_from_num_handler`,
 | `BLEInterface.log_radio_handler`        | Required callable compat shim | Silent         | Keep historical `async def` signature. |
 | `BLEInterface.legacy_log_radio_handler` | Required callable compat shim | Silent         | Keep historical `async def` signature. |
 
-## How to check your code (pytest/pylint) before a PR
+## How to check your code (pytest/pylint/mypy) before a PR
 
 - [Pre-requisites](https://meshtastic.org/docs/development/python/building/#pre-requisites)
 - also execute `poetry install --all-extras --with dev,powermon` for all optional dependencies
@@ -94,6 +94,16 @@ make ci
 ```
 
 This runs the same checks as CI (pylint, mypy, pytest with coverage).
+
+### Unified lint/type check via Trunk
+
+Run lint and type checks (including Poetry-managed `pylint` + `mypy`) with one command:
+
+```bash
+TRUNK_INTERACTIVE=0 .trunk/trunk check --fix --show-existing
+```
+
+This does not run `pytest`; use `make ci` (or `poetry run pytest ...`) for test execution.
 
 ### Manual checks
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR consolidates CI maintenance updates focused on improving the release and development workflows. It introduces OIDC authentication for PyPI publishing, integrates mypy and pylint type checking into the Trunk linting framework, and updates development documentation to reflect the unified checking approach.

## Key Changes

**CI/CD & Release Workflow**
- Updates PyPI publish workflow to use OIDC token authentication instead of password-based authentication
- Adds `id-token: write` permissions to the release workflow
- Updates the PyPI publish action to use the `release/v1` tag (removes password input)

**Linting & Type Checking Integration**
- Adds mypy-poetry linter configuration to `.trunk/trunk.yaml` with strict checking against the `meshtastic/` directory
- Adds pylint-poetry linter configuration to `.trunk/trunk.yaml` targeting `meshtastic/` and `examples/` directories
- Enables both linters in the global lint configuration
- Retains existing ignores for generated protobuf files

**Documentation Updates**
- Consolidates development workflow in copilot-instructions.md with a single unified lint/type check command replacing separate pylint and mypy invocations
- Updates CONTRIBUTING.md to document the unified Trunk-based lint/type check workflow
- Clarifies that the Trunk check command does not run tests (pytest runs separately)

## Migration Notes
Developers should now use the Trunk command for linting and type checking instead of running `pylint` and `mypy` separately. The unified approach is documented in the updated development guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->