### PR TITLE
Enhance test coverage and configure Codecov JUnit reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,9 @@ jobs:
       - name: Run tests with pytest
         run: |
           if [ "${{ matrix.python-version }}" = "3.13" ]; then
-            poetry run pytest --cov=meshtastic --cov-report=xml
+            poetry run pytest --cov=meshtastic --cov-report=xml --junitxml=junit.xml
           else
-            poetry run pytest --cov=meshtastic
+            poetry run pytest --cov=meshtastic --junitxml=junit.xml
           fi
       - name: Upload coverage reports to Codecov
         if: ${{ matrix.python-version == '3.13' }}
@@ -76,6 +76,11 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: jeremiah-k/meshtastic-python
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() && matrix.python-version == '3.13' }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
   pylint:
     name: Pylint (py3.13)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           slug: jeremiah-k/meshtastic-python
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && matrix.python-version == '3.13' }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
   pylint:

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ examples/__pycache__
 meshtastic.spec
 .hypothesis/
 coverage.xml
+junit.xml
 .ipynb_checkpoints
 .cursor/

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -367,7 +367,9 @@ class Node:
                     f"{configType.name.upper()}_CONFIG"
                 )
             else:
-                p.get_module_config_request = msg_index  # pyright: ignore[reportAttributeAccessIssue]
+                p.get_module_config_request = (
+                    msg_index  # pyright: ignore[reportAttributeAccessIssue]
+                )
 
         self._send_admin(p, wantResponse=True, onResponse=onResponse)
         if onResponse:

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -1013,8 +1013,8 @@ def test_concurrent_node_database_access() -> None:
             try:
                 for i in range(50):
                     node_id = f"!{node_num:08x}"
+                    node = iface._get_or_create_by_num(node_num)
                     with iface._node_db_lock:
-                        node = iface._get_or_create_by_num(node_num)
                         node["lastHeard"] = i
                         if iface.nodes is not None:
                             iface.nodes[node_id] = node

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -974,14 +974,18 @@ def test_concurrent_packet_id_generation() -> None:
     with MeshInterface(noProto=True) as iface:
         packet_ids = []
         errors = []
+        packet_ids_lock = threading.Lock()
+        errors_lock = threading.Lock()
 
         def generate_packet_ids() -> None:
             try:
                 for _ in range(100):
                     packet_id = iface._generate_packet_id()
-                    packet_ids.append(packet_id)
+                    with packet_ids_lock:
+                        packet_ids.append(packet_id)
             except Exception as e:  # noqa: BLE001 - intentionally recording thread errors
-                errors.append(e)
+                with errors_lock:
+                    errors.append(e)
 
         threads = [threading.Thread(target=generate_packet_ids) for _ in range(10)]
         for t in threads:
@@ -1003,6 +1007,7 @@ def test_concurrent_node_database_access() -> None:
         iface.nodes = {}
         iface.nodesByNum = {}
         errors = []
+        errors_lock = threading.Lock()
 
         def update_nodes(node_num: int) -> None:
             try:
@@ -1016,7 +1021,8 @@ def test_concurrent_node_database_access() -> None:
                         if iface.nodesByNum is not None:
                             iface.nodesByNum[node_num] = node
             except Exception as e:  # noqa: BLE001 - intentionally recording thread errors
-                errors.append(e)
+                with errors_lock:
+                    errors.append(e)
 
         threads = [threading.Thread(target=update_nodes, args=(i,)) for i in range(20)]
         for t in threads:
@@ -1033,6 +1039,7 @@ def test_concurrent_queue_operations() -> None:
     with MeshInterface(noProto=True) as iface:
         iface.queue = OrderedDict()
         errors = []
+        errors_lock = threading.Lock()
 
         def add_to_queue(start_id: int) -> None:
             try:
@@ -1042,7 +1049,8 @@ def test_concurrent_queue_operations() -> None:
                     with iface._queue_lock:
                         iface.queue[packet_id] = packet
             except Exception as e:  # noqa: BLE001 - intentionally recording thread errors
-                errors.append(e)
+                with errors_lock:
+                    errors.append(e)
 
         def remove_from_queue() -> None:
             try:
@@ -1052,7 +1060,8 @@ def test_concurrent_queue_operations() -> None:
                             key = next(iter(iface.queue))
                             iface.queue.pop(key, None)
             except Exception as e:  # noqa: BLE001 - intentionally recording thread errors
-                errors.append(e)
+                with errors_lock:
+                    errors.append(e)
 
         add_threads = [
             threading.Thread(target=add_to_queue, args=(i,)) for i in range(4)
@@ -1075,6 +1084,7 @@ def test_concurrent_response_handler_registration() -> None:
         errors = []
         added_ids = []
         added_ids_lock = threading.Lock()
+        errors_lock = threading.Lock()
 
         def register_handlers(start_id: int) -> None:
             try:
@@ -1085,7 +1095,8 @@ def test_concurrent_response_handler_registration() -> None:
                     with added_ids_lock:
                         added_ids.append(request_id)
             except Exception as e:  # noqa: BLE001 - intentionally recording thread errors
-                errors.append(e)
+                with errors_lock:
+                    errors.append(e)
 
         threads = [
             threading.Thread(target=register_handlers, args=(i,)) for i in range(10)
@@ -1107,6 +1118,7 @@ def test_concurrent_close_with_packet_id_generation() -> None:
     errors = []
     stop_flag = threading.Event()
     started = threading.Event()
+    errors_lock = threading.Lock()
 
     with MeshInterface(noProto=True) as iface:
 
@@ -1116,13 +1128,16 @@ def test_concurrent_close_with_packet_id_generation() -> None:
                     iface._generate_packet_id()
                     started.set()
             except Exception as e:  # noqa: BLE001 - intentionally recording thread errors
-                errors.append(e)
+                with errors_lock:
+                    errors.append(e)
 
         threads = [threading.Thread(target=generate_ids) for _ in range(5)]
         for t in threads:
             t.start()
 
         assert started.wait(timeout=1.0)
+        # Exercise close() while packet-id generation is active.
+        iface.close()
 
         # Signal threads to stop
         stop_flag.set()
@@ -1151,13 +1166,15 @@ def test_concurrent_showNodes() -> None:
         iface.myInfo.my_node_num = 0
 
         errors = []
+        errors_lock = threading.Lock()
 
         def call_show_nodes() -> None:
             try:
                 for _ in range(10):
                     iface.showNodes()
             except Exception as e:  # noqa: BLE001 - intentionally recording thread errors
-                errors.append(e)
+                with errors_lock:
+                    errors.append(e)
 
         threads = [threading.Thread(target=call_show_nodes) for _ in range(10)]
         for t in threads:
@@ -1176,6 +1193,7 @@ def test_concurrent_getNode() -> None:
             i: {"num": i, "user": {"id": f"!{i:08x}"}} for i in range(100)
         }
         errors = []
+        errors_lock = threading.Lock()
 
         def get_nodes() -> None:
             try:
@@ -1185,7 +1203,8 @@ def test_concurrent_getNode() -> None:
                     node = iface.getNode(f"!{i:08x}", requestChannels=False)
                     assert node is not None
             except Exception as e:  # noqa: BLE001 - intentionally recording thread errors
-                errors.append(e)
+                with errors_lock:
+                    errors.append(e)
 
         threads = [threading.Thread(target=get_nodes) for _ in range(10)]
         for t in threads:
@@ -1227,13 +1246,15 @@ def test_concurrent_sendText_with_queue() -> None:
         iface.myInfo.my_node_num = 12345
         iface._localChannels = [channel_pb2.Channel(index=0)]
         errors = []
+        errors_lock = threading.Lock()
 
         def send_texts() -> None:
             try:
                 for i in range(10):
                     iface.sendText(f"message_{i}", wantAck=True)
             except Exception as e:  # noqa: BLE001 - intentionally recording thread errors
-                errors.append(e)
+                with errors_lock:
+                    errors.append(e)
 
         threads = [threading.Thread(target=send_texts) for _ in range(5)]
         for t in threads:

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -1039,16 +1039,18 @@ def test_concurrent_queue_operations() -> None:
                 for i in range(50):
                     packet_id = start_id * 100 + i
                     packet = mesh_pb2.ToRadio()
-                    iface.queue[packet_id] = packet
+                    with iface._queue_lock:
+                        iface.queue[packet_id] = packet
             except Exception as e:
                 errors.append(e)
 
         def remove_from_queue() -> None:
             try:
                 for _ in range(25):
-                    if iface.queue:
-                        key = next(iter(iface.queue))
-                        iface.queue.pop(key, None)
+                    with iface._queue_lock:
+                        if iface.queue:
+                            key = next(iter(iface.queue))
+                            iface.queue.pop(key, None)
             except Exception as e:
                 errors.append(e)
 
@@ -1112,7 +1114,7 @@ def test_concurrent_close_with_packet_id_generation() -> None:
             except Exception as e:
                 errors.append(e)
 
-        threads = [threading.Thread(target=generate_ids, daemon=True) for _ in range(5)]
+        threads = [threading.Thread(target=generate_ids) for _ in range(5)]
         for t in threads:
             t.start()
 
@@ -1121,6 +1123,9 @@ def test_concurrent_close_with_packet_id_generation() -> None:
 
         # Signal threads to stop
         stop_flag.set()
+        for t in threads:
+            t.join(timeout=1.0)
+        assert all(not t.is_alive() for t in threads)
 
     # Close is implicit in context manager exit
     assert len(errors) == 0
@@ -1189,8 +1194,15 @@ def test_concurrent_getNode() -> None:
 
 
 @pytest.mark.unit
-def test_packet_id_no_collision_after_many_generations() -> None:
+def test_packet_id_no_collision_after_many_generations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Test that packet IDs don't collide after many generations."""
+    next_random = iter(range(1_000_000))
+    monkeypatch.setattr(
+        "meshtastic.mesh_interface.random.randint",
+        lambda _a, _b: next(next_random),
+    )
     with MeshInterface(noProto=True) as iface:
         packet_ids = set()
 

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -4,7 +4,6 @@ from collections import OrderedDict
 import logging
 import re
 import threading
-import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, create_autospec, patch
@@ -981,7 +980,7 @@ def test_concurrent_packet_id_generation() -> None:
                 for _ in range(100):
                     packet_id = iface._generate_packet_id()
                     packet_ids.append(packet_id)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - intentionally recording thread errors
                 errors.append(e)
 
         threads = [threading.Thread(target=generate_packet_ids) for _ in range(10)]
@@ -1009,13 +1008,14 @@ def test_concurrent_node_database_access() -> None:
             try:
                 for i in range(50):
                     node_id = f"!{node_num:08x}"
-                    node = {"num": node_num, "user": {"id": node_id}, "lastHeard": i}
-                    iface._get_or_create_by_num(node_num)
-                    if iface.nodes is not None:
-                        iface.nodes[node_id] = node
-                    if iface.nodesByNum is not None:
-                        iface.nodesByNum[node_num] = node
-            except Exception as e:
+                    with iface._node_db_lock:
+                        node = iface._get_or_create_by_num(node_num)
+                        node["lastHeard"] = i
+                        if iface.nodes is not None:
+                            iface.nodes[node_id] = node
+                        if iface.nodesByNum is not None:
+                            iface.nodesByNum[node_num] = node
+            except Exception as e:  # noqa: BLE001 - intentionally recording thread errors
                 errors.append(e)
 
         threads = [threading.Thread(target=update_nodes, args=(i,)) for i in range(20)]
@@ -1041,7 +1041,7 @@ def test_concurrent_queue_operations() -> None:
                     packet = mesh_pb2.ToRadio()
                     with iface._queue_lock:
                         iface.queue[packet_id] = packet
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - intentionally recording thread errors
                 errors.append(e)
 
         def remove_from_queue() -> None:
@@ -1051,7 +1051,7 @@ def test_concurrent_queue_operations() -> None:
                         if iface.queue:
                             key = next(iter(iface.queue))
                             iface.queue.pop(key, None)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - intentionally recording thread errors
                 errors.append(e)
 
         add_threads = [
@@ -1074,6 +1074,7 @@ def test_concurrent_response_handler_registration() -> None:
         iface.responseHandlers = {}
         errors = []
         added_ids = []
+        added_ids_lock = threading.Lock()
 
         def register_handlers(start_id: int) -> None:
             try:
@@ -1081,8 +1082,9 @@ def test_concurrent_response_handler_registration() -> None:
                     request_id = start_id * 100 + i
                     handler = MagicMock()
                     iface._add_response_handler(request_id, handler)
-                    added_ids.append(request_id)
-            except Exception as e:
+                    with added_ids_lock:
+                        added_ids.append(request_id)
+            except Exception as e:  # noqa: BLE001 - intentionally recording thread errors
                 errors.append(e)
 
         threads = [
@@ -1104,6 +1106,7 @@ def test_concurrent_close_with_packet_id_generation() -> None:
     """Test that close() properly handles concurrent packet ID generation."""
     errors = []
     stop_flag = threading.Event()
+    started = threading.Event()
 
     with MeshInterface(noProto=True) as iface:
 
@@ -1111,15 +1114,15 @@ def test_concurrent_close_with_packet_id_generation() -> None:
             try:
                 while not stop_flag.is_set():
                     iface._generate_packet_id()
-            except Exception as e:
+                    started.set()
+            except Exception as e:  # noqa: BLE001 - intentionally recording thread errors
                 errors.append(e)
 
         threads = [threading.Thread(target=generate_ids) for _ in range(5)]
         for t in threads:
             t.start()
 
-        # Let threads run for a bit
-        time.sleep(0.1)
+        assert started.wait(timeout=1.0)
 
         # Signal threads to stop
         stop_flag.set()
@@ -1153,7 +1156,7 @@ def test_concurrent_showNodes() -> None:
             try:
                 for _ in range(10):
                     iface.showNodes()
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - intentionally recording thread errors
                 errors.append(e)
 
         threads = [threading.Thread(target=call_show_nodes) for _ in range(10)]
@@ -1181,7 +1184,7 @@ def test_concurrent_getNode() -> None:
                     # validates concurrent access safety for getNode().
                     node = iface.getNode(f"!{i:08x}", requestChannels=False)
                     assert node is not None
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - intentionally recording thread errors
                 errors.append(e)
 
         threads = [threading.Thread(target=get_nodes) for _ in range(10)]
@@ -1229,7 +1232,7 @@ def test_concurrent_sendText_with_queue() -> None:
             try:
                 for i in range(10):
                     iface.sendText(f"message_{i}", wantAck=True)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - intentionally recording thread errors
                 errors.append(e)
 
         threads = [threading.Thread(target=send_texts) for _ in range(5)]

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -14,7 +14,7 @@ from hypothesis import strategies as st
 from .. import BROADCAST_ADDR, LOCAL_ADDR
 from ..mesh_interface import MeshInterface, _timeago
 from ..node import Node
-from ..protobuf import config_pb2, mesh_pb2, portnums_pb2
+from ..protobuf import channel_pb2, config_pb2, mesh_pb2, portnums_pb2
 
 # TODO
 # from ..config import Config
@@ -964,3 +964,266 @@ def test_timeago_fuzz(seconds: int) -> None:
     """Fuzz _timeago to ensure it works with any integer."""
     val = _timeago(seconds)
     assert re.fullmatch(r"now|\d+ (secs?|mins?|hours?|days?|months?|years?) ago", val)
+
+
+# Concurrent access edge case tests
+@pytest.mark.unit
+def test_concurrent_packet_id_generation() -> None:
+    """Test that packet ID generation is thread-safe."""
+    with MeshInterface(noProto=True) as iface:
+        packet_ids = []
+        errors = []
+
+        def generate_packet_ids() -> None:
+            try:
+                for _ in range(100):
+                    packet_id = iface._generate_packet_id()
+                    packet_ids.append(packet_id)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=generate_packet_ids) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0
+        # All packet IDs should be unique
+        assert len(packet_ids) == len(set(packet_ids))
+        # All packet IDs should be within valid range
+        assert all(0 <= pid <= 0xFFFFFFFF for pid in packet_ids)
+
+
+@pytest.mark.unit
+def test_concurrent_node_database_access() -> None:
+    """Test that node database access is thread-safe."""
+    with MeshInterface(noProto=True) as iface:
+        iface.nodes = {}
+        iface.nodesByNum = {}
+        errors = []
+
+        def update_nodes(node_num: int) -> None:
+            try:
+                for i in range(50):
+                    node_id = f"!{node_num:08x}"
+                    node = {"num": node_num, "user": {"id": node_id}, "lastHeard": i}
+                    iface._get_or_create_by_num(node_num)
+                    if iface.nodes is not None:
+                        iface.nodes[node_id] = node
+                    if iface.nodesByNum is not None:
+                        iface.nodesByNum[node_num] = node
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=update_nodes, args=(i,)) for i in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0
+
+
+@pytest.mark.unit
+def test_concurrent_queue_operations() -> None:
+    """Test that queue operations are thread-safe."""
+    import collections
+
+    with MeshInterface(noProto=True) as iface:
+        iface.queue = collections.OrderedDict()
+        errors = []
+
+        def add_to_queue(start_id: int) -> None:
+            try:
+                for i in range(50):
+                    packet_id = start_id * 100 + i
+                    packet = mesh_pb2.ToRadio()
+                    iface.queue[packet_id] = packet
+            except Exception as e:
+                errors.append(e)
+
+        def remove_from_queue() -> None:
+            try:
+                for _ in range(25):
+                    if iface.queue:
+                        key = next(iter(iface.queue))
+                        iface.queue.pop(key, None)
+            except Exception as e:
+                errors.append(e)
+
+        add_threads = [
+            threading.Thread(target=add_to_queue, args=(i,)) for i in range(4)
+        ]
+        remove_threads = [threading.Thread(target=remove_from_queue) for _ in range(4)]
+
+        for t in add_threads + remove_threads:
+            t.start()
+        for t in add_threads + remove_threads:
+            t.join()
+
+        assert len(errors) == 0
+
+
+@pytest.mark.unit
+def test_concurrent_response_handler_registration() -> None:
+    """Test that response handler registration is thread-safe."""
+    with MeshInterface(noProto=True) as iface:
+        iface.responseHandlers = {}
+        errors = []
+        added_ids = []
+
+        def register_handlers(start_id: int) -> None:
+            try:
+                for i in range(50):
+                    request_id = start_id * 100 + i
+                    handler = MagicMock()
+                    iface._add_response_handler(request_id, handler)
+                    added_ids.append(request_id)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=register_handlers, args=(i,)) for i in range(10)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0
+        # All registered IDs should be in responseHandlers
+        for request_id in added_ids:
+            assert request_id in iface.responseHandlers
+
+
+@pytest.mark.unit
+def test_concurrent_close_with_packet_id_generation() -> None:
+    """Test that close() properly handles concurrent packet ID generation."""
+    errors = []
+    stop_flag = threading.Event()
+
+    with MeshInterface(noProto=True) as iface:
+
+        def generate_ids() -> None:
+            try:
+                while not stop_flag.is_set():
+                    iface._generate_packet_id()
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=generate_ids, daemon=True) for _ in range(5)]
+        for t in threads:
+            t.start()
+
+        # Let threads run for a bit
+        import time
+
+        time.sleep(0.1)
+
+        # Signal threads to stop
+        stop_flag.set()
+
+    # Close is implicit in context manager exit
+    assert len(errors) == 0
+
+
+@pytest.mark.unit
+def test_concurrent_showNodes() -> None:
+    """Test that showNodes() is thread-safe."""
+    with MeshInterface(noProto=True) as iface:
+        iface.nodes = {
+            f"!{i:08x}": {
+                "num": i,
+                "user": {"id": f"!{i:08x}", "longName": f"Node{i}"},
+                "position": {},
+            }
+            for i in range(100)
+        }
+        iface.nodesByNum = {i: iface.nodes[f"!{i:08x}"] for i in range(100)}
+        iface.myInfo = MagicMock()
+        iface.myInfo.my_node_num = 0
+
+        errors = []
+
+        def call_show_nodes() -> None:
+            try:
+                for _ in range(10):
+                    iface.showNodes()
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=call_show_nodes) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0
+
+
+@pytest.mark.unit
+def test_concurrent_getNode() -> None:
+    """Test that getNode() is thread-safe."""
+    with MeshInterface(noProto=True) as iface:
+        iface.nodesByNum = {
+            i: {"num": i, "user": {"id": f"!{i:08x}"}} for i in range(100)
+        }
+        errors = []
+
+        def get_nodes() -> None:
+            try:
+                for i in range(50):
+                    node = iface.getNode(f"!{i:08x}")
+                    assert node is not None
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=get_nodes) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0
+
+
+@pytest.mark.unit
+def test_packet_id_no_collision_after_many_generations() -> None:
+    """Test that packet IDs don't collide after many generations."""
+    with MeshInterface(noProto=True) as iface:
+        packet_ids = set()
+
+        # Generate many packet IDs
+        for _ in range(10000):
+            packet_id = iface._generate_packet_id()
+            assert packet_id not in packet_ids
+            packet_ids.add(packet_id)
+
+        # Verify all are unique
+        assert len(packet_ids) == 10000
+
+
+@pytest.mark.unit
+def test_concurrent_sendText_with_queue() -> None:
+    """Test that sendText() with queue is thread-safe."""
+    with MeshInterface(noProto=True) as iface:
+        iface.myInfo = MagicMock()
+        iface.myInfo.my_node_num = 12345
+        iface._localChannels = [channel_pb2.Channel(index=0)]
+        errors = []
+
+        def send_texts() -> None:
+            try:
+                for i in range(10):
+                    iface.sendText(f"message_{i}", wantAck=True)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=send_texts) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -1,8 +1,10 @@
 """Meshtastic unit tests for mesh_interface.py."""
 
+from collections import OrderedDict
 import logging
 import re
 import threading
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, create_autospec, patch
@@ -1028,10 +1030,8 @@ def test_concurrent_node_database_access() -> None:
 @pytest.mark.unit
 def test_concurrent_queue_operations() -> None:
     """Test that queue operations are thread-safe."""
-    import collections
-
     with MeshInterface(noProto=True) as iface:
-        iface.queue = collections.OrderedDict()
+        iface.queue = OrderedDict()
         errors = []
 
         def add_to_queue(start_id: int) -> None:
@@ -1117,8 +1117,6 @@ def test_concurrent_close_with_packet_id_generation() -> None:
             t.start()
 
         # Let threads run for a bit
-        import time
-
         time.sleep(0.1)
 
         # Signal threads to stop
@@ -1174,7 +1172,9 @@ def test_concurrent_getNode() -> None:
         def get_nodes() -> None:
             try:
                 for i in range(50):
-                    node = iface.getNode(f"!{i:08x}")
+                    # Avoid channel/config waits in noProto mode; this test only
+                    # validates concurrent access safety for getNode().
+                    node = iface.getNode(f"!{i:08x}", requestChannels=False)
                     assert node is not None
             except Exception as e:
                 errors.append(e)

--- a/meshtastic/tests/test_mt_config.py
+++ b/meshtastic/tests/test_mt_config.py
@@ -246,14 +246,17 @@ def test_compat_aliases_mapping() -> None:
 def test_concurrent_access_thread_safety() -> None:
     """Concurrent access to deprecation tracking should be thread-safe."""
     results = []
+    results_lock = threading.Lock()
 
     def access_deprecated_alias() -> None:
         try:
             # Access the deprecated alias (warns once per process)
             _ = mt_config.tunnelInstance  # pyright: ignore[reportAttributeAccessIssue]
-            results.append("success")
+            with results_lock:
+                results.append("success")
         except Exception as e:  # noqa: BLE001 - test captures thread errors
-            results.append(f"error: {e}")
+            with results_lock:
+                results.append(f"error: {e}")
 
     threads = [threading.Thread(target=access_deprecated_alias) for _ in range(20)]
     for t in threads:

--- a/meshtastic/tests/test_mt_config.py
+++ b/meshtastic/tests/test_mt_config.py
@@ -252,7 +252,7 @@ def test_concurrent_access_thread_safety() -> None:
             # Access the deprecated alias (warns once per process)
             _ = mt_config.tunnelInstance  # pyright: ignore[reportAttributeAccessIssue]
             results.append("success")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - test captures thread errors
             results.append(f"error: {e}")
 
     threads = [threading.Thread(target=access_deprecated_alias) for _ in range(20)]

--- a/meshtastic/tests/test_mt_config.py
+++ b/meshtastic/tests/test_mt_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import threading
 from typing import Any
 
 import pytest
@@ -25,6 +26,43 @@ def test_reset_restores_module_defaults() -> None:
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("mt_config_state")
+def test_reset_clears_warned_deprecations() -> None:
+    """reset() should clear the warn-once deprecation tracking."""
+    # Trigger a deprecation warning
+    with pytest.warns(DeprecationWarning):
+        _ = mt_config.tunnelInstance  # pyright: ignore[reportAttributeAccessIssue]
+
+    # Verify it was tracked
+    assert "tunnelInstance" in mt_config._warned_deprecations
+
+    # Reset should clear it
+    mt_config.reset()
+    assert "tunnelInstance" not in mt_config._warned_deprecations
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("mt_config_state")
+def test_reset_with_thread_safety() -> None:
+    """reset() should work correctly with the deprecation lock."""
+    # Set some state
+    mt_config.channel_index = 5
+
+    # Reset from multiple threads
+    threads = []
+    for _ in range(10):
+        t = threading.Thread(target=mt_config.reset)
+        threads.append(t)
+        t.start()
+
+    for t in threads:
+        t.join()
+
+    # Should be reset to default
+    assert mt_config.channel_index is None
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("mt_config_state")
 def test_getattr_compat_alias_emits_deprecation_warning() -> None:
     """Accessing tunnelInstance should return tunnel_instance and warn."""
     marker: Any = object()
@@ -32,6 +70,26 @@ def test_getattr_compat_alias_emits_deprecation_warning() -> None:
     with pytest.warns(DeprecationWarning):
         result = mt_config.tunnelInstance  # pyright: ignore[reportAttributeAccessIssue]
     assert result is marker
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("mt_config_state")
+def test_getattr_compat_alias_warn_once() -> None:
+    """Accessing tunnelInstance should only warn once per process."""
+    marker: Any = object()
+    mt_config.tunnel_instance = marker
+
+    # First access warns
+    with pytest.warns(DeprecationWarning):
+        _ = mt_config.tunnelInstance  # pyright: ignore[reportAttributeAccessIssue]
+
+    # Second access does not warn
+    import warnings
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _ = mt_config.tunnelInstance  # pyright: ignore[reportAttributeAccessIssue]
+        assert len(caught) == 0
 
 
 @pytest.mark.unit
@@ -46,7 +104,204 @@ def test_setattr_compat_alias_sets_new_name_and_warns() -> None:
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("mt_config_state")
+def test_setattr_compat_alias_warn_once() -> None:
+    """Setting tunnelInstance should only warn once per process."""
+    marker1: Any = object()
+    marker2: Any = object()
+
+    # First set warns
+    with pytest.warns(DeprecationWarning):
+        mt_config.tunnelInstance = (
+            marker1  # pyright: ignore[reportAttributeAccessIssue]
+        )
+
+    # Second set does not warn
+    import warnings
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        mt_config.tunnelInstance = (
+            marker2  # pyright: ignore[reportAttributeAccessIssue]
+        )
+        assert len(caught) == 0
+
+    assert mt_config.tunnel_instance is marker2
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("mt_config_state")
+def test_delattr_compat_alias_deletes_new_name_and_warns() -> None:
+    """Deleting tunnelInstance should route to tunnel_instance and warn."""
+    marker: Any = object()
+    mt_config.tunnel_instance = marker
+
+    with pytest.warns(DeprecationWarning):
+        del mt_config.tunnelInstance  # pyright: ignore[reportAttributeAccessIssue]
+
+    assert not hasattr(mt_config, "tunnel_instance")
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("mt_config_state")
+def test_delattr_compat_alias_warn_once() -> None:
+    """Deleting tunnelInstance should only warn once per process."""
+    marker: Any = object()
+    mt_config.tunnel_instance = marker
+
+    # First delete warns
+    with pytest.warns(DeprecationWarning):
+        del mt_config.tunnelInstance  # pyright: ignore[reportAttributeAccessIssue]
+
+    # Reset and set again for second delete
+    mt_config.tunnel_instance = marker
+    import warnings
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        del mt_config.tunnelInstance  # pyright: ignore[reportAttributeAccessIssue]
+        assert len(caught) == 0
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("mt_config_state")
 def test_getattr_unknown_name_raises_attribute_error() -> None:
     """Unknown mt_config attributes should raise AttributeError."""
     with pytest.raises(AttributeError):
         _ = mt_config.this_attribute_does_not_exist
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("mt_config_state")
+def test_setattr_unknown_name_sets_attribute() -> None:
+    """Setting unknown attributes should work normally."""
+    mt_config.new_attribute = (
+        "test_value"  # pyright: ignore[reportAttributeAccessIssue]
+    )
+    assert (
+        mt_config.new_attribute == "test_value"
+    )  # pyright: ignore[reportAttributeAccessIssue]
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("mt_config_state")
+def test_delattr_unknown_name_deletes_attribute() -> None:
+    """Deleting unknown attributes should work normally."""
+    mt_config.new_attribute = (
+        "test_value"  # pyright: ignore[reportAttributeAccessIssue]
+    )
+    del mt_config.new_attribute  # pyright: ignore[reportAttributeAccessIssue]
+    assert not hasattr(mt_config, "new_attribute")
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("mt_config_state")
+def test_module_state_defaults_complete() -> None:
+    """All module state variables should have defaults."""
+    expected_keys = {
+        "args",
+        "parser",
+        "channel_index",
+        "logfile",
+        "tunnel_instance",
+        "camel_case",
+    }
+    assert set(mt_config.MODULE_STATE_DEFAULTS.keys()) == expected_keys
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("mt_config_state")
+def test_module_state_defaults_types() -> None:
+    """Module state defaults should have correct types."""
+    assert mt_config.MODULE_STATE_DEFAULTS["args"] is None
+    assert mt_config.MODULE_STATE_DEFAULTS["parser"] is None
+    assert mt_config.MODULE_STATE_DEFAULTS["channel_index"] is None
+    assert mt_config.MODULE_STATE_DEFAULTS["logfile"] is None
+    assert mt_config.MODULE_STATE_DEFAULTS["tunnel_instance"] is None
+    assert mt_config.MODULE_STATE_DEFAULTS["camel_case"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("mt_config_state")
+def test_state_isolation_between_tests_part1() -> None:
+    """First test in isolation pair - set state."""
+    mt_config.channel_index = 42
+    assert mt_config.channel_index == 42
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("mt_config_state")
+def test_state_isolation_between_tests_part2() -> None:
+    """Second test in isolation pair - verify state is reset."""
+    # mt_config_state fixture should have reset the state
+    assert mt_config.channel_index is None
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("mt_config_state")
+def test_compat_aliases_mapping() -> None:
+    """Compatibility aliases mapping should be correct."""
+    assert "tunnelInstance" in mt_config._COMPAT_ALIASES
+    assert mt_config._COMPAT_ALIASES["tunnelInstance"] == "tunnel_instance"
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("mt_config_state")
+def test_concurrent_access_thread_safety() -> None:
+    """Concurrent access to deprecation tracking should be thread-safe."""
+    results = []
+
+    def access_deprecated_alias() -> None:
+        try:
+            # Access the deprecated alias (warns once per process)
+            _ = mt_config.tunnelInstance  # pyright: ignore[reportAttributeAccessIssue]
+            results.append("success")
+        except Exception as e:
+            results.append(f"error: {e}")
+
+    threads = [threading.Thread(target=access_deprecated_alias) for _ in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # All threads should complete without errors
+    assert len(results) == 20
+    assert all(r == "success" for r in results)
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("mt_config_state")
+def test_setattr_normal_attribute() -> None:
+    """Setting normal attributes should work without warnings."""
+    import warnings
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        mt_config.channel_index = 99
+        assert len(caught) == 0
+
+    assert mt_config.channel_index == 99
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("mt_config_state")
+def test_getattr_normal_attribute() -> None:
+    """Getting normal attributes should work without warnings."""
+    import warnings
+
+    mt_config.channel_index = 99
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _ = mt_config.channel_index
+        assert len(caught) == 0
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("mt_config_state")
+def test_module_class_is_mt_config_module() -> None:
+    """Module should use custom _MtConfigModule class."""
+    import types
+
+    assert isinstance(mt_config, types.ModuleType)
+    assert mt_config.__class__.__name__ == "_MtConfigModule"

--- a/meshtastic/tests/test_mt_config.py
+++ b/meshtastic/tests/test_mt_config.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import argparse
 import threading
+import types
+import warnings
 from typing import Any
 
 import pytest
@@ -84,8 +86,6 @@ def test_getattr_compat_alias_warn_once() -> None:
         _ = mt_config.tunnelInstance  # pyright: ignore[reportAttributeAccessIssue]
 
     # Second access does not warn
-    import warnings
-
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         _ = mt_config.tunnelInstance  # pyright: ignore[reportAttributeAccessIssue]
@@ -116,8 +116,6 @@ def test_setattr_compat_alias_warn_once() -> None:
         )
 
     # Second set does not warn
-    import warnings
-
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         mt_config.tunnelInstance = (
@@ -154,7 +152,6 @@ def test_delattr_compat_alias_warn_once() -> None:
 
     # Reset and set again for second delete
     mt_config.tunnel_instance = marker
-    import warnings
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
@@ -273,8 +270,6 @@ def test_concurrent_access_thread_safety() -> None:
 @pytest.mark.usefixtures("mt_config_state")
 def test_setattr_normal_attribute() -> None:
     """Setting normal attributes should work without warnings."""
-    import warnings
-
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         mt_config.channel_index = 99
@@ -287,8 +282,6 @@ def test_setattr_normal_attribute() -> None:
 @pytest.mark.usefixtures("mt_config_state")
 def test_getattr_normal_attribute() -> None:
     """Getting normal attributes should work without warnings."""
-    import warnings
-
     mt_config.channel_index = 99
 
     with warnings.catch_warnings(record=True) as caught:
@@ -301,7 +294,5 @@ def test_getattr_normal_attribute() -> None:
 @pytest.mark.usefixtures("mt_config_state")
 def test_module_class_is_mt_config_module() -> None:
     """Module should use custom _MtConfigModule class."""
-    import types
-
     assert isinstance(mt_config, types.ModuleType)
     assert mt_config.__class__.__name__ == "_MtConfigModule"

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -14,7 +14,13 @@ from pytest import CaptureFixture, LogCaptureFixture
 
 from ..mesh_interface import MeshInterface
 from ..node import Node
-from ..protobuf import admin_pb2, apponly_pb2, config_pb2, localonly_pb2, mesh_pb2
+from ..protobuf import (
+    admin_pb2,
+    apponly_pb2,
+    config_pb2,
+    localonly_pb2,
+    mesh_pb2,
+)
 from ..protobuf.channel_pb2 import Channel  # pylint: disable=E0611
 from ..serial_interface import SerialInterface
 from ..util import Acknowledgment

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -733,3 +733,32 @@ def test_start_ota_remote_node_raises_error() -> None:
         MeshInterface.MeshInterfaceError, match="startOTA only possible on local node"
     ):
         remote_node.startOTA(mode=admin_pb2.OTAMode.OTA_WIFI, hash=test_hash)
+
+
+@pytest.mark.unit
+def test_requestConfig_with_module_config_descriptor(
+    mock_serial_interface: MagicMock,
+) -> None:
+    """Verify requestConfig sets get_module_config_request for LocalModuleConfig fields.
+
+    Tests line 370: when configType is a field descriptor with containing_type.name
+    != 'LocalConfig', it should set get_module_config_request to the field index.
+    """
+    anode = Node(mock_serial_interface, "!12345678", noProto=True)
+    mock_serial_interface.localNode = anode
+
+    # Get a field descriptor from LocalModuleConfig (not LocalConfig)
+    module_config = localonly_pb2.LocalModuleConfig()
+    mqtt_field = module_config.DESCRIPTOR.fields_by_name["mqtt"]
+
+    sent_messages: list[admin_pb2.AdminMessage] = []
+    anode._send_admin = _make_fake_send_admin(  # type: ignore[method-assign,assignment]
+        sent_messages=sent_messages
+    )
+
+    anode.requestConfig(mqtt_field)
+
+    assert len(sent_messages) == 1
+    sent_msg = sent_messages[0]
+    # mqtt field has index 0, should be set as get_module_config_request
+    assert sent_msg.get_module_config_request == 0

--- a/meshtastic/tests/test_supported_device.py
+++ b/meshtastic/tests/test_supported_device.py
@@ -216,7 +216,7 @@ def test_supported_device_usb_id_aliases_list() -> None:
         name="Test",
         usb_vendor_id_in_hex="10c4",
         usb_product_id_in_hex="ea60",
-        usb_id_aliases=(("303A", "1001"), ("1A86", "55D4")),  # type: ignore[arg-type]
+        usb_id_aliases=(("303A", "1001"), ("1A86", "55D4")),
     )
     assert device.usb_id_aliases == (("303a", "1001"), ("1a86", "55d4"))
 
@@ -228,7 +228,7 @@ def test_supported_device_usb_id_aliases_none() -> None:
         name="Test",
         usb_vendor_id_in_hex="10c4",
         usb_product_id_in_hex="ea60",
-        usb_id_aliases=(),  # type: ignore[arg-type]
+        usb_id_aliases=(),
     )
     assert device.usb_id_aliases == ()
 
@@ -240,7 +240,7 @@ def test_supported_device_usb_id_aliases_deduplication() -> None:
         name="Test",
         usb_vendor_id_in_hex="10c4",
         usb_product_id_in_hex="ea60",
-        usb_id_aliases=(  # type: ignore[arg-type]
+        usb_id_aliases=(
             ("303A", "1001"),
             ("303a", "1001"),  # Duplicate after normalization
             ("1A86", "55D4"),
@@ -290,7 +290,7 @@ def test_supported_device_usb_id_aliases_non_string() -> None:
             name="Test",
             usb_vendor_id_in_hex="10c4",
             usb_product_id_in_hex="ea60",
-            usb_id_aliases=((1234, "1001"),),  # type: ignore[list-item]
+            usb_id_aliases=((1234, "1001"),),  # type: ignore[arg-type]
         )
 
 

--- a/meshtastic/tests/test_supported_device.py
+++ b/meshtastic/tests/test_supported_device.py
@@ -1,5 +1,7 @@
 """Meshtastic unit tests for supported_device.py."""
 
+from typing import cast
+
 import pytest
 
 from meshtastic.supported_device import (
@@ -29,7 +31,7 @@ def test_supported_device_creation_minimal() -> None:
     assert device.baseport_on_windows == "COM"
     assert device.usb_vendor_id_in_hex is None
     assert device.usb_product_id_in_hex is None
-    assert device.usb_id_aliases == ()
+    assert not device.usb_id_aliases
 
 
 @pytest.mark.unit
@@ -230,7 +232,7 @@ def test_supported_device_usb_id_aliases_none() -> None:
         usb_product_id_in_hex="ea60",
         usb_id_aliases=(),
     )
-    assert device.usb_id_aliases == ()
+    assert not device.usb_id_aliases
 
 
 @pytest.mark.unit
@@ -355,7 +357,7 @@ def test_supported_device_usb_ids_property_with_aliases() -> None:
 def test_supported_device_usb_ids_property_no_ids() -> None:
     """Test usb_ids property with no USB IDs."""
     device = SupportedDevice(name="Test")
-    assert device.usb_ids == ()
+    assert not device.usb_ids
 
 
 @pytest.mark.unit
@@ -526,8 +528,6 @@ def test_device_with_special_chars_in_usb_id() -> None:
 @pytest.mark.unit
 def test_usb_id_aliases_preserve_order() -> None:
     """Test that USB ID aliases preserve insertion order after deduplication."""
-    from typing import cast
-
     device = SupportedDevice(
         name="Test",
         usb_vendor_id_in_hex="10c4",
@@ -552,8 +552,6 @@ def test_usb_id_aliases_preserve_order() -> None:
 @pytest.mark.unit
 def test_usb_ids_property_preserves_order() -> None:
     """Test that usb_ids property preserves primary-then-aliases order."""
-    from typing import cast
-
     device = SupportedDevice(
         name="Test",
         usb_vendor_id_in_hex="10c4",

--- a/meshtastic/tests/test_supported_device.py
+++ b/meshtastic/tests/test_supported_device.py
@@ -485,7 +485,7 @@ def test_supported_devices_list() -> None:
 
 @pytest.mark.unit
 def test_supported_devices_no_duplicates() -> None:
-    """Test that supported_devices list has no duplicate entries."""
+    """Test that supported_devices has no duplicate device definitions."""
     assert len(supported_devices) == len(set(map(repr, supported_devices)))
 
 

--- a/meshtastic/tests/test_supported_device.py
+++ b/meshtastic/tests/test_supported_device.py
@@ -1,0 +1,587 @@
+"""Meshtastic unit tests for supported_device.py."""
+
+import pytest
+
+from meshtastic.supported_device import (
+    USB_ID_HEX_RE,
+    SupportedDevice,
+    SupportedDeviceValidationError,
+    rak4631_5005,
+    rak4631_19003,
+    seeed_xiao_s3,
+    supported_devices,
+    tbeam_v1_1,
+    tdeck,
+    tlora_v1,
+)
+
+
+@pytest.mark.unit
+def test_supported_device_creation_minimal() -> None:
+    """Test creating a SupportedDevice with minimal required fields."""
+    device = SupportedDevice(name="Test Device")
+    assert device.name == "Test Device"
+    assert device.version is None
+    assert device.for_firmware is None
+    assert device.device_class == "esp32"
+    assert device.baseport_on_linux is None
+    assert device.baseport_on_mac is None
+    assert device.baseport_on_windows == "COM"
+    assert device.usb_vendor_id_in_hex is None
+    assert device.usb_product_id_in_hex is None
+    assert device.usb_id_aliases == ()
+
+
+@pytest.mark.unit
+def test_supported_device_creation_full() -> None:
+    """Test creating a SupportedDevice with all fields."""
+    device = SupportedDevice(
+        name="Test Device",
+        version="1.0",
+        for_firmware="test-firmware",
+        device_class="nrf52",
+        baseport_on_linux="ttyUSB",
+        baseport_on_mac="cu.usbserial",
+        baseport_on_windows="COM",
+        usb_vendor_id_in_hex="10c4",
+        usb_product_id_in_hex="ea60",
+    )
+    assert device.name == "Test Device"
+    assert device.version == "1.0"
+    assert device.for_firmware == "test-firmware"
+    assert device.device_class == "nrf52"
+    assert device.baseport_on_linux == "ttyUSB"
+    assert device.baseport_on_mac == "cu.usbserial"
+    assert device.baseport_on_windows == "COM"
+    assert device.usb_vendor_id_in_hex == "10c4"
+    assert device.usb_product_id_in_hex == "ea60"
+
+
+@pytest.mark.unit
+def test_supported_device_usb_id_normalization() -> None:
+    """Test that USB IDs are normalized to lowercase."""
+    device = SupportedDevice(
+        name="Test",
+        usb_vendor_id_in_hex="10C4",
+        usb_product_id_in_hex="EA60",
+    )
+    assert device.usb_vendor_id_in_hex == "10c4"
+    assert device.usb_product_id_in_hex == "ea60"
+
+
+@pytest.mark.unit
+def test_supported_device_usb_id_whitespace() -> None:
+    """Test that USB IDs have whitespace stripped."""
+    device = SupportedDevice(
+        name="Test",
+        usb_vendor_id_in_hex=" 10c4 ",
+        usb_product_id_in_hex=" ea60 ",
+    )
+    assert device.usb_vendor_id_in_hex == "10c4"
+    assert device.usb_product_id_in_hex == "ea60"
+
+
+@pytest.mark.unit
+def test_supported_device_usb_id_empty_string() -> None:
+    """Test that empty string USB IDs are treated as None."""
+    device = SupportedDevice(
+        name="Test",
+        usb_vendor_id_in_hex="",
+        usb_product_id_in_hex="",
+    )
+    assert device.usb_vendor_id_in_hex is None
+    assert device.usb_product_id_in_hex is None
+
+
+@pytest.mark.unit
+def test_supported_device_usb_id_partial_vendor_only() -> None:
+    """Test that providing only vendor ID without product ID raises error."""
+    with pytest.raises(
+        SupportedDeviceValidationError,
+        match="must be provided together",
+    ):
+        SupportedDevice(name="Test", usb_vendor_id_in_hex="10c4")
+
+
+@pytest.mark.unit
+def test_supported_device_usb_id_partial_product_only() -> None:
+    """Test that providing only product ID without vendor ID raises error."""
+    with pytest.raises(
+        SupportedDeviceValidationError,
+        match="must be provided together",
+    ):
+        SupportedDevice(name="Test", usb_product_id_in_hex="ea60")
+
+
+@pytest.mark.unit
+def test_supported_device_usb_id_invalid_vendor_format() -> None:
+    """Test that invalid vendor ID format raises error."""
+    with pytest.raises(
+        SupportedDeviceValidationError,
+        match="Invalid usb_vendor_id_in_hex",
+    ):
+        SupportedDevice(
+            name="Test",
+            usb_vendor_id_in_hex="ZZZZ",
+            usb_product_id_in_hex="ea60",
+        )
+
+
+@pytest.mark.unit
+def test_supported_device_usb_id_invalid_product_format() -> None:
+    """Test that invalid product ID format raises error."""
+    with pytest.raises(
+        SupportedDeviceValidationError,
+        match="Invalid usb_product_id_in_hex",
+    ):
+        SupportedDevice(
+            name="Test",
+            usb_vendor_id_in_hex="10c4",
+            usb_product_id_in_hex="ZZZZ",
+        )
+
+
+@pytest.mark.unit
+def test_supported_device_usb_id_too_short() -> None:
+    """Test that too-short USB IDs raise error."""
+    with pytest.raises(
+        SupportedDeviceValidationError,
+        match="Invalid usb_vendor_id_in_hex",
+    ):
+        SupportedDevice(
+            name="Test",
+            usb_vendor_id_in_hex="10c",
+            usb_product_id_in_hex="ea60",
+        )
+
+
+@pytest.mark.unit
+def test_supported_device_usb_id_too_long() -> None:
+    """Test that too-long USB IDs raise error."""
+    with pytest.raises(
+        SupportedDeviceValidationError,
+        match="Invalid usb_vendor_id_in_hex",
+    ):
+        SupportedDevice(
+            name="Test",
+            usb_vendor_id_in_hex="10c40",
+            usb_product_id_in_hex="ea60",
+        )
+
+
+@pytest.mark.unit
+def test_supported_device_usb_vendor_id_non_string() -> None:
+    """Test that non-string vendor ID is handled by type checker."""
+    # Type hints prevent passing non-string values at type-check time.
+    # Runtime behavior is covered by other tests.
+    # This test is a placeholder for type safety documentation.
+    device = SupportedDevice(
+        name="Test",
+        usb_vendor_id_in_hex="1234",
+        usb_product_id_in_hex="ea60",
+    )
+    assert device.usb_vendor_id_in_hex == "1234"
+
+
+@pytest.mark.unit
+def test_supported_device_usb_product_id_non_string() -> None:
+    """Test that non-string product ID is handled by type checker."""
+    # Type hints prevent passing non-string values at type-check time.
+    # Runtime behavior is covered by other tests.
+    # This test is a placeholder for type safety documentation.
+    device = SupportedDevice(
+        name="Test",
+        usb_vendor_id_in_hex="10c4",
+        usb_product_id_in_hex="ea60",
+    )
+    assert device.usb_product_id_in_hex == "ea60"
+
+
+@pytest.mark.unit
+def test_supported_device_usb_id_aliases_tuple() -> None:
+    """Test that USB ID aliases are normalized."""
+    device = SupportedDevice(
+        name="Test",
+        usb_vendor_id_in_hex="10c4",
+        usb_product_id_in_hex="ea60",
+        usb_id_aliases=(("303A", "1001"), ("1A86", "55D4")),
+    )
+    assert device.usb_id_aliases == (("303a", "1001"), ("1a86", "55d4"))
+
+
+@pytest.mark.unit
+def test_supported_device_usb_id_aliases_list() -> None:
+    """Test that USB ID aliases can be provided as list."""
+    device = SupportedDevice(
+        name="Test",
+        usb_vendor_id_in_hex="10c4",
+        usb_product_id_in_hex="ea60",
+        usb_id_aliases=(("303A", "1001"), ("1A86", "55D4")),  # type: ignore[arg-type]
+    )
+    assert device.usb_id_aliases == (("303a", "1001"), ("1a86", "55d4"))
+
+
+@pytest.mark.unit
+def test_supported_device_usb_id_aliases_none() -> None:
+    """Test that None USB ID aliases are treated as empty tuple."""
+    device = SupportedDevice(
+        name="Test",
+        usb_vendor_id_in_hex="10c4",
+        usb_product_id_in_hex="ea60",
+        usb_id_aliases=(),  # type: ignore[arg-type]
+    )
+    assert device.usb_id_aliases == ()
+
+
+@pytest.mark.unit
+def test_supported_device_usb_id_aliases_deduplication() -> None:
+    """Test that duplicate USB ID aliases are deduplicated."""
+    device = SupportedDevice(
+        name="Test",
+        usb_vendor_id_in_hex="10c4",
+        usb_product_id_in_hex="ea60",
+        usb_id_aliases=(  # type: ignore[arg-type]
+            ("303A", "1001"),
+            ("303a", "1001"),  # Duplicate after normalization
+            ("1A86", "55D4"),
+        ),
+    )
+    assert device.usb_id_aliases == (("303a", "1001"), ("1a86", "55d4"))
+
+
+@pytest.mark.unit
+def test_supported_device_usb_id_aliases_invalid_format() -> None:
+    """Test that invalid alias format raises error."""
+    with pytest.raises(
+        SupportedDeviceValidationError,
+        match="Invalid usb_id_aliases entry",
+    ):
+        SupportedDevice(
+            name="Test",
+            usb_vendor_id_in_hex="10c4",
+            usb_product_id_in_hex="ea60",
+            usb_id_aliases=(("303A",),),  # type: ignore[arg-type] # Missing product ID
+        )
+
+
+@pytest.mark.unit
+def test_supported_device_usb_id_aliases_invalid_tuple_length() -> None:
+    """Test that alias tuple with wrong length raises error."""
+    with pytest.raises(
+        SupportedDeviceValidationError,
+        match="Invalid usb_id_aliases entry",
+    ):
+        SupportedDevice(
+            name="Test",
+            usb_vendor_id_in_hex="10c4",
+            usb_product_id_in_hex="ea60",
+            usb_id_aliases=(("303A", "1001", "extra"),),  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.unit
+def test_supported_device_usb_id_aliases_non_string() -> None:
+    """Test that non-string alias values raise error."""
+    with pytest.raises(
+        SupportedDeviceValidationError,
+        match="Invalid usb_id_aliases entry",
+    ):
+        SupportedDevice(
+            name="Test",
+            usb_vendor_id_in_hex="10c4",
+            usb_product_id_in_hex="ea60",
+            usb_id_aliases=((1234, "1001"),),  # type: ignore[list-item]
+        )
+
+
+@pytest.mark.unit
+def test_supported_device_usb_id_aliases_invalid_hex() -> None:
+    """Test that invalid hex values in aliases raise error."""
+    with pytest.raises(
+        SupportedDeviceValidationError,
+        match="Invalid usb_id_aliases entry",
+    ):
+        SupportedDevice(
+            name="Test",
+            usb_vendor_id_in_hex="10c4",
+            usb_product_id_in_hex="ea60",
+            usb_id_aliases=(("ZZZZ", "1001"),),
+        )
+
+
+@pytest.mark.unit
+def test_supported_device_usb_id_aliases_non_container() -> None:
+    """Test that non-container aliases value raises error."""
+    with pytest.raises(
+        SupportedDeviceValidationError,
+        match="expected tuple/list",
+    ):
+        SupportedDevice(
+            name="Test",
+            usb_vendor_id_in_hex="10c4",
+            usb_product_id_in_hex="ea60",
+            usb_id_aliases="invalid",  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.unit
+def test_supported_device_usb_ids_property_primary_only() -> None:
+    """Test usb_ids property with primary USB ID only."""
+    device = SupportedDevice(
+        name="Test",
+        usb_vendor_id_in_hex="10c4",
+        usb_product_id_in_hex="ea60",
+    )
+    assert device.usb_ids == (("10c4", "ea60"),)
+
+
+@pytest.mark.unit
+def test_supported_device_usb_ids_property_with_aliases() -> None:
+    """Test usb_ids property includes both primary and aliases."""
+    device = SupportedDevice(
+        name="Test",
+        usb_vendor_id_in_hex="10c4",
+        usb_product_id_in_hex="ea60",
+        usb_id_aliases=(("303a", "1001"), ("1a86", "55d4")),
+    )
+    assert device.usb_ids == (
+        ("10c4", "ea60"),
+        ("303a", "1001"),
+        ("1a86", "55d4"),
+    )
+
+
+@pytest.mark.unit
+def test_supported_device_usb_ids_property_no_ids() -> None:
+    """Test usb_ids property with no USB IDs."""
+    device = SupportedDevice(name="Test")
+    assert device.usb_ids == ()
+
+
+@pytest.mark.unit
+def test_supported_device_usb_ids_property_deduplicates() -> None:
+    """Test that usb_ids property deduplicates."""
+    device = SupportedDevice(
+        name="Test",
+        usb_vendor_id_in_hex="303a",
+        usb_product_id_in_hex="1001",
+        usb_id_aliases=(("303a", "1001"),),  # Same as primary
+    )
+    # Should deduplicate while preserving order
+    assert device.usb_ids == (("303a", "1001"),)
+
+
+@pytest.mark.unit
+def test_supported_device_equality() -> None:
+    """Test that SupportedDevice instances are not equal by default (eq=False)."""
+    device1 = SupportedDevice(
+        name="Test",
+        usb_vendor_id_in_hex="10c4",
+        usb_product_id_in_hex="ea60",
+    )
+    device2 = SupportedDevice(
+        name="Test",
+        usb_vendor_id_in_hex="10c4",
+        usb_product_id_in_hex="ea60",
+    )
+    # With eq=False, different instances are never equal
+    assert device1 != device2
+
+
+@pytest.mark.unit
+def test_supported_device_usb_hex_regex_valid() -> None:
+    """Test USB_ID_HEX_RE matches valid 4-digit hex strings."""
+    assert USB_ID_HEX_RE.fullmatch("10c4") is not None
+    assert USB_ID_HEX_RE.fullmatch("ea60") is not None
+    assert USB_ID_HEX_RE.fullmatch("abcd") is not None
+    assert USB_ID_HEX_RE.fullmatch("1234") is not None
+
+
+@pytest.mark.unit
+def test_supported_device_usb_hex_regex_invalid() -> None:
+    """Test USB_ID_HEX_RE rejects invalid hex strings."""
+    assert USB_ID_HEX_RE.fullmatch("10C4") is None  # Uppercase
+    assert USB_ID_HEX_RE.fullmatch("10c") is None  # Too short
+    assert USB_ID_HEX_RE.fullmatch("10c40") is None  # Too long
+    assert USB_ID_HEX_RE.fullmatch("ZZZZ") is None  # Non-hex
+    assert USB_ID_HEX_RE.fullmatch("") is None  # Empty
+    assert USB_ID_HEX_RE.fullmatch("10c4 ") is None  # Whitespace
+
+
+@pytest.mark.unit
+def test_tbeam_v1_1_properties() -> None:
+    """Test tbeam_v1_1 device properties."""
+    assert tbeam_v1_1.name == "T-Beam"
+    assert tbeam_v1_1.version == "1.1"
+    assert tbeam_v1_1.for_firmware == "tbeam"
+    assert tbeam_v1_1.device_class == "esp32"
+    assert tbeam_v1_1.baseport_on_linux == "ttyACM"
+    assert tbeam_v1_1.baseport_on_mac == "cu.usbmodem"
+    assert tbeam_v1_1.usb_vendor_id_in_hex == "1a86"
+    assert tbeam_v1_1.usb_product_id_in_hex == "55d4"
+
+
+@pytest.mark.unit
+def test_tlora_v1_properties() -> None:
+    """Test tlora_v1 device properties."""
+    assert tlora_v1.name == "T-Lora"
+    assert tlora_v1.version == "1"
+    assert tlora_v1.for_firmware == "tlora-v1"
+    assert tlora_v1.baseport_on_linux == "ttyUSB"
+    assert tlora_v1.baseport_on_mac == "cu.usbserial"
+
+
+@pytest.mark.unit
+def test_tdeck_properties() -> None:
+    """Test tdeck device properties."""
+    assert tdeck.name == "T-Deck"
+    assert tdeck.for_firmware == "t-deck"
+    assert tdeck.device_class == "esp32"
+    assert tdeck.usb_vendor_id_in_hex == "303a"
+    assert tdeck.usb_product_id_in_hex == "1001"
+    assert ("1a86", "55d4") in tdeck.usb_id_aliases
+
+
+@pytest.mark.unit
+def test_seeed_xiao_s3_properties() -> None:
+    """Test seeed_xiao_s3 device properties."""
+    assert seeed_xiao_s3.name == "Seeed Xiao ESP32-S3"
+    assert seeed_xiao_s3.for_firmware == "seeed-xiao-esp32s3"
+    assert seeed_xiao_s3.usb_vendor_id_in_hex == "2886"
+    assert seeed_xiao_s3.usb_product_id_in_hex == "0059"
+    assert ("303a", "1001") in seeed_xiao_s3.usb_id_aliases
+
+
+@pytest.mark.unit
+def test_rak4631_5005_properties() -> None:
+    """Test rak4631_5005 device properties."""
+    assert rak4631_5005.name == "RAK 4631 5005"
+    assert rak4631_5005.device_class == "nrf52"
+    assert rak4631_5005.baseport_on_linux == "ttyACM"
+    assert rak4631_5005.baseport_on_mac == "cu.usbmodem"
+
+
+@pytest.mark.unit
+def test_rak4631_19003_properties() -> None:
+    """Test rak4631_19003 device properties."""
+    assert rak4631_19003.name == "RAK 4631 19003"
+    assert rak4631_19003.device_class == "nrf52"
+    assert rak4631_19003.usb_vendor_id_in_hex == "239a"
+    assert rak4631_19003.usb_product_id_in_hex == "8029"
+
+
+@pytest.mark.unit
+def test_supported_devices_list() -> None:
+    """Test that supported_devices list contains expected devices."""
+    assert len(supported_devices) > 0
+    assert tbeam_v1_1 in supported_devices
+    assert tlora_v1 in supported_devices
+    assert tdeck in supported_devices
+    assert seeed_xiao_s3 in supported_devices
+
+
+@pytest.mark.unit
+def test_supported_devices_no_duplicates() -> None:
+    """Test that supported_devices list has no duplicate entries."""
+    # With eq=False, all instances are different, so just check count
+    assert len(supported_devices) == len(supported_devices)
+
+
+@pytest.mark.unit
+def test_tdeck_and_xiao_s3_shared_alias() -> None:
+    """Test that T-Deck and Seeed Xiao S3 share the 303a:1001 alias.
+
+    This is an important edge case where both devices can enumerate
+    with the same VID/PID, requiring explicit port selection.
+    """
+    # Both have 303a:1001 as either primary or alias
+    tdeck_has_303a_1001 = ("303a", "1001") in tdeck.usb_ids
+    xiao_has_303a_1001 = ("303a", "1001") in seeed_xiao_s3.usb_ids
+
+    assert tdeck_has_303a_1001, "T-Deck should have 303a:1001 in usb_ids"
+    assert xiao_has_303a_1001, "Seeed Xiao S3 should have 303a:1001 in usb_ids"
+
+
+@pytest.mark.unit
+def test_device_with_whitespace_in_name() -> None:
+    """Test that device names with whitespace are preserved."""
+    device = SupportedDevice(name="  Test Device  ")
+    assert device.name == "  Test Device  "
+
+
+@pytest.mark.unit
+def test_device_with_special_chars_in_usb_id() -> None:
+    """Test that special characters in USB IDs raise error."""
+    with pytest.raises(
+        SupportedDeviceValidationError,
+        match="Invalid usb_vendor_id_in_hex",
+    ):
+        SupportedDevice(
+            name="Test",
+            usb_vendor_id_in_hex="10c$",
+            usb_product_id_in_hex="ea60",
+        )
+
+
+@pytest.mark.unit
+def test_usb_id_aliases_preserve_order() -> None:
+    """Test that USB ID aliases preserve insertion order after deduplication."""
+    from typing import cast
+
+    device = SupportedDevice(
+        name="Test",
+        usb_vendor_id_in_hex="10c4",
+        usb_product_id_in_hex="ea60",
+        usb_id_aliases=cast(
+            tuple[tuple[str, str], ...],
+            (
+                ("1111", "2222"),
+                ("3333", "4444"),
+                ("1111", "2222"),  # Duplicate
+                ("5555", "6666"),
+            ),
+        ),
+    )
+    assert device.usb_id_aliases == (
+        ("1111", "2222"),
+        ("3333", "4444"),
+        ("5555", "6666"),
+    )
+
+
+@pytest.mark.unit
+def test_usb_ids_property_preserves_order() -> None:
+    """Test that usb_ids property preserves primary-then-aliases order."""
+    from typing import cast
+
+    device = SupportedDevice(
+        name="Test",
+        usb_vendor_id_in_hex="10c4",
+        usb_product_id_in_hex="ea60",
+        usb_id_aliases=cast(
+            tuple[tuple[str, str], ...],
+            (
+                ("3333", "4444"),
+                ("5555", "6666"),
+            ),
+        ),
+    )
+    usb_ids = device.usb_ids
+    assert usb_ids[0] == ("10c4", "ea60")
+    assert usb_ids[1] == ("3333", "4444")
+    assert usb_ids[2] == ("5555", "6666")
+
+
+@pytest.mark.unit
+def test_nrf52_device_class() -> None:
+    """Test that nrf52 devices have correct device_class."""
+    nrf52_devices = [d for d in supported_devices if d.device_class == "nrf52"]
+    assert len(nrf52_devices) > 0
+    assert all(d.device_class == "nrf52" for d in nrf52_devices)
+
+
+@pytest.mark.unit
+def test_esp32_device_class_default() -> None:
+    """Test that esp32 is the default device class."""
+    device = SupportedDevice(name="Test")
+    assert device.device_class == "esp32"

--- a/meshtastic/tests/test_supported_device.py
+++ b/meshtastic/tests/test_supported_device.py
@@ -173,30 +173,30 @@ def test_supported_device_usb_id_too_long() -> None:
 
 @pytest.mark.unit
 def test_supported_device_usb_vendor_id_non_string() -> None:
-    """Test that non-string vendor ID is handled by type checker."""
-    # Type hints prevent passing non-string values at type-check time.
-    # Runtime behavior is covered by other tests.
-    # This test is a placeholder for type safety documentation.
-    device = SupportedDevice(
-        name="Test",
-        usb_vendor_id_in_hex="1234",
-        usb_product_id_in_hex="ea60",
-    )
-    assert device.usb_vendor_id_in_hex == "1234"
+    """Test that non-string vendor ID raises a validation error at runtime."""
+    with pytest.raises(
+        SupportedDeviceValidationError,
+        match="expected str or None",
+    ):
+        SupportedDevice(
+            name="Test",
+            usb_vendor_id_in_hex=1234,  # type: ignore[arg-type]
+            usb_product_id_in_hex="ea60",
+        )
 
 
 @pytest.mark.unit
 def test_supported_device_usb_product_id_non_string() -> None:
-    """Test that non-string product ID is handled by type checker."""
-    # Type hints prevent passing non-string values at type-check time.
-    # Runtime behavior is covered by other tests.
-    # This test is a placeholder for type safety documentation.
-    device = SupportedDevice(
-        name="Test",
-        usb_vendor_id_in_hex="10c4",
-        usb_product_id_in_hex="ea60",
-    )
-    assert device.usb_product_id_in_hex == "ea60"
+    """Test that non-string product ID raises a validation error at runtime."""
+    with pytest.raises(
+        SupportedDeviceValidationError,
+        match="expected str or None",
+    ):
+        SupportedDevice(
+            name="Test",
+            usb_vendor_id_in_hex="10c4",
+            usb_product_id_in_hex=0xEA60,  # type: ignore[arg-type]
+        )
 
 
 @pytest.mark.unit
@@ -218,7 +218,7 @@ def test_supported_device_usb_id_aliases_list() -> None:
         name="Test",
         usb_vendor_id_in_hex="10c4",
         usb_product_id_in_hex="ea60",
-        usb_id_aliases=(("303A", "1001"), ("1A86", "55D4")),
+        usb_id_aliases=[("303A", "1001"), ("1A86", "55D4")],  # type: ignore[arg-type]
     )
     assert device.usb_id_aliases == (("303a", "1001"), ("1a86", "55d4"))
 
@@ -230,8 +230,9 @@ def test_supported_device_usb_id_aliases_none() -> None:
         name="Test",
         usb_vendor_id_in_hex="10c4",
         usb_product_id_in_hex="ea60",
-        usb_id_aliases=(),
+        usb_id_aliases=None,  # type: ignore[arg-type]
     )
+    assert isinstance(device.usb_id_aliases, tuple)
     assert not device.usb_id_aliases
 
 
@@ -485,8 +486,7 @@ def test_supported_devices_list() -> None:
 @pytest.mark.unit
 def test_supported_devices_no_duplicates() -> None:
     """Test that supported_devices list has no duplicate entries."""
-    # With eq=False, all instances are different, so just check count
-    assert len(supported_devices) == len(supported_devices)
+    assert len(supported_devices) == len(set(map(repr, supported_devices)))
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_tcp_interface.py
+++ b/meshtastic/tests/test_tcp_interface.py
@@ -2,6 +2,7 @@
 
 import re
 import threading
+import time
 from typing import cast
 from unittest.mock import MagicMock, patch
 
@@ -433,12 +434,8 @@ def test_TCPInterface_sleep_reconnect_delay_interrupted_by_shutdown() -> None:
 
             # Start a delay and trigger shutdown during it
             def trigger_shutdown_during_sleep() -> None:
-                import time
-
                 time.sleep(0.1)  # Small delay before triggering
                 iface._wantExit = True
-
-            import threading
 
             thread = threading.Thread(target=trigger_shutdown_during_sleep)
             thread.start()
@@ -463,12 +460,8 @@ def test_TCPInterface_sleep_reconnect_delay_interrupted_by_fatal_disconnect() ->
 
             # Start a delay and trigger fatal disconnect during it
             def trigger_fatal_during_sleep() -> None:
-                import time
-
                 time.sleep(0.1)  # Small delay before triggering
                 iface._fatal_disconnect = True
-
-            import threading
 
             thread = threading.Thread(target=trigger_fatal_during_sleep)
             thread.start()

--- a/meshtastic/tests/test_tcp_interface.py
+++ b/meshtastic/tests/test_tcp_interface.py
@@ -443,6 +443,7 @@ def test_TCPInterface_sleep_reconnect_delay_interrupted_by_shutdown() -> None:
             # Should return False when interrupted
             result = iface._sleep_reconnect_delay(10.0)
             thread.join(timeout=1.0)
+            assert not thread.is_alive(), "Thread should complete after _wantExit is set"
 
             assert result is False
         finally:
@@ -469,6 +470,9 @@ def test_TCPInterface_sleep_reconnect_delay_interrupted_by_fatal_disconnect() ->
             # Should return False when interrupted
             result = iface._sleep_reconnect_delay(10.0)
             thread.join(timeout=1.0)
+            assert (
+                not thread.is_alive()
+            ), "Thread should complete after _fatal_disconnect is set"
 
             assert result is False
         finally:

--- a/meshtastic/tests/test_tcp_interface.py
+++ b/meshtastic/tests/test_tcp_interface.py
@@ -325,3 +325,250 @@ def test_TCPInterface_attempt_reconnect_does_not_wait_connected() -> None:
             mock_wait_connected.assert_not_called()
         finally:
             iface.close()
+
+
+@pytest.mark.unit
+def test_TCPInterface_compute_reconnect_delay_exponential_backoff() -> None:
+    """Test _compute_reconnect_delay implements exponential backoff correctly."""
+    with patch("socket.socket"):
+        iface = TCPInterface(hostname="localhost", noProto=True, connectNow=False)
+        try:
+            # Test defaults: base=1.0, backoff=1.6, max=30.0
+            # Attempt 1: exponent = max(0, 1-1) = 0, delay = 1.0 * 1.6^0 = 1.0
+            iface._reconnect_attempts = 1
+            assert iface._compute_reconnect_delay() == 1.0
+
+            # Attempt 2: exponent = max(0, 2-1) = 1, delay = 1.0 * 1.6^1 = 1.6
+            iface._reconnect_attempts = 2
+            assert iface._compute_reconnect_delay() == 1.6
+
+            # Attempt 3: exponent = 2, delay = 1.0 * 1.6^2 = 2.56
+            iface._reconnect_attempts = 3
+            assert abs(iface._compute_reconnect_delay() - 2.56) < 0.001
+
+            # Attempt 4: exponent = 3, delay = 1.0 * 1.6^3 = 4.096
+            iface._reconnect_attempts = 4
+            assert abs(iface._compute_reconnect_delay() - 4.096) < 0.001
+
+            # Attempt 8: should cap at max_delay (30.0)
+            iface._reconnect_attempts = 8
+            # Without cap: 1.0 * 1.6^7 = 26.8435456
+            # With cap: min(30.0, 26.8435456) = 26.8435456
+            expected = 1.0 * (1.6**7)
+            assert abs(iface._compute_reconnect_delay() - expected) < 0.001
+
+            # Attempt 10: would exceed max_delay without cap
+            iface._reconnect_attempts = 10
+            # Without cap: 1.0 * 1.6^9 = 68.719476736
+            # With cap: min(30.0, 68.719476736) = 30.0
+            assert iface._compute_reconnect_delay() == 30.0
+        finally:
+            iface.close()
+
+
+@pytest.mark.unit
+def test_TCPInterface_compute_reconnect_delay_custom_parameters() -> None:
+    """Test _compute_reconnect_delay with custom backoff parameters."""
+    with patch("socket.socket"):
+        iface = TCPInterface(hostname="localhost", noProto=True, connectNow=False)
+        try:
+            # Customize parameters
+            iface._reconnect_base_delay = 2.0
+            iface._reconnect_backoff = 2.0
+            iface._reconnect_max_delay = 60.0
+
+            # Attempt 1: exponent = 0, delay = 2.0 * 2.0^0 = 2.0
+            iface._reconnect_attempts = 1
+            assert iface._compute_reconnect_delay() == 2.0
+
+            # Attempt 2: exponent = 1, delay = 2.0 * 2.0^1 = 4.0
+            iface._reconnect_attempts = 2
+            assert iface._compute_reconnect_delay() == 4.0
+
+            # Attempt 3: exponent = 2, delay = 2.0 * 2.0^2 = 8.0
+            iface._reconnect_attempts = 3
+            assert iface._compute_reconnect_delay() == 8.0
+
+            # Attempt 5: exponent = 4, delay = 2.0 * 2.0^4 = 32.0
+            iface._reconnect_attempts = 5
+            assert iface._compute_reconnect_delay() == 32.0
+
+            # Attempt 6: should cap at max_delay (60.0)
+            iface._reconnect_attempts = 6
+            # Without cap: 2.0 * 2.0^5 = 64.0
+            # With cap: min(60.0, 64.0) = 60.0
+            assert iface._compute_reconnect_delay() == 60.0
+        finally:
+            iface.close()
+
+
+@pytest.mark.unit
+def test_TCPInterface_attempt_reconnect_max_attempts_triggers_fatal() -> None:
+    """Test that exceeding max reconnect attempts triggers fatal disconnect."""
+    with patch("socket.socket"):
+        iface = TCPInterface(hostname="localhost", noProto=True, connectNow=False)
+        try:
+            # Set up to trigger max attempts (already at max)
+            iface._reconnect_attempts = iface._max_reconnect_attempts
+            assert iface._fatal_disconnect is False
+
+            result = iface._attempt_reconnect()
+
+            # Should return False and mark fatal disconnect
+            assert result is False
+            assert iface._fatal_disconnect is True
+            assert iface._wantExit is True
+        finally:
+            iface.close()
+
+
+@pytest.mark.unit
+def test_TCPInterface_sleep_reconnect_delay_interrupted_by_shutdown() -> None:
+    """Test that _sleep_reconnect_delay returns False when shutdown is requested."""
+    with patch("socket.socket"):
+        iface = TCPInterface(hostname="localhost", noProto=True, connectNow=False)
+        try:
+            iface._wantExit = False
+            iface._fatal_disconnect = False
+
+            # Start a delay and trigger shutdown during it
+            def trigger_shutdown_during_sleep() -> None:
+                import time
+
+                time.sleep(0.1)  # Small delay before triggering
+                iface._wantExit = True
+
+            import threading
+
+            thread = threading.Thread(target=trigger_shutdown_during_sleep)
+            thread.start()
+
+            # Should return False when interrupted
+            result = iface._sleep_reconnect_delay(10.0)
+            thread.join(timeout=1.0)
+
+            assert result is False
+        finally:
+            iface.close()
+
+
+@pytest.mark.unit
+def test_TCPInterface_sleep_reconnect_delay_interrupted_by_fatal_disconnect() -> None:
+    """Test that _sleep_reconnect_delay returns False on fatal disconnect."""
+    with patch("socket.socket"):
+        iface = TCPInterface(hostname="localhost", noProto=True, connectNow=False)
+        try:
+            iface._wantExit = False
+            iface._fatal_disconnect = False
+
+            # Start a delay and trigger fatal disconnect during it
+            def trigger_fatal_during_sleep() -> None:
+                import time
+
+                time.sleep(0.1)  # Small delay before triggering
+                iface._fatal_disconnect = True
+
+            import threading
+
+            thread = threading.Thread(target=trigger_fatal_during_sleep)
+            thread.start()
+
+            # Should return False when interrupted
+            result = iface._sleep_reconnect_delay(10.0)
+            thread.join(timeout=1.0)
+
+            assert result is False
+        finally:
+            iface.close()
+
+
+@pytest.mark.unit
+def test_TCPInterface_sleep_reconnect_delay_completes_full_delay() -> None:
+    """Test that _sleep_reconnect_delay returns True when delay completes."""
+    with patch("socket.socket"):
+        iface = TCPInterface(hostname="localhost", noProto=True, connectNow=False)
+        try:
+            iface._wantExit = False
+            iface._fatal_disconnect = False
+
+            # Small delay should complete
+            result = iface._sleep_reconnect_delay(0.3)
+
+            assert result is True
+        finally:
+            iface.close()
+
+
+@pytest.mark.unit
+def test_TCPInterface_attempt_reconnect_already_in_progress() -> None:
+    """Test that _attempt_reconnect returns False if already in progress."""
+    with patch("socket.socket"):
+        iface = TCPInterface(hostname="localhost", noProto=True, connectNow=False)
+        try:
+            # Mark reconnect as in progress
+            iface._reconnect_attempt_in_progress = True
+
+            result = iface._attempt_reconnect()
+
+            # Should return False without attempting
+            assert result is False
+        finally:
+            iface.close()
+
+
+@pytest.mark.unit
+def test_TCPInterface_attempt_reconnect_aborted_by_shutdown() -> None:
+    """Test that _attempt_reconnect returns False when shutdown is requested."""
+    with patch("socket.socket"):
+        iface = TCPInterface(hostname="localhost", noProto=True, connectNow=False)
+        try:
+            iface._wantExit = True
+            iface._reconnect_attempt_in_progress = False
+
+            result = iface._attempt_reconnect()
+
+            # Should return False without attempting
+            assert result is False
+        finally:
+            iface.close()
+
+
+@pytest.mark.unit
+def test_TCPInterface_attempt_reconnect_aborted_by_fatal_disconnect() -> None:
+    """Test that _attempt_reconnect returns False on fatal disconnect."""
+    with patch("socket.socket"):
+        iface = TCPInterface(hostname="localhost", noProto=True, connectNow=False)
+        try:
+            iface._wantExit = False
+            iface._fatal_disconnect = True
+            iface._reconnect_attempt_in_progress = False
+
+            result = iface._attempt_reconnect()
+
+            # Should return False without attempting
+            assert result is False
+        finally:
+            iface.close()
+
+
+@pytest.mark.unit
+def test_TCPInterface_on_fatal_disconnect_idempotent() -> None:
+    """Test that _on_fatal_disconnect is idempotent."""
+    with patch("socket.socket"):
+        iface = TCPInterface(hostname="localhost", noProto=True, connectNow=False)
+        try:
+            iface._fatal_disconnect = False
+            iface._wantExit = False
+            iface._reconnect_attempts = 5
+
+            # First call should set flags
+            iface._on_fatal_disconnect("test reason")
+            assert iface._fatal_disconnect is True
+            assert iface._wantExit is True
+
+            # Second call should be no-op
+            iface._on_fatal_disconnect("another reason")
+            assert iface._fatal_disconnect is True
+            assert iface._wantExit is True
+        finally:
+            iface.close()

--- a/meshtastic/tests/test_util.py
+++ b/meshtastic/tests/test_util.py
@@ -1228,12 +1228,16 @@ def test_flagsToList_single_flag() -> None:
 
     # Create a simple mock enum wrapper
     class MockEnum:
+        """Minimal enum-like wrapper used by flagsToList tests."""
+
         @staticmethod
         def keys() -> list[str]:
+            """Return enum key names."""
             return ["FLAG_A", "FLAG_B", "EXCLUDED_NONE"]
 
         @staticmethod
         def Value(name: str) -> int:
+            """Return integer value for enum key."""
             return {"FLAG_A": 1, "FLAG_B": 2, "EXCLUDED_NONE": 0}[name]
 
     result = flagsToList(MockEnum, 1)  # pyright: ignore[reportArgumentType]
@@ -1245,16 +1249,20 @@ def test_flagsToList_zero_flags() -> None:
     """Test flagsToList with zero flags."""
 
     class MockEnum:
+        """Minimal enum-like wrapper used by flagsToList tests."""
+
         @staticmethod
         def keys() -> list[str]:
+            """Return enum key names."""
             return ["FLAG_A", "FLAG_B"]
 
         @staticmethod
         def Value(name: str) -> int:
+            """Return integer value for enum key."""
             return {"FLAG_A": 1, "FLAG_B": 2}[name]
 
     result = flagsToList(MockEnum, 0)  # pyright: ignore[reportArgumentType]
-    assert result == []
+    assert not result
 
 
 @pytest.mark.unit
@@ -1262,12 +1270,16 @@ def test_flagsToList_unknown_flags() -> None:
     """Test flagsToList with unknown flag bits."""
 
     class MockEnum:
+        """Minimal enum-like wrapper used by flagsToList tests."""
+
         @staticmethod
         def keys() -> list[str]:
+            """Return enum key names."""
             return ["FLAG_A"]
 
         @staticmethod
         def Value(name: str) -> int:
+            """Return integer value for enum key."""
             return {"FLAG_A": 1}[name]
 
     # Use a value with unknown bits
@@ -1363,8 +1375,6 @@ def test_deferred_execution_handles_exceptions(
         de.queueWork(bad_closure)
 
         # Wait for work to complete
-        import time
-
         time.sleep(0.2)
 
     # Should have logged the exception

--- a/meshtastic/tests/test_util.py
+++ b/meshtastic/tests/test_util.py
@@ -5,7 +5,8 @@ import binascii
 import json
 import logging
 import re
-import time
+import threading
+import warnings
 from collections import Counter
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
@@ -1344,19 +1345,14 @@ def test_our_exit_empty_message(capsys: pytest.CaptureFixture[str]) -> None:
 def test_deferred_execution_runs_closure() -> None:
     """Test that DeferredExecution runs closures in background thread."""
 
-    result_list: list[int] = []
+    first = threading.Event()
+    second = threading.Event()
     de = DeferredExecution(name="test_thread")
 
-    # Queue some work
-    de.queueWork(lambda: result_list.append(1))
-    de.queueWork(lambda: result_list.append(2))
-
-    # Wait for work to complete
-
-    time.sleep(0.2)
-
-    assert 1 in result_list
-    assert 2 in result_list
+    de.queueWork(first.set)
+    de.queueWork(second.set)
+    assert first.wait(timeout=1.0)
+    assert second.wait(timeout=1.0)
 
 
 @pytest.mark.unit
@@ -1365,17 +1361,20 @@ def test_deferred_execution_handles_exceptions(
 ) -> None:
     """Test that DeferredExecution logs exceptions without crashing."""
 
+    completion = threading.Event()
     de = DeferredExecution(name="test_exception_thread")
 
     # Queue work that raises exception
     def bad_closure() -> None:
         raise ValueError("Test exception")
 
+    def signal_completion() -> None:
+        completion.set()
+
     with caplog.at_level(logging.DEBUG):
         de.queueWork(bad_closure)
-
-        # Wait for work to complete
-        time.sleep(0.2)
+        de.queueWork(signal_completion)
+        assert completion.wait(timeout=1.0)
 
     # Should have logged the exception
     assert "Unexpected error in deferred execution" in caplog.text
@@ -1556,9 +1555,13 @@ def test_dotdict_missing_attr_returns_none() -> None:
 
 @pytest.mark.unit
 def test_dotdict_deprecated_warns() -> None:
-    """Test dotdict deprecated alias warns."""
+    """Test dotdict deprecated alias warns once per process."""
 
-    with pytest.warns(DeprecationWarning):
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("once", DeprecationWarning)
         dd = dotdict()  # pyright: ignore[reportDeprecated]
-
+        _ = dotdict()  # pyright: ignore[reportDeprecated]
     assert isinstance(dd, dict)
+    assert len(captured) == 1
+    assert issubclass(captured[0].category, DeprecationWarning)
+    assert "dotdict" in str(captured[0].message).lower()

--- a/meshtastic/tests/test_util.py
+++ b/meshtastic/tests/test_util.py
@@ -5,6 +5,7 @@ import binascii
 import json
 import logging
 import re
+import time
 from collections import Counter
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
@@ -24,6 +25,8 @@ from meshtastic.supported_device import (
 from meshtastic.util import (
     DEFAULT_KEY,
     Acknowledgment,
+    DeferredExecution,
+    DotDict,
     FixmeError,
     Timeout,
     active_ports_on_supported_devices,
@@ -31,9 +34,11 @@ from meshtastic.util import (
     catchAndIgnore,
     channel_hash,
     convert_mac_addr,
+    dotdict,
     eliminate_duplicate_port,
     findPorts,
     fixme,
+    flagsToList,
     fromPSK,
     fromStr,
     generate_channel_hash,
@@ -45,12 +50,15 @@ from meshtastic.util import (
     is_windows11,
     message_to_json,
     messageToJson,
+    our_exit,
     pskToString,
     quoteBooleans,
     readnet_u16,
     remove_keys_from_dict,
     snake_to_camel,
     stripnl,
+    toNodeNum,
+    toStr,
 )
 
 _BASE64_ALLOWED_CHARS = (
@@ -1094,3 +1102,453 @@ def test_vendor_lookup_uses_alias_vids() -> None:
     assert "303a" in vids
     alias_devices = get_devices_with_vendor_id("303a")
     assert any(device.name == "Seeed Xiao ESP32-S3" for device in alias_devices)
+
+
+# Tests for toStr
+@pytest.mark.unit
+def test_toStr_bytes() -> None:
+    """Test toStr with bytes input."""
+
+    result = toStr(b"hello")
+    assert result == "base64:aGVsbG8="
+    assert isinstance(result, str)
+
+
+@pytest.mark.unit
+def test_toStr_string() -> None:
+    """Test toStr with string input."""
+
+    result = toStr("hello")
+    assert result == "hello"
+
+
+@pytest.mark.unit
+def test_toStr_int() -> None:
+    """Test toStr with int input."""
+
+    result = toStr(123)
+    assert result == "123"
+
+
+@pytest.mark.unit
+def test_toStr_float() -> None:
+    """Test toStr with float input."""
+
+    result = toStr(3.14)
+    assert result == "3.14"
+
+
+@pytest.mark.unit
+def test_toStr_bool() -> None:
+    """Test toStr with bool input."""
+
+    assert toStr(True) == "True"
+    assert toStr(False) == "False"
+
+
+@pytest.mark.unit
+def test_toStr_none() -> None:
+    """Test toStr with None input."""
+
+    result = toStr(None)
+    assert result == "None"
+
+
+@pytest.mark.unitslow
+@given(st.binary())
+def test_fuzz_toStr_bytes_roundtrip(raw_bytes: bytes) -> None:
+    """Test that toStr produces valid base64 for any bytes."""
+
+    result = toStr(raw_bytes)
+    assert result.startswith("base64:")
+    # Verify it's valid base64
+    encoded = result[7:]  # Remove "base64:" prefix
+    decoded = base64.b64decode(encoded)
+    assert decoded == raw_bytes
+
+
+# Tests for toNodeNum
+@pytest.mark.unit
+def test_toNodeNum_int() -> None:
+    """Test toNodeNum with int input."""
+
+    assert toNodeNum(123456789) == 123456789
+
+
+@pytest.mark.unit
+def test_toNodeNum_string_decimal() -> None:
+    """Test toNodeNum with decimal string."""
+
+    assert toNodeNum("123456789") == 123456789
+
+
+@pytest.mark.unit
+def test_toNodeNum_string_hex_with_prefix() -> None:
+    """Test toNodeNum with hex string with 0x prefix."""
+
+    assert toNodeNum("0x1234abcd") == 0x1234ABCD
+
+
+@pytest.mark.unit
+def test_toNodeNum_string_hex_without_prefix() -> None:
+    """Test toNodeNum with hex string without 0x prefix (falls back to hex)."""
+
+    # When decimal parse fails, it should try hex
+    assert toNodeNum("deadbeef") == 0xDEADBEEF
+
+
+@pytest.mark.unit
+def test_toNodeNum_string_with_bang_prefix() -> None:
+    """Test toNodeNum with ! prefix (node ID format)."""
+
+    assert toNodeNum("!12345678") == 12345678
+    assert toNodeNum("!0xabcdef") == 0xABCDEF
+
+
+@pytest.mark.unit
+def test_toNodeNum_string_with_bang_and_hex() -> None:
+    """Test toNodeNum with !0x prefix."""
+
+    assert toNodeNum("!0x1234") == 0x1234
+
+
+@pytest.mark.unitslow
+@given(st.integers(min_value=0, max_value=0xFFFFFFFF))
+def test_fuzz_toNodeNum_int_roundtrip(node_num: int) -> None:
+    """Test that toNodeNum preserves any valid node number."""
+
+    result = toNodeNum(node_num)
+    assert result == node_num
+
+
+# Tests for flagsToList
+@pytest.mark.unit
+def test_flagsToList_single_flag() -> None:
+    """Test flagsToList with single flag."""
+
+    # Create a simple mock enum wrapper
+    class MockEnum:
+        @staticmethod
+        def keys() -> list[str]:
+            return ["FLAG_A", "FLAG_B", "EXCLUDED_NONE"]
+
+        @staticmethod
+        def Value(name: str) -> int:
+            return {"FLAG_A": 1, "FLAG_B": 2, "EXCLUDED_NONE": 0}[name]
+
+    result = flagsToList(MockEnum, 1)  # pyright: ignore[reportArgumentType]
+    assert "FLAG_A" in result
+
+
+@pytest.mark.unit
+def test_flagsToList_zero_flags() -> None:
+    """Test flagsToList with zero flags."""
+
+    class MockEnum:
+        @staticmethod
+        def keys() -> list[str]:
+            return ["FLAG_A", "FLAG_B"]
+
+        @staticmethod
+        def Value(name: str) -> int:
+            return {"FLAG_A": 1, "FLAG_B": 2}[name]
+
+    result = flagsToList(MockEnum, 0)  # pyright: ignore[reportArgumentType]
+    assert result == []
+
+
+@pytest.mark.unit
+def test_flagsToList_unknown_flags() -> None:
+    """Test flagsToList with unknown flag bits."""
+
+    class MockEnum:
+        @staticmethod
+        def keys() -> list[str]:
+            return ["FLAG_A"]
+
+        @staticmethod
+        def Value(name: str) -> int:
+            return {"FLAG_A": 1}[name]
+
+    # Use a value with unknown bits
+    result = flagsToList(MockEnum, 0xFFFF)  # pyright: ignore[reportArgumentType]
+    assert "FLAG_A" in result
+    assert any("UNKNOWN_ADDITIONAL_FLAGS" in item for item in result)
+
+
+# Tests for our_exit
+@pytest.mark.unit
+def test_our_exit_default_return_code(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test our_exit with default return code (1)."""
+
+    with pytest.raises(SystemExit) as exc_info:
+        our_exit("Error message")
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "Error message" in captured.err
+
+
+@pytest.mark.unit
+def test_our_exit_custom_return_code(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test our_exit with custom return code."""
+
+    with pytest.raises(SystemExit) as exc_info:
+        our_exit("Error message", return_value=42)
+
+    assert exc_info.value.code == 42
+    captured = capsys.readouterr()
+    assert "Error message" in captured.err
+
+
+@pytest.mark.unit
+def test_our_exit_zero_return_code(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test our_exit with return code 0 (success)."""
+
+    with pytest.raises(SystemExit) as exc_info:
+        our_exit("Success", return_value=0)
+
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    # Return code 0 should write to stdout
+    assert "Success" in captured.out
+
+
+@pytest.mark.unit
+def test_our_exit_empty_message(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test our_exit with empty message."""
+
+    with pytest.raises(SystemExit) as exc_info:
+        our_exit("")
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    # Empty message still emits newline
+    assert captured.err == "\n"
+
+
+# Tests for DeferredExecution
+@pytest.mark.unit
+def test_deferred_execution_runs_closure() -> None:
+    """Test that DeferredExecution runs closures in background thread."""
+
+    result_list: list[int] = []
+    de = DeferredExecution(name="test_thread")
+
+    # Queue some work
+    de.queueWork(lambda: result_list.append(1))
+    de.queueWork(lambda: result_list.append(2))
+
+    # Wait for work to complete
+
+    time.sleep(0.2)
+
+    assert 1 in result_list
+    assert 2 in result_list
+
+
+@pytest.mark.unit
+def test_deferred_execution_handles_exceptions(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that DeferredExecution logs exceptions without crashing."""
+
+    de = DeferredExecution(name="test_exception_thread")
+
+    # Queue work that raises exception
+    def bad_closure() -> None:
+        raise ValueError("Test exception")
+
+    with caplog.at_level(logging.DEBUG):
+        de.queueWork(bad_closure)
+
+        # Wait for work to complete
+        import time
+
+        time.sleep(0.2)
+
+    # Should have logged the exception
+    assert "Unexpected error in deferred execution" in caplog.text
+
+
+# Tests for Timeout.waitForAckNak
+@pytest.mark.unit
+def test_timeout_waitForAckNak_timeout() -> None:
+    """Test Timeout.waitForAckNak when timeout expires."""
+
+    to = Timeout(0.1)  # Very short timeout
+    ack = Acknowledgment()
+
+    result = to.waitForAckNak(ack)
+    assert result is False
+
+
+@pytest.mark.unit
+def test_timeout_waitForAckNak_received() -> None:
+    """Test Timeout.waitForAckNak when ack received."""
+
+    to = Timeout(5.0)  # Long timeout
+    ack = Acknowledgment()
+
+    # Set ack flag immediately
+    ack.receivedAck = True
+
+    result = to.waitForAckNak(ack)
+    assert result is True
+    # Should reset after reading
+    assert ack.receivedAck is False
+
+
+@pytest.mark.unit
+def test_timeout_waitForAckNak_custom_attrs() -> None:
+    """Test Timeout.waitForAckNak with custom attribute names."""
+
+    to = Timeout(5.0)
+    ack = Acknowledgment()
+
+    # Set nak flag
+    ack.receivedNak = True
+
+    result = to.waitForAckNak(ack, attrs=("receivedNak",))
+    assert result is True
+
+
+# Tests for Timeout.waitForTelemetry
+@pytest.mark.unit
+def test_timeout_waitForTelemetry_timeout() -> None:
+    """Test Timeout.waitForTelemetry when timeout expires."""
+
+    to = Timeout(0.1)
+    ack = Acknowledgment()
+
+    result = to.waitForTelemetry(ack)
+    assert result is False
+
+
+@pytest.mark.unit
+def test_timeout_waitForTelemetry_received() -> None:
+    """Test Timeout.waitForTelemetry when telemetry received."""
+
+    to = Timeout(5.0)
+    ack = Acknowledgment()
+    ack.receivedTelemetry = True
+
+    result = to.waitForTelemetry(ack)
+    assert result is True
+
+
+# Tests for Timeout.waitForPosition
+@pytest.mark.unit
+def test_timeout_waitForPosition_timeout() -> None:
+    """Test Timeout.waitForPosition when timeout expires."""
+
+    to = Timeout(0.1)
+    ack = Acknowledgment()
+
+    result = to.waitForPosition(ack)
+    assert result is False
+
+
+@pytest.mark.unit
+def test_timeout_waitForPosition_received() -> None:
+    """Test Timeout.waitForPosition when position received."""
+
+    to = Timeout(5.0)
+    ack = Acknowledgment()
+    ack.receivedPosition = True
+
+    result = to.waitForPosition(ack)
+    assert result is True
+
+
+# Tests for Timeout.waitForWaypoint
+@pytest.mark.unit
+def test_timeout_waitForWaypoint_timeout() -> None:
+    """Test Timeout.waitForWaypoint when timeout expires."""
+
+    to = Timeout(0.1)
+    ack = Acknowledgment()
+
+    result = to.waitForWaypoint(ack)
+    assert result is False
+
+
+@pytest.mark.unit
+def test_timeout_waitForWaypoint_received() -> None:
+    """Test Timeout.waitForWaypoint when waypoint received."""
+
+    to = Timeout(5.0)
+    ack = Acknowledgment()
+    ack.receivedWaypoint = True
+
+    result = to.waitForWaypoint(ack)
+    assert result is True
+
+
+# Tests for Timeout.waitForTraceRoute
+@pytest.mark.unit
+def test_timeout_waitForTraceRoute_timeout() -> None:
+    """Test Timeout.waitForTraceRoute when timeout expires."""
+
+    to = Timeout(0.1)
+    ack = Acknowledgment()
+
+    result = to.waitForTraceRoute(1.0, ack)
+    assert result is False
+
+
+@pytest.mark.unit
+def test_timeout_waitForTraceRoute_received() -> None:
+    """Test Timeout.waitForTraceRoute when traceroute received."""
+
+    to = Timeout(5.0)
+    ack = Acknowledgment()
+    ack.receivedTraceRoute = True
+
+    result = to.waitForTraceRoute(1.0, ack)
+    assert result is True
+
+
+# Tests for DotDict
+@pytest.mark.unit
+def test_dotdict_getattr() -> None:
+    """Test DotDict attribute access."""
+
+    dd = DotDict({"key": "value"})
+    assert dd.key == "value"
+
+
+@pytest.mark.unit
+def test_dotdict_setattr() -> None:
+    """Test DotDict attribute setting."""
+
+    dd = DotDict()
+    dd.key = "value"
+    assert dd["key"] == "value"
+
+
+@pytest.mark.unit
+def test_dotdict_delattr() -> None:
+    """Test DotDict attribute deletion."""
+
+    dd = DotDict({"key": "value"})
+    del dd.key
+    assert "key" not in dd
+
+
+@pytest.mark.unit
+def test_dotdict_missing_attr_returns_none() -> None:
+    """Test DotDict returns None for missing attributes."""
+
+    dd = DotDict()
+    assert dd.nonexistent is None
+
+
+@pytest.mark.unit
+def test_dotdict_deprecated_warns() -> None:
+    """Test dotdict deprecated alias warns."""
+
+    with pytest.warns(DeprecationWarning):
+        dd = dotdict()  # pyright: ignore[reportDeprecated]
+
+    assert isinstance(dd, dict)

--- a/meshtastic/tests/test_util.py
+++ b/meshtastic/tests/test_util.py
@@ -643,9 +643,9 @@ def test_messageToJson_shows_all() -> None:
         "nodedbCount": 0,
     }
     for key, value in expected.items():
-        assert (
-            actual.get(key) == value
-        ), f"Key {key}: expected {value}, got {actual.get(key)}"
+        assert actual.get(key) == value, (
+            f"Key {key}: expected {value}, got {actual.get(key)}"
+        )
     # firmwareEdition presence only — value depends on proto enum default name
     assert "firmwareEdition" in actual
 
@@ -954,15 +954,15 @@ def test_tdeck_vid_pid_mapping() -> None:
         for d in supported_devices
         if d.usb_vendor_id_in_hex == "303a" and d.usb_product_id_in_hex == "1001"
     ]
-    assert (
-        len(tdeck_devices) == 1
-    ), "Expected exactly one T-Deck device with VID 303a and PID 1001"
-    assert (
-        tdeck_devices[0].name == "T-Deck"
-    ), f"Expected device name 'T-Deck', got '{tdeck_devices[0].name}'"
-    assert (
-        tdeck_devices[0].for_firmware == "t-deck"
-    ), f"Expected for_firmware 't-deck', got '{tdeck_devices[0].for_firmware}'"
+    assert len(tdeck_devices) == 1, (
+        "Expected exactly one T-Deck device with VID 303a and PID 1001"
+    )
+    assert tdeck_devices[0].name == "T-Deck", (
+        f"Expected device name 'T-Deck', got '{tdeck_devices[0].name}'"
+    )
+    assert tdeck_devices[0].for_firmware == "t-deck", (
+        f"Expected for_firmware 't-deck', got '{tdeck_devices[0].for_firmware}'"
+    )
 
 
 @pytest.mark.unit
@@ -1515,7 +1515,7 @@ def test_dotdict_getattr() -> None:
     """Test DotDict attribute access."""
 
     dd = DotDict({"key": "value"})
-    assert dd.key == "value"
+    assert dd.key == "value"  # type: ignore[attr-defined]
 
 
 @pytest.mark.unit
@@ -1523,7 +1523,7 @@ def test_dotdict_setattr() -> None:
     """Test DotDict attribute setting."""
 
     dd = DotDict()
-    dd.key = "value"
+    dd.key = "value"  # type: ignore[attr-defined]
     assert dd["key"] == "value"
 
 
@@ -1532,7 +1532,7 @@ def test_dotdict_delattr() -> None:
     """Test DotDict attribute deletion."""
 
     dd = DotDict({"key": "value"})
-    del dd.key
+    del dd.key  # type: ignore[attr-defined]
     assert "key" not in dd
 
 
@@ -1541,7 +1541,7 @@ def test_dotdict_missing_attr_returns_none() -> None:
     """Test DotDict returns None for missing attributes."""
 
     dd = DotDict()
-    assert dd.nonexistent is None
+    assert dd.nonexistent is None  # type: ignore[attr-defined]
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_util.py
+++ b/meshtastic/tests/test_util.py
@@ -1558,7 +1558,7 @@ def test_dotdict_deprecated_warns() -> None:
     """Test dotdict deprecated alias warns once per process."""
 
     with warnings.catch_warnings(record=True) as captured:
-        warnings.simplefilter("once", DeprecationWarning)
+        warnings.simplefilter("always", DeprecationWarning)
         dd = dotdict()  # pyright: ignore[reportDeprecated]
         _ = dotdict()  # pyright: ignore[reportDeprecated]
     assert isinstance(dd, dict)

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,8 @@
 
 addopts = -m "not int and not smoke1 and not smoke2 and not smokewifi and not examples and not smokevirt and not slow"
 
+junit_family = legacy
+
 filterwarnings =
     ignore::DeprecationWarning
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This pull request expands automated test coverage across the codebase, improves test reliability and concurrency handling in tests, and updates CI to produce and upload JUnit XML test results to Codecov. It also includes small formatting and import adjustments in a few modules and test modernizations to make tests more robust.

## Key changes

Features
- CI: Pytest now emits JUnit XML (--junitxml=junit.xml) and a Codecov test-results upload step was added (pinned action commit). junit.xml was added to .gitignore and pytest.ini sets junit_family = legacy.
- Tests: New and expanded tests added across many modules to increase coverage and validate behavior under concurrency, edge cases, and deprecation paths.

Fixes (test reliability / concurrency)
- MeshInterface tests: added many thread-safety and concurrency tests (packet ID generation, node DB access, queue ops, response handler registration, safe close behavior, showNodes/getNode, sendText) and replaced fragile sleeps with thread events.
- MTConfig tests: added tests for reset behavior, clearing warned deprecations, compat-alias warn-once semantics, getattr/setattr/delattr coverage, default state validation, and concurrent access/thread-safety checks.
- TCPInterface tests: added reconnect/backoff tests, abort/early-exit scenarios, fatal-disconnect idempotence, and timing/cleanup behavior.
- SupportedDevice tests: extensive validation of USB ID parsing/normalization/aliases, equality semantics, device list contents, and edge cases.
- Util tests: coverage for DeferredExecution, DotDict/dotdict, our_exit, toNodeNum, toStr, flagsToList.

Refactors / test modernizations
- Replaced time.sleep usage with threading events where appropriate, removed daemon threads and added joins/locking to avoid races in tests, reorganized imports and added docstrings, replaced placeholder assertions with concrete checks, and improved deprecation-warn testing.
- Minor formatting changes: multi-line import formatting in test_node.py and wrapping a long assignment in meshtastic/node.py (no behavioral change).

Breaking changes / migration notes

- No production API changes or behavior-breaking changes were introduced. The PR is additive (tests, CI changes) and contains only small formatting refactors; no migration steps are required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->