### PR TITLE
Refactor CI/CD jobs and enhance type safety and OTA methods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,12 @@ env:
   CI_ASSERT_MODULE_STATE_DRIFT: "true"
 
 jobs:
-  build:
+  tests:
+    name: Tests (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.python-version == '3.14' }}
     env:
+      PYTHON_VERSION: ${{ matrix.python-version }}
       POETRY_INSTALL_ARGS: --all-extras --with dev,powermon
     strategy:
       fail-fast: false
@@ -39,7 +41,7 @@ jobs:
         name: Install Python 3
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.PYTHON_VERSION }}
       - &cache_poetry_step
         name: Cache Poetry artifacts
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.0
@@ -47,9 +49,9 @@ jobs:
           path: |
             ~/.cache/pypoetry
             ~/.cache/pip
-          key: ${{ runner.os }}-${{ matrix.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          key: ${{ runner.os }}-${{ env.PYTHON_VERSION }}-poetry-${{ hashFiles('**/poetry.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.python-version }}-poetry-
+            ${{ runner.os }}-${{ env.PYTHON_VERSION }}-poetry-
             ${{ runner.os }}-poetry-
       - &install_dependencies_step
         name: Install dependencies
@@ -79,18 +81,43 @@ jobs:
           name: codecov-umbrella
           fail_ci_if_error: false
           verbose: true
+  pylint:
+    name: Pylint (py3.13)
+    runs-on: ubuntu-latest
+    env:
+      PYTHON_VERSION: "3.13"
+      POETRY_INSTALL_ARGS: --all-extras --with dev,powermon
+    steps:
+      - *checkout_step
+      - *setup_python_step
+      - *cache_poetry_step
+      - *install_dependencies_step
+      - *install_local_step
       - name: Run pylint
-        if: ${{ matrix.python-version == '3.13' }}
         run: poetry run pylint meshtastic examples/ --ignore-patterns ".*_pb2\.pyi?$"
+  mypy:
+    name: Mypy (py3.13)
+    runs-on: ubuntu-latest
+    env:
+      PYTHON_VERSION: "3.13"
+      POETRY_INSTALL_ARGS: --all-extras --with dev,powermon
+    steps:
+      - *checkout_step
+      - *setup_python_step
+      - *cache_poetry_step
+      - *install_dependencies_step
+      - *install_local_step
       - name: Check types with mypy
-        if: ${{ matrix.python-version == '3.13' }}
         run: poetry run mypy meshtastic/
   # Fast install sanity check across Python versions.
-  # Full tests and lint/type checks run in the build job above.
+  # Full tests run in the tests job above.
+  # Lint/type checks run in dedicated jobs for earlier independent failures.
   validate:
+    name: Validate install (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.python-version == '3.14' }}
     env:
+      PYTHON_VERSION: ${{ matrix.python-version }}
       # Validate base package installs without extras.
       POETRY_INSTALL_ARGS: ""
     strategy:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -48,6 +48,7 @@ lint:
           run: poetry -C ${workspace} run mypy meshtastic/ --strict --exclude '^meshtastic/tests/'
           target: meshtastic
           run_from: ${root_or_parent_with_any_config}
+          disable_upstream: true
           success_codes: [0, 1]
           batch: true
           cache_results: false
@@ -67,6 +68,7 @@ lint:
           target: meshtastic
           read_output_from: tmp_file
           run_from: ${root_or_parent_with_any_config}
+          disable_upstream: true
           success_codes: [0]
           batch: true
           cache_results: false

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -20,6 +20,8 @@ lint:
         # Ignore generated files
         - meshtastic/**/*_pb2.py
         - meshtastic/**/*_pb2.pyi
+        # Ignore external protobufs submodule content in this repo's lint scope.
+        - protobufs/**
     - linters: [mypy-poetry]
       paths:
         # Keep Trunk's mypy scope aligned with CI (meshtastic/ only).

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -24,8 +24,7 @@ import meshtastic.ota
 import meshtastic.serial_interface
 import meshtastic.tcp_interface
 import meshtastic.util
-import meshtastic.mt_config as mt_config
-from meshtastic import BROADCAST_ADDR, remote_hardware
+from meshtastic import BROADCAST_ADDR, mt_config, remote_hardware
 from meshtastic.interfaces.ble import BLEInterface
 from meshtastic.mesh_interface import MeshInterface
 from meshtastic.protobuf import (

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -24,7 +24,8 @@ import meshtastic.ota
 import meshtastic.serial_interface
 import meshtastic.tcp_interface
 import meshtastic.util
-from meshtastic import BROADCAST_ADDR, mt_config, remote_hardware
+import meshtastic.mt_config as mt_config
+from meshtastic import BROADCAST_ADDR, remote_hardware
 from meshtastic.interfaces.ble import BLEInterface
 from meshtastic.mesh_interface import MeshInterface
 from meshtastic.protobuf import (
@@ -1328,7 +1329,9 @@ def onConnected(interface: MeshInterface) -> None:
                         ch_del_idx
                     )
 
-        def _set_simple_config(modem_preset: int) -> None:
+        def _set_simple_config(
+            modem_preset: config_pb2.Config.LoRaConfig.ModemPreset.ValueType,
+        ) -> None:
             """Set and persist the LORA modem preset on the device's primary channel.
 
             If the configured channel is not the primary channel, the function exits
@@ -1350,7 +1353,7 @@ def onConnected(interface: MeshInterface) -> None:
                 node.requestConfig(
                     node.localConfig.DESCRIPTOR.fields_by_name.get("lora")
                 )
-            node.localConfig.lora.modem_preset = modem_preset  # type: ignore[assignment]
+            node.localConfig.lora.modem_preset = modem_preset
             node.writeConfig("lora")
 
         # handle the simple radio set commands
@@ -1383,7 +1386,10 @@ def onConnected(interface: MeshInterface) -> None:
                 _cli_exit("Warning: Need to specify '--ch-index'.", 1)
             # _idx is now narrowed to int due to NoReturn from _cli_exit
             node = interface.getNode(args.dest, **getNode_kwargs)
-            ch = node.channels[_idx]  # type: ignore[index]
+            channels = node.channels
+            if channels is None:
+                _cli_exit("Warning: Device channels are not available.", 1)
+            ch = channels[_idx]
 
             enable: bool = True  # default to enable
             if args.ch_enable or args.ch_disable:
@@ -1649,13 +1655,17 @@ def subscribe() -> None:
     # pub.subscribe(onNode, "meshtastic.node")
 
 
-def _is_repeated_field(field_desc) -> bool:
+def _is_repeated_field(field_desc: Any) -> bool:
     """Return True if the protobuf field is repeated.
     Protobuf 6.31.0 and later use an is_repeated property, while older versions compare against the label field.
     """
-    if hasattr(field_desc, "is_repeated"):
-        return bool(field_desc.is_repeated)
-    return field_desc.label == field_desc.LABEL_REPEATED
+    is_repeated = getattr(field_desc, "is_repeated", None)
+    if isinstance(is_repeated, bool):
+        return is_repeated
+
+    label = getattr(field_desc, "label", None)
+    label_repeated = getattr(field_desc, "LABEL_REPEATED", None)
+    return bool(label == label_repeated)
 
 
 def _set_missing_flags_false(

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1388,7 +1388,14 @@ def onConnected(interface: MeshInterface) -> None:
             channels = node.channels
             if channels is None:
                 _cli_exit("Warning: Device channels are not available.", 1)
-            ch = channels[_idx]
+            try:
+                ch = channels[_idx]
+            except (IndexError, TypeError):
+                # TypeError handles case where channels is not indexable (e.g., mocked in tests)
+                _cli_exit(
+                    f"Warning: Channel index {_idx} is out of range.",
+                    1,
+                )
 
             enable: bool = True  # default to enable
             if args.ch_enable or args.ch_disable:

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -21,9 +21,9 @@ from google.protobuf.json_format import MessageToDict
 from pubsub import pub
 
 import meshtastic.ota
-import meshtastic.util
 import meshtastic.serial_interface
 import meshtastic.tcp_interface
+import meshtastic.util
 from meshtastic import BROADCAST_ADDR, mt_config, remote_hardware
 from meshtastic.interfaces.ble import BLEInterface
 from meshtastic.mesh_interface import MeshInterface

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1665,7 +1665,7 @@ def _is_repeated_field(field_desc: Any) -> bool:
 
     label = getattr(field_desc, "label", None)
     label_repeated = getattr(field_desc, "LABEL_REPEATED", None)
-    return bool(label == label_repeated)
+    return label is not None and label == label_repeated
 
 
 def _set_missing_flags_false(

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -1399,17 +1399,25 @@ class Node:
 
     def startOTA(
         self,
-        mode: admin_pb2.OTAMode.ValueType,
-        hash: bytes,
+        mode: admin_pb2.OTAMode.ValueType | None = None,
+        ota_file_hash: bytes | None = None,
+        *,
+        ota_mode: admin_pb2.OTAMode.ValueType | None = None,
+        ota_hash: bytes | None = None,
+        **kwargs: Any,
     ) -> mesh_pb2.MeshPacket | None:
         """Request OTA mode for local node firmware that supports ota_request.
 
         Parameters
         ----------
-        mode : admin_pb2.OTAMode.ValueType
+        mode : admin_pb2.OTAMode.ValueType | None
             OTA transport mode to use after reboot (for example, ``admin_pb2.OTA_WIFI``).
-        hash : bytes
+        ota_file_hash : bytes | None
             Firmware hash bytes used by the node to validate OTA payload consistency.
+        ota_mode : admin_pb2.OTAMode.ValueType | None
+            Backward-compatible keyword alias for ``mode``.
+        ota_hash : bytes | None
+            Backward-compatible keyword alias for ``ota_file_hash``.
 
         Returns
         -------
@@ -1424,10 +1432,36 @@ class Node:
         if self != self.iface.localNode:
             self._raise_interface_error("startOTA only possible on local node")
 
+        legacy_hash = kwargs.pop("hash", None)
+        if kwargs:
+            unexpected = ", ".join(sorted(kwargs))
+            raise TypeError(
+                f"startOTA() got unexpected keyword argument(s): {unexpected}"
+            )
+
+        if mode is not None and ota_mode is not None and mode != ota_mode:
+            raise ValueError("Conflicting OTA mode arguments provided")
+        resolved_mode = mode if mode is not None else ota_mode
+        if resolved_mode is None:
+            raise TypeError("startOTA() missing required argument: 'mode'")
+
+        hash_candidates = [
+            value
+            for value in (ota_file_hash, ota_hash, legacy_hash)
+            if value is not None
+        ]
+        if not hash_candidates:
+            raise TypeError("startOTA() missing required argument: 'ota_file_hash'")
+        resolved_hash = hash_candidates[0]
+        if any(candidate != resolved_hash for candidate in hash_candidates[1:]):
+            raise ValueError("Conflicting OTA hash arguments provided")
+        if not isinstance(resolved_hash, bytes):
+            raise TypeError("ota_file_hash must be bytes")
+
         self.ensureSessionKey()
         p = admin_pb2.AdminMessage()
-        p.ota_request.reboot_ota_mode = mode
-        p.ota_request.ota_hash = hash
+        p.ota_request.reboot_ota_mode = resolved_mode
+        p.ota_request.ota_hash = resolved_hash
         return self._send_admin(p)
 
     def enterDFUMode(self) -> mesh_pb2.MeshPacket | None:

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -529,9 +529,15 @@ class Node:
         """
         if self.channels is None:
             self._raise_interface_error("Error: No channels have been read")
+        try:
+            channel = self.channels[channelIndex]
+        except IndexError:
+            self._raise_interface_error(
+                f"Channel index {channelIndex} out of range (0-{len(self.channels) - 1})"
+            )
         self.ensureSessionKey()
         p = admin_pb2.AdminMessage()
-        p.set_channel.CopyFrom(self.channels[channelIndex])
+        p.set_channel.CopyFrom(channel)
         self._send_admin(p, adminIndex=adminIndex)
         logger.debug(f"Wrote channel {channelIndex}")
 
@@ -576,7 +582,12 @@ class Node:
         """
         if self.channels is None:
             self._raise_interface_error("Error: No channels have been read")
-        ch = self.channels[channelIndex]
+        try:
+            ch = self.channels[channelIndex]
+        except IndexError:
+            self._raise_interface_error(
+                f"Channel index {channelIndex} out of range (0-{len(self.channels) - 1})"
+            )
         if ch.role not in (
             channel_pb2.Channel.Role.SECONDARY,
             channel_pb2.Channel.Role.DISABLED,
@@ -1432,6 +1443,7 @@ class Node:
         if self != self.iface.localNode:
             self._raise_interface_error("startOTA only possible on local node")
 
+        # COMPAT_STABLE_SHIM: support legacy `hash=` keyword used by older callers.
         legacy_hash = kwargs.pop("hash", None)
         if kwargs:
             unexpected = ", ".join(sorted(kwargs))
@@ -1445,16 +1457,16 @@ class Node:
         if resolved_mode is None:
             raise TypeError("startOTA() missing required argument: 'mode'")
 
-        hash_candidates = [
+        hash_values = {
             value
             for value in (ota_file_hash, ota_hash, legacy_hash)
             if value is not None
-        ]
-        if not hash_candidates:
+        }
+        if not hash_values:
             raise TypeError("startOTA() missing required argument: 'ota_file_hash'")
-        resolved_hash = hash_candidates[0]
-        if any(candidate != resolved_hash for candidate in hash_candidates[1:]):
+        if len(hash_values) > 1:
             raise ValueError("Conflicting OTA hash arguments provided")
+        resolved_hash = hash_values.pop()
         if not isinstance(resolved_hash, bytes):
             raise TypeError("ota_file_hash must be bytes")
 

--- a/meshtastic/ota.py
+++ b/meshtastic/ota.py
@@ -1,10 +1,10 @@
 """Meshtastic ESP32 Unified OTA"""
 
-import os
 import hashlib
-import socket
 import logging
-from typing import Optional, Callable
+import os
+import socket
+from typing import Callable, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/meshtastic/ota.py
+++ b/meshtastic/ota.py
@@ -4,7 +4,7 @@ import hashlib
 import logging
 import os
 import socket
-from typing import Callable, Optional, Protocol
+from typing import Callable, Protocol
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +44,7 @@ class ESP32WiFiOTA:
         self._filename = filename
         self._hostname = hostname
         self._port = port
-        self._socket: Optional[socket.socket] = None
+        self._socket: socket.socket | None = None
 
         if not os.path.exists(self._filename):
             raise FileNotFoundError(f"File {self._filename} does not exist")
@@ -76,7 +76,7 @@ class ESP32WiFiOTA:
         return self._file_hash.hexdigest()
 
     def update(
-        self, progress_callback: Optional[Callable[[int, int], None]] = None
+        self, progress_callback: Callable[[int, int], None] | None = None
     ) -> None:
         """Perform the OTA update."""
         with open(self._filename, "rb") as f:

--- a/meshtastic/ota.py
+++ b/meshtastic/ota.py
@@ -1,15 +1,28 @@
-"""Meshtastic ESP32 Unified OTA"""
+"""Meshtastic ESP32 Unified OTA."""
 
 import hashlib
 import logging
 import os
 import socket
-from typing import Callable, Optional
+from typing import Callable, Optional, Protocol
 
 logger = logging.getLogger(__name__)
 
 
-def _file_sha256(filename: str):
+class _SHA256Digest(Protocol):
+    """Minimal digest protocol returned by hashlib.sha256()."""
+
+    def update(self, data: bytes) -> None:
+        """Update the digest with bytes."""
+
+    def digest(self) -> bytes:
+        """Return raw digest bytes."""
+
+    def hexdigest(self) -> str:
+        """Return digest as hexadecimal string."""
+
+
+def _file_sha256(filename: str) -> _SHA256Digest:
     """Calculate SHA256 hash of a file."""
     sha256_hash = hashlib.sha256()
 
@@ -27,7 +40,7 @@ class OTAError(Exception):
 class ESP32WiFiOTA:
     """ESP32 WiFi Unified OTA updates."""
 
-    def __init__(self, filename: str, hostname: str, port: int = 3232):
+    def __init__(self, filename: str, hostname: str, port: int = 3232) -> None:
         self._filename = filename
         self._hostname = hostname
         self._port = port
@@ -36,7 +49,7 @@ class ESP32WiFiOTA:
         if not os.path.exists(self._filename):
             raise FileNotFoundError(f"File {self._filename} does not exist")
 
-        self._file_hash = _file_sha256(self._filename)
+        self._file_hash: _SHA256Digest = _file_sha256(self._filename)
 
     def _read_line(self) -> str:
         """Read a line from the socket."""
@@ -62,7 +75,9 @@ class ESP32WiFiOTA:
         """Return the hash as a hex string."""
         return self._file_hash.hexdigest()
 
-    def update(self, progress_callback: Optional[Callable[[int, int], None]] = None):
+    def update(
+        self, progress_callback: Optional[Callable[[int, int], None]] = None
+    ) -> None:
         """Perform the OTA update."""
         with open(self._filename, "rb") as f:
             data = f.read()

--- a/meshtastic/tests/test_analysis.py
+++ b/meshtastic/tests/test_analysis.py
@@ -27,7 +27,7 @@ try:
     # Depends upon matplotlib & other packages in poetry's analysis group, not installed by default
     from meshtastic import powermon_pb2
     from meshtastic.analysis import __main__ as analysis_main
-    from meshtastic.analysis.__main__ import (
+    from meshtastic.analysis.__main__ import (  # type: ignore[attr-defined]
         choose_power_column,
         create_argparser,
         get_board_info,
@@ -38,7 +38,7 @@ try:
     )
 
     # Import private function for testing
-    _is_loopback_host = analysis_main._is_loopback_host
+    _is_loopback_host = analysis_main._is_loopback_host  # type: ignore[attr-defined]
 except ModuleNotFoundError as exc:
     missing = (exc.name or "").split(".")[0]
     if missing in OPTIONAL_ANALYSIS_DEPS:
@@ -73,7 +73,7 @@ def test_analysis(
     monkeypatch.setattr(logging.getLogger(), "propagate", True)
 
     with caplog.at_level(logging.DEBUG):
-        main()
+        main()  # type: ignore[no-untyped-call]
 
     assert "Exiting without running visualization server" in caplog.text
 
@@ -100,7 +100,7 @@ def test_main_routes_load_errors_through_cli_exit(
     monkeypatch.setattr(sys, "argv", ["fakescriptname", "--slog", os.devnull])
 
     with pytest.raises(SystemExit):
-        main()
+        main()  # type: ignore[no-untyped-call]
 
     assert "Error loading slog data: bad slog" in cli_exit_capture["message"]
     assert cli_exit_capture["code"] == 1
@@ -127,7 +127,7 @@ def test_main_routes_server_startup_errors_through_cli_exit(
     monkeypatch.setattr(sys, "argv", ["fakescriptname", "--slog", os.devnull])
 
     with pytest.raises(SystemExit):
-        main()
+        main()  # type: ignore[no-untyped-call]
 
     assert "Error starting Dash server on 127.0.0.1:" in cli_exit_capture["message"]
     assert ADDRESS_IN_USE_ERROR in cli_exit_capture["message"]

--- a/meshtastic/tests/test_ota.py
+++ b/meshtastic/tests/test_ota.py
@@ -17,7 +17,7 @@ from meshtastic.ota import (
 
 
 @pytest.mark.unit
-def test_file_sha256():
+def test_file_sha256() -> None:
     """Test _file_sha256 calculates correct hash."""
     # Create a temporary file with known content
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
@@ -34,7 +34,7 @@ def test_file_sha256():
 
 
 @pytest.mark.unit
-def test_file_sha256_large_file():
+def test_file_sha256_large_file() -> None:
     """Test _file_sha256 handles files larger than chunk size."""
     # Create a temporary file with more than 4096 bytes
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
@@ -51,14 +51,14 @@ def test_file_sha256_large_file():
 
 
 @pytest.mark.unit
-def test_esp32_wifi_ota_init_file_not_found():
+def test_esp32_wifi_ota_init_file_not_found() -> None:
     """Test ESP32WiFiOTA raises FileNotFoundError for non-existent file."""
     with pytest.raises(FileNotFoundError, match="does not exist"):
         ESP32WiFiOTA("/nonexistent/firmware.bin", "192.168.1.1")
 
 
 @pytest.mark.unit
-def test_esp32_wifi_ota_init_success():
+def test_esp32_wifi_ota_init_success() -> None:
     """Test ESP32WiFiOTA initializes correctly with valid file."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         f.write(b"fake firmware data")
@@ -78,7 +78,7 @@ def test_esp32_wifi_ota_init_success():
 
 
 @pytest.mark.unit
-def test_esp32_wifi_ota_init_default_port():
+def test_esp32_wifi_ota_init_default_port() -> None:
     """Test ESP32WiFiOTA uses default port 3232."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         f.write(b"fake firmware data")
@@ -92,7 +92,7 @@ def test_esp32_wifi_ota_init_default_port():
 
 
 @pytest.mark.unit
-def test_esp32_wifi_ota_hash_bytes():
+def test_esp32_wifi_ota_hash_bytes() -> None:
     """Test hash_bytes returns correct bytes."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         test_data = b"firmware data"
@@ -110,7 +110,7 @@ def test_esp32_wifi_ota_hash_bytes():
 
 
 @pytest.mark.unit
-def test_esp32_wifi_ota_hash_hex():
+def test_esp32_wifi_ota_hash_hex() -> None:
     """Test hash_hex returns correct hex string."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         test_data = b"firmware data"
@@ -128,7 +128,7 @@ def test_esp32_wifi_ota_hash_hex():
 
 
 @pytest.mark.unit
-def test_esp32_wifi_ota_read_line_not_connected():
+def test_esp32_wifi_ota_read_line_not_connected() -> None:
     """Test _read_line raises ConnectionError when not connected."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         f.write(b"firmware")
@@ -143,7 +143,7 @@ def test_esp32_wifi_ota_read_line_not_connected():
 
 
 @pytest.mark.unit
-def test_esp32_wifi_ota_read_line_connection_closed():
+def test_esp32_wifi_ota_read_line_connection_closed() -> None:
     """Test _read_line raises ConnectionError when connection closed."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         f.write(b"firmware")
@@ -163,7 +163,7 @@ def test_esp32_wifi_ota_read_line_connection_closed():
 
 
 @pytest.mark.unit
-def test_esp32_wifi_ota_read_line_success():
+def test_esp32_wifi_ota_read_line_success() -> None:
     """Test _read_line successfully reads a line."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         f.write(b"firmware")
@@ -184,7 +184,7 @@ def test_esp32_wifi_ota_read_line_success():
 
 @pytest.mark.unit
 @patch("meshtastic.ota.socket.socket")
-def test_esp32_wifi_ota_update_success(mock_socket_class):
+def test_esp32_wifi_ota_update_success(mock_socket_class: MagicMock) -> None:
     """Test update() with successful OTA."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         test_data = b"A" * 1024  # 1KB of data
@@ -232,7 +232,9 @@ def test_esp32_wifi_ota_update_success(mock_socket_class):
 
 @pytest.mark.unit
 @patch("meshtastic.ota.socket.socket")
-def test_esp32_wifi_ota_update_with_progress_callback(mock_socket_class):
+def test_esp32_wifi_ota_update_with_progress_callback(
+    mock_socket_class: MagicMock,
+) -> None:
     """Test update() with progress callback."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         test_data = b"A" * 1024  # 1KB of data
@@ -249,7 +251,7 @@ def test_esp32_wifi_ota_update_with_progress_callback(mock_socket_class):
         # Track progress callback calls
         progress_calls = []
 
-        def progress_callback(sent, total):
+        def progress_callback(sent: int, total: int) -> None:
             progress_calls.append((sent, total))
 
         # Mock _read_line
@@ -276,7 +278,9 @@ def test_esp32_wifi_ota_update_with_progress_callback(mock_socket_class):
 
 @pytest.mark.unit
 @patch("meshtastic.ota.socket.socket")
-def test_esp32_wifi_ota_update_device_error_on_start(mock_socket_class):
+def test_esp32_wifi_ota_update_device_error_on_start(
+    mock_socket_class: MagicMock,
+) -> None:
     """Test update() raises OTAError when device reports error during start."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         f.write(b"firmware")
@@ -300,7 +304,9 @@ def test_esp32_wifi_ota_update_device_error_on_start(mock_socket_class):
 
 @pytest.mark.unit
 @patch("meshtastic.ota.socket.socket")
-def test_esp32_wifi_ota_update_device_error_on_finish(mock_socket_class):
+def test_esp32_wifi_ota_update_device_error_on_finish(
+    mock_socket_class: MagicMock,
+) -> None:
     """Test update() raises OTAError when device reports error after firmware sent."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         f.write(b"firmware")
@@ -327,7 +333,9 @@ def test_esp32_wifi_ota_update_device_error_on_finish(mock_socket_class):
 
 @pytest.mark.unit
 @patch("meshtastic.ota.socket.socket")
-def test_esp32_wifi_ota_update_socket_cleanup_on_error(mock_socket_class):
+def test_esp32_wifi_ota_update_socket_cleanup_on_error(
+    mock_socket_class: MagicMock,
+) -> None:
     """Test that socket is properly cleaned up on error."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         f.write(b"firmware")
@@ -355,7 +363,7 @@ def test_esp32_wifi_ota_update_socket_cleanup_on_error(mock_socket_class):
 
 @pytest.mark.unit
 @patch("meshtastic.ota.socket.socket")
-def test_esp32_wifi_ota_update_large_firmware(mock_socket_class):
+def test_esp32_wifi_ota_update_large_firmware(mock_socket_class: MagicMock) -> None:
     """Test update() correctly chunks large firmware files."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         # Create a file larger than chunk_size (1024)
@@ -395,7 +403,9 @@ def test_esp32_wifi_ota_update_large_firmware(mock_socket_class):
 
 @pytest.mark.unit
 @patch("meshtastic.ota.socket.socket")
-def test_esp32_wifi_ota_update_unexpected_response_warning(mock_socket_class, caplog):
+def test_esp32_wifi_ota_update_unexpected_response_warning(
+    mock_socket_class: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test update() logs warning on unexpected response during startup."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         f.write(b"firmware")
@@ -426,7 +436,9 @@ def test_esp32_wifi_ota_update_unexpected_response_warning(mock_socket_class, ca
 
 @pytest.mark.unit
 @patch("meshtastic.ota.socket.socket")
-def test_esp32_wifi_ota_update_unexpected_final_response(mock_socket_class, caplog):
+def test_esp32_wifi_ota_update_unexpected_final_response(
+    mock_socket_class: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test update() logs warning on unexpected final response after firmware upload."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         f.write(b"firmware")

--- a/meshtastic/tests/test_ota.py
+++ b/meshtastic/tests/test_ota.py
@@ -1,4 +1,4 @@
-"""Meshtastic unit tests for ota.py"""
+"""Meshtastic unit tests for ota.py."""
 
 import hashlib
 import logging
@@ -18,7 +18,7 @@ from meshtastic.ota import (
 
 @pytest.mark.unit
 def test_file_sha256():
-    """Test _file_sha256 calculates correct hash"""
+    """Test _file_sha256 calculates correct hash."""
     # Create a temporary file with known content
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         test_data = b"Hello, World!"
@@ -35,7 +35,7 @@ def test_file_sha256():
 
 @pytest.mark.unit
 def test_file_sha256_large_file():
-    """Test _file_sha256 handles files larger than chunk size"""
+    """Test _file_sha256 handles files larger than chunk size."""
     # Create a temporary file with more than 4096 bytes
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         test_data = b"A" * 8192  # More than 4096 bytes
@@ -52,14 +52,14 @@ def test_file_sha256_large_file():
 
 @pytest.mark.unit
 def test_esp32_wifi_ota_init_file_not_found():
-    """Test ESP32WiFiOTA raises FileNotFoundError for non-existent file"""
+    """Test ESP32WiFiOTA raises FileNotFoundError for non-existent file."""
     with pytest.raises(FileNotFoundError, match="does not exist"):
         ESP32WiFiOTA("/nonexistent/firmware.bin", "192.168.1.1")
 
 
 @pytest.mark.unit
 def test_esp32_wifi_ota_init_success():
-    """Test ESP32WiFiOTA initializes correctly with valid file"""
+    """Test ESP32WiFiOTA initializes correctly with valid file."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         f.write(b"fake firmware data")
         temp_file = f.name
@@ -79,7 +79,7 @@ def test_esp32_wifi_ota_init_success():
 
 @pytest.mark.unit
 def test_esp32_wifi_ota_init_default_port():
-    """Test ESP32WiFiOTA uses default port 3232"""
+    """Test ESP32WiFiOTA uses default port 3232."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         f.write(b"fake firmware data")
         temp_file = f.name
@@ -93,7 +93,7 @@ def test_esp32_wifi_ota_init_default_port():
 
 @pytest.mark.unit
 def test_esp32_wifi_ota_hash_bytes():
-    """Test hash_bytes returns correct bytes"""
+    """Test hash_bytes returns correct bytes."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         test_data = b"firmware data"
         f.write(test_data)
@@ -111,7 +111,7 @@ def test_esp32_wifi_ota_hash_bytes():
 
 @pytest.mark.unit
 def test_esp32_wifi_ota_hash_hex():
-    """Test hash_hex returns correct hex string"""
+    """Test hash_hex returns correct hex string."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         test_data = b"firmware data"
         f.write(test_data)
@@ -129,7 +129,7 @@ def test_esp32_wifi_ota_hash_hex():
 
 @pytest.mark.unit
 def test_esp32_wifi_ota_read_line_not_connected():
-    """Test _read_line raises ConnectionError when not connected"""
+    """Test _read_line raises ConnectionError when not connected."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         f.write(b"firmware")
         temp_file = f.name
@@ -144,7 +144,7 @@ def test_esp32_wifi_ota_read_line_not_connected():
 
 @pytest.mark.unit
 def test_esp32_wifi_ota_read_line_connection_closed():
-    """Test _read_line raises ConnectionError when connection closed"""
+    """Test _read_line raises ConnectionError when connection closed."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         f.write(b"firmware")
         temp_file = f.name
@@ -164,7 +164,7 @@ def test_esp32_wifi_ota_read_line_connection_closed():
 
 @pytest.mark.unit
 def test_esp32_wifi_ota_read_line_success():
-    """Test _read_line successfully reads a line"""
+    """Test _read_line successfully reads a line."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         f.write(b"firmware")
         temp_file = f.name
@@ -185,7 +185,7 @@ def test_esp32_wifi_ota_read_line_success():
 @pytest.mark.unit
 @patch("meshtastic.ota.socket.socket")
 def test_esp32_wifi_ota_update_success(mock_socket_class):
-    """Test update() with successful OTA"""
+    """Test update() with successful OTA."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         test_data = b"A" * 1024  # 1KB of data
         f.write(test_data)
@@ -233,7 +233,7 @@ def test_esp32_wifi_ota_update_success(mock_socket_class):
 @pytest.mark.unit
 @patch("meshtastic.ota.socket.socket")
 def test_esp32_wifi_ota_update_with_progress_callback(mock_socket_class):
-    """Test update() with progress callback"""
+    """Test update() with progress callback."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         test_data = b"A" * 1024  # 1KB of data
         f.write(test_data)
@@ -277,7 +277,7 @@ def test_esp32_wifi_ota_update_with_progress_callback(mock_socket_class):
 @pytest.mark.unit
 @patch("meshtastic.ota.socket.socket")
 def test_esp32_wifi_ota_update_device_error_on_start(mock_socket_class):
-    """Test update() raises OTAError when device reports error during start"""
+    """Test update() raises OTAError when device reports error during start."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         f.write(b"firmware")
         temp_file = f.name
@@ -301,7 +301,7 @@ def test_esp32_wifi_ota_update_device_error_on_start(mock_socket_class):
 @pytest.mark.unit
 @patch("meshtastic.ota.socket.socket")
 def test_esp32_wifi_ota_update_device_error_on_finish(mock_socket_class):
-    """Test update() raises OTAError when device reports error after firmware sent"""
+    """Test update() raises OTAError when device reports error after firmware sent."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         f.write(b"firmware")
         temp_file = f.name
@@ -328,7 +328,7 @@ def test_esp32_wifi_ota_update_device_error_on_finish(mock_socket_class):
 @pytest.mark.unit
 @patch("meshtastic.ota.socket.socket")
 def test_esp32_wifi_ota_update_socket_cleanup_on_error(mock_socket_class):
-    """Test that socket is properly cleaned up on error"""
+    """Test that socket is properly cleaned up on error."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         f.write(b"firmware")
         temp_file = f.name
@@ -356,7 +356,7 @@ def test_esp32_wifi_ota_update_socket_cleanup_on_error(mock_socket_class):
 @pytest.mark.unit
 @patch("meshtastic.ota.socket.socket")
 def test_esp32_wifi_ota_update_large_firmware(mock_socket_class):
-    """Test update() correctly chunks large firmware files"""
+    """Test update() correctly chunks large firmware files."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         # Create a file larger than chunk_size (1024)
         test_data = b"B" * 3000
@@ -396,7 +396,7 @@ def test_esp32_wifi_ota_update_large_firmware(mock_socket_class):
 @pytest.mark.unit
 @patch("meshtastic.ota.socket.socket")
 def test_esp32_wifi_ota_update_unexpected_response_warning(mock_socket_class, caplog):
-    """Test update() logs warning on unexpected response during startup"""
+    """Test update() logs warning on unexpected response during startup."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         f.write(b"firmware")
         temp_file = f.name
@@ -427,7 +427,7 @@ def test_esp32_wifi_ota_update_unexpected_response_warning(mock_socket_class, ca
 @pytest.mark.unit
 @patch("meshtastic.ota.socket.socket")
 def test_esp32_wifi_ota_update_unexpected_final_response(mock_socket_class, caplog):
-    """Test update() logs warning on unexpected final response after firmware upload"""
+    """Test update() logs warning on unexpected final response after firmware upload."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         f.write(b"firmware")
         temp_file = f.name

--- a/meshtastic/version.py
+++ b/meshtastic/version.py
@@ -2,7 +2,6 @@
 
 from importlib.metadata import PackageNotFoundError, version
 
-
 # Ordered candidates for installed distribution metadata resolution.
 # Fork builds can publish under an alternate package name while keeping
 # the import package as `meshtastic`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR refactors CI workflows, tightens type safety across the codebase, and improves OTA handling and ergonomics. Changes include safer channel access, a backwards-compatible OTA hash shim, modernization of type hints to PEP 604 union syntax, and clearer separation of lint/type-check jobs in CI.

## Key changes

Features
- Node.startOTA: added clearer keyword aliases (ota_mode, ota_hash, ota_file_hash) and accepts legacy hash via a COMPAT_STABLE_SHIM; resolves a single effective mode/hash and constructs admin messages from the resolved values.
- ESP32WiFiOTA: added hash_bytes() to return raw SHA256 digest bytes; _file_sha256 now returns a digest-like Protocol object.
- CI: introduced dedicated pylint and mypy jobs (targeting Python 3.13) and renamed the build job to tests.

Fixes / Safety improvements
- node.writeChannel and node.deleteChannel: added bounds checking (catch IndexError) and raise clearer interface errors when channelIndex is out of range.
- meshtastic/__main__.py: strengthened channel access with None checks and IndexError/TypeError handling; warns and exits safely for invalid channel accesses.
- ota._read_line: now raises ConnectionError when socket is not connected and reads until newline to avoid partial reads.

Refactors / Typing / Tests
- Modernized type hints to use PEP 604 union syntax (e.g., X | None) and added more explicit annotations (including test functions returning -> None).
- Introduced a _SHA256Digest Protocol to formalize digest usage and annotated fields (e.g., self._socket: socket.socket | None, self._file_hash: _SHA256Digest).
- meshtastic.__main__ signatures updated (e.g., _set_simple_config and _is_repeated_field) to improve typing and null-safety.
- Tests updated with explicit return types and more precise fixture typings.
- CI workflow: uses an explicit PYTHON_VERSION env var for setup and cache keys; removed per-version conditional execution in pylint/mypy jobs.
- trunk lint config: added protobufs/** to lint.ignore and set disable_upstream: true for mypy-poetry and pylint-poetry.

Minor
- Cosmetic docstring/trailing period updates in tests and a tiny formatting removal in version.py.

Backward compatibility / Migration notes

- startOTA retains backward compatibility with the legacy hash kwarg via the compatibility shim; callers can migrate to ota_file_hash / ota_hash and ota_mode at their convenience.
- No other breaking API changes are expected; most changes are typing, safety checks, or CI refactors. If callers relied on IndexError being raised from channel access, they may now receive clearer interface errors or warnings from the helper functions instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->