### PR TITLE
Consolidate compatibility documentation into COMPATIBILITY.md; expand tests; linting/misc modernization fixes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,22 +1,24 @@
 # Contributing to Meshtastic Python
 
 ## Development resources
+
 - [API Documentation](https://python.meshtastic.org/)
 - [Meshtastic Python Development](https://meshtastic.org/docs/development/python/)
 - [Building Meshtastic Python](https://meshtastic.org/docs/development/python/building/)
 - [Using the Meshtastic Python Library](https://meshtastic.org/docs/development/python/library/)
 
 ## How to check your code (pytest/pylint) before a PR
+
 - [Pre-requisites](https://meshtastic.org/docs/development/python/building/#pre-requisites)
 - also execute `poetry install --all-extras --with dev,powermon` for all optional dependencies
 - check your code with github ci actions locally
-    - You need to have act installed. You can get it at https://nektosact.com/ 
-    - on linux: `act -P ubuntu-latest=-self-hosted --matrix "python-version:3.12"`
-    - on windows:
-      - linux checks (linux docker): `act --matrix "python-version:3.12"`
-      - windows checks (windows host): `act -P ubuntu-latest=-self-hosted --matrix "python-version:3.12"`
+  - You need to have act installed. You can get it at https://nektosact.com/
+  - on linux: `act -P ubuntu-latest=-self-hosted --matrix "python-version:3.12"`
+  - on windows:
+    - linux checks (linux docker): `act --matrix "python-version:3.12"`
+    - windows checks (windows host): `act -P ubuntu-latest=-self-hosted --matrix "python-version:3.12"`
 - or run all locally:
-    - run `poetry run pylint meshtastic examples/ --ignore-patterns ".*_pb2.pyi?$"`
-    - run `poetry run mypy meshtastic/`
-    - run `poetry run pytest`
-    - more commands see [CI workflow](https://github.com/meshtastic/python/blob/master/.github/workflows/ci.yml)
+  - run `poetry run pylint meshtastic examples/ --ignore-patterns ".*_pb2.pyi?$"`
+  - run `poetry run mypy meshtastic/`
+  - run `poetry run pytest`
+  - more commands see [CI workflow](https://github.com/meshtastic/python/blob/master/.github/workflows/ci.yml)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,5 +20,6 @@
 - or run all locally:
   - run `poetry run pylint meshtastic examples/ --ignore-patterns ".*_pb2.pyi?$"`
   - run `poetry run mypy meshtastic/`
+  - run `poetry run mypy meshtastic/ --strict` (the codebase is currently strict-compatible)
   - run `poetry run pytest`
   - more commands see [CI workflow](https://github.com/meshtastic/python/blob/master/.github/workflows/ci.yml)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,12 +11,12 @@
 
 - [Pre-requisites](https://meshtastic.org/docs/development/python/building/#pre-requisites)
 - also execute `poetry install --all-extras --with dev,powermon` for all optional dependencies
-- check your code with github ci actions locally
+- check your code with GitHub CI actions locally
   - You need to have act installed. You can get it at https://nektosact.com/
-  - on linux: `act -P ubuntu-latest=-self-hosted --matrix "python-version:3.12"`
-  - on windows:
-    - linux checks (linux docker): `act --matrix "python-version:3.12"`
-    - windows checks (windows host): `act -P ubuntu-latest=-self-hosted --matrix "python-version:3.12"`
+  - on Linux: `act -P ubuntu-latest=-self-hosted --matrix "python-version:3.12"`
+  - on Windows:
+    - Linux checks (Linux Docker): `act --matrix "python-version:3.12"`
+    - Windows checks (Windows host): `act -P ubuntu-latest=-self-hosted --matrix "python-version:3.12"`
 - or run all locally:
   - run `poetry run pylint meshtastic examples/ --ignore-patterns ".*_pb2.pyi?$"`
   - run `poetry run mypy meshtastic/`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -76,6 +76,8 @@ protobufs/            # Protocol Buffer source definitions
 - Classes: `PascalCase` (e.g., `MeshInterface`, `SerialInterface`)
 - Functions/methods: `camelCase` for public API (e.g., `sendText`, `sendData`)
 - Internal functions: `snake_case` with leading underscore (e.g., `_send_packet`)
+- Canonical compatibility/deprecation inventory is `COMPATIBILITY.md`; keep
+  alias/warning behavior aligned with that document.
 - BLE compatibility exception: keep the historical BLE public method names from
   the pre-refactor `meshtastic.ble_interface` surface (snake_case such as
   `find_device`, `read_gatt_char`, `start_notify`) to preserve existing project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,40 @@ jobs:
       - *install_local_step
       - name: Check types with mypy
         run: poetry run mypy meshtastic/
+  compatibility:
+    name: Compatibility Inventory (py3.13)
+    runs-on: ubuntu-latest
+    env:
+      PYTHON_VERSION: "3.13"
+      POETRY_INSTALL_ARGS: --all-extras --with dev,powermon
+    steps:
+      - *checkout_step
+      - *setup_python_step
+      - *cache_poetry_step
+      - *install_dependencies_step
+      - *install_local_step
+      - name: Validate compatibility markers inventory
+        run: |
+          if command -v rg >/dev/null 2>&1; then
+            rg -n "COMPAT_STABLE_SHIM|COMPAT_DEPRECATE" meshtastic
+          else
+            grep -R -nE "COMPAT_STABLE_SHIM|COMPAT_DEPRECATE" meshtastic
+          fi
+      - name: Run compatibility alias checks
+        run: |
+          poetry run pytest \
+            tests/test_ble_naming_compatibility.py \
+            tests/test_ble_runner.py::TestBLECoroutineRunner::test_run_coroutine_threadsafe_timeout_alias_warns_deprecated \
+            tests/test_ble_runner.py::TestBLECoroutineRunner::test_run_coroutine_threadsafe_timeout_alias_warns_once \
+            meshtastic/tests/test_init.py::test_init_serial_alias_points_to_pyserial_module \
+            meshtastic/tests/test_mt_config.py \
+            meshtastic/tests/test_util.py::test_dotdict_deprecated_warns \
+            meshtastic/tests/test_powermon_power_supply.py::test_deprecated_current_aliases_warn_once_per_method \
+            meshtastic/tests/test_slog_power_logger.py::test_root_dir_legacy_alias_warns_once \
+            meshtastic/tests/test_slog_power_logger.py::test_store_current_reading_warns_once_when_voltage_unavailable \
+            meshtastic/tests/test_mesh_interface.py::test_sendPacket_alias_with_destination_as_int \
+            meshtastic/tests/test_mesh_interface.py::test_sendPacket_alias_with_no_destination \
+            meshtastic/tests/test_mesh_interface.py::test_send_telemetry_supported_and_fallback_paths
   # Fast install sanity check across Python versions.
   # Full tests run in the tests job above.
   # Lint/type checks run in dedicated jobs for earlier independent failures.

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -22,6 +22,8 @@ lint:
         - meshtastic/**/*_pb2.pyi
         # Ignore external protobufs submodule content in this repo's lint scope.
         - protobufs/**
+        # Keep project license text untouched by automated lint/format tools.
+        - LICENSE.md
     - linters: [mypy-poetry]
       paths:
         # Keep Trunk's mypy scope aligned with CI (meshtastic/ only).
@@ -63,8 +65,8 @@ lint:
       commands:
         - name: lint
           output: pylint
-          run: poetry -C ${workspace} run pylint meshtastic examples/ --exit-zero --output ${tmpfile} --output-format json
-          target: [meshtastic, examples]
+          run: poetry -C ${workspace} run pylint meshtastic examples/ --exit-zero --ignore-patterns='.*_pb2.py,.*_pb2.pyi' --ignore-paths='^meshtastic/tests/|^meshtastic/protobuf/.*_pb2\\.pyi?$' --output ${tmpfile} --output-format json
+          target: meshtastic
           read_output_from: tmp_file
           run_from: ${root_or_parent_with_any_config}
           disable_upstream: true

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,6 @@
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
-
     {
       "name": "meshtastic BLE",
       "type": "debugpy",
@@ -13,7 +12,7 @@
       "justMyCode": false,
       "args": ["--ble", "--info", "--seriallog", "stdout"]
     },
-     {
+    {
       "name": "meshtastic BLE scan",
       "type": "python",
       "request": "launch",
@@ -51,7 +50,12 @@
       "request": "launch",
       "module": "meshtastic",
       "justMyCode": true,
-      "args": ["--setchan", "psk", "0x1a1a1a1a2b2b2b2b1a1a1a1a2b2b2b2b1a1a1a1a2b2b2b2b1a1a1a1a2b2b2b2b", "--debug"]
+      "args": [
+        "--setchan",
+        "psk",
+        "0x1a1a1a1a2b2b2b2b1a1a1a1a2b2b2b2b1a1a1a1a2b2b2b2b1a1a1a1a2b2b2b2b",
+        "--debug"
+      ]
     },
     {
       "name": "meshtastic debug",
@@ -139,7 +143,12 @@
       "request": "launch",
       "module": "meshtastic",
       "justMyCode": true,
-      "args": ["--debug", "--set", "telemetry.environment_measurement_enabled", "1"]
+      "args": [
+        "--debug",
+        "--set",
+        "telemetry.environment_measurement_enabled",
+        "1"
+      ]
     },
     {
       "name": "meshtastic debug setPref telemetry.environment_screen_enabled",
@@ -155,7 +164,12 @@
       "request": "launch",
       "module": "meshtastic",
       "justMyCode": true,
-      "args": ["--debug", "--set", "telemetry.environment_measurement_enabled", "1"]
+      "args": [
+        "--debug",
+        "--set",
+        "telemetry.environment_measurement_enabled",
+        "1"
+      ]
     },
     {
       "name": "meshtastic setpref",
@@ -173,15 +187,14 @@
       "justMyCode": true,
       "args": ["--debug", "--ch-set", "channel_num", "0", "--ch-index", "0"]
     },
-    
+
     {
       "name": "meshtastic seturl",
       "type": "debugpy",
       "request": "launch",
       "module": "meshtastic",
       "justMyCode": true,
-      "args": ["--seturl", "https://www.meshtastic.org/d/#CgIYAw"
-      ]
+      "args": ["--seturl", "https://www.meshtastic.org/d/#CgIYAw"]
     },
     {
       "name": "meshtastic shell",
@@ -197,7 +210,18 @@
       "request": "launch",
       "module": "meshtastic",
       "justMyCode": false,
-      "args": ["--slog-out", "default", "--power-sim", "--power-voltage", "3.3", "--port", "/dev/ttyUSB0", "--noproto", "--seriallog", "stdout"]
+      "args": [
+        "--slog-out",
+        "default",
+        "--power-sim",
+        "--power-voltage",
+        "3.3",
+        "--port",
+        "/dev/ttyUSB0",
+        "--noproto",
+        "--seriallog",
+        "stdout"
+      ]
     },
     {
       "name": "meshtastic powermon ppk2",
@@ -205,7 +229,17 @@
       "request": "launch",
       "module": "meshtastic",
       "justMyCode": false,
-      "args": ["--slog-out", "default", "--power-ppk2-meter", "--power-wait", "--power-voltage", "3.3", "--noproto", "--seriallog", "stdout"]
+      "args": [
+        "--slog-out",
+        "default",
+        "--power-ppk2-meter",
+        "--power-wait",
+        "--power-voltage",
+        "3.3",
+        "--noproto",
+        "--seriallog",
+        "stdout"
+      ]
     },
     {
       "name": "meshtastic stress ppk2",
@@ -213,7 +247,14 @@
       "request": "launch",
       "module": "meshtastic",
       "justMyCode": false,
-      "args": ["--slog", "--power-ppk2-supply", "--power-stress", "--power-voltage", "3.3", "--ble"]
+      "args": [
+        "--slog",
+        "--power-ppk2-supply",
+        "--power-stress",
+        "--power-voltage",
+        "3.3",
+        "--ble"
+      ]
     },
     {
       "name": "meshtastic test",
@@ -255,13 +296,17 @@
       "justMyCode": true,
       "args": ["--nodes"]
     },
-        {
+    {
       "name": "meshtastic nodes table with show-fields",
       "type": "debugpy",
       "request": "launch",
       "module": "meshtastic",
       "justMyCode": true,
-      "args": ["--nodes", "--show-fields", "AKA,Pubkey,Role,Role,Role,Latitude,Latitude,deviceMetrics.voltage"]
+      "args": [
+        "--nodes",
+        "--show-fields",
+        "AKA,Pubkey,Role,Role,Role,Latitude,Latitude,deviceMetrics.voltage"
+      ]
     },
     {
       "name": "meshtastic --export-config",
@@ -270,6 +315,6 @@
       "module": "meshtastic",
       "justMyCode": true,
       "args": ["--export-config", "config.json"]
-    },
+    }
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,22 +1,20 @@
 {
-    "cSpell.words": [
-        "bitmask",
-        "boardid",
-        "DEEPSLEEP",
-        "Meshtastic",
-        "milliwatt",
-        "portnums",
-        "powermon",
-        "POWERSTRESS",
-        "pyarrow",
-        "TORADIO",
-        "Vids"
-    ],
-    "python.pythonPath": "/usr/bin/python3",
-    "flake8.enabled": false,
-    "python.testing.pytestArgs": [
-        "meshtastic/tests"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true // we are using trunk for formatting/linting rules, don't yell at us about line length
+  "cSpell.words": [
+    "bitmask",
+    "boardid",
+    "DEEPSLEEP",
+    "Meshtastic",
+    "milliwatt",
+    "portnums",
+    "powermon",
+    "POWERSTRESS",
+    "pyarrow",
+    "TORADIO",
+    "Vids"
+  ],
+  "python.pythonPath": "/usr/bin/python3",
+  "flake8.enabled": false,
+  "python.testing.pytestArgs": ["meshtastic/tests"],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true // we are using trunk for formatting/linting rules, don't yell at us about line length
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,9 +30,10 @@ This document tracks coding standards and API refactoring decisions for the Mesh
 
 ## BLE API Refactoring Decisions
 
-Canonical BLE compatibility baseline and matrix now live in
-`CONTRIBUTING.md` under **API naming and compatibility policy**.
-Use that section as the single source of truth for:
+Canonical compatibility/deprecation inventory now lives in
+`COMPATIBILITY.md`.
+`CONTRIBUTING.md` keeps the policy summary and links to the inventory.
+Use `COMPATIBILITY.md` as the single source of truth for:
 
 - pinned BLE baseline (`2.7.7`),
 - required historical BLE compatibility shims (including
@@ -90,9 +91,12 @@ Quick inventory command:
 
 ### Compatibility Alias Inventory (source of truth)
 
-- Treat the pinned BLE 2.7.7 matrix in `CONTRIBUTING.md` as authoritative for historical BLE compatibility names.
-- Treat `COMPAT_STABLE_SHIM` / `COMPAT_DEPRECATE` markers as the grep-able inventory for intentionally maintained aliases elsewhere in the codebase.
-- If a symbol is not in the BLE matrix and is not marked with a `COMPAT_*` marker, do not add compatibility aliases by default.
+- Treat `COMPATIBILITY.md` as authoritative for maintained compatibility names,
+  warning policy, and status.
+- Treat `COMPAT_STABLE_SHIM` / `COMPAT_DEPRECATE` markers as the grep-able
+  implementation inventory for intentionally maintained aliases.
+- If a symbol is not listed in `COMPATIBILITY.md` and is not marked with a
+  `COMPAT_*` marker in code, do not add compatibility aliases by default.
 - `meshtastic.interfaces.ble.runner.get_zombie_runner_count()` is internal diagnostics and intentionally remains snake_case-only unless explicitly approved to expand public surface.
 
 Current `COMPAT_DEPRECATE` methods:
@@ -101,6 +105,7 @@ Current `COMPAT_DEPRECATE` methods:
 - util: `dotdict` (class alias to `DotDict`, warn-once)
 - Slog: `root_dir`, `PowerLogger.store_current_reading` (warn-once)
 - Powermon: `PowerMeter.getAverageCurrentmA`, `PowerMeter.getMinCurrentmA`, `PowerMeter.getMaxCurrentmA`
+- BLE runner: `_run_coroutine_threadsafe(timeout=...)` alias for `startup_timeout=...` (warn-once)
 
 ## Powermon API Refactoring Decisions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,7 @@ Current `COMPAT_DEPRECATE` methods:
 - util: `dotdict` (class alias to `DotDict`, warn-once)
 - Slog: `root_dir`, `PowerLogger.store_current_reading` (warn-once)
 - Powermon: `PowerMeter.getAverageCurrentmA`, `PowerMeter.getMinCurrentmA`, `PowerMeter.getMaxCurrentmA`
-- BLE runner: `_run_coroutine_threadsafe(timeout=...)` alias for `startup_timeout=...` (warn-once)
+- BLE runner: `BLECoroutineRunner.run_coroutine_threadsafe(timeout=...)` alias for `startup_timeout=...` (warn-once, old internal alias: `_run_coroutine_threadsafe`)
 
 ## Powermon API Refactoring Decisions
 

--- a/BLE.md
+++ b/BLE.md
@@ -138,7 +138,8 @@ policy = RetryPolicy._empty_read()  # or ._transient_error() / ._auto_reconnect(
 
 delay = policy._get_delay(attempt)       # float, jittered exponential backoff
 should_go = policy._should_retry(count)  # bool, respects max_retries
-delay, ok = policy.next_attempt()        # combined: compute delay + advance counter
+delay, ok = policy.next_attempt()        # canonical: compute delay + advance counter
+attempt_count = policy.get_attempt_count()  # int, current retry attempt number
 ```
 
 Compatibility note: the core library does not currently expose camelCase policy
@@ -170,7 +171,7 @@ Contributor rule for naming updates:
 ### One interface per device address
 
 ```python
-from meshtastic.interfaces.ble import BLEInterface
+from meshtastic.ble_interface import BLEInterface
 from pubsub import pub
 import time
 
@@ -230,7 +231,7 @@ seconds will continue to be suppressed.
 ## Minimal pubsub example
 
 ```python
-from meshtastic.interfaces.ble import BLEInterface
+from meshtastic.ble_interface import BLEInterface
 from pubsub import pub
 import time
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -125,26 +125,26 @@ Semantic deprecation:
 
 ### Node and Tunnel
 
-| Module              | Compatibility symbol                                   | Canonical symbol                        |
-| ------------------- | ------------------------------------------------------ | --------------------------------------- |
-| `meshtastic.mesh_interface` | `_generatePacketId()`                         | `_generate_packet_id()`                 |
-| `meshtastic.node`   | `position_flags_list()`                                | `positionFlagsList()`                   |
-| `meshtastic.node`   | `excluded_modules_list()`                              | `excludedModulesList()`                 |
-| `meshtastic.node`   | `module_available()`                                   | `moduleAvailable()`                     |
-| `meshtastic.node`   | `get_ringtone()`                                       | `getRingtone()`                         |
-| `meshtastic.node`   | `set_ringtone()`                                       | `setRingtone()`                         |
-| `meshtastic.node`   | `get_canned_message()`                                 | `getCannedMessage()`                    |
-| `meshtastic.node`   | `set_canned_message()`                                 | `setCannedMessage()`                    |
-| `meshtastic.node`   | `get_channels_with_hash()`                             | `getChannelsWithHash()`                 |
-| `meshtastic.node`   | `startOTA(ota_mode=..., ota_hash=..., hash=...)`       | `startOTA(mode=..., ota_file_hash=...)` |
-| `meshtastic.node`   | live-channel semantics of `getChannelByChannelIndex()` | historical mutate-then-write behavior   |
-| `meshtastic.tunnel` | `udpBlacklist`                                         | `UDP_BLACKLIST`                         |
-| `meshtastic.tunnel` | `tcpBlacklist`                                         | `TCP_BLACKLIST`                         |
-| `meshtastic.tunnel` | `protocolBlacklist`                                    | `PROTOCOL_BLACKLIST`                    |
-| `meshtastic.tunnel` | `_shouldFilterPacket()`                                | `_should_filter_packet()`               |
-| `meshtastic.tunnel` | `_ipToNodeId()`                                        | `_ip_to_node_id()`                      |
-| `meshtastic.tunnel` | `_nodeNumToIp()`                                       | `_node_num_to_ip()`                     |
-| `meshtastic.tunnel` | `sendPacket()`                                         | `_send_packet()`                        |
+| Module                      | Compatibility symbol                                   | Canonical symbol                        |
+| --------------------------- | ------------------------------------------------------ | --------------------------------------- |
+| `meshtastic.mesh_interface` | `_generatePacketId()`                                  | `_generate_packet_id()`                 |
+| `meshtastic.node`           | `position_flags_list()`                                | `positionFlagsList()`                   |
+| `meshtastic.node`           | `excluded_modules_list()`                              | `excludedModulesList()`                 |
+| `meshtastic.node`           | `module_available()`                                   | `moduleAvailable()`                     |
+| `meshtastic.node`           | `get_ringtone()`                                       | `getRingtone()`                         |
+| `meshtastic.node`           | `set_ringtone()`                                       | `setRingtone()`                         |
+| `meshtastic.node`           | `get_canned_message()`                                 | `getCannedMessage()`                    |
+| `meshtastic.node`           | `set_canned_message()`                                 | `setCannedMessage()`                    |
+| `meshtastic.node`           | `get_channels_with_hash()`                             | `getChannelsWithHash()`                 |
+| `meshtastic.node`           | `startOTA(ota_mode=..., ota_hash=..., hash=...)`       | `startOTA(mode=..., ota_file_hash=...)` |
+| `meshtastic.node`           | live-channel semantics of `getChannelByChannelIndex()` | historical mutate-then-write behavior   |
+| `meshtastic.tunnel`         | `udpBlacklist`                                         | `UDP_BLACKLIST`                         |
+| `meshtastic.tunnel`         | `tcpBlacklist`                                         | `TCP_BLACKLIST`                         |
+| `meshtastic.tunnel`         | `protocolBlacklist`                                    | `PROTOCOL_BLACKLIST`                    |
+| `meshtastic.tunnel`         | `_shouldFilterPacket()`                                | `_should_filter_packet()`               |
+| `meshtastic.tunnel`         | `_ipToNodeId()`                                        | `_ip_to_node_id()`                      |
+| `meshtastic.tunnel`         | `_nodeNumToIp()`                                       | `_node_num_to_ip()`                     |
+| `meshtastic.tunnel`         | `sendPacket()`                                         | `_send_packet()`                        |
 
 ### BLE and Related Exports
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,225 @@
+# Compatibility Inventory and Deprecation Matrix
+
+This document is the canonical source of truth for compatibility aliases,
+deprecations, and legacy compatibility behaviors in this repository.
+
+If a compatibility symbol is not listed here, do not add or keep it by default.
+
+## Scope and Policy
+
+- Runtime baseline is Python 3.10+.
+- Public API names prefer `camelCase`.
+- Historical compatibility shims remain callable where documented below.
+- Internal helpers prefer underscore-prefixed `snake_case`.
+- Naming-only compatibility aliases are silent unless explicitly marked deprecated.
+- Naming-only deprecations must be warn-once.
+- Semantic deprecations may warn on every invalid usage.
+
+## Status Legend
+
+- `PRIMARY`: canonical symbol for new code.
+- `COMPAT_STABLE_SHIM`: maintained compatibility alias; callable and silent.
+- `COMPAT_DEPRECATE`: maintained compatibility alias that emits
+  `DeprecationWarning` (warn-once unless explicitly noted).
+- `SEMANTIC_DEPRECATE`: behavioral migration warning (not naming-only).
+- `INTERNAL_COMPAT`: compatibility entrypoint intentionally retained for
+  integrations, but not considered public API growth.
+
+## Authoritative Baselines
+
+- BLE historical baseline tag: `2.7.7`
+- BLE baseline commit: `b26d80f1866ffa765467e5cb7688c59dee7f2bb2`
+- Baseline file: `meshtastic/ble_interface.py`
+
+## BLE Historical Baseline (2.7.7)
+
+The following historical BLE symbols are required compatibility surface and must
+remain callable and silent.
+
+| Symbol                                  | Status               | Warning policy | Notes                                  |
+| --------------------------------------- | -------------------- | -------------- | -------------------------------------- |
+| `BLEClient.async_await`                 | `COMPAT_STABLE_SHIM` | Silent         | Delegates to `_async_await`.           |
+| `BLEClient.async_run`                   | `COMPAT_STABLE_SHIM` | Silent         | Delegates to `_async_run`.             |
+| `BLEInterface.from_num_handler`         | `COMPAT_STABLE_SHIM` | Silent         | Delegates to `_from_num_handler`.      |
+| `BLEInterface.log_radio_handler`        | `COMPAT_STABLE_SHIM` | Silent         | Keep historical `async def` signature. |
+| `BLEInterface.legacy_log_radio_handler` | `COMPAT_STABLE_SHIM` | Silent         | Keep historical `async def` signature. |
+
+Additional approved BLE compatibility and promotions:
+
+| Symbol                                    | Status               | Warning policy | Notes                                          |
+| ----------------------------------------- | -------------------- | -------------- | ---------------------------------------------- |
+| `BLEClient.find_device`                   | `COMPAT_STABLE_SHIM` | Silent         | Historical snake_case.                         |
+| `BLEClient.findDevice`                    | `PRIMARY`            | Silent         | Approved promoted camelCase name.              |
+| `BLEClient.is_connected`                  | `COMPAT_STABLE_SHIM` | Silent         | Shim for `isConnected`.                        |
+| `BLEClient.isConnected`                   | `PRIMARY`            | Silent         | Approved promoted camelCase name.              |
+| `BLEClient.stop_notify`                   | `COMPAT_STABLE_SHIM` | Silent         | Shim for `stopNotify`.                         |
+| `BLEClient.stopNotify`                    | `PRIMARY`            | Silent         | Approved promoted camelCase name.              |
+| `BLEInterface.find_device`                | `COMPAT_STABLE_SHIM` | Silent         | Historical snake_case wrapper.                 |
+| `BLEInterface.findDevice`                 | `PRIMARY`            | Silent         | Approved promoted camelCase name.              |
+| `BLEStateManager._lock`                   | `INTERNAL_COMPAT`    | Silent         | Alias to `lock` property for legacy internals. |
+| `meshtastic.ble_interface.BleakClient`    | `COMPAT_STABLE_SHIM` | Silent         | Legacy module-level import compatibility.      |
+| `meshtastic.ble_interface.BleakScanner`   | `COMPAT_STABLE_SHIM` | Silent         | Legacy module-level import compatibility.      |
+| `meshtastic.ble_interface.BLEDevice`      | `COMPAT_STABLE_SHIM` | Silent         | Legacy module-level import compatibility.      |
+| `meshtastic.ble_interface.BleakError`     | `COMPAT_STABLE_SHIM` | Silent         | Legacy module-level import compatibility.      |
+| `meshtastic.ble_interface.BleakDBusError` | `COMPAT_STABLE_SHIM` | Silent         | Legacy module-level import compatibility.      |
+
+Approved BLE deprecation:
+
+| Symbol                                                      | Status             | Warning policy                | Notes                            |
+| ----------------------------------------------------------- | ------------------ | ----------------------------- | -------------------------------- |
+| `BLECoroutineRunner._run_coroutine_threadsafe(timeout=...)` | `COMPAT_DEPRECATE` | Warn-once per runner instance | Alias for `startup_timeout=...`. |
+
+## Deprecated Compatibility Aliases
+
+These are intentionally maintained deprecated aliases.
+
+| Symbol                                | Canonical replacement               | Status             | Warning policy                             |
+| ------------------------------------- | ----------------------------------- | ------------------ | ------------------------------------------ |
+| `mt_config.tunnelInstance`            | `mt_config.tunnel_instance`         | `COMPAT_DEPRECATE` | Warn-once per process (read/write/delete). |
+| `util.dotdict`                        | `util.DotDict`                      | `COMPAT_DEPRECATE` | Warn-once per process.                     |
+| `slog.root_dir()`                     | `slog.rootDir()`                    | `COMPAT_DEPRECATE` | Warn-once per process.                     |
+| `PowerLogger.store_current_reading()` | `PowerLogger.storeCurrentReading()` | `COMPAT_DEPRECATE` | Warn-once per instance.                    |
+| `PowerMeter.getAverageCurrentmA()`    | `PowerMeter.getAverageCurrentMA()`  | `COMPAT_DEPRECATE` | Warn-once per process key.                 |
+| `PowerMeter.getMinCurrentmA()`        | `PowerMeter.getMinCurrentMA()`      | `COMPAT_DEPRECATE` | Warn-once per process key.                 |
+| `PowerMeter.getMaxCurrentmA()`        | `PowerMeter.getMaxCurrentMA()`      | `COMPAT_DEPRECATE` | Warn-once per process key.                 |
+
+Semantic deprecation:
+
+| Behavior                                                                                | Status               | Warning policy               | Notes                                          |
+| --------------------------------------------------------------------------------------- | -------------------- | ---------------------------- | ---------------------------------------------- |
+| `MeshInterface.sendTelemetry(telemetryType=<unsupported>)` fallback to `device_metrics` | `SEMANTIC_DEPRECATE` | Warn every unsupported input | Behavioral migration warning, not naming-only. |
+
+## Stable Compatibility Aliases (Silent)
+
+### Core Package and CLI
+
+| Module                | Compatibility symbol                    | Canonical symbol                     |
+| --------------------- | --------------------------------------- | ------------------------------------ |
+| `meshtastic.__init__` | `meshtastic.serial` (lazy module alias) | `meshtastic.serial_interface` module |
+| `meshtastic.__main__` | `support_info()`                        | `supportInfo()`                      |
+| `meshtastic.__main__` | `export_config`                         | `exportConfig`                       |
+| `meshtastic.__main__` | `create_power_meter`                    | `_create_power_meter`                |
+| `meshtastic.__main__` | `_PREFERENCE_FIELD_ALIASES` legacy keys | canonical protobuf preference names  |
+| `meshtastic.version`  | `get_active_version()`                  | `getActiveVersion()`                 |
+| `meshtastic.test`     | `subscribe()`                           | `subscribeToNodeUpdates()`           |
+
+`_PREFERENCE_FIELD_ALIASES` currently normalizes:
+
+- `display.use_12_hour -> display.use_12h_clock`
+- `display.use12_hour -> display.use_12h_clock`
+- `display.use12h_clock -> display.use_12h_clock`
+- `display.use12_h_clock -> display.use_12h_clock`
+
+### Utility and Config
+
+| Module            | Compatibility symbol      | Canonical symbol       |
+| ----------------- | ------------------------- | ---------------------- |
+| `meshtastic.util` | `blacklistVids`           | `BLACKLIST_VIDS`       |
+| `meshtastic.util` | `whitelistVids`           | `WHITELIST_VIDS`       |
+| `meshtastic.util` | `our_exit()`              | `ourExit()`            |
+| `meshtastic.util` | `remove_keys_from_dict()` | `removeKeysFromDict()` |
+| `meshtastic.util` | `detect_windows_port()`   | `detectWindowsPort()`  |
+| `meshtastic.util` | `message_to_json()`       | `messageToJson()`      |
+| `meshtastic.util` | `to_node_num()`           | `toNodeNum()`          |
+| `meshtastic.util` | `flags_to_list()`         | `flagsToList()`        |
+
+### Node and Tunnel
+
+| Module              | Compatibility symbol                                   | Canonical symbol                        |
+| ------------------- | ------------------------------------------------------ | --------------------------------------- |
+| `meshtastic.node`   | `position_flags_list()`                                | `positionFlagsList()`                   |
+| `meshtastic.node`   | `excluded_modules_list()`                              | `excludedModulesList()`                 |
+| `meshtastic.node`   | `module_available()`                                   | `moduleAvailable()`                     |
+| `meshtastic.node`   | `get_ringtone()`                                       | `getRingtone()`                         |
+| `meshtastic.node`   | `set_ringtone()`                                       | `setRingtone()`                         |
+| `meshtastic.node`   | `get_canned_message()`                                 | `getCannedMessage()`                    |
+| `meshtastic.node`   | `set_canned_message()`                                 | `setCannedMessage()`                    |
+| `meshtastic.node`   | `get_channels_with_hash()`                             | `getChannelsWithHash()`                 |
+| `meshtastic.node`   | `startOTA(ota_mode=..., ota_hash=..., hash=...)`       | `startOTA(mode=..., ota_file_hash=...)` |
+| `meshtastic.node`   | live-channel semantics of `getChannelByChannelIndex()` | historical mutate-then-write behavior   |
+| `meshtastic.tunnel` | `udpBlacklist`                                         | `UDP_BLACKLIST`                         |
+| `meshtastic.tunnel` | `tcpBlacklist`                                         | `TCP_BLACKLIST`                         |
+| `meshtastic.tunnel` | `protocolBlacklist`                                    | `PROTOCOL_BLACKLIST`                    |
+| `meshtastic.tunnel` | `_shouldFilterPacket()`                                | `_should_filter_packet()`               |
+| `meshtastic.tunnel` | `_ipToNodeId()`                                        | `_ip_to_node_id()`                      |
+| `meshtastic.tunnel` | `_nodeNumToIp()`                                       | `_node_num_to_ip()`                     |
+| `meshtastic.tunnel` | `sendPacket()`                                         | `_send_packet()`                        |
+
+### BLE and Related Exports
+
+| Module                                | Compatibility symbol         | Canonical symbol              |
+| ------------------------------------- | ---------------------------- | ----------------------------- |
+| `meshtastic.interfaces.ble.client`    | `find_device()`              | `discover()`                  |
+| `meshtastic.interfaces.ble.client`    | `is_connected()`             | `isConnected()`               |
+| `meshtastic.interfaces.ble.client`    | `stop_notify()`              | `stopNotify()`                |
+| `meshtastic.interfaces.ble.client`    | `async_await()`              | `_async_await()`              |
+| `meshtastic.interfaces.ble.client`    | `async_run()`                | `_async_run()`                |
+| `meshtastic.interfaces.ble.interface` | `find_device()`              | `findDevice()`                |
+| `meshtastic.interfaces.ble.interface` | `from_num_handler()`         | `_from_num_handler()`         |
+| `meshtastic.interfaces.ble.interface` | `log_radio_handler()`        | `_log_radio_handler()`        |
+| `meshtastic.interfaces.ble.interface` | `legacy_log_radio_handler()` | `_legacy_log_radio_handler()` |
+| `meshtastic.interfaces.ble.state`     | `_lock` property             | `lock` property               |
+
+### Powermon and Slog
+
+| Module                                        | Compatibility symbol             | Canonical symbol                                                       |
+| --------------------------------------------- | -------------------------------- | ---------------------------------------------------------------------- |
+| `meshtastic.powermon.power_supply.PowerMeter` | `get_average_current_mA()`       | `getAverageCurrentMA()`                                                |
+| `meshtastic.powermon.power_supply.PowerMeter` | `get_min_current_mA()`           | `getMinCurrentMA()`                                                    |
+| `meshtastic.powermon.power_supply.PowerMeter` | `get_max_current_mA()`           | `getMaxCurrentMA()`                                                    |
+| `meshtastic.powermon.power_supply.PowerMeter` | `reset_measurements()`           | `resetMeasurements()`                                                  |
+| `meshtastic.powermon.ppk2.PPK2PowerSupply`    | `reset_measurements()`           | `resetMeasurements()`                                                  |
+| `meshtastic.powermon.riden.RidenPowerSupply`  | `get_average_current_mA()`       | `getAverageCurrentMA()`                                                |
+| `meshtastic.powermon.riden.RidenPowerSupply`  | `_getRawWattHour()`              | `_get_raw_watt_hour()`                                                 |
+| `meshtastic.powermon.riden.RidenPowerSupply`  | `nowWattHour` attribute          | `now_watt_hour`-style internal value not introduced (legacy preserved) |
+| `meshtastic.powermon.sim.SimPowerSupply`      | `get_average_current_mA()`       | `getAverageCurrentMA()`                                                |
+| `meshtastic.powermon.stress`                  | `handle_power_stress_response()` | `handlePowerStressResponse()`                                          |
+| `meshtastic.powermon.stress`                  | `onPowerStressResponse()`        | `handlePowerStressResponse()`                                          |
+| `meshtastic.slog.arrow.ArrowWriter`           | `set_schema()`                   | `setSchema()`                                                          |
+| `meshtastic.slog.arrow.ArrowWriter`           | `add_row()`                      | `addRow()`                                                             |
+| `meshtastic.slog.slog`                        | `p_meter` property               | `pMeter` property                                                      |
+| `meshtastic.slog.slog`                        | `_onLogMessage()`                | `_on_log_message()`                                                    |
+
+Slog schema compatibility fields retained in `PowerLogger` rows and Arrow schema:
+
+- `average_mW` (legacy alias field)
+- `max_mW` (legacy alias field)
+- `min_mW` (legacy alias field)
+
+Preferred fields for current values are `average_mA`, `max_mA`, and `min_mA`.
+
+### Other Modules
+
+| Module                                        | Compatibility symbol | Canonical symbol  |
+| --------------------------------------------- | -------------------- | ----------------- |
+| `meshtastic.analysis.__main__`                | `to_pmon_names()`    | `toPmonNames()`   |
+| `meshtastic.ota.ESP32WiFiOTA`                 | `hash_bytes()`       | `hashBytes()`     |
+| `meshtastic.ota.ESP32WiFiOTA`                 | `hash_hex()`         | `hashHex()`       |
+| `meshtastic.remote_hardware`                  | `onGpioReceive()`    | `onGPIOReceive()` |
+| `meshtastic.remote_hardware`                  | `onGPIOreceive()`    | `onGPIOReceive()` |
+| `meshtastic.supported_device.SupportedDevice` | `usb_ids` property   | `usbIds` property |
+
+## Non-Public and Boundary Rules
+
+- Symbols under `meshtastic/interfaces/ble/*` are internal by default unless
+  explicitly exported via:
+  - `meshtastic/ble_interface.py`, or
+  - `meshtastic/interfaces/ble/__init__.py`.
+- Do not add compatibility aliases for internal orchestration helpers
+  (`runner`, `policies`, `coordination`, etc.) without explicit approval.
+- `ReconnectPolicy` canonical names remain `next_attempt` and
+  `get_attempt_count` (snake_case).
+- `meshtastic.interfaces.ble.runner.get_zombie_runner_count()` remains
+  internal snake_case-only.
+
+## Maintenance Checklist
+
+When adding/changing compatibility behavior:
+
+1. Update or add the code path with explicit `COMPAT_STABLE_SHIM` or
+   `COMPAT_DEPRECATE` marker where appropriate.
+2. Update this document in the same change.
+3. Add/adjust tests for callability and warning behavior.
+4. Run compatibility inventory grep and verify changes:
+   - `rg -n "COMPAT_STABLE_SHIM|COMPAT_DEPRECATE" meshtastic`
+5. Run full project checks as documented in `CONTRIBUTING.md`.

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -224,4 +224,7 @@ When adding/changing compatibility behavior:
 3. Add/adjust tests for callability and warning behavior.
 4. Run compatibility inventory grep and verify changes:
    - `rg -n "COMPAT_STABLE_SHIM|COMPAT_DEPRECATE" meshtastic`
-5. Run full project checks as documented in `CONTRIBUTING.md`.
+5. Keep `.github/workflows/ci.yml` compatibility validation green:
+   - inventory marker check (`rg -n "COMPAT_STABLE_SHIM|COMPAT_DEPRECATE" meshtastic`)
+   - compatibility-focused pytest targets for alias callability and warning behavior
+6. Run full project checks as documented in `CONTRIBUTING.md`.

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -128,6 +128,7 @@ Semantic deprecation:
 | Module                      | Compatibility symbol                                   | Canonical symbol                        |
 | --------------------------- | ------------------------------------------------------ | --------------------------------------- |
 | `meshtastic.mesh_interface` | `_generatePacketId()`                                  | `_generate_packet_id()`                 |
+| `meshtastic.mesh_interface` | `_sendPacket()`                                        | `_send_packet()`                        |
 | `meshtastic.node`           | `position_flags_list()`                                | `positionFlagsList()`                   |
 | `meshtastic.node`           | `excluded_modules_list()`                              | `excludedModulesList()`                 |
 | `meshtastic.node`           | `module_available()`                                   | `moduleAvailable()`                     |

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -93,15 +93,15 @@ Semantic deprecation:
 
 ### Core Package and CLI
 
-| Module                | Compatibility symbol                    | Canonical symbol                     |
-| --------------------- | --------------------------------------- | ------------------------------------ |
-| `meshtastic.__init__` | `meshtastic.serial` (lazy module alias) | `meshtastic.serial_interface` module |
-| `meshtastic.__main__` | `support_info()`                        | `supportInfo()`                      |
-| `meshtastic.__main__` | `export_config`                         | `exportConfig`                       |
-| `meshtastic.__main__` | `create_power_meter`                    | `_create_power_meter`                |
-| `meshtastic.__main__` | `_PREFERENCE_FIELD_ALIASES` legacy keys | canonical protobuf preference names  |
-| `meshtastic.version`  | `get_active_version()`                  | `getActiveVersion()`                 |
-| `meshtastic.test`     | `subscribe()`                           | `subscribeToNodeUpdates()`           |
+| Module                | Compatibility symbol                    | Canonical symbol                       |
+| --------------------- | --------------------------------------- | -------------------------------------- |
+| `meshtastic.__init__` | `meshtastic.serial` (lazy module alias) | third-party `serial` (pyserial) module |
+| `meshtastic.__main__` | `support_info()`                        | `supportInfo()`                        |
+| `meshtastic.__main__` | `export_config`                         | `exportConfig`                         |
+| `meshtastic.__main__` | `create_power_meter`                    | `_create_power_meter`                  |
+| `meshtastic.__main__` | `_PREFERENCE_FIELD_ALIASES` legacy keys | canonical protobuf preference names    |
+| `meshtastic.version`  | `get_active_version()`                  | `getActiveVersion()`                   |
+| `meshtastic.test`     | `subscribe()`                           | `subscribeToNodeUpdates()`             |
 
 `_PREFERENCE_FIELD_ALIASES` currently normalizes:
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -127,6 +127,7 @@ Semantic deprecation:
 
 | Module              | Compatibility symbol                                   | Canonical symbol                        |
 | ------------------- | ------------------------------------------------------ | --------------------------------------- |
+| `meshtastic.mesh_interface` | `_generatePacketId()`                         | `_generate_packet_id()`                 |
 | `meshtastic.node`   | `position_flags_list()`                                | `positionFlagsList()`                   |
 | `meshtastic.node`   | `excluded_modules_list()`                              | `excludedModulesList()`                 |
 | `meshtastic.node`   | `module_available()`                                   | `moduleAvailable()`                     |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,10 +30,12 @@
 
 Use this policy for all code changes (especially AI-assisted refactors):
 
+- Canonical compatibility/deprecation inventory is maintained in
+  `COMPATIBILITY.md`.
 - New public API names should prefer `camelCase` (for example `sendText`,
   `sendData`).
 - Existing public compatibility names must remain callable, including legacy BLE
-  `snake_case` names documented below.
+  `snake_case` names documented in `COMPATIBILITY.md`.
 - Internal helpers should be underscore-prefixed `snake_case` (for example
   `_send_packet`).
 - Do not break existing public API names for compatibility.
@@ -60,7 +62,7 @@ When modernizing BLE naming:
 5. Do not silently remove or hard-rename legacy methods.
 6. Update tests/monkeypatch points if alias names are introduced.
 
-#### Historical BLE compatibility baseline (source of truth)
+#### Historical BLE compatibility baseline
 
 Use this pinned baseline for BLE compatibility decisions:
 
@@ -68,17 +70,8 @@ Use this pinned baseline for BLE compatibility decisions:
 - Commit: `b26d80f1866ffa765467e5cb7688c59dee7f2bb2`
 - Baseline file: `meshtastic/ble_interface.py`
 
-Historical names below must remain callable as compatibility wrappers over
-canonical internal helpers (`_async_await`, `_async_run`, `_from_num_handler`,
-`_log_radio_handler`, `_legacy_log_radio_handler`):
-
-| Symbol                                  | Status                        | Warning policy | Notes                                  |
-| --------------------------------------- | ----------------------------- | -------------- | -------------------------------------- |
-| `BLEClient.async_await`                 | Required callable compat shim | Silent         | Keep historical argument behavior.     |
-| `BLEClient.async_run`                   | Required callable compat shim | Silent         | Keep historical argument behavior.     |
-| `BLEInterface.from_num_handler`         | Required callable compat shim | Silent         | Delegates to `_from_num_handler`.      |
-| `BLEInterface.log_radio_handler`        | Required callable compat shim | Silent         | Keep historical `async def` signature. |
-| `BLEInterface.legacy_log_radio_handler` | Required callable compat shim | Silent         | Keep historical `async def` signature. |
+Historical required BLE wrappers and warning policy are tracked in
+`COMPATIBILITY.md` under **BLE Historical Baseline (2.7.7)**.
 
 ## How to check your code (pytest/pylint/mypy) before a PR
 

--- a/REFACTOR_PROGRAM.md
+++ b/REFACTOR_PROGRAM.md
@@ -327,8 +327,10 @@ Security signal from trunk was also monitored with `osv-scanner`.
 
 ## 11) Documentation and Policy Artifacts
 
-Two key documents now serve different levels:
+Three key documents now serve different levels:
 
+- `COMPATIBILITY.md`: canonical compatibility/deprecation inventory
+  (symbols, status, warning policy, and boundary rules).
 - `BLE.md`: BLE-specific architecture and integration details.
 - `AGENTS.md`: coding/refactor policy, naming/typing conventions, and
   compatibility marker discipline.
@@ -351,6 +353,7 @@ When touching APIs after this refactor:
 
 - Confirm whether the symbol is historical public surface.
 - Use `COMPAT_STABLE_SHIM` or `COMPAT_DEPRECATE` intentionally.
+- Update `COMPATIBILITY.md` in the same change when compatibility behavior changes.
 - Prefer warn-once for deprecated hot-path aliases.
 - Add or update regression tests when changing compatibility behavior.
 - Avoid broad behavior changes unless clearly justified and documented.

--- a/bin/build-bin.sh
+++ b/bin/build-bin.sh
@@ -5,7 +5,7 @@ set -e
 echo Building ubuntu binary
 poetry install
 POETRYDIR="$(poetry env info --path)"
-if [[ -z ${POETRYDIR} || ! -f "${POETRYDIR}/bin/activate" ]]; then
+if [[ -z ${POETRYDIR-} || ! -f "${POETRYDIR}/bin/activate" ]]; then
 	echo "Unable to resolve Poetry virtualenv activate script at ${POETRYDIR}/bin/activate" >&2
 	exit 1
 fi

--- a/bin/build-bin.sh
+++ b/bin/build-bin.sh
@@ -6,4 +6,3 @@ echo Building ubuntu binary
 poetry install
 source $(poetry env info --path)/bin/activate
 pyinstaller -F -n meshtastic --collect-all meshtastic meshtastic/__main__.py
-

--- a/bin/build-bin.sh
+++ b/bin/build-bin.sh
@@ -4,8 +4,8 @@ set -e
 
 echo Building ubuntu binary
 poetry install
-POETRYDIR="$(poetry env info --path)"
-if [[ -z ${POETRYDIR-} || ! -f "${POETRYDIR}/bin/activate" ]]; then
+POETRYDIR="$(poetry env info --path 2>/dev/null || true)"
+if [[ -z ${POETRYDIR} || ! -f "${POETRYDIR}/bin/activate" ]]; then
 	echo "Unable to resolve Poetry virtualenv activate script at ${POETRYDIR}/bin/activate" >&2
 	exit 1
 fi

--- a/bin/build-bin.sh
+++ b/bin/build-bin.sh
@@ -4,5 +4,11 @@ set -e
 
 echo Building ubuntu binary
 poetry install
-source $(poetry env info --path)/bin/activate
+POETRYDIR="$(poetry env info --path)"
+if [[ -z ${POETRYDIR} || ! -f "${POETRYDIR}/bin/activate" ]]; then
+	echo "Unable to resolve Poetry virtualenv activate script at ${POETRYDIR}/bin/activate" >&2
+	exit 1
+fi
+# shellcheck disable=SC1090,SC1091
+source "${POETRYDIR}/bin/activate"
 pyinstaller -F -n meshtastic --collect-all meshtastic meshtastic/__main__.py

--- a/bin/regen-protobufs.sh
+++ b/bin/regen-protobufs.sh
@@ -6,13 +6,19 @@ set -e
 #gsed -i 's/import "\//import ".\//g' ./protobufs/meshtastic/*
 #gsed -i 's/package meshtastic;//g' ./protobufs/meshtastic/*
 
-POETRYDIR=$(poetry env info --path)
+POETRYDIR="$(poetry env info --path 2>/dev/null || true)"
 
 if [[ -z ${POETRYDIR} ]]; then
 	poetry install
+	POETRYDIR="$(poetry env info --path)"
 fi
 
 # protoc looks for mypy plugin in the python path
+if [[ -z ${POETRYDIR} || ! -f "${POETRYDIR}/bin/activate" ]]; then
+	echo "Unable to resolve Poetry virtualenv activate script at ${POETRYDIR}/bin/activate" >&2
+	exit 1
+fi
+# shellcheck disable=SC1090,SC1091
 source "${POETRYDIR}/bin/activate"
 
 # Put our temp files in the poetry build directory
@@ -30,24 +36,24 @@ cp ./protobufs/meshtastic/*.proto "${INDIR}"
 cp ./protobufs/nanopb.proto "${INDIR}"
 
 # OS-X sed is apparently a little different and expects an arg for -i
-if [[ ${OSTYPE} == 'darwin'* ]]; then
-	SEDCMD="sed -i '' -E"
+if [[ ${OSTYPE} == darwin* ]]; then
+	SEDCMD=(sed -i '' -E)
 else
-	SEDCMD="sed -i -E"
+	SEDCMD=(sed -i -E)
 fi
 
 # change the package names to meshtastic.protobuf
-${SEDCMD} 's/^package meshtastic;/package meshtastic.protobuf;/' "${INDIR}/"*.proto
+"${SEDCMD[@]}" 's/^package meshtastic;/package meshtastic.protobuf;/' "${INDIR}/"*.proto
 # fix the imports to match
-${SEDCMD} 's/^import "meshtastic\//import "meshtastic\/protobuf\//' "${INDIR}/"*.proto
+"${SEDCMD[@]}" 's/^import "meshtastic\//import "meshtastic\/protobuf\//' "${INDIR}/"*.proto
 
-${SEDCMD} 's/^import "nanopb.proto"/import "meshtastic\/protobuf\/nanopb.proto"/' "${INDIR}/"*.proto
+"${SEDCMD[@]}" 's/^import "nanopb.proto"/import "meshtastic\/protobuf\/nanopb.proto"/' "${INDIR}/"*.proto
 
 # Generate the python files
-./nanopb-0.4.8/generator-bin/protoc -I="${TMPDIR}"/in --python_out "${OUTDIR}" "--mypy_out=${PYIDIR}" "${INDIR}"/*.proto
+./nanopb-0.4.8/generator-bin/protoc -I="${TMPDIR}/in" --python_out "${OUTDIR}" "--mypy_out=${PYIDIR}" "${INDIR}"/*.proto
 
 # Change "from meshtastic.protobuf import" to "from . import"
-${SEDCMD} 's/^from meshtastic.protobuf import/from . import/' "${OUTDIR}"/meshtastic/protobuf/*pb2*.py[i]
+"${SEDCMD[@]}" 's/^from meshtastic.protobuf import/from . import/' "${OUTDIR}"/meshtastic/protobuf/*pb2*.py[i]
 
 # Create a __init__.py in the out directory
 touch "${OUTDIR}/meshtastic/protobuf/__init__.py"

--- a/bin/regen-protobufs.sh
+++ b/bin/regen-protobufs.sh
@@ -13,7 +13,7 @@ if [[ -z ${POETRYDIR} ]]; then
 fi
 
 # protoc looks for mypy plugin in the python path
-source $(poetry env info --path)/bin/activate
+source "${POETRYDIR}/bin/activate"
 
 # Put our temp files in the poetry build directory
 TMPDIR=./build/meshtastic/protofixup

--- a/bin/regen-protobufs.sh
+++ b/bin/regen-protobufs.sh
@@ -8,13 +8,13 @@ set -e
 
 POETRYDIR="$(poetry env info --path 2>/dev/null || true)"
 
-if [[ -z ${POETRYDIR-} ]]; then
+if [[ -z ${POETRYDIR} ]]; then
 	poetry install
 	POETRYDIR="$(poetry env info --path)"
 fi
 
 # protoc looks for mypy plugin in the python path
-if [[ -z ${POETRYDIR-} || ! -f "${POETRYDIR}/bin/activate" ]]; then
+if [[ -z ${POETRYDIR} || ! -f "${POETRYDIR}/bin/activate" ]]; then
 	echo "Unable to resolve Poetry virtualenv activate script at ${POETRYDIR}/bin/activate" >&2
 	exit 1
 fi

--- a/bin/regen-protobufs.sh
+++ b/bin/regen-protobufs.sh
@@ -8,13 +8,13 @@ set -e
 
 POETRYDIR="$(poetry env info --path 2>/dev/null || true)"
 
-if [[ -z ${POETRYDIR} ]]; then
+if [[ -z ${POETRYDIR-} ]]; then
 	poetry install
 	POETRYDIR="$(poetry env info --path)"
 fi
 
 # protoc looks for mypy plugin in the python path
-if [[ -z ${POETRYDIR} || ! -f "${POETRYDIR}/bin/activate" ]]; then
+if [[ -z ${POETRYDIR-} || ! -f "${POETRYDIR}/bin/activate" ]]; then
 	echo "Unable to resolve Poetry virtualenv activate script at ${POETRYDIR}/bin/activate" >&2
 	exit 1
 fi
@@ -36,7 +36,7 @@ cp ./protobufs/meshtastic/*.proto "${INDIR}"
 cp ./protobufs/nanopb.proto "${INDIR}"
 
 # OS-X sed is apparently a little different and expects an arg for -i
-if [[ ${OSTYPE} == darwin* ]]; then
+if [[ ${OSTYPE-} == darwin* ]]; then
 	SEDCMD=(sed -i '' -E)
 else
 	SEDCMD=(sed -i -E)
@@ -53,7 +53,8 @@ fi
 ./nanopb-0.4.8/generator-bin/protoc -I="${TMPDIR}/in" --python_out "${OUTDIR}" "--mypy_out=${PYIDIR}" "${INDIR}"/*.proto
 
 # Change "from meshtastic.protobuf import" to "from . import"
-"${SEDCMD[@]}" 's/^from meshtastic.protobuf import/from . import/' "${OUTDIR}"/meshtastic/protobuf/*pb2*.py[i]
+"${SEDCMD[@]}" 's/^from meshtastic.protobuf import/from . import/' "${OUTDIR}"/meshtastic/protobuf/*pb2*.py
+"${SEDCMD[@]}" 's/^from meshtastic.protobuf import/from . import/' "${OUTDIR}"/meshtastic/protobuf/*pb2*.pyi
 
 # Create a __init__.py in the out directory
 touch "${OUTDIR}/meshtastic/protobuf/__init__.py"

--- a/bin/regen-protobufs.sh
+++ b/bin/regen-protobufs.sh
@@ -8,7 +8,7 @@ set -e
 
 POETRYDIR=$(poetry env info --path)
 
-if [[ -z "${POETRYDIR}" ]]; then
+if [[ -z ${POETRYDIR} ]]; then
 	poetry install
 fi
 
@@ -19,9 +19,8 @@ source $(poetry env info --path)/bin/activate
 TMPDIR=./build/meshtastic/protofixup
 echo "Fixing up protobuf paths in ${TMPDIR} temp directory"
 
-
 # Ensure a clean build
-[ -e "${TMPDIR}" ] && rm -r "${TMPDIR}"
+[[ -e ${TMPDIR} ]] && rm -r "${TMPDIR}"
 
 INDIR=${TMPDIR}/in/meshtastic/protobuf
 OUTDIR=${TMPDIR}/out
@@ -31,25 +30,24 @@ cp ./protobufs/meshtastic/*.proto "${INDIR}"
 cp ./protobufs/nanopb.proto "${INDIR}"
 
 # OS-X sed is apparently a little different and expects an arg for -i
-if [[ $OSTYPE == 'darwin'* ]]; then
+if [[ ${OSTYPE} == 'darwin'* ]]; then
 	SEDCMD="sed -i '' -E"
 else
 	SEDCMD="sed -i -E"
 fi
 
-
 # change the package names to meshtastic.protobuf
-$SEDCMD 's/^package meshtastic;/package meshtastic.protobuf;/' "${INDIR}/"*.proto
+${SEDCMD} 's/^package meshtastic;/package meshtastic.protobuf;/' "${INDIR}/"*.proto
 # fix the imports to match
-$SEDCMD 's/^import "meshtastic\//import "meshtastic\/protobuf\//' "${INDIR}/"*.proto
+${SEDCMD} 's/^import "meshtastic\//import "meshtastic\/protobuf\//' "${INDIR}/"*.proto
 
-$SEDCMD 's/^import "nanopb.proto"/import "meshtastic\/protobuf\/nanopb.proto"/' "${INDIR}/"*.proto
+${SEDCMD} 's/^import "nanopb.proto"/import "meshtastic\/protobuf\/nanopb.proto"/' "${INDIR}/"*.proto
 
 # Generate the python files
-./nanopb-0.4.8/generator-bin/protoc -I=$TMPDIR/in --python_out "${OUTDIR}" "--mypy_out=${PYIDIR}" $INDIR/*.proto
+./nanopb-0.4.8/generator-bin/protoc -I="${TMPDIR}"/in --python_out "${OUTDIR}" "--mypy_out=${PYIDIR}" "${INDIR}"/*.proto
 
 # Change "from meshtastic.protobuf import" to "from . import"
-$SEDCMD 's/^from meshtastic.protobuf import/from . import/' "${OUTDIR}"/meshtastic/protobuf/*pb2*.py[i]
+${SEDCMD} 's/^from meshtastic.protobuf import/from . import/' "${OUTDIR}"/meshtastic/protobuf/*pb2*.py[i]
 
 # Create a __init__.py in the out directory
 touch "${OUTDIR}/meshtastic/protobuf/__init__.py"

--- a/bin/upload-release.sh
+++ b/bin/upload-release.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 rm dist/*
 set -e
 

--- a/bin/upload-release.sh
+++ b/bin/upload-release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-rm dist/*
 set -e
+rm -f dist/* 2>/dev/null || true
 
 poetry build
 poetry run pytest

--- a/bin/upload-release.sh
+++ b/bin/upload-release.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 set -e
-rm -f dist/* 2>/dev/null || true
+if [[ -d dist ]]; then
+	rm -f dist/*
+fi
 
 poetry build
 poetry run pytest

--- a/bin/upload-release.sh
+++ b/bin/upload-release.sh
@@ -3,6 +3,6 @@ set -e
 
 poetry build
 poetry run pytest
-poetry publish 
+poetry publish
 #python3 setup.py sdist bdist_wheel
 #python3 -m twine upload dist/*

--- a/examples/show_ports.py
+++ b/examples/show_ports.py
@@ -1,12 +1,17 @@
 """Simple program to show serial ports."""
 
+import logging
+
 from meshtastic.util import findPorts
 
+LOGGER = logging.getLogger(__name__)
 
-def main() -> None:
+
+def _main() -> None:
     """Print discovered serial ports for local debugging."""
-    print(findPorts())
+    LOGGER.info("Discovered ports: %s", findPorts())
 
 
 if __name__ == "__main__":
-    main()
+    logging.basicConfig(level=logging.INFO)
+    _main()

--- a/examples/show_ports.py
+++ b/examples/show_ports.py
@@ -1,5 +1,4 @@
-"""Simple program to show serial ports.
-"""
+"""Simple program to show serial ports."""
 
 from meshtastic.util import findPorts
 

--- a/examples/show_ports.py
+++ b/examples/show_ports.py
@@ -8,7 +8,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def _main() -> None:
-    """Print discovered serial ports for local debugging."""
+    """Log discovered serial ports for local debugging."""
     LOGGER.info("Discovered ports: %s", findPorts())
 
 

--- a/examples/show_ports.py
+++ b/examples/show_ports.py
@@ -2,4 +2,11 @@
 
 from meshtastic.util import findPorts
 
-print(findPorts())
+
+def main() -> None:
+    """Print discovered serial ports for local debugging."""
+    print(findPorts())
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tcp_gps_example.py
+++ b/examples/tcp_gps_example.py
@@ -21,11 +21,11 @@ def main() -> None:
                 logger.error(
                     "myInfo is not available - radio may not yet have joined a mesh."
                 )
-                return
+                sys.exit(1)
 
             if my_info.my_node_num <= 0:
                 logger.error("Local node has not joined the mesh yet.")
-                return
+                sys.exit(1)
 
             nodes_by_num = (
                 iface.nodesByNum if isinstance(iface.nodesByNum, dict) else {}
@@ -33,12 +33,12 @@ def main() -> None:
             node = nodes_by_num.get(my_info.my_node_num)
             if not isinstance(node, dict):
                 logger.error("Local node not found in node database yet.")
-                return
+                sys.exit(1)
 
             position = node.get("position")
             if position is None:
                 logger.error("Node has no position data yet.")
-                return
+                sys.exit(1)
 
             print(position)
     except OSError:

--- a/examples/tcp_gps_example.py
+++ b/examples/tcp_gps_example.py
@@ -8,12 +8,13 @@ import sys
 import meshtastic.tcp_interface
 
 RADIO_HOSTNAME = "meshtastic.local"  # Can also be an IP
+EXIT_SUCCESS = 0
 EXIT_FAILURE = 1
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def main() -> None:
+def main() -> int:
     """Connect to the configured TCP radio and print local node position when available."""
     try:
         with meshtastic.tcp_interface.TCPInterface(RADIO_HOSTNAME) as iface:
@@ -22,11 +23,11 @@ def main() -> None:
                 logger.error(
                     "myInfo is not available - radio may not yet have joined a mesh."
                 )
-                sys.exit(EXIT_FAILURE)
+                return EXIT_FAILURE
 
             if my_info.my_node_num <= 0:
                 logger.error("Local node has not joined the mesh yet.")
-                sys.exit(EXIT_FAILURE)
+                return EXIT_FAILURE
 
             nodes_by_num = (
                 iface.nodesByNum if isinstance(iface.nodesByNum, dict) else {}
@@ -34,18 +35,19 @@ def main() -> None:
             node = nodes_by_num.get(my_info.my_node_num)
             if not isinstance(node, dict):
                 logger.error("Local node not found in node database yet.")
-                sys.exit(EXIT_FAILURE)
+                return EXIT_FAILURE
 
             position = node.get("position")
             if position is None:
                 logger.error("Node has no position data yet.")
-                sys.exit(EXIT_FAILURE)
+                return EXIT_FAILURE
 
             print(position)
+            return EXIT_SUCCESS
     except OSError:
         logger.exception("Could not connect to %s", RADIO_HOSTNAME)
-        sys.exit(EXIT_FAILURE)
+        return EXIT_FAILURE
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/examples/tcp_gps_example.py
+++ b/examples/tcp_gps_example.py
@@ -18,7 +18,9 @@ def main() -> None:
         with meshtastic.tcp_interface.TCPInterface(RADIO_HOSTNAME) as iface:
             my_info = iface.myInfo
             if my_info is None:
-                logger.error("myInfo is not available - radio may not yet have joined a mesh.")
+                logger.error(
+                    "myInfo is not available - radio may not yet have joined a mesh."
+                )
                 return
 
             if my_info.my_node_num <= 0:

--- a/examples/tcp_gps_example.py
+++ b/examples/tcp_gps_example.py
@@ -8,6 +8,7 @@ import sys
 import meshtastic.tcp_interface
 
 RADIO_HOSTNAME = "meshtastic.local"  # Can also be an IP
+EXIT_FAILURE = 1
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
@@ -21,11 +22,11 @@ def main() -> None:
                 logger.error(
                     "myInfo is not available - radio may not yet have joined a mesh."
                 )
-                sys.exit(1)
+                sys.exit(EXIT_FAILURE)
 
             if my_info.my_node_num <= 0:
                 logger.error("Local node has not joined the mesh yet.")
-                sys.exit(1)
+                sys.exit(EXIT_FAILURE)
 
             nodes_by_num = (
                 iface.nodesByNum if isinstance(iface.nodesByNum, dict) else {}
@@ -33,17 +34,17 @@ def main() -> None:
             node = nodes_by_num.get(my_info.my_node_num)
             if not isinstance(node, dict):
                 logger.error("Local node not found in node database yet.")
-                sys.exit(1)
+                sys.exit(EXIT_FAILURE)
 
             position = node.get("position")
             if position is None:
                 logger.error("Node has no position data yet.")
-                sys.exit(1)
+                sys.exit(EXIT_FAILURE)
 
             print(position)
     except OSError:
         logger.exception("Could not connect to %s", RADIO_HOSTNAME)
-        sys.exit(1)
+        sys.exit(EXIT_FAILURE)
 
 
 if __name__ == "__main__":

--- a/meshtastic/__init__.py
+++ b/meshtastic/__init__.py
@@ -46,7 +46,7 @@ unicode scripts they can be different.
 ```
 import meshtastic
 import meshtastic.serial_interface
-from pubsub import pub  # type: ignore[import-untyped]
+from pubsub import pub  # type: ignore[import-untyped,unused-ignore]
 
 def onReceive(packet, interface): # called when a packet arrives
     print(f"Received: {packet}")
@@ -62,15 +62,15 @@ interface = meshtastic.serial_interface.SerialInterface()
 
 ```
 """
+
 # ruff: noqa: F401
 
 import copy
 import logging
 from importlib import import_module
-from typing import Any, Callable, NamedTuple, TypeGuard
+from typing import Any, Callable, NamedTuple, TypeGuard, cast
 
 from google.protobuf.json_format import MessageToJson
-from pubsub import pub
 
 from meshtastic.node import Node
 from meshtastic.util import (
@@ -95,6 +95,8 @@ from .protobuf import (
     storeforward_pb2,
     telemetry_pb2,
 )
+
+pub = cast(Any, import_module("pubsub.pub"))
 
 # Keep this module aligned with historical master behavior by intentionally not
 # defining __all__. Public names remain available as module attributes.
@@ -123,6 +125,7 @@ def __getattr__(name: str) -> Any:
     AttributeError
         If the requested attribute is not provided by this lazy loader.
     """
+    # COMPAT_STABLE_SHIM: preserve historical `meshtastic.serial` module access.
     if name == "serial":
         # Keep historical `meshtastic.serial` access, but map it to our
         # internal serial interface module (not the third-party pyserial module).

--- a/meshtastic/__init__.py
+++ b/meshtastic/__init__.py
@@ -105,7 +105,7 @@ pub = cast(Any, import_module("pubsub.pub"))
 def __getattr__(name: str) -> Any:
     """Provide lazy access to legacy module attributes.
 
-    When the attribute "serial" is requested, import the internal serial_interface
+    When the attribute "serial" is requested, import the third-party pyserial
     module, cache it on the module globals as "serial", and return it. For any
     other attribute, raise AttributeError.
 
@@ -118,7 +118,7 @@ def __getattr__(name: str) -> Any:
     -------
     Any
         The resolved module object for the requested legacy attribute
-        (e.g., the internal serial_interface for "serial").
+        (e.g., the third-party pyserial module for "serial").
 
     Raises
     ------
@@ -127,9 +127,9 @@ def __getattr__(name: str) -> Any:
     """
     # COMPAT_STABLE_SHIM: preserve historical `meshtastic.serial` module access.
     if name == "serial":
-        # Keep historical `meshtastic.serial` access, but map it to our
-        # internal serial interface module (not the third-party pyserial module).
-        serial_module = import_module(".serial_interface", __name__)
+        # Keep historical `meshtastic.serial` access to the third-party
+        # pyserial module as exposed on master.
+        serial_module = import_module("serial")
         # Cache in module namespace so subsequent accesses bypass __getattr__
         globals()["serial"] = serial_module
         return serial_module

--- a/meshtastic/__init__.py
+++ b/meshtastic/__init__.py
@@ -46,7 +46,7 @@ unicode scripts they can be different.
 ```
 import meshtastic
 import meshtastic.serial_interface
-from pubsub import pub  # type: ignore[import-untyped,unused-ignore]
+from pubsub import pub
 
 def onReceive(packet, interface): # called when a packet arrives
     print(f"Received: {packet}")

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -107,6 +107,7 @@ POWER_ON_BOOT_DELAY_SECONDS = 5.0
 MAIN_LOOP_IDLE_SLEEP_SECONDS = 1000
 
 
+# COMPAT_STABLE_SHIM: accept historical config field spellings.
 # Backward-compatible aliases for renamed config fields.
 _PREFERENCE_FIELD_ALIASES: dict[str, str] = {
     "display.use_12_hour": "display.use_12h_clock",

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -525,10 +525,9 @@ class ConnectionOrchestrator:
                         direct_err,
                         exc_info=True,
                     )
-                    skip_discovery_scan = (
-                        _looks_like_ble_address(target_address)
-                        and _is_device_not_found_error(direct_err)
-                    )
+                    skip_discovery_scan = _looks_like_ble_address(
+                        target_address
+                    ) and _is_device_not_found_error(direct_err)
                     if skip_discovery_scan:
                         logger.debug(
                             "Direct connect reported device-not-found for %s; skipping discovery scan and retrying explicit address connect.",

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -1014,9 +1014,7 @@ class BLEInterface(MeshInterface):
                         timeout=NOTIFICATION_START_TIMEOUT,
                     )
                 if attempt + 1 < max_attempts:
-                    _sleep(
-                        BLEConfig.SERVICE_CHARACTERISTIC_RETRY_DELAY * (attempt + 1)
-                    )
+                    _sleep(BLEConfig.SERVICE_CHARACTERISTIC_RETRY_DELAY * (attempt + 1))
                     continue
                 logger.warning(
                     "Unable to start FROMNUM notifications for %s after %d attempts due to BlueZ 'Notify acquired'; falling back to polling reads.",

--- a/meshtastic/interfaces/ble/state.py
+++ b/meshtastic/interfaces/ble/state.py
@@ -40,55 +40,53 @@ class BLEStateManager:
     for clearer connection management and reduced complexity.
     """
 
-    _VALID_TRANSITIONS: ClassVar[
-        dict[ConnectionState, frozenset[ConnectionState]]
-    ] = {
+    _VALID_TRANSITIONS: ClassVar[dict[ConnectionState, frozenset[ConnectionState]]] = {
         ConnectionState.DISCONNECTED: frozenset(
             {
-            ConnectionState.CONNECTING,
-            ConnectionState.ERROR,
-            # Note: DISCONNECTING is intentionally NOT allowed from DISCONNECTED.
-            # A disconnected interface cannot "begin disconnecting" - it's already disconnected.
-            # close() explicitly checks for DISCONNECTED state and skips the transition.
+                ConnectionState.CONNECTING,
+                ConnectionState.ERROR,
+                # Note: DISCONNECTING is intentionally NOT allowed from DISCONNECTED.
+                # A disconnected interface cannot "begin disconnecting" - it's already disconnected.
+                # close() explicitly checks for DISCONNECTED state and skips the transition.
             }
         ),
         ConnectionState.CONNECTING: frozenset(
             {
-            ConnectionState.CONNECTED,
-            ConnectionState.DISCONNECTING,
-            ConnectionState.ERROR,
-            ConnectionState.DISCONNECTED,
+                ConnectionState.CONNECTED,
+                ConnectionState.DISCONNECTING,
+                ConnectionState.ERROR,
+                ConnectionState.DISCONNECTED,
             }
         ),
         ConnectionState.CONNECTED: frozenset(
             {
-            ConnectionState.DISCONNECTING,
-            ConnectionState.RECONNECTING,
-            ConnectionState.DISCONNECTED,
-            ConnectionState.ERROR,
+                ConnectionState.DISCONNECTING,
+                ConnectionState.RECONNECTING,
+                ConnectionState.DISCONNECTED,
+                ConnectionState.ERROR,
             }
         ),
         ConnectionState.DISCONNECTING: frozenset(
             {
-            ConnectionState.DISCONNECTED,
-            ConnectionState.ERROR,
+                ConnectionState.DISCONNECTED,
+                ConnectionState.ERROR,
             }
         ),
         ConnectionState.RECONNECTING: frozenset(
             {
-            ConnectionState.CONNECTED,
-            ConnectionState.DISCONNECTING,
-            ConnectionState.CONNECTING,
-            ConnectionState.ERROR,
-            ConnectionState.DISCONNECTED,
+                ConnectionState.CONNECTED,
+                ConnectionState.DISCONNECTING,
+                ConnectionState.CONNECTING,
+                ConnectionState.ERROR,
+                ConnectionState.DISCONNECTED,
             }
         ),
         ConnectionState.ERROR: frozenset(
             {
-            ConnectionState.DISCONNECTED,
-            ConnectionState.DISCONNECTING,
-            ConnectionState.CONNECTING,
-            ConnectionState.RECONNECTING,
+                ConnectionState.DISCONNECTED,
+                ConnectionState.DISCONNECTING,
+                ConnectionState.CONNECTING,
+                ConnectionState.RECONNECTING,
             }
         ),
     }

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -1985,6 +1985,11 @@ class MeshInterface:  # pylint: disable=R0902
             self.currentPacketId = next_packet_id | random_part  # combine
             return self.currentPacketId
 
+    # COMPAT_STABLE_SHIM: historical private camelCase helper used by external integrations.
+    def _generatePacketId(self) -> int:
+        """Backward-compatible alias for `_generate_packet_id`."""
+        return self._generate_packet_id()
+
     def _disconnected(self) -> None:
         """Mark the interface as disconnected and publish meshtastic.connection.lost once per connection.
 

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -1751,6 +1751,26 @@ class MeshInterface:  # pylint: disable=R0902
             self._send_to_radio(toRadio)
         return meshPacket
 
+    # COMPAT_STABLE_SHIM: historical private camelCase helper used by external integrations.
+    def _sendPacket(
+        self,
+        meshPacket: mesh_pb2.MeshPacket,
+        destinationId: int | str = BROADCAST_ADDR,
+        wantAck: bool = False,
+        hopLimit: int | None = None,
+        pkiEncrypted: bool | None = False,
+        publicKey: bytes | None = None,
+    ) -> mesh_pb2.MeshPacket:
+        """Backward-compatible alias for `_send_packet`."""
+        return self._send_packet(
+            meshPacket=meshPacket,
+            destinationId=destinationId,
+            wantAck=wantAck,
+            hopLimit=hopLimit,
+            pkiEncrypted=pkiEncrypted,
+            publicKey=publicKey,
+        )
+
     def waitForConfig(self) -> None:
         """Block until the radio configuration and the local node's configuration are available.
 

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -1626,7 +1626,8 @@ class Node:
         if self != self.iface.localNode:
             self._raise_interface_error("startOTA only possible on local node")
 
-        # COMPAT_STABLE_SHIM: support legacy `hash=` keyword used by older callers.
+        # COMPAT_STABLE_SHIM: support legacy keyword aliases used by older callers:
+        # `ota_mode` -> `mode`, and `ota_hash`/`hash` -> `ota_file_hash`.
         legacy_hash = kwargs.pop("hash", None)
         if kwargs:
             unexpected = ", ".join(sorted(kwargs))
@@ -2127,7 +2128,9 @@ class Node:
             f"position_flags: {self.position_flags_list(c.position_flags)}"
         )
         if c.hw_model in mesh_pb2.HardwareModel.values():
-            self._emit_metadata_line(f"hw_model: {mesh_pb2.HardwareModel.Name(c.hw_model)}")
+            self._emit_metadata_line(
+                f"hw_model: {mesh_pb2.HardwareModel.Name(c.hw_model)}"
+            )
         else:
             self._emit_metadata_line(f"hw_model: {c.hw_model}")
         self._emit_metadata_line(f"hasPKC: {c.hasPKC}")

--- a/meshtastic/slog/__init__.py
+++ b/meshtastic/slog/__init__.py
@@ -1,5 +1,5 @@
 """Structured logging framework (see dev docs for more info)."""
 
-from .slog import LogSet, rootDir, root_dir
+from .slog import LogSet, root_dir, rootDir
 
 __all__ = ["LogSet", "rootDir", "root_dir"]

--- a/meshtastic/slog/arrow.py
+++ b/meshtastic/slog/arrow.py
@@ -1,11 +1,11 @@
 """Utilities for Apache Arrow serialization."""
 
-from copy import deepcopy
 import logging
 import os
 import tempfile
 import threading
 import types
+from copy import deepcopy
 
 import pyarrow as pa
 
@@ -356,7 +356,9 @@ class FeatherWriter(ArrowWriter):
                 conversion_succeeded = True
                 return
             if os.path.getsize(src_name) == 0:
-                self._discard_empty_source(src_name, dest_name, DISCARD_EMPTY_FILE_MESSAGE)
+                self._discard_empty_source(
+                    src_name, dest_name, DISCARD_EMPTY_FILE_MESSAGE
+                )
                 conversion_succeeded = True
                 return
 

--- a/meshtastic/slog/slog.py
+++ b/meshtastic/slog/slog.py
@@ -366,7 +366,8 @@ class PowerLogger:
         """Use `storeCurrentReading()` instead."""
         deprecation_warning_lock = getattr(self, "_deprecation_warning_lock", None)
         if deprecation_warning_lock is None:
-            deprecation_warning_lock = threading.Lock()
+            # Fall back to a shared lock for unusually-constructed test doubles.
+            deprecation_warning_lock = _warned_deprecations_lock
             self._deprecation_warning_lock = deprecation_warning_lock
         with deprecation_warning_lock:
             if not self._warned_store_current_reading_deprecation:

--- a/meshtastic/tcp_interface.py
+++ b/meshtastic/tcp_interface.py
@@ -14,7 +14,7 @@ import threading
 import time
 from typing import IO, Any, Callable
 
-from meshtastic.stream_interface import StreamInterface, WRITE_PROGRESS_TIMEOUT_SECONDS
+from meshtastic.stream_interface import WRITE_PROGRESS_TIMEOUT_SECONDS, StreamInterface
 
 DEFAULT_TCP_PORT = 4403
 logger = logging.getLogger(__name__)

--- a/meshtastic/tests/test_analysis.py
+++ b/meshtastic/tests/test_analysis.py
@@ -27,19 +27,19 @@ try:
     # Depends upon matplotlib & other packages in poetry's analysis group, not installed by default
     from meshtastic import powermon_pb2
     from meshtastic.analysis import __main__ as analysis_main
-    from meshtastic.protobuf import mesh_pb2
     from meshtastic.analysis.__main__ import (
-        choosePowerColumn,
         choose_power_column,
+        choosePowerColumn,
         create_argparser,
-        getBoardInfo,
         get_board_info,
-        getPmonRaises,
         get_pmon_raises,
+        getBoardInfo,
+        getPmonRaises,
         main,
         read_pandas,
         to_pmon_names,
     )
+    from meshtastic.protobuf import mesh_pb2
 
     # Import private function for testing
     _is_loopback_host = analysis_main._is_loopback_host

--- a/meshtastic/tests/test_init.py
+++ b/meshtastic/tests/test_init.py
@@ -218,12 +218,16 @@ def test_init_on_admin_receive_uses_sentinel_when_object_redaction_fails(
         @session_passkey.setter
         def session_passkey(self, _value: bytes) -> None:
             """Reject writes to simulate an immutable field."""
-            raise RuntimeError("session_passkey is read-only")  # noqa: TRY003 - intentional immutable sentinel
+            raise RuntimeError(
+                "session_passkey is read-only"
+            )  # noqa: TRY003 - intentional immutable sentinel
 
         def __delattr__(self, name: str) -> None:
             """Reject deletion of the session passkey attribute."""
             if name == "session_passkey":
-                raise RuntimeError("cannot delete session_passkey")  # noqa: TRY003 - intentional immutable sentinel
+                raise RuntimeError(
+                    "cannot delete session_passkey"
+                )  # noqa: TRY003 - intentional immutable sentinel
             super().__delattr__(name)
 
         def __deepcopy__(self, _memo: dict[int, Any]) -> "_UnredactableRaw":
@@ -259,7 +263,9 @@ def test_init_on_admin_receive_uses_delattr_fallback_when_assignment_fails(
 
         def __setattr__(self, name: str, value: Any) -> None:
             if name == "session_passkey" and hasattr(self, "session_passkey"):
-                raise RuntimeError("session_passkey is immutable")  # noqa: TRY003 - intentional test sentinel
+                raise RuntimeError(
+                    "session_passkey is immutable"
+                )  # noqa: TRY003 - intentional test sentinel
             object.__setattr__(self, name, value)
 
     iface = iface_with_nodes

--- a/meshtastic/tests/test_init.py
+++ b/meshtastic/tests/test_init.py
@@ -218,16 +218,12 @@ def test_init_on_admin_receive_uses_sentinel_when_object_redaction_fails(
         @session_passkey.setter
         def session_passkey(self, _value: bytes) -> None:
             """Reject writes to simulate an immutable field."""
-            raise RuntimeError(
-                "session_passkey is read-only"
-            )  # noqa: TRY003 - intentional immutable sentinel
+            raise RuntimeError("session_passkey is read-only")
 
         def __delattr__(self, name: str) -> None:
             """Reject deletion of the session passkey attribute."""
             if name == "session_passkey":
-                raise RuntimeError(
-                    "cannot delete session_passkey"
-                )  # noqa: TRY003 - intentional immutable sentinel
+                raise RuntimeError("cannot delete session_passkey")
             super().__delattr__(name)
 
         def __deepcopy__(self, _memo: dict[int, Any]) -> "_UnredactableRaw":
@@ -263,9 +259,7 @@ def test_init_on_admin_receive_uses_delattr_fallback_when_assignment_fails(
 
         def __setattr__(self, name: str, value: Any) -> None:
             if name == "session_passkey" and hasattr(self, "session_passkey"):
-                raise RuntimeError(
-                    "session_passkey is immutable"
-                )  # noqa: TRY003 - intentional test sentinel
+                raise RuntimeError("session_passkey is immutable")
             object.__setattr__(self, name, value)
 
     iface = iface_with_nodes

--- a/meshtastic/tests/test_init.py
+++ b/meshtastic/tests/test_init.py
@@ -7,6 +7,7 @@ from typing import Any
 from unittest.mock import create_autospec
 
 import pytest
+import serial as pyserial  # type: ignore[import-untyped]
 
 import meshtastic
 from meshtastic import (
@@ -17,7 +18,6 @@ from meshtastic import (
     _on_text_receive,
     _receive_info_update,
     mt_config,
-    serial_interface,
 )
 
 from ..mesh_interface import MeshInterface
@@ -25,12 +25,12 @@ from ..serial_interface import SerialInterface
 
 
 @pytest.mark.unit
-def test_init_serial_alias_points_to_internal_module(
+def test_init_serial_alias_points_to_pyserial_module(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Verify meshtastic.serial resolves to the internal serial_interface module."""
+    """Verify meshtastic.serial resolves to the third-party pyserial module."""
     monkeypatch.delattr(meshtastic, "serial", raising=False)
-    assert meshtastic.serial is serial_interface
+    assert meshtastic.serial is pyserial
 
 
 @pytest.mark.unit
@@ -451,9 +451,9 @@ def test_init_getattr_caches_serial_on_first_access(
 
     # First access should trigger lazy load.
     serial = meshtastic.serial
-    assert serial is serial_interface
+    assert serial is pyserial
 
     # Second access should use cached value.
     serial2 = meshtastic.serial
     assert serial2 is serial
-    assert serial2 is serial_interface
+    assert serial2 is pyserial

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -19,8 +19,8 @@ import yaml
 import meshtastic.__main__ as main_module
 from meshtastic import mt_config
 from meshtastic.__main__ import (
-    _normalize_pref_name,
     _create_power_meter,
+    _normalize_pref_name,
     _parse_host_port,
     _prefix_base64_key,
     _set_missing_flags_false,
@@ -4536,7 +4536,7 @@ def test_create_power_meter_sleeps_after_power_on_when_not_waiting(
     monkeypatch.setattr(main_module, "SimPowerSupply", lambda: fake_meter)
     monkeypatch.setattr(mt_config, "args", args)
     sleep_mock = MagicMock()
-    monkeypatch.setattr(main_module.time, "sleep", sleep_mock)
+    monkeypatch.setattr(main_module.time, "sleep", sleep_mock)  # type: ignore[attr-defined]
 
     _create_power_meter()
 

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -2387,9 +2387,11 @@ def test_handle_packet_from_radio_toid_warning_and_response_handler_paths(
             on_receive_calls.append(1)
 
         def _raising_callback(_packet: dict[str, Any]) -> None:
-            raise RuntimeError("handler boom")  # noqa: TRY003 - intentional test sentinel
+            raise RuntimeError(
+                "handler boom"
+            )  # noqa: TRY003 - intentional test sentinel
 
-        def _on_ack_nak(_packet: dict[str, Any]) -> None:
+        def onAckNak(_packet: dict[str, Any]) -> None:  # noqa: N802
             on_ack_calls.append(1)
 
         def _ack_permitted_callback(_packet: dict[str, Any]) -> None:
@@ -2427,7 +2429,7 @@ def test_handle_packet_from_radio_toid_warning_and_response_handler_paths(
         p2.decoded.payload = routing.SerializeToString()
         p2.decoded.request_id = 78
         iface.responseHandlers[78] = ResponseHandler(
-            callback=_on_ack_nak, ackPermitted=False
+            callback=onAckNak, ackPermitted=False
         )
         iface._handle_packet_from_radio(p2, hack=True)
 

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -57,9 +57,9 @@ def test_mesh_interface_import_handles_missing_print_color(
         level: int = 0,
     ) -> Any:
         if name == "print_color":
-            raise ImportError(
+            raise ImportError(  # noqa: TRY003 - intentional test sentinel
                 "simulated missing print_color"
-            ) from None  # noqa: TRY003 - intentional test sentinel
+            ) from None
         return real_import(name, globals_dict, locals_dict, from_list, level)
 
     monkeypatch.setattr(builtins, "__import__", _import_with_print_color_failure)
@@ -872,14 +872,17 @@ def test_getRingtone() -> None:
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_generatePacketId() -> None:
-    """Test _generate_packet_id() when no currentPacketId (not connected)."""
+    """Test packet-id generation helpers when no currentPacketId (not connected)."""
     with MeshInterface(noProto=True) as iface:
         # not sure when this condition would ever happen... but we can simulate it
         iface.currentPacketId = None  # type: ignore[assignment]
         assert iface.currentPacketId is None
         with pytest.raises(MeshInterface.MeshInterfaceError) as excinfo:
             iface._generate_packet_id()
+        with pytest.raises(MeshInterface.MeshInterfaceError) as excinfo_alias:
+            iface._generatePacketId()
     assert "Not connected yet, can not generate packet" in str(excinfo.value)
+    assert "Not connected yet, can not generate packet" in str(excinfo_alias.value)
 
 
 @pytest.mark.unit
@@ -1093,6 +1096,7 @@ def test_timeago() -> None:
     assert _timeago(-999) == "now"
 
 
+@pytest.mark.unit
 @given(seconds=st.integers())
 def test_timeago_fuzz(seconds: int) -> None:
     """Fuzz _timeago to ensure it works with any integer."""
@@ -1775,7 +1779,7 @@ def test_send_telemetry_supported_and_fallback_paths(
         monkeypatch.setattr(
             iface,
             "sendData",
-            lambda payload, *args, **kwargs: telemetry_calls.append((payload, kwargs)),
+            lambda payload, *_args, **kwargs: telemetry_calls.append((payload, kwargs)),
         )
         wait_for_telemetry = MagicMock()
         monkeypatch.setattr(iface, "waitForTelemetry", wait_for_telemetry)
@@ -2383,9 +2387,9 @@ def test_handle_packet_from_radio_toid_warning_and_response_handler_paths(
             on_receive_calls.append(1)
 
         def _raising_callback(_packet: dict[str, Any]) -> None:
-            raise RuntimeError("handler boom")
+            raise RuntimeError("handler boom")  # noqa: TRY003 - intentional test sentinel
 
-        def onAckNak(_packet: dict[str, Any]) -> None:
+        def _on_ack_nak(_packet: dict[str, Any]) -> None:
             on_ack_calls.append(1)
 
         def _ack_permitted_callback(_packet: dict[str, Any]) -> None:
@@ -2423,7 +2427,7 @@ def test_handle_packet_from_radio_toid_warning_and_response_handler_paths(
         p2.decoded.payload = routing.SerializeToString()
         p2.decoded.request_id = 78
         iface.responseHandlers[78] = ResponseHandler(
-            callback=onAckNak, ackPermitted=False
+            callback=_on_ack_nak, ackPermitted=False
         )
         iface._handle_packet_from_radio(p2, hack=True)
 

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -12,7 +12,7 @@ import time
 import types
 from collections import OrderedDict
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, cast
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
@@ -1451,7 +1451,7 @@ def test_init_subscribes_log_line_when_debug_output_enabled(
     with MeshInterface(noProto=True, debugOut=io.StringIO()):
         pass
 
-    assert subscribed == [(MeshInterface._print_log_line, "meshtastic.log.line")]
+    assert (MeshInterface._print_log_line, "meshtastic.log.line") in subscribed
 
 
 @pytest.mark.unit
@@ -1524,19 +1524,29 @@ def test_show_info_includes_metadata_summary() -> None:
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-def test_show_nodes_nested_value_helper_paths() -> None:
-    """Extract _get_nested_value closure from showNodes and exercise non-dict/single-level paths."""
-    code_obj = next(
-        const
-        for const in MeshInterface.showNodes.__code__.co_consts
-        if isinstance(const, types.CodeType) and const.co_name == "_get_nested_value"
-    )
-    get_nested_value = cast(Callable[[Any, str], Any], types.FunctionType(code_obj, {}))
+def test_show_nodes_handles_single_level_and_missing_nested_fields(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """showNodes() should handle single-level keys and missing nested paths without introspecting internals."""
+    with MeshInterface(noProto=True) as iface:
+        iface.nodesByNum = {
+            1: {
+                "num": 1,
+                "shortName": "N1",
+                "user": {"id": "!00000001"},
+            }
+        }
+        iface.nodes = {"!00000001": iface.nodesByNum[1]}
+        iface.localNode.nodeNum = 999
+        table = iface.showNodes(
+            showFields=["shortName", "user.id", "missing.path", "position.latitude"]
+        )
+        _ = capsys.readouterr()
 
-    # pylint: disable=not-callable
-    assert get_nested_value("not-a-dict", "user.id") is None
-    assert get_nested_value({"shortName": "N1"}, "shortName") == "N1"
-    # pylint: enable=not-callable
+    assert "shortName" in table
+    assert "N1" in table
+    assert "!00000001" in table
+    assert "N/A" in table
 
 
 @pytest.mark.unit
@@ -1817,6 +1827,8 @@ def test_send_telemetry_supported_and_fallback_paths(
         iface.sendTelemetry(telemetryType="device_metrics")
         with pytest.warns(DeprecationWarning):
             iface.sendTelemetry(telemetryType="invalid")
+        with pytest.warns(DeprecationWarning):
+            iface.sendTelemetry(telemetryType="invalid2")
         iface.sendTelemetry(telemetryType="device_metrics", wantResponse=True)
 
     assert telemetry_calls[0][0].HasField("environment_metrics")
@@ -1825,7 +1837,8 @@ def test_send_telemetry_supported_and_fallback_paths(
     assert telemetry_calls[3][0].HasField("local_stats")
     assert telemetry_calls[4][0].HasField("device_metrics")
     assert telemetry_calls[5][0].HasField("device_metrics")
-    assert telemetry_calls[6][1]["onResponse"] is not None
+    assert telemetry_calls[6][0].HasField("device_metrics")
+    assert telemetry_calls[7][1]["onResponse"] is not None
     wait_for_telemetry.assert_called_once()
 
 

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -1,5 +1,7 @@
 """Meshtastic unit tests for mesh_interface.py."""
 
+# pylint: disable=too-many-lines
+
 import builtins
 import importlib.util
 import io
@@ -10,7 +12,7 @@ import time
 import types
 from collections import OrderedDict
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable, cast
 from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
@@ -55,7 +57,9 @@ def test_mesh_interface_import_handles_missing_print_color(
         level: int = 0,
     ) -> Any:
         if name == "print_color":
-            raise ImportError("simulated missing print_color") from None  # noqa: TRY003 - intentional test sentinel
+            raise ImportError(
+                "simulated missing print_color"
+            ) from None  # noqa: TRY003 - intentional test sentinel
         return real_import(name, globals_dict, locals_dict, from_list, level)
 
     monkeypatch.setattr(builtins, "__import__", _import_with_print_color_failure)
@@ -1408,7 +1412,11 @@ def test_init_subscribes_log_line_when_debug_output_enabled(
     def _subscribe(handler: Any, topic: str) -> None:
         subscribed.append((handler, topic))
 
-    monkeypatch.setattr(mesh_interface_module.pub, "subscribe", _subscribe)
+    monkeypatch.setattr(
+        mesh_interface_module.pub,  # type: ignore[attr-defined]
+        "subscribe",
+        _subscribe,
+    )
 
     with MeshInterface(noProto=True, debugOut=io.StringIO()):
         pass
@@ -1447,7 +1455,7 @@ def test_print_log_line_and_record_handlers(monkeypatch: pytest.MonkeyPatch) -> 
     MeshInterface._print_log_line("callable", interface)
     assert captured_callable == ["callable"]
 
-    interface.debugOut = mesh_interface_module.sys.stdout
+    interface.debugOut = mesh_interface_module.sys.stdout  # type: ignore[attr-defined]
     MeshInterface._print_log_line("DEBUG log", interface)
     MeshInterface._print_log_line("INFO log", interface)
     MeshInterface._print_log_line("WARN log", interface)
@@ -1460,7 +1468,7 @@ def test_print_log_line_and_record_handlers(monkeypatch: pytest.MonkeyPatch) -> 
 
     sent_lines: list[str] = []
     monkeypatch.setattr(
-        mesh_interface_module.pub,
+        mesh_interface_module.pub,  # type: ignore[attr-defined]
         "sendMessage",
         lambda _topic, **kwargs: sent_lines.append(kwargs["line"]),
     )
@@ -1493,10 +1501,12 @@ def test_show_nodes_nested_value_helper_paths() -> None:
         for const in MeshInterface.showNodes.__code__.co_consts
         if isinstance(const, types.CodeType) and const.co_name == "_get_nested_value"
     )
-    get_nested_value = types.FunctionType(code_obj, {})
+    get_nested_value = cast(Callable[[Any, str], Any], types.FunctionType(code_obj, {}))
 
+    # pylint: disable=not-callable
     assert get_nested_value("not-a-dict", "user.id") is None
     assert get_nested_value({"shortName": "N1"}, "shortName") == "N1"
+    # pylint: enable=not-callable
 
 
 @pytest.mark.unit
@@ -1545,9 +1555,11 @@ def test_get_node_resets_retry_budget_on_new_channel_progress() -> None:
             self.wait_calls = 0
 
         def requestChannels(self, startingIndex: int = 0) -> None:
+            """Track channel request starting indexes."""
             self.request_calls.append(startingIndex)
 
         def waitForConfig(self) -> bool:
+            """Return False once before succeeding to simulate partial progress."""
             self.wait_calls += 1
             if self.wait_calls == 1:
                 self.partialChannels = [1]
@@ -1559,7 +1571,7 @@ def test_get_node_resets_retry_budget_on_new_channel_progress() -> None:
         with patch("meshtastic.node.Node", return_value=fake_node):
             result = iface.getNode("!00112233", requestChannelAttempts=2)
 
-    assert result is fake_node
+    assert cast(Any, result) is fake_node
     assert fake_node.request_calls == [0, 1]
 
 
@@ -1586,9 +1598,7 @@ def test_send_alert_and_mqtt_proxy_paths(monkeypatch: pytest.MonkeyPatch) -> Non
         assert send_args.kwargs["priority"] == mesh_pb2.MeshPacket.Priority.ALERT
 
         sent_to_radio: list[mesh_pb2.ToRadio] = []
-        monkeypatch.setattr(
-            iface, "_send_to_radio", lambda msg: sent_to_radio.append(msg)
-        )
+        monkeypatch.setattr(iface, "_send_to_radio", sent_to_radio.append)
         iface.sendMqttClientProxyMessage("mesh/topic", b"payload")
 
         assert sent_to_radio
@@ -1624,7 +1634,11 @@ def test_send_position_waits_when_response_requested(
             wantResponse=True,
         )
 
-        assert send_data.call_args.kwargs["onResponse"] == iface.onResponsePosition
+        on_response = send_data.call_args.kwargs["onResponse"]
+        assert getattr(on_response, "__self__", None) is iface
+        assert (
+            getattr(on_response, "__func__", None) is MeshInterface.onResponsePosition
+        )
         wait_for_position.assert_called_once()
 
 
@@ -1772,7 +1786,7 @@ def test_send_telemetry_supported_and_fallback_paths(
         iface.sendTelemetry(telemetryType="local_stats")
         iface.sendTelemetry(telemetryType="device_metrics")
         with pytest.warns(DeprecationWarning):
-            iface.sendTelemetry(telemetryType="invalid")  # type: ignore[arg-type]
+            iface.sendTelemetry(telemetryType="invalid")
         iface.sendTelemetry(telemetryType="device_metrics", wantResponse=True)
 
     assert telemetry_calls[0][0].HasField("environment_metrics")
@@ -1882,14 +1896,16 @@ def test_send_and_delete_waypoint_response_paths(
         monkeypatch.setattr(iface, "waitForWaypoint", wait_for_waypoint)
 
         def _capture_send_data(
-            payload: mesh_pb2.Waypoint, *args: Any, **kwargs: Any
+            payload: mesh_pb2.Waypoint, *_args: Any, **_kwargs: Any
         ) -> mesh_pb2.MeshPacket:
             sent_payloads.append(payload)
             return mesh_pb2.MeshPacket()
 
         monkeypatch.setattr(iface, "sendData", _capture_send_data)
         monkeypatch.setattr(
-            mesh_interface_module.secrets, "randbits", lambda _n: (1 << 32) - 1
+            mesh_interface_module.secrets,  # type: ignore[attr-defined]
+            "randbits",
+            lambda _n: (1 << 32) - 1,
         )
 
         iface.sendWaypoint(
@@ -1933,7 +1949,7 @@ def test_send_packet_calls_transport_when_proto_enabled(
         iface.myInfo = MagicMock()
         iface.myInfo.my_node_num = 1
         sent: list[mesh_pb2.ToRadio] = []
-        monkeypatch.setattr(iface, "_send_to_radio", lambda msg: sent.append(msg))
+        monkeypatch.setattr(iface, "_send_to_radio", sent.append)
         iface._send_packet(mesh_pb2.MeshPacket(), destinationId=1)
         assert sent
 
@@ -1967,10 +1983,11 @@ def test_wait_helpers_raise_expected_timeout_errors() -> None:
 def test_public_key_and_optional_getters_none_paths(
     iface_with_nodes: MeshInterface,
 ) -> None:
-    """getPublicKey should return user key while optional local-node getters return None when absent."""
+    """GetPublicKey should return user key while optional local-node getters return None when absent."""
     iface = iface_with_nodes
     assert iface.myInfo is not None
     iface.myInfo.my_node_num = 2475227164
+    assert iface.nodesByNum is not None
     node = iface.nodesByNum[2475227164]
     node["user"]["publicKey"] = b"abc"
     assert iface.getPublicKey() == b"abc"
@@ -1992,7 +2009,7 @@ def test_send_heartbeat_builds_to_radio_heartbeat(
     """sendHeartbeat() should send a ToRadio with heartbeat field populated."""
     with MeshInterface(noProto=True) as iface:
         sent: list[mesh_pb2.ToRadio] = []
-        monkeypatch.setattr(iface, "_send_to_radio", lambda msg: sent.append(msg))
+        monkeypatch.setattr(iface, "_send_to_radio", sent.append)
         iface.sendHeartbeat()
         assert sent[0].HasField("heartbeat")
 
@@ -2005,12 +2022,12 @@ def test_start_config_skips_reserved_nodeless_id(
     """_start_config() should bump generated config id if it equals NODELESS_WANT_CONFIG_ID."""
     with MeshInterface(noProto=True) as iface:
         monkeypatch.setattr(
-            mesh_interface_module.random,
+            mesh_interface_module.random,  # type: ignore[attr-defined]
             "randint",
             lambda _a, _b: NODELESS_WANT_CONFIG_ID,
         )
         sent: list[mesh_pb2.ToRadio] = []
-        monkeypatch.setattr(iface, "_send_to_radio", lambda msg: sent.append(msg))
+        monkeypatch.setattr(iface, "_send_to_radio", sent.append)
         iface._start_config()
     assert iface.configId == NODELESS_WANT_CONFIG_ID + 1
     assert sent[0].want_config_id == NODELESS_WANT_CONFIG_ID + 1
@@ -2072,7 +2089,11 @@ def test_send_to_radio_waits_resends_and_tracks_requeue(
             assert iface.queueStatus is not None
             iface.queueStatus.free = 10
 
-        monkeypatch.setattr(mesh_interface_module.time, "sleep", _sleep_and_free)
+        monkeypatch.setattr(
+            mesh_interface_module.time,  # type: ignore[attr-defined]
+            "sleep",
+            _sleep_and_free,
+        )
 
         with caplog.at_level(logging.DEBUG):
             iface._send_to_radio(incoming)
@@ -2085,7 +2106,7 @@ def test_send_to_radio_waits_resends_and_tracks_requeue(
         def __bool__(self) -> bool:
             return False
 
-        def pop(
+        def pop(  # type: ignore[override]
             self, key: int, default: mesh_pb2.ToRadio | bool = False
         ) -> mesh_pb2.ToRadio | bool:
             if key == 123:
@@ -2123,17 +2144,17 @@ def test_handle_config_complete_and_queue_status_branches() -> None:
         queued.packet.id = 111
         iface.queue[111] = queued
 
-        status_hit = mesh_pb2.QueueStatus(free=1, maxlen=4, res=False, mesh_packet_id=111)
+        status_hit = mesh_pb2.QueueStatus(free=1, maxlen=4, res=0, mesh_packet_id=111)
         iface._handle_queue_status_from_radio(status_hit)
         assert 111 not in iface.queue
 
         status_unexpected = mesh_pb2.QueueStatus(
-            free=1, maxlen=4, res=False, mesh_packet_id=222
+            free=1, maxlen=4, res=0, mesh_packet_id=222
         )
         iface._handle_queue_status_from_radio(status_unexpected)
         assert iface.queue[222] is False
 
-        status_res = mesh_pb2.QueueStatus(free=1, maxlen=4, res=True, mesh_packet_id=222)
+        status_res = mesh_pb2.QueueStatus(free=1, maxlen=4, res=1, mesh_packet_id=222)
         iface._handle_queue_status_from_radio(status_res)
         assert iface.queue[222] is False
 
@@ -2147,10 +2168,12 @@ def test_handle_from_radio_branch_matrix(
     """_handle_from_radio() should handle metadata/node-info and non-config branch dispatch paths."""
     published_topics: list[str] = []
     monkeypatch.setattr(
-        mesh_interface_module.publishingThread, "queueWork", lambda callback: callback()
+        mesh_interface_module.publishingThread,  # type: ignore[attr-defined]
+        "queueWork",
+        lambda callback: callback(),
     )
     monkeypatch.setattr(
-        mesh_interface_module.pub,
+        mesh_interface_module.pub,  # type: ignore[attr-defined]
         "sendMessage",
         lambda topic, **_kwargs: published_topics.append(topic),
     )
@@ -2182,7 +2205,9 @@ def test_handle_from_radio_branch_matrix(
         monkeypatch.setattr(iface, "_handle_channel", handle_channel)
         monkeypatch.setattr(iface, "_handle_packet_from_radio", handle_packet)
         monkeypatch.setattr(iface, "_handle_log_record", handle_log_record)
-        monkeypatch.setattr(iface, "_handle_queue_status_from_radio", handle_queue_status)
+        monkeypatch.setattr(
+            iface, "_handle_queue_status_from_radio", handle_queue_status
+        )
 
         config_complete_msg = mesh_pb2.FromRadio()
         assert iface.configId is not None
@@ -2220,7 +2245,7 @@ def test_handle_from_radio_branch_matrix(
         iface._handle_from_radio(mqtt_msg.SerializeToString())
 
         xmodem_msg = mesh_pb2.FromRadio()
-        xmodem_msg.xmodemPacket.control = 1
+        xmodem_msg.xmodemPacket.control = cast(Any, 1)
         iface._handle_from_radio(xmodem_msg.SerializeToString())
 
         disconnected_calls: list[int] = []
@@ -2282,13 +2307,13 @@ def test_handle_from_radio_config_and_module_config_branches() -> None:
             msg = mesh_pb2.FromRadio()
             getattr(msg.config, field).SetInParent()
             iface._handle_from_radio(msg.SerializeToString())
-            assert iface.localNode.localConfig.HasField(field)
+            assert iface.localNode.localConfig.HasField(cast(Any, field))
 
         for field in module_fields:
             msg = mesh_pb2.FromRadio()
             getattr(msg.moduleConfig, field).SetInParent()
             iface._handle_from_radio(msg.SerializeToString())
-            assert iface.localNode.moduleConfig.HasField(field)
+            assert iface.localNode.moduleConfig.HasField(cast(Any, field))
 
 
 @pytest.mark.unit
@@ -2332,7 +2357,9 @@ def test_handle_packet_from_radio_toid_warning_and_response_handler_paths(
 ) -> None:
     """_handle_packet_from_radio() should log toId failures and execute protobuf/response-handler paths."""
     monkeypatch.setattr(
-        mesh_interface_module.publishingThread, "queueWork", lambda callback: callback()
+        mesh_interface_module.publishingThread,  # type: ignore[attr-defined]
+        "queueWork",
+        lambda callback: callback(),
     )
 
     with MeshInterface(noProto=True) as iface:

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -678,6 +678,19 @@ def test_sendPacket_with_destination_as_int(caplog: pytest.LogCaptureFixture) ->
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+def test_sendPacket_alias_with_destination_as_int(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test _sendPacket() compatibility alias delegates to _send_packet()."""
+    with MeshInterface(noProto=True) as iface:
+        with caplog.at_level(logging.DEBUG):
+            meshPacket = mesh_pb2.MeshPacket()
+            iface._sendPacket(meshPacket, destinationId=123)
+            assert re.search(r"Not sending packet", caplog.text, re.MULTILINE)
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
 def test_sendPacket_with_destination_starting_with_a_bang(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -883,6 +896,19 @@ def test_generatePacketId() -> None:
             iface._generatePacketId()
     assert "Not connected yet, can not generate packet" in str(excinfo.value)
     assert "Not connected yet, can not generate packet" in str(excinfo_alias.value)
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_sendPacket_alias_with_no_destination() -> None:
+    """Test _sendPacket() alias raises MeshInterfaceError when destinationId is None."""
+    with MeshInterface(noProto=True) as iface:
+        with pytest.raises(
+            MeshInterface.MeshInterfaceError,
+            match="destinationId must not be None",
+        ):
+            mesh_packet = mesh_pb2.MeshPacket()
+            iface._sendPacket(mesh_packet, destinationId=None)  # type: ignore[arg-type]
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -2413,9 +2413,9 @@ def test_handle_packet_from_radio_toid_warning_and_response_handler_paths(
             on_receive_calls.append(1)
 
         def _raising_callback(_packet: dict[str, Any]) -> None:
-            raise RuntimeError(
+            raise RuntimeError(  # noqa: TRY003 - intentional test sentinel
                 "handler boom"
-            )  # noqa: TRY003 - intentional test sentinel
+            )
 
         def onAckNak(_packet: dict[str, Any]) -> None:  # noqa: N802
             on_ack_calls.append(1)

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -6,6 +6,8 @@ import io
 import logging
 import re
 import threading
+import time
+import types
 from collections import OrderedDict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -17,10 +19,10 @@ from hypothesis import strategies as st
 
 import meshtastic.mesh_interface as mesh_interface_module
 
-from .. import BROADCAST_ADDR, LOCAL_ADDR
+from .. import BROADCAST_ADDR, LOCAL_ADDR, NODELESS_WANT_CONFIG_ID, ResponseHandler
 from ..mesh_interface import MeshInterface, _timeago
 from ..node import Node
-from ..protobuf import channel_pb2, config_pb2, mesh_pb2, portnums_pb2
+from ..protobuf import channel_pb2, config_pb2, mesh_pb2, portnums_pb2, telemetry_pb2
 
 # TODO
 # from ..config import Config
@@ -1393,3 +1395,1022 @@ def test_concurrent_sendText_with_queue() -> None:
             t.join()
 
         assert len(errors) == 0
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_init_subscribes_log_line_when_debug_output_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MeshInterface should subscribe log-line printing when debugOut is provided."""
+    subscribed: list[tuple[Any, str]] = []
+
+    def _subscribe(handler: Any, topic: str) -> None:
+        subscribed.append((handler, topic))
+
+    monkeypatch.setattr(mesh_interface_module.pub, "subscribe", _subscribe)
+
+    with MeshInterface(noProto=True, debugOut=io.StringIO()):
+        pass
+
+    assert subscribed == [(MeshInterface._print_log_line, "meshtastic.log.line")]
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_exit_close_failure_paths(caplog: pytest.LogCaptureFixture) -> None:
+    """__exit__ should suppress close() failures only while unwinding another exception."""
+    iface = MeshInterface(noProto=True)
+    iface.close = MagicMock(side_effect=RuntimeError("close failed"))  # type: ignore[method-assign]
+
+    with caplog.at_level(logging.WARNING):
+        iface.__exit__(ValueError, ValueError("inner"), None)
+    assert "close() failed while unwinding an existing exception." in caplog.text
+
+    with pytest.raises(RuntimeError, match="close failed"):
+        iface.__exit__(None, None, None)
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_print_log_line_and_record_handlers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_print_log_line should route by output type and _handle_log_* should normalize output."""
+    color_printer = MagicMock()
+    monkeypatch.setattr(mesh_interface_module, "print_color", color_printer)
+
+    interface = types.SimpleNamespace(debugOut=io.StringIO())
+    MeshInterface._print_log_line("message", interface)
+    assert interface.debugOut.getvalue().strip() == "message"
+
+    captured_callable: list[str] = []
+    interface.debugOut = captured_callable.append
+    MeshInterface._print_log_line("callable", interface)
+    assert captured_callable == ["callable"]
+
+    interface.debugOut = mesh_interface_module.sys.stdout
+    MeshInterface._print_log_line("DEBUG log", interface)
+    MeshInterface._print_log_line("INFO log", interface)
+    MeshInterface._print_log_line("WARN log", interface)
+    MeshInterface._print_log_line("ERR log", interface)
+    MeshInterface._print_log_line("OTHER log", interface)
+    assert color_printer.print.call_args_list[0].kwargs["color"] == "cyan"
+    assert color_printer.print.call_args_list[1].kwargs["color"] == "white"
+    assert color_printer.print.call_args_list[2].kwargs["color"] == "yellow"
+    assert color_printer.print.call_args_list[3].kwargs["color"] == "red"
+
+    sent_lines: list[str] = []
+    monkeypatch.setattr(
+        mesh_interface_module.pub,
+        "sendMessage",
+        lambda _topic, **kwargs: sent_lines.append(kwargs["line"]),
+    )
+    with MeshInterface(noProto=True) as iface:
+        iface._handle_log_line("line-with-newline\n")
+        record = mesh_pb2.LogRecord()
+        record.message = "record-line\n"
+        iface._handle_log_record(record)
+
+    assert sent_lines == ["line-with-newline", "record-line"]
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_show_info_includes_metadata_summary() -> None:
+    """showInfo() should include metadata output when metadata is present."""
+    with MeshInterface(noProto=True) as iface:
+        iface.metadata = mesh_pb2.DeviceMetadata(firmware_version="2.7.18")
+        summary = iface.showInfo(file=io.StringIO())
+
+    assert "Metadata:" in summary
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_show_nodes_nested_value_helper_paths() -> None:
+    """Extract _get_nested_value closure from showNodes and exercise non-dict/single-level paths."""
+    code_obj = next(
+        const
+        for const in MeshInterface.showNodes.__code__.co_consts
+        if isinstance(const, types.CodeType) and const.co_name == "_get_nested_value"
+    )
+    get_nested_value = types.FunctionType(code_obj, {})
+
+    assert get_nested_value("not-a-dict", "user.id") is None
+    assert get_nested_value({"shortName": "N1"}, "shortName") == "N1"
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_show_nodes_formats_powered_battery_and_future_since(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """showNodes() should render battery sentinel values and future timestamps safely."""
+    future_ts = int(time.time()) + 600
+    with MeshInterface(noProto=True) as iface:
+        iface.nodesByNum = {
+            1: {
+                "num": 1,
+                "user": {
+                    "id": "!00000001",
+                    "longName": "Node1",
+                    "shortName": "N1",
+                    "hwModel": "UNSET",
+                    "publicKey": "x",
+                    "role": "CLIENT",
+                },
+                "deviceMetrics": {"batteryLevel": 101},
+                "lastHeard": future_ts,
+            }
+        }
+        iface.nodes = {"!00000001": iface.nodesByNum[1]}
+        iface.localNode.nodeNum = 999
+        table = iface.showNodes(
+            showFields=["deviceMetrics.batteryLevel", "since", "user.id"]
+        )
+        _ = capsys.readouterr()
+
+    assert "Powered" in table
+    assert "N/A" in table
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_get_node_resets_retry_budget_on_new_channel_progress() -> None:
+    """getNode() should reset retry countdown when partial channel progress is observed."""
+
+    class _FakeNode:
+        def __init__(self) -> None:
+            self.partialChannels: list[int] = []
+            self.request_calls: list[int] = []
+            self.wait_calls = 0
+
+        def requestChannels(self, startingIndex: int = 0) -> None:
+            self.request_calls.append(startingIndex)
+
+        def waitForConfig(self) -> bool:
+            self.wait_calls += 1
+            if self.wait_calls == 1:
+                self.partialChannels = [1]
+                return False
+            return True
+
+    fake_node = _FakeNode()
+    with MeshInterface(noProto=True) as iface:
+        with patch("meshtastic.node.Node", return_value=fake_node):
+            result = iface.getNode("!00112233", requestChannelAttempts=2)
+
+    assert result is fake_node
+    assert fake_node.request_calls == [0, 1]
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_send_alert_and_mqtt_proxy_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    """sendAlert() and sendMqttClientProxyMessage() should delegate with expected payloads."""
+    with MeshInterface(noProto=True) as iface:
+        send_data = MagicMock(return_value=mesh_pb2.MeshPacket())
+        monkeypatch.setattr(iface, "sendData", send_data)
+        response_cb = MagicMock()
+        iface.sendAlert(
+            "SOS",
+            destinationId=42,
+            onResponse=response_cb,
+            channelIndex=2,
+            hopLimit=3,
+        )
+
+        assert send_data.call_count == 1
+        send_args = send_data.call_args
+        assert send_args.args[0] == b"SOS"
+        assert send_args.kwargs["portNum"] == portnums_pb2.PortNum.ALERT_APP
+        assert send_args.kwargs["priority"] == mesh_pb2.MeshPacket.Priority.ALERT
+
+        sent_to_radio: list[mesh_pb2.ToRadio] = []
+        monkeypatch.setattr(
+            iface, "_send_to_radio", lambda msg: sent_to_radio.append(msg)
+        )
+        iface.sendMqttClientProxyMessage("mesh/topic", b"payload")
+
+        assert sent_to_radio
+        assert sent_to_radio[0].mqttClientProxyMessage.topic == "mesh/topic"
+        assert sent_to_radio[0].mqttClientProxyMessage.data == b"payload"
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_send_data_sets_reply_id_field() -> None:
+    """sendData() should preserve the caller-provided reply id."""
+    with MeshInterface(noProto=True) as iface:
+        packet = iface.sendData(b"ok", destinationId=123, replyId=77)
+    assert packet.decoded.reply_id == 77
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_send_position_waits_when_response_requested(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """sendPosition(wantResponse=True) should wire response callback and wait for position."""
+    with MeshInterface(noProto=True) as iface:
+        send_data = MagicMock(return_value=mesh_pb2.MeshPacket())
+        wait_for_position = MagicMock()
+        monkeypatch.setattr(iface, "sendData", send_data)
+        monkeypatch.setattr(iface, "waitForPosition", wait_for_position)
+
+        iface.sendPosition(
+            latitude=47.0,
+            longitude=-122.0,
+            altitude=100,
+            wantResponse=True,
+        )
+
+        assert send_data.call_args.kwargs["onResponse"] == iface.onResponsePosition
+        wait_for_position.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_on_response_position_success_and_routing_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """onResponsePosition() should print parsed position and raise on NO_RESPONSE routing errors."""
+    with MeshInterface(noProto=True) as iface:
+        position = mesh_pb2.Position()
+        position.latitude_i = 471234567
+        position.longitude_i = -971234567
+        position.altitude = 250
+        position.precision_bits = 32
+        iface.onResponsePosition(
+            {
+                "decoded": {
+                    "portnum": portnums_pb2.PortNum.Name(
+                        portnums_pb2.PortNum.POSITION_APP
+                    ),
+                    "payload": position.SerializeToString(),
+                }
+            }
+        )
+        out, _ = capsys.readouterr()
+        assert "Position received:" in out
+        assert "full precision" in out
+
+        unknown_position = mesh_pb2.Position()
+        unknown_position.precision_bits = 5
+        iface.onResponsePosition(
+            {
+                "decoded": {
+                    "portnum": portnums_pb2.PortNum.Name(
+                        portnums_pb2.PortNum.POSITION_APP
+                    ),
+                    "payload": unknown_position.SerializeToString(),
+                }
+            }
+        )
+        out_unknown, _ = capsys.readouterr()
+        assert "(unknown)" in out_unknown
+        assert "precision:5" in out_unknown
+
+        disabled_position = mesh_pb2.Position()
+        disabled_position.precision_bits = 0
+        iface.onResponsePosition(
+            {
+                "decoded": {
+                    "portnum": portnums_pb2.PortNum.Name(
+                        portnums_pb2.PortNum.POSITION_APP
+                    ),
+                    "payload": disabled_position.SerializeToString(),
+                }
+            }
+        )
+        out_disabled, _ = capsys.readouterr()
+        assert "position disabled" in out_disabled
+
+        with pytest.raises(MeshInterface.MeshInterfaceError, match="No response"):
+            iface.onResponsePosition(
+                {
+                    "decoded": {
+                        "portnum": portnums_pb2.PortNum.Name(
+                            portnums_pb2.PortNum.ROUTING_APP
+                        ),
+                        "routing": {"errorReason": "NO_RESPONSE"},
+                    }
+                }
+            )
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_send_traceroute_and_response_rendering(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Trace-route send/wait logic and response formatting should execute end-to-end."""
+    with MeshInterface(noProto=True) as iface:
+        iface.nodes = {
+            "!1": {"num": 1},
+            "!2": {"num": 2},
+            "!3": {"num": 3},
+        }
+        send_data = MagicMock()
+        wait_for_traceroute = MagicMock()
+        monkeypatch.setattr(iface, "sendData", send_data)
+        monkeypatch.setattr(iface, "waitForTraceRoute", wait_for_traceroute)
+        iface.sendTraceRoute(dest=123, hopLimit=3, channelIndex=1)
+        wait_for_traceroute.assert_called_once_with(2)
+
+        route = mesh_pb2.RouteDiscovery()
+        route.route.extend([11])
+        route.snr_towards.extend([8, 12])
+        route.route_back.extend([12])
+        route.snr_back.extend([16, 20])
+        iface.onResponseTraceRoute(
+            {
+                "decoded": {"payload": route.SerializeToString()},
+                "to": 20,
+                "from": 21,
+                "hopStart": 1,
+            }
+        )
+        out, _ = capsys.readouterr()
+
+    assert "Route traced towards destination:" in out
+    assert "Route traced back to us:" in out
+    assert iface._acknowledgment.receivedTraceRoute is True
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_send_telemetry_supported_and_fallback_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """sendTelemetry() should populate each supported payload and warn/fallback for unknown values."""
+    telemetry_calls: list[tuple[telemetry_pb2.Telemetry, dict[str, Any]]] = []
+    with MeshInterface(noProto=True) as iface:
+        iface.localNode.nodeNum = 77
+        iface.nodesByNum = {
+            77: {
+                "deviceMetrics": {
+                    "batteryLevel": 55,
+                    "voltage": 4.1,
+                    "channelUtilization": 1.5,
+                    "airUtilTx": 0.5,
+                    "uptimeSeconds": 123,
+                }
+            }
+        }
+        monkeypatch.setattr(
+            iface,
+            "sendData",
+            lambda payload, *args, **kwargs: telemetry_calls.append((payload, kwargs)),
+        )
+        wait_for_telemetry = MagicMock()
+        monkeypatch.setattr(iface, "waitForTelemetry", wait_for_telemetry)
+
+        iface.sendTelemetry(telemetryType="environment_metrics")
+        iface.sendTelemetry(telemetryType="air_quality_metrics")
+        iface.sendTelemetry(telemetryType="power_metrics")
+        iface.sendTelemetry(telemetryType="local_stats")
+        iface.sendTelemetry(telemetryType="device_metrics")
+        with pytest.warns(DeprecationWarning):
+            iface.sendTelemetry(telemetryType="invalid")  # type: ignore[arg-type]
+        iface.sendTelemetry(telemetryType="device_metrics", wantResponse=True)
+
+    assert telemetry_calls[0][0].HasField("environment_metrics")
+    assert telemetry_calls[1][0].HasField("air_quality_metrics")
+    assert telemetry_calls[2][0].HasField("power_metrics")
+    assert telemetry_calls[3][0].HasField("local_stats")
+    assert telemetry_calls[4][0].HasField("device_metrics")
+    assert telemetry_calls[5][0].HasField("device_metrics")
+    assert telemetry_calls[6][1]["onResponse"] is not None
+    wait_for_telemetry.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_on_response_telemetry_paths(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """onResponseTelemetry() should handle device metrics, non-device metrics, and routing errors."""
+    with MeshInterface(noProto=True) as iface:
+        device_t = telemetry_pb2.Telemetry()
+        device_t.device_metrics.battery_level = 95
+        device_t.device_metrics.voltage = 4.23
+        iface.onResponseTelemetry(
+            {
+                "decoded": {
+                    "portnum": portnums_pb2.PortNum.Name(
+                        portnums_pb2.PortNum.TELEMETRY_APP
+                    ),
+                    "payload": device_t.SerializeToString(),
+                }
+            }
+        )
+        out1, _ = capsys.readouterr()
+        assert "Telemetry received:" in out1
+        assert "Battery level:" in out1
+
+        env_t = telemetry_pb2.Telemetry()
+        env_t.environment_metrics.temperature = 21.5
+        iface.onResponseTelemetry(
+            {
+                "decoded": {
+                    "portnum": portnums_pb2.PortNum.Name(
+                        portnums_pb2.PortNum.TELEMETRY_APP
+                    ),
+                    "payload": env_t.SerializeToString(),
+                }
+            }
+        )
+        out2, _ = capsys.readouterr()
+        assert "environmentMetrics:" in out2
+
+        with pytest.raises(MeshInterface.MeshInterfaceError, match="No response"):
+            iface.onResponseTelemetry(
+                {
+                    "decoded": {
+                        "portnum": portnums_pb2.PortNum.Name(
+                            portnums_pb2.PortNum.ROUTING_APP
+                        ),
+                        "routing": {"errorReason": "NO_RESPONSE"},
+                    }
+                }
+            )
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_on_response_waypoint_paths(capsys: pytest.CaptureFixture[str]) -> None:
+    """onResponseWaypoint() should parse waypoint payloads and raise on routing NO_RESPONSE."""
+    with MeshInterface(noProto=True) as iface:
+        waypoint = mesh_pb2.Waypoint(name="WPT", id=5)
+        iface.onResponseWaypoint(
+            {
+                "decoded": {
+                    "portnum": portnums_pb2.PortNum.Name(
+                        portnums_pb2.PortNum.WAYPOINT_APP
+                    ),
+                    "payload": waypoint.SerializeToString(),
+                }
+            }
+        )
+        out, _ = capsys.readouterr()
+        assert "Waypoint received:" in out
+        assert iface._acknowledgment.receivedWaypoint is True
+
+        with pytest.raises(MeshInterface.MeshInterfaceError, match="No response"):
+            iface.onResponseWaypoint(
+                {
+                    "decoded": {
+                        "portnum": portnums_pb2.PortNum.Name(
+                            portnums_pb2.PortNum.ROUTING_APP
+                        ),
+                        "routing": {"errorReason": "NO_RESPONSE"},
+                    }
+                }
+            )
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_send_and_delete_waypoint_response_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """sendWaypoint()/deleteWaypoint() should set payload fields and wait when response is requested."""
+    sent_payloads: list[mesh_pb2.Waypoint] = []
+    with MeshInterface(noProto=True) as iface:
+        wait_for_waypoint = MagicMock()
+        monkeypatch.setattr(iface, "waitForWaypoint", wait_for_waypoint)
+
+        def _capture_send_data(
+            payload: mesh_pb2.Waypoint, *args: Any, **kwargs: Any
+        ) -> mesh_pb2.MeshPacket:
+            sent_payloads.append(payload)
+            return mesh_pb2.MeshPacket()
+
+        monkeypatch.setattr(iface, "sendData", _capture_send_data)
+        monkeypatch.setattr(
+            mesh_interface_module.secrets, "randbits", lambda _n: (1 << 32) - 1
+        )
+
+        iface.sendWaypoint(
+            name="A",
+            description="B",
+            icon=1,
+            expire=60,
+            waypoint_id=None,
+            latitude=47.1,
+            longitude=-96.2,
+            wantResponse=True,
+        )
+        iface.sendWaypoint(
+            name="C",
+            description="D",
+            icon=2,
+            expire=120,
+            waypoint_id=7,
+            wantResponse=False,
+        )
+        iface.deleteWaypoint(9, wantResponse=True)
+        iface.deleteWaypoint(10, wantResponse=False)
+
+    assert sent_payloads[0].id != 0
+    assert sent_payloads[0].latitude_i != 0
+    assert sent_payloads[0].longitude_i != 0
+    assert sent_payloads[1].id == 7
+    assert sent_payloads[2].id == 9 and sent_payloads[2].expire == 0
+    assert sent_payloads[3].id == 10 and sent_payloads[3].expire == 0
+    assert wait_for_waypoint.call_count == 2
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_send_packet_calls_transport_when_proto_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_send_packet() should invoke _send_to_radio() when protocol I/O is enabled."""
+    with MeshInterface(noProto=True) as iface:
+        iface.noProto = False
+        iface.myInfo = MagicMock()
+        iface.myInfo.my_node_num = 1
+        sent: list[mesh_pb2.ToRadio] = []
+        monkeypatch.setattr(iface, "_send_to_radio", lambda msg: sent.append(msg))
+        iface._send_packet(mesh_pb2.MeshPacket(), destinationId=1)
+        assert sent
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_wait_helpers_raise_expected_timeout_errors() -> None:
+    """waitFor* helper methods should raise MeshInterfaceError on timeout."""
+    with MeshInterface(noProto=True) as iface:
+        iface._timeout = MagicMock()
+        iface._timeout.waitForAckNak.return_value = False
+        iface._timeout.waitForTraceRoute.return_value = False
+        iface._timeout.waitForTelemetry.return_value = False
+        iface._timeout.waitForPosition.return_value = False
+        iface._timeout.waitForWaypoint.return_value = False
+
+        with pytest.raises(MeshInterface.MeshInterfaceError, match="acknowledgment"):
+            iface.waitForAckNak()
+        with pytest.raises(MeshInterface.MeshInterfaceError, match="traceroute"):
+            iface.waitForTraceRoute(1)
+        with pytest.raises(MeshInterface.MeshInterfaceError, match="telemetry"):
+            iface.waitForTelemetry()
+        with pytest.raises(MeshInterface.MeshInterfaceError, match="position"):
+            iface.waitForPosition()
+        with pytest.raises(MeshInterface.MeshInterfaceError, match="waypoint"):
+            iface.waitForWaypoint()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_public_key_and_optional_getters_none_paths(
+    iface_with_nodes: MeshInterface,
+) -> None:
+    """getPublicKey should return user key while optional local-node getters return None when absent."""
+    iface = iface_with_nodes
+    assert iface.myInfo is not None
+    iface.myInfo.my_node_num = 2475227164
+    node = iface.nodesByNum[2475227164]
+    node["user"]["publicKey"] = b"abc"
+    assert iface.getPublicKey() == b"abc"
+    node["user"] = {}
+    assert iface.getPublicKey() is None
+    iface.myInfo = None
+    assert iface.getPublicKey() is None
+
+    iface.localNode = None  # type: ignore[assignment]
+    assert iface.getCannedMessage() is None
+    assert iface.getRingtone() is None
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_send_heartbeat_builds_to_radio_heartbeat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """sendHeartbeat() should send a ToRadio with heartbeat field populated."""
+    with MeshInterface(noProto=True) as iface:
+        sent: list[mesh_pb2.ToRadio] = []
+        monkeypatch.setattr(iface, "_send_to_radio", lambda msg: sent.append(msg))
+        iface.sendHeartbeat()
+        assert sent[0].HasField("heartbeat")
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_start_config_skips_reserved_nodeless_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_start_config() should bump generated config id if it equals NODELESS_WANT_CONFIG_ID."""
+    with MeshInterface(noProto=True) as iface:
+        monkeypatch.setattr(
+            mesh_interface_module.random,
+            "randint",
+            lambda _a, _b: NODELESS_WANT_CONFIG_ID,
+        )
+        sent: list[mesh_pb2.ToRadio] = []
+        monkeypatch.setattr(iface, "_send_to_radio", lambda msg: sent.append(msg))
+        iface._start_config()
+    assert iface.configId == NODELESS_WANT_CONFIG_ID + 1
+    assert sent[0].want_config_id == NODELESS_WANT_CONFIG_ID + 1
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_queue_helpers_cover_state_transitions() -> None:
+    """Queue helper methods should cover unknown status, full queue, and pop/decrement logic."""
+    with MeshInterface(noProto=True) as iface:
+        iface.queueStatus = None
+        assert iface._queue_has_free_space() is True
+        iface._queue_claim()
+
+        iface.queueStatus = mesh_pb2.QueueStatus(free=1, maxlen=2)
+        assert iface._queue_has_free_space() is True
+        iface._queue_claim()
+        assert iface.queueStatus.free == 0
+
+        iface.queue = OrderedDict()
+        assert iface._queue_pop_for_send() is None
+
+        iface.queue[1] = mesh_pb2.ToRadio()
+        iface.queueStatus.free = 0
+        assert iface._queue_pop_for_send() is None
+        iface.queueStatus.free = 1
+        popped = iface._queue_pop_for_send()
+        assert popped is not None
+        assert popped[0] == 1
+        assert iface.queueStatus.free == 0
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_send_to_radio_waits_resends_and_tracks_requeue(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """_send_to_radio() should wait for queue space, resend queued packets, and requeue unacked items."""
+    with MeshInterface(noProto=True) as iface:
+        iface.noProto = False
+        iface.queueStatus = mesh_pb2.QueueStatus(free=0, maxlen=10)
+        existing = mesh_pb2.ToRadio()
+        existing.packet.id = 100
+        iface.queue[100] = existing
+        iface.queue[150] = False
+
+        incoming = mesh_pb2.ToRadio()
+        incoming.packet.id = 200
+
+        sent_ids: list[int] = []
+
+        def _send_impl(msg: mesh_pb2.ToRadio) -> None:
+            sent_ids.append(msg.packet.id if msg.HasField("packet") else -1)
+
+        monkeypatch.setattr(iface, "_send_to_radio_impl", _send_impl)
+
+        def _sleep_and_free(_seconds: float) -> None:
+            assert iface.queueStatus is not None
+            iface.queueStatus.free = 10
+
+        monkeypatch.setattr(mesh_interface_module.time, "sleep", _sleep_and_free)
+
+        with caplog.at_level(logging.DEBUG):
+            iface._send_to_radio(incoming)
+
+        assert "Waiting for free space in TX Queue" in caplog.text
+        assert 100 in sent_ids
+        assert 200 in sent_ids
+
+    class _RequeueQueue(OrderedDict[int, mesh_pb2.ToRadio | bool]):
+        def __bool__(self) -> bool:
+            return False
+
+        def pop(
+            self, key: int, default: mesh_pb2.ToRadio | bool = False
+        ) -> mesh_pb2.ToRadio | bool:
+            if key == 123:
+                return True
+            return super().pop(key, default)
+
+    with MeshInterface(noProto=True) as iface:
+        iface.noProto = False
+        iface.queue = _RequeueQueue()
+        packet = mesh_pb2.ToRadio()
+        packet.packet.id = 123
+        monkeypatch.setattr(iface, "_send_to_radio_impl", lambda _msg: None)
+        pops = iter([(123, packet), None])
+        original_pop = iface._queue_pop_for_send
+        monkeypatch.setattr(iface, "_queue_pop_for_send", lambda: next(pops))
+        iface._send_to_radio(mesh_pb2.ToRadio())
+        monkeypatch.setattr(iface, "_queue_pop_for_send", original_pop)
+        assert 123 in iface.queue
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_handle_config_complete_and_queue_status_branches() -> None:
+    """_handle_config_complete() and _handle_queue_status_from_radio() should execute all key branches."""
+    with MeshInterface(noProto=True) as iface:
+        channel = channel_pb2.Channel(index=1)
+        iface._localChannels = [channel]
+        iface.localNode = MagicMock()
+        iface._connected = MagicMock()  # type: ignore[method-assign]
+        iface._handle_config_complete()
+        iface.localNode.setChannels.assert_called_once_with([channel])
+        iface._connected.assert_called_once()
+
+        queued = mesh_pb2.ToRadio()
+        queued.packet.id = 111
+        iface.queue[111] = queued
+
+        status_hit = mesh_pb2.QueueStatus(free=1, maxlen=4, res=False, mesh_packet_id=111)
+        iface._handle_queue_status_from_radio(status_hit)
+        assert 111 not in iface.queue
+
+        status_unexpected = mesh_pb2.QueueStatus(
+            free=1, maxlen=4, res=False, mesh_packet_id=222
+        )
+        iface._handle_queue_status_from_radio(status_unexpected)
+        assert iface.queue[222] is False
+
+        status_res = mesh_pb2.QueueStatus(free=1, maxlen=4, res=True, mesh_packet_id=222)
+        iface._handle_queue_status_from_radio(status_res)
+        assert iface.queue[222] is False
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_handle_from_radio_branch_matrix(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """_handle_from_radio() should handle metadata/node-info and non-config branch dispatch paths."""
+    published_topics: list[str] = []
+    monkeypatch.setattr(
+        mesh_interface_module.publishingThread, "queueWork", lambda callback: callback()
+    )
+    monkeypatch.setattr(
+        mesh_interface_module.pub,
+        "sendMessage",
+        lambda topic, **_kwargs: published_topics.append(topic),
+    )
+
+    with MeshInterface(noProto=True) as iface:
+        iface._start_config()
+
+        metadata_msg = mesh_pb2.FromRadio()
+        metadata_msg.metadata.firmware_version = "2.7.18"
+        iface._handle_from_radio(metadata_msg.SerializeToString())
+        assert iface.metadata is not None
+        assert iface.metadata.firmware_version == "2.7.18"
+
+        node_info_msg = mesh_pb2.FromRadio()
+        node_info_msg.node_info.num = 999
+        node_info_msg.node_info.user.id = "!000003e7"
+        node_info_msg.node_info.user.long_name = "N999"
+        node_info_msg.node_info.user.short_name = "N9"
+        with caplog.at_level(logging.DEBUG):
+            iface._handle_from_radio(node_info_msg.SerializeToString())
+        assert "Node has no position key" in caplog.text
+
+        handle_config_complete = MagicMock()
+        handle_channel = MagicMock()
+        handle_packet = MagicMock()
+        handle_log_record = MagicMock()
+        handle_queue_status = MagicMock()
+        monkeypatch.setattr(iface, "_handle_config_complete", handle_config_complete)
+        monkeypatch.setattr(iface, "_handle_channel", handle_channel)
+        monkeypatch.setattr(iface, "_handle_packet_from_radio", handle_packet)
+        monkeypatch.setattr(iface, "_handle_log_record", handle_log_record)
+        monkeypatch.setattr(iface, "_handle_queue_status_from_radio", handle_queue_status)
+
+        config_complete_msg = mesh_pb2.FromRadio()
+        assert iface.configId is not None
+        config_complete_msg.config_complete_id = iface.configId
+        iface._handle_from_radio(config_complete_msg.SerializeToString())
+        handle_config_complete.assert_called_once()
+
+        channel_msg = mesh_pb2.FromRadio()
+        channel_msg.channel.index = 1
+        iface._handle_from_radio(channel_msg.SerializeToString())
+        handle_channel.assert_called_once()
+
+        packet_msg = mesh_pb2.FromRadio()
+        packet_msg.packet.id = 10
+        iface._handle_from_radio(packet_msg.SerializeToString())
+        handle_packet.assert_called_once()
+
+        log_msg = mesh_pb2.FromRadio()
+        log_msg.log_record.message = "hello"
+        iface._handle_from_radio(log_msg.SerializeToString())
+        handle_log_record.assert_called_once()
+
+        queue_msg = mesh_pb2.FromRadio()
+        queue_msg.queueStatus.free = 1
+        queue_msg.queueStatus.maxlen = 5
+        iface._handle_from_radio(queue_msg.SerializeToString())
+        handle_queue_status.assert_called_once()
+
+        notif_msg = mesh_pb2.FromRadio()
+        notif_msg.clientNotification.reply_id = 1
+        iface._handle_from_radio(notif_msg.SerializeToString())
+
+        mqtt_msg = mesh_pb2.FromRadio()
+        mqtt_msg.mqttClientProxyMessage.topic = "t"
+        iface._handle_from_radio(mqtt_msg.SerializeToString())
+
+        xmodem_msg = mesh_pb2.FromRadio()
+        xmodem_msg.xmodemPacket.control = 1
+        iface._handle_from_radio(xmodem_msg.SerializeToString())
+
+        disconnected_calls: list[int] = []
+        monkeypatch.setattr(
+            MeshInterface,
+            "_disconnected",
+            lambda _iface: disconnected_calls.append(1),
+        )
+        restart_config = MagicMock()
+        monkeypatch.setattr(iface, "_start_config", restart_config)
+        rebooted_msg = mesh_pb2.FromRadio(rebooted=True)
+        iface._handle_from_radio(rebooted_msg.SerializeToString())
+        assert disconnected_calls == [1]
+        restart_config.assert_called_once()
+
+        with caplog.at_level(logging.DEBUG):
+            iface._handle_from_radio(mesh_pb2.FromRadio().SerializeToString())
+        assert "Unexpected FromRadio payload" in caplog.text
+
+    assert "meshtastic.node.updated" in published_topics
+    assert "meshtastic.clientNotification" in published_topics
+    assert "meshtastic.mqttclientproxymessage" in published_topics
+    assert "meshtastic.xmodempacket" in published_topics
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_handle_from_radio_config_and_module_config_branches() -> None:
+    """_handle_from_radio() should copy each config/moduleConfig branch into localNode caches."""
+    config_fields = [
+        "device",
+        "position",
+        "power",
+        "network",
+        "display",
+        "lora",
+        "bluetooth",
+        "security",
+    ]
+    module_fields = [
+        "mqtt",
+        "serial",
+        "external_notification",
+        "store_forward",
+        "range_test",
+        "telemetry",
+        "canned_message",
+        "audio",
+        "remote_hardware",
+        "neighbor_info",
+        "detection_sensor",
+        "ambient_lighting",
+        "paxcounter",
+        "traffic_management",
+    ]
+
+    with MeshInterface(noProto=True) as iface:
+        for field in config_fields:
+            msg = mesh_pb2.FromRadio()
+            getattr(msg.config, field).SetInParent()
+            iface._handle_from_radio(msg.SerializeToString())
+            assert iface.localNode.localConfig.HasField(field)
+
+        for field in module_fields:
+            msg = mesh_pb2.FromRadio()
+            getattr(msg.moduleConfig, field).SetInParent()
+            iface._handle_from_radio(msg.SerializeToString())
+            assert iface.localNode.moduleConfig.HasField(field)
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_node_num_to_id_invalid_user_payloads() -> None:
+    """_node_num_to_id() should return None when user payload is missing or has invalid id type."""
+    with MeshInterface(noProto=True) as iface:
+        iface.nodesByNum = {
+            1: {"num": 1, "user": "bad-user"},
+            2: {"num": 2, "user": {"id": 123}},
+        }
+        assert iface._node_num_to_id(1) is None
+        assert iface._node_num_to_id(2) is None
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_get_or_create_by_num_requires_initialized_database() -> None:
+    """_get_or_create_by_num() should raise when nodesByNum is not initialized."""
+    with MeshInterface(noProto=True) as iface:
+        iface.nodesByNum = None
+        with pytest.raises(MeshInterface.MeshInterfaceError, match="not initialized"):
+            iface._get_or_create_by_num(5)
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_handle_channel_appends_to_local_channel_list() -> None:
+    """_handle_channel() should append received channels to _localChannels."""
+    with MeshInterface(noProto=True) as iface:
+        channel = channel_pb2.Channel(index=3)
+        iface._handle_channel(channel)
+        assert iface._localChannels[-1].index == 3
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_handle_packet_from_radio_toid_warning_and_response_handler_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """_handle_packet_from_radio() should log toId failures and execute protobuf/response-handler paths."""
+    monkeypatch.setattr(
+        mesh_interface_module.publishingThread, "queueWork", lambda callback: callback()
+    )
+
+    with MeshInterface(noProto=True) as iface:
+        packet_for_toid = mesh_pb2.MeshPacket()
+        setattr(packet_for_toid, "from", 1)
+        packet_for_toid.to = 2
+        with patch.object(
+            iface,
+            "_node_num_to_id",
+            side_effect=["!00000001", RuntimeError("toId failure")],
+        ):
+            with caplog.at_level(logging.WARNING):
+                iface._handle_packet_from_radio(packet_for_toid, hack=True)
+        assert "Not populating toId" in caplog.text
+
+        on_receive_calls: list[int] = []
+        on_ack_calls: list[int] = []
+        ack_permitted_calls: list[int] = []
+
+        def _on_receive(_iface: MeshInterface, _packet: dict[str, Any]) -> None:
+            on_receive_calls.append(1)
+
+        def _raising_callback(_packet: dict[str, Any]) -> None:
+            raise RuntimeError("handler boom")
+
+        def onAckNak(_packet: dict[str, Any]) -> None:
+            on_ack_calls.append(1)
+
+        def _ack_permitted_callback(_packet: dict[str, Any]) -> None:
+            ack_permitted_calls.append(1)
+
+        fake_protocol = types.SimpleNamespace(
+            name="routing",
+            protobufFactory=mesh_pb2.Routing,
+            onReceive=_on_receive,
+        )
+        monkeypatch.setattr(
+            mesh_interface_module,
+            "protocols",
+            {portnums_pb2.PortNum.ROUTING_APP: fake_protocol},
+        )
+
+        routing = mesh_pb2.Routing()
+        routing.error_reason = mesh_pb2.Routing.Error.NONE
+
+        p1 = mesh_pb2.MeshPacket()
+        setattr(p1, "from", 10)
+        p1.to = 11
+        p1.decoded.portnum = portnums_pb2.PortNum.ROUTING_APP
+        p1.decoded.payload = routing.SerializeToString()
+        p1.decoded.request_id = 77
+        iface.responseHandlers[77] = ResponseHandler(
+            callback=_raising_callback, ackPermitted=True
+        )
+        iface._handle_packet_from_radio(p1, hack=True)
+
+        p2 = mesh_pb2.MeshPacket()
+        setattr(p2, "from", 12)
+        p2.to = 13
+        p2.decoded.portnum = portnums_pb2.PortNum.ROUTING_APP
+        p2.decoded.payload = routing.SerializeToString()
+        p2.decoded.request_id = 78
+        iface.responseHandlers[78] = ResponseHandler(
+            callback=onAckNak, ackPermitted=False
+        )
+        iface._handle_packet_from_radio(p2, hack=True)
+
+        p3 = mesh_pb2.MeshPacket()
+        setattr(p3, "from", 14)
+        p3.to = 15
+        p3.decoded.portnum = portnums_pb2.PortNum.ROUTING_APP
+        p3.decoded.payload = routing.SerializeToString()
+        p3.decoded.request_id = 79
+        iface.responseHandlers[79] = ResponseHandler(
+            callback=_ack_permitted_callback, ackPermitted=True
+        )
+        iface._handle_packet_from_radio(p3, hack=True)
+
+    assert on_receive_calls == [1, 1, 1]
+    assert on_ack_calls == [1]
+    assert ack_permitted_calls == [1]

--- a/meshtastic/tests/test_mesh_interface_traffic_management.py
+++ b/meshtastic/tests/test_mesh_interface_traffic_management.py
@@ -19,6 +19,8 @@ def test_handle_from_radio_with_traffic_management_module_config() -> None:
         iface._handle_from_radio(from_radio.SerializeToString())
 
         assert iface.localNode.moduleConfig.traffic_management.enabled is True
-        assert iface.localNode.moduleConfig.traffic_management.rate_limit_enabled is True
+        assert (
+            iface.localNode.moduleConfig.traffic_management.rate_limit_enabled is True
+        )
     finally:
         iface.close()

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -13,8 +13,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pytest import CaptureFixture, LogCaptureFixture
 
-from ..mesh_interface import MeshInterface
 from .. import node as node_module
+from ..mesh_interface import MeshInterface
 from ..node import MAX_CHANNELS, Node
 from ..protobuf import (
     admin_pb2,
@@ -1028,7 +1028,9 @@ def test_deleteChannel_rewrites_following_channels_and_updates_admin_index(
     assert anode.channels is not None
     assert len(anode.channels) == CHANNEL_LIMIT
     assert anode._send_admin.call_count == CHANNEL_LIMIT - 1
-    assert all(call.kwargs["adminIndex"] == 0 for call in anode._send_admin.call_args_list)
+    assert all(
+        call.kwargs["adminIndex"] == 0 for call in anode._send_admin.call_args_list
+    )
 
 
 @pytest.mark.unit
@@ -1669,7 +1671,9 @@ def test_onRequestGetMetadata_emits_stdout_when_redirected(
     resp.hw_model = mesh_pb2.HardwareModel.PORTDUINO
     resp.hasPKC = True
 
-    anode.onRequestGetMetadata({"decoded": {"portnum": "ADMIN_APP", "admin": {"raw": raw}}})
+    anode.onRequestGetMetadata(
+        {"decoded": {"portnum": "ADMIN_APP", "admin": {"raw": raw}}}
+    )
 
     out, _err = capsys.readouterr()
     assert "firmware_version: 2.7.18" in out
@@ -1806,7 +1810,7 @@ def test_on_response_request_settings_warns_for_unrecognized_payload_shape(
     mock_serial_interface: MagicMock,
     caplog: LogCaptureFixture,
 ) -> None:
-    """onResponseRequestSettings should warn and return for unsupported response payloads."""
+    """OnResponseRequestSettings should warn and return for unsupported response payloads."""
     anode = Node(mock_serial_interface, "!12345678", noProto=True)
     anode.iface._acknowledgment = Acknowledgment()
 

--- a/meshtastic/tests/test_powermon_ppk2.py
+++ b/meshtastic/tests/test_powermon_ppk2.py
@@ -7,8 +7,8 @@ from unittest.mock import MagicMock
 import pytest
 
 try:
-    from meshtastic.powermon.ppk2 import PPK2PowerSupply
     from meshtastic.powermon.power_supply import PowerSupply
+    from meshtastic.powermon.ppk2 import PPK2PowerSupply
 except ImportError:
     pytest.skip("Can't import PPK2PowerSupply", allow_module_level=True)
 

--- a/meshtastic/tests/test_slog_arrow.py
+++ b/meshtastic/tests/test_slog_arrow.py
@@ -183,7 +183,9 @@ def test_feather_writer_discard_empty_source_logs_remove_failure(
             )
 
     assert "Failed to remove empty Arrow source file" in caplog.text
-    writer._remove_stale_dest_file.assert_called_once_with(str(tmp_path / "dest.feather"))
+    writer._remove_stale_dest_file.assert_called_once_with(
+        str(tmp_path / "dest.feather")
+    )
 
 
 @pytest.mark.unit
@@ -196,7 +198,7 @@ def test_feather_writer_close_returns_early_when_conversion_already_set(
     conversion_in_progress: bool,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """close should return early when conversion is already done or in-progress."""
+    """Close should return early when conversion is already done or in-progress."""
     writer = object.__new__(FeatherWriter)
     writer._lock = threading.RLock()
     writer._conversion_done = conversion_done
@@ -215,7 +217,7 @@ def test_feather_writer_close_treats_missing_source_as_success(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """close should remove stale destination and finish when source file is missing."""
+    """Close should remove stale destination and finish when source file is missing."""
     writer = object.__new__(FeatherWriter)
     writer._lock = threading.RLock()
     writer._conversion_done = False
@@ -224,7 +226,7 @@ def test_feather_writer_close_treats_missing_source_as_success(
     writer._remove_stale_dest_file = MagicMock()  # type: ignore[method-assign]
 
     monkeypatch.setattr(arrow_module.ArrowWriter, "close", lambda _self: None)
-    monkeypatch.setattr(arrow_module.os.path, "exists", lambda _path: False)
+    monkeypatch.setattr(arrow_module.os.path, "exists", lambda _path: False)  # type: ignore[attr-defined]
 
     writer.close()
 
@@ -240,7 +242,7 @@ def test_feather_writer_close_discards_zero_size_source(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """close should route zero-size Arrow sources through discard helper."""
+    """Close should route zero-size Arrow sources through discard helper."""
     writer = object.__new__(FeatherWriter)
     writer._lock = threading.RLock()
     writer._conversion_done = False
@@ -249,8 +251,8 @@ def test_feather_writer_close_discards_zero_size_source(
     writer._discard_empty_source = MagicMock()  # type: ignore[method-assign]
 
     monkeypatch.setattr(arrow_module.ArrowWriter, "close", lambda _self: None)
-    monkeypatch.setattr(arrow_module.os.path, "exists", lambda _path: True)
-    monkeypatch.setattr(arrow_module.os.path, "getsize", lambda _path: 0)
+    monkeypatch.setattr(arrow_module.os.path, "exists", lambda _path: True)  # type: ignore[attr-defined]
+    monkeypatch.setattr(arrow_module.os.path, "getsize", lambda _path: 0)  # type: ignore[attr-defined]
 
     writer.close()
 
@@ -268,7 +270,7 @@ def test_feather_writer_close_logs_when_temp_remove_fails_for_empty_batches(
     caplog: pytest.LogCaptureFixture,
     tmp_path: Path,
 ) -> None:
-    """close should warn when temp Feather cleanup fails in empty-batch conversion path."""
+    """Close should warn when temp Feather cleanup fails in empty-batch conversion path."""
     base_path = tmp_path / "empty-batches"
     writer = FeatherWriter(str(base_path))
     writer.setSchema(_test_schema())
@@ -280,7 +282,9 @@ def test_feather_writer_close_logs_when_temp_remove_fails_for_empty_batches(
         original_remove(path)
 
     with caplog.at_level(logging.WARNING):
-        with patch("meshtastic.slog.arrow.os.remove", side_effect=_remove_with_temp_failure):
+        with patch(
+            "meshtastic.slog.arrow.os.remove", side_effect=_remove_with_temp_failure
+        ):
             writer.close()
 
     assert "Failed to remove temporary Feather file" in caplog.text
@@ -291,7 +295,7 @@ def test_feather_writer_close_logs_when_temp_remove_fails_after_conversion_excep
     caplog: pytest.LogCaptureFixture,
     tmp_path: Path,
 ) -> None:
-    """close should warn if temp Feather file cannot be removed after conversion failure."""
+    """Close should warn if temp Feather file cannot be removed after conversion failure."""
     base_path = tmp_path / "conversion-exception"
     writer = FeatherWriter(str(base_path))
     writer.setSchema(_test_schema())
@@ -309,7 +313,9 @@ def test_feather_writer_close_logs_when_temp_remove_fails_after_conversion_excep
                 "meshtastic.slog.arrow.pa.memory_map",
                 side_effect=RuntimeError("conversion failed"),
             ),
-            patch("meshtastic.slog.arrow.os.remove", side_effect=_remove_with_temp_failure),
+            patch(
+                "meshtastic.slog.arrow.os.remove", side_effect=_remove_with_temp_failure
+            ),
             pytest.raises(RuntimeError, match="conversion failed"),
         ):
             writer.close()
@@ -322,7 +328,7 @@ def test_feather_writer_close_logs_when_source_remove_fails_after_success(
     caplog: pytest.LogCaptureFixture,
     tmp_path: Path,
 ) -> None:
-    """close should warn and continue if temporary Arrow source removal fails."""
+    """Close should warn and continue if temporary Arrow source removal fails."""
     base_path = tmp_path / "source-remove-fail"
     writer = FeatherWriter(str(base_path))
     writer.setSchema(_test_schema())
@@ -336,7 +342,9 @@ def test_feather_writer_close_logs_when_source_remove_fails_after_success(
         original_remove(path)
 
     with caplog.at_level(logging.WARNING):
-        with patch("meshtastic.slog.arrow.os.remove", side_effect=_remove_with_source_failure):
+        with patch(
+            "meshtastic.slog.arrow.os.remove", side_effect=_remove_with_source_failure
+        ):
             writer.close()
 
     assert "Failed to remove temporary Arrow source file" in caplog.text

--- a/meshtastic/tests/test_slog_power_logger.py
+++ b/meshtastic/tests/test_slog_power_logger.py
@@ -451,7 +451,9 @@ def test_log_set_init_raises_collision_error_after_retry_exhaustion(
     mkdir_mock = MagicMock(side_effect=FileExistsError("collision"))
     monkeypatch.setattr("meshtastic.slog.slog.Path.mkdir", mkdir_mock)
 
-    with pytest.raises(slog_module.SlogDirectoryCollisionError, match="after 3 attempts"):
+    with pytest.raises(
+        slog_module.SlogDirectoryCollisionError, match="after 3 attempts"
+    ):
         LogSet(MagicMock(), dir_name=None)
 
     assert mkdir_mock.call_count == 3

--- a/meshtastic/tests/test_tcp_interface.py
+++ b/meshtastic/tests/test_tcp_interface.py
@@ -312,9 +312,7 @@ def test_TCPInterface_connect_fails_fast_after_fatal_disconnect() -> None:
 
 
 @pytest.mark.unit
-def test_TCPInterface_connect_socket_waits_for_inflight_reconnect_then_connects() -> (
-    None
-):
+def test_TCPInterface_connect_socket_waits_for_inflight_reconnect_then_connects() -> None:
     """_connect_socket_if_needed should poll while reconnect is in-flight and then connect."""
     with patch("socket.socket"):
         iface = TCPInterface(hostname="localhost", noProto=True, connectNow=False)

--- a/meshtastic/tests/test_tcp_interface.py
+++ b/meshtastic/tests/test_tcp_interface.py
@@ -144,7 +144,10 @@ def test_TCPInterface_write_uses_partial_send_loop() -> None:
             mock_socket = MagicMock()
             mock_socket.send.side_effect = [1, 2]
             iface.socket = mock_socket
-            with patch("meshtastic.tcp_interface.select.select", return_value=([], [mock_socket], [])):
+            with patch(
+                "meshtastic.tcp_interface.select.select",
+                return_value=([], [mock_socket], []),
+            ):
                 iface._write_bytes(b"abc")
             assert mock_socket.send.call_args_list == [call(b"abc"), call(b"bc")]
         finally:
@@ -175,7 +178,10 @@ def test_TCPInterface_write_reraises_socket_errors() -> None:
             iface.socket = mock_socket
 
             with (
-                patch("meshtastic.tcp_interface.select.select", return_value=([], [mock_socket], [])),
+                patch(
+                    "meshtastic.tcp_interface.select.select",
+                    return_value=([], [mock_socket], []),
+                ),
                 pytest.raises(OSError, match="boom"),
             ):
                 iface._write_bytes(b"abc")
@@ -217,8 +223,12 @@ def test_TCPInterface_write_times_out_when_socket_not_writable() -> None:
             mock_socket = MagicMock()
             iface.socket = mock_socket
             with (
-                patch("meshtastic.tcp_interface.select.select", return_value=([], [], [])),
-                pytest.raises(TimeoutError, match="timed out waiting for socket readiness"),
+                patch(
+                    "meshtastic.tcp_interface.select.select", return_value=([], [], [])
+                ),
+                pytest.raises(
+                    TimeoutError, match="timed out waiting for socket readiness"
+                ),
             ):
                 iface._write_bytes(b"abc")
             assert iface.socket is None
@@ -302,7 +312,9 @@ def test_TCPInterface_connect_fails_fast_after_fatal_disconnect() -> None:
 
 
 @pytest.mark.unit
-def test_TCPInterface_connect_socket_waits_for_inflight_reconnect_then_connects() -> None:
+def test_TCPInterface_connect_socket_waits_for_inflight_reconnect_then_connects() -> (
+    None
+):
     """_connect_socket_if_needed should poll while reconnect is in-flight and then connect."""
     with patch("socket.socket"):
         iface = TCPInterface(hostname="localhost", noProto=True, connectNow=False)
@@ -318,7 +330,10 @@ def test_TCPInterface_connect_socket_waits_for_inflight_reconnect_then_connects(
                         iface._reconnect_attempt_in_progress = False
 
             with (
-                patch("meshtastic.tcp_interface.time.sleep", side_effect=_finish_reconnect_slice) as sleep_mock,
+                patch(
+                    "meshtastic.tcp_interface.time.sleep",
+                    side_effect=_finish_reconnect_slice,
+                ) as sleep_mock,
                 patch.object(iface, "myConnect") as my_connect_mock,
             ):
                 iface._connect_socket_if_needed()
@@ -507,7 +522,9 @@ def test_TCPInterface_write_times_out_before_select_when_deadline_elapsed() -> N
                     "meshtastic.tcp_interface.time.monotonic",
                     side_effect=[0.0, 9999.0],
                 ),
-                pytest.raises(TimeoutError, match="timed out waiting for socket readiness"),
+                pytest.raises(
+                    TimeoutError, match="timed out waiting for socket readiness"
+                ),
             ):
                 iface._write_bytes(b"abc")
         finally:
@@ -525,7 +542,10 @@ def test_TCPInterface_write_raises_when_send_returns_zero_bytes() -> None:
             iface.socket = mock_socket
 
             with (
-                patch("meshtastic.tcp_interface.select.select", return_value=([], [mock_socket], [])),
+                patch(
+                    "meshtastic.tcp_interface.select.select",
+                    return_value=([], [mock_socket], []),
+                ),
                 pytest.raises(OSError, match="TCP write returned no bytes"),
             ):
                 iface._write_bytes(b"abc")

--- a/meshtastic/tests/test_tunnel.py
+++ b/meshtastic/tests/test_tunnel.py
@@ -4,8 +4,8 @@ import argparse
 import logging
 import re
 import sys
-from contextlib import contextmanager
 from collections.abc import Generator
+from contextlib import contextmanager
 from unittest.mock import MagicMock
 
 import pytest

--- a/meshtastic/tests/test_util_windows_port.py
+++ b/meshtastic/tests/test_util_windows_port.py
@@ -18,7 +18,7 @@ def test_detectWindowsPort_parses_com_port_from_powershell_output(
     _mock_subprocess: MagicMock,
     _mock_system: MagicMock,
 ) -> None:
-    """detectWindowsPort should parse COM ports from PowerShell output on Windows."""
+    """DetectWindowsPort should parse COM ports from PowerShell output on Windows."""
     device = SupportedDevice(
         name="x",
         for_firmware="heltec-v3",

--- a/meshtastic/util.py
+++ b/meshtastic/util.py
@@ -383,6 +383,7 @@ class DotDict(dict[str, Any]):
 
 # Track warn-once state for dotdict deprecation (process-wide).
 _warned_deprecations: set[str] = set()
+_warned_deprecations_lock = threading.Lock()
 
 
 # COMPAT_DEPRECATE: snake_case alias for DotDict (warns once)
@@ -400,13 +401,17 @@ class dotdict(DotDict):  # pylint: disable=invalid-name
         **kwargs : Any
             Keyword arguments passed to dict constructor.
         """
-        if "dotdict" not in _warned_deprecations:
+        should_warn = False
+        with _warned_deprecations_lock:
+            if "dotdict" not in _warned_deprecations:
+                _warned_deprecations.add("dotdict")
+                should_warn = True
+        if should_warn:
             warnings.warn(
                 "dotdict is deprecated; use DotDict instead",
                 DeprecationWarning,
                 stacklevel=2,
             )
-            _warned_deprecations.add("dotdict")
         super().__init__(*args, **kwargs)
 
 

--- a/tests/test_ble_client_edge_cases.py
+++ b/tests/test_ble_client_edge_cases.py
@@ -8,6 +8,7 @@ import pytest
 
 try:
     from bleak.exc import BleakError
+
     from meshtastic.interfaces.ble.client import (
         SERVICE_CHARACTERISTIC_RETRY_COUNT,
         BLEClient,
@@ -32,7 +33,9 @@ def test_bleclient_discovery_mode_without_address(ble_client: BLEClient) -> None
 
 
 @pytest.mark.unit
-def test_bleclient_isConnected_handles_missing_bleak_client(ble_client: BLEClient) -> None:
+def test_bleclient_isConnected_handles_missing_bleak_client(
+    ble_client: BLEClient,
+) -> None:
     """IsConnected should return False when bleak_client is None."""
     assert not ble_client.isConnected()
 
@@ -69,19 +72,29 @@ def test_bleclient_error_class_exists() -> None:
 @pytest.mark.unit
 def test_bleclient_operations_require_initialized_client(ble_client: BLEClient) -> None:
     """BLEClient operations should raise BLEError when bleak_client is not initialized."""
-    with pytest.raises(BLEClient.BLEError, match="Cannot connect: BLE client not initialized"):
+    with pytest.raises(
+        BLEClient.BLEError, match="Cannot connect: BLE client not initialized"
+    ):
         ble_client.connect()
 
-    with pytest.raises(BLEClient.BLEError, match="Cannot disconnect: BLE client not initialized"):
+    with pytest.raises(
+        BLEClient.BLEError, match="Cannot disconnect: BLE client not initialized"
+    ):
         ble_client.disconnect()
 
-    with pytest.raises(BLEClient.BLEError, match="Cannot read: BLE client not initialized"):
+    with pytest.raises(
+        BLEClient.BLEError, match="Cannot read: BLE client not initialized"
+    ):
         ble_client.read_gatt_char("uuid")
 
-    with pytest.raises(BLEClient.BLEError, match="Cannot write: BLE client not initialized"):
+    with pytest.raises(
+        BLEClient.BLEError, match="Cannot write: BLE client not initialized"
+    ):
         ble_client.write_gatt_char("uuid", b"data")
 
-    with pytest.raises(BLEClient.BLEError, match="Cannot pair: BLE client not initialized"):
+    with pytest.raises(
+        BLEClient.BLEError, match="Cannot pair: BLE client not initialized"
+    ):
         ble_client.pair()
 
     with pytest.raises(
@@ -94,7 +107,9 @@ def test_bleclient_operations_require_initialized_client(ble_client: BLEClient) 
     ):
         ble_client.start_notify("uuid", lambda *_args: None)
 
-    with pytest.raises(BLEClient.BLEError, match="Cannot stop notify: BLE client not initialized"):
+    with pytest.raises(
+        BLEClient.BLEError, match="Cannot stop notify: BLE client not initialized"
+    ):
         ble_client.stopNotify("uuid")
 
 

--- a/tests/test_ble_connection_edge_cases.py
+++ b/tests/test_ble_connection_edge_cases.py
@@ -1,14 +1,15 @@
 """Edge case tests for BLE connection management."""
 
 import logging
-from types import SimpleNamespace
 from threading import Event, RLock
+from types import SimpleNamespace
 from unittest.mock import ANY, MagicMock
 
 import pytest
 
 try:
     from bleak.exc import BleakDBusError, BleakDeviceNotFoundError
+
     from meshtastic.interfaces.ble.connection import (
         AWAIT_TIMEOUT_BUFFER_SECONDS,
         DIRECT_CONNECT_TIMEOUT_SECONDS,
@@ -369,7 +370,9 @@ def test_connection_orchestrator_aborts_fallback_when_interface_closing() -> Non
 
 
 @pytest.mark.unit
-def test_transition_failure_to_disconnected_forces_reset_when_transitions_reject() -> None:
+def test_transition_failure_to_disconnected_forces_reset_when_transitions_reject() -> (
+    None
+):
     """_transition_failure_to_disconnected should force reset if transition calls fail."""
     state_manager = MagicMock()
     state_manager._current_state = ConnectionState.CONNECTING
@@ -462,7 +465,9 @@ def test_establish_connection_rejects_whitespace_target_address() -> None:
 
 
 @pytest.mark.unit
-def test_connection_orchestrator_rejects_direct_connect_when_interface_already_closed() -> None:
+def test_connection_orchestrator_rejects_direct_connect_when_interface_already_closed() -> (
+    None
+):
     """_establish_connection should fail before creating a client when shutdown is in progress."""
     state_manager = BLEStateManager()
     state_lock = RLock()

--- a/tests/test_ble_gating.py
+++ b/tests/test_ble_gating.py
@@ -23,6 +23,8 @@ from meshtastic.interfaces.ble.gating import (
     _release_addr_lock,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class _ConnectedOwner:
     """Owner stub that reports an active connection."""

--- a/tests/test_ble_gating.py
+++ b/tests/test_ble_gating.py
@@ -1,8 +1,10 @@
 """Tests for BLE gating utilities."""
 
 import gc
+
 import pytest
-from hypothesis import given, strategies as st
+from hypothesis import given
+from hypothesis import strategies as st
 
 from meshtastic.interfaces.ble.constants import BLEConfig
 from meshtastic.interfaces.ble.gating import (
@@ -49,9 +51,7 @@ class TestAddrKey:
         """Test that None/empty/whitespace inputs all normalize to None."""
         assert _addr_key(input_val) is None
 
-    @given(
-        st.from_regex(r"[0-9a-fA-F]{2}([:_\- ][0-9a-fA-F]{2}){5}", fullmatch=True)
-    )
+    @given(st.from_regex(r"[0-9a-fA-F]{2}([:_\- ][0-9a-fA-F]{2}){5}", fullmatch=True))
     def test_valid_address_formats_normalize_to_lower_hex(self, addr: str) -> None:
         """Any valid MAC-like address should normalize to 12 lowercase hex chars."""
         normalized = _addr_key(addr)

--- a/tests/test_ble_integration_scenarios.py
+++ b/tests/test_ble_integration_scenarios.py
@@ -244,7 +244,7 @@ def test_ble_config_can_be_modified_at_runtime() -> None:
         # Module-level alias won't change (it's an import-time snapshot).
         from meshtastic.interfaces.ble import constants
 
-        module_alias_snapshot = getattr(constants, "CONNECTION_TIMEOUT")
+        module_alias_snapshot = constants.CONNECTION_TIMEOUT
         assert module_alias_snapshot == original_timeout
     finally:
         # Restore

--- a/tests/test_ble_integration_scenarios.py
+++ b/tests/test_ble_integration_scenarios.py
@@ -244,8 +244,8 @@ def test_ble_config_can_be_modified_at_runtime() -> None:
         # Module-level alias won't change (it's an import-time snapshot).
         from meshtastic.interfaces.ble import constants
 
-        via_getattr = constants.CONNECTION_TIMEOUT
-        assert via_getattr == original_timeout
+        module_alias_snapshot = getattr(constants, "CONNECTION_TIMEOUT")
+        assert module_alias_snapshot == original_timeout
     finally:
         # Restore
         BLEConfig.CONNECTION_TIMEOUT = original_timeout

--- a/tests/test_ble_interface_advanced.py
+++ b/tests/test_ble_interface_advanced.py
@@ -593,7 +593,11 @@ def test_rapid_connect_disconnect_stress_test(
     ):
         """Create and yield a BLEInterface configured for stress testing with auto-reconnect enabled.
 
-        Patches BLEInterface.scan and BLEInterface.connect so the interface discovers a mocked device and receives a StressTestClient. Yields a tuple (iface, client). On generator exit the interface is closed and all patches are undone.
+        Patches BLEInterface.connect so the interface receives a StressTestClient.
+        The interface is created with an explicit address to exercise reconnect
+        scheduling against a concrete target address. Yields a tuple
+        `(iface, client)`. On generator exit the interface is closed and all
+        patches are undone.
 
         Yields
         ------
@@ -606,11 +610,6 @@ def test_rapid_connect_disconnect_stress_test(
         connect_calls: list[str | None] = []
 
         stack = ExitStack()
-
-        # Mock the scan method to return our test device
-        stack.enter_context(
-            patch.object(BLEInterface, "scan", return_value=[mock_device])
-        )
 
         def _patched_connect(
             self: BLEInterface,

--- a/tests/test_ble_interface_advanced.py
+++ b/tests/test_ble_interface_advanced.py
@@ -595,7 +595,8 @@ def test_rapid_connect_disconnect_stress_test(
 
         Patches BLEInterface.connect so the interface receives a StressTestClient.
         The interface is created with an explicit address to exercise reconnect
-        scheduling against a concrete target address. Yields a tuple
+        scheduling against a concrete target address; discovery is intentionally
+        bypassed in this helper and BLEInterface.scan is not patched. Yields a tuple
         `(iface, client)`. On generator exit the interface is closed and all
         patches are undone.
 

--- a/tests/test_ble_interface_advanced.py
+++ b/tests/test_ble_interface_advanced.py
@@ -595,8 +595,9 @@ def test_rapid_connect_disconnect_stress_test(
 
         Patches BLEInterface.connect so the interface receives a StressTestClient.
         The interface is created with an explicit address to exercise reconnect
-        scheduling against a concrete target address; discovery is intentionally
-        bypassed in this helper and BLEInterface.scan is not patched. Yields a tuple
+        scheduling against a concrete target address. Discovery is bypassed in
+        this helper because connect is patched; BLEInterface.scan is intentionally
+        left unpatched. Yields a tuple
         `(iface, client)`. On generator exit the interface is closed and all
         patches are undone.
 

--- a/tests/test_ble_interface_advanced.py
+++ b/tests/test_ble_interface_advanced.py
@@ -29,6 +29,8 @@ from meshtastic.protobuf import mesh_pb2
 # Import common fixtures
 from tests.test_ble_interface_fixtures import DummyClient, _build_interface
 
+pytestmark = pytest.mark.unit
+
 
 def _get_connect_stub_calls(iface: BLEInterface) -> list[str | None]:
     """Retrieve the test-only list of addresses recorded for BLEInterface.connect calls.
@@ -449,8 +451,10 @@ def test_send_to_radio_specific_exceptions(
     iface3.close()
 
 
-@pytest.mark.slow
-def test_rapid_connect_disconnect_stress_test(caplog):
+@pytest.mark.unitslow
+def test_rapid_connect_disconnect_stress_test(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test rapid connect/disconnect cycles to validate thread-safety and reconnect logic."""
     # logging, threading, and time already imported at top
     # MagicMock, patch already imported at top
@@ -639,7 +643,7 @@ def test_rapid_connect_disconnect_stress_test(caplog):
         iface = None
         try:
             iface = BLEInterface(
-                address=None,  # Required positional argument
+                address=mock_device.address,
                 noProto=True,
                 auto_reconnect=True,
             )

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -45,6 +45,8 @@ from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
 # Import common fixtures
 from tests.test_ble_interface_fixtures import DummyClient, _build_interface
 
+pytestmark = pytest.mark.unit
+
 if TYPE_CHECKING:
 
     class _PubProtocol(Protocol):
@@ -646,7 +648,10 @@ def test_concurrent_connect_and_disconnect_do_not_deadlock(
         iface.close()
 
 
-def test_connect_finalizes_gates_after_address_lock_scope(monkeypatch, clear_registry):
+def test_connect_finalizes_gates_after_address_lock_scope(
+    monkeypatch: pytest.MonkeyPatch,
+    clear_registry: None,
+) -> None:
     """connect() should finalize address gates only after per-address lock scope exits."""
     _ = clear_registry
     import meshtastic.interfaces.ble.interface as ble_iface_mod
@@ -1353,7 +1358,7 @@ def test_ble_interface_sanitize_address_wrapper_delegates(
     assert iface._sanitize_address("AA-BB-CC-DD-EE-FF") == "normalized"
 
 
-def test_discovery_manager_destructor_does_not_close_client():
+def test_discovery_manager_destructor_does_not_close_client() -> None:
     """DiscoveryManager.__del__ should avoid active client close I/O during GC."""
 
     class StubDiscoveryClient:
@@ -1364,14 +1369,14 @@ def test_discovery_manager_destructor_does_not_close_client():
         close()
         """
 
-        def __init__(self):
+        def __init__(self) -> None:
             """Initialize the test stub and reset its close-call counter.
 
             Sets the `close_calls` attribute to 0; tests increment this counter when the stub's `close()` is invoked to verify that discovery clients are not closed unexpectedly.
             """
             self.close_calls = 0
 
-        def close(self):
+        def close(self) -> None:
             """Record that the client's close method was invoked by incrementing an internal call counter.
 
             This method exists for tests to track how many times close() was called on the object by incrementing the `close_calls` attribute.

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -1161,7 +1161,9 @@ def test_close_discovery_client_best_effort_closes_coroutine_when_task_creation_
         return awaitable
 
     monkeypatch.setattr(discovery_mod.asyncio, "get_running_loop", _get_running_loop)
-    monkeypatch.setattr(discovery_mod, "_await_close_result", _await_close_result_passthrough)
+    monkeypatch.setattr(
+        discovery_mod, "_await_close_result", _await_close_result_passthrough
+    )
     monkeypatch.setattr(discovery_mod.asyncio, "wait_for", _wait_for_passthrough)
     monkeypatch.setattr(
         discovery_mod.inspect,
@@ -1194,7 +1196,9 @@ def test_finalize_discovery_close_task_discards_task_and_logs_exception(
 
     with discovery_mod._PENDING_DISCOVERY_CLOSE_TASKS_LOCK:
         assert task not in discovery_mod._PENDING_DISCOVERY_CLOSE_TASKS
-    assert "Async close/disconnect failed for discarded discovery client." in caplog.text
+    assert (
+        "Async close/disconnect failed for discarded discovery client." in caplog.text
+    )
 
 
 def test_close_discovery_client_best_effort_tracks_pending_task_on_running_loop(
@@ -1247,7 +1251,9 @@ def test_close_discovery_client_best_effort_tracks_pending_task_on_running_loop(
         return awaitable
 
     monkeypatch.setattr(discovery_mod.asyncio, "get_running_loop", _get_running_loop)
-    monkeypatch.setattr(discovery_mod, "_await_close_result", _await_close_result_passthrough)
+    monkeypatch.setattr(
+        discovery_mod, "_await_close_result", _await_close_result_passthrough
+    )
     monkeypatch.setattr(discovery_mod.asyncio, "wait_for", _wait_for_passthrough)
 
     _close_discovery_client_best_effort(_Client())

--- a/tests/test_ble_interface_fixtures.py
+++ b/tests/test_ble_interface_fixtures.py
@@ -276,9 +276,7 @@ def mock_bleak(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     class _StubBLEDevice:
         """Minimal BLEDevice test double."""
 
-        def __init__(
-            self, address: str | None = None, name: str | None = None
-        ) -> None:
+        def __init__(self, address: str | None = None, name: str | None = None) -> None:
             """Create a minimal BLE device representation with an optional address and name.
 
             Parameters

--- a/tests/test_ble_interface_fixtures.py
+++ b/tests/test_ble_interface_fixtures.py
@@ -428,7 +428,7 @@ class DummyClient:
         """Backward-compatible snake_case alias for stopNotify."""
         return self.stopNotify(*args, **kwargs)
 
-    def read_gatt_char(self, *_args, **_kwargs) -> bytes:
+    def read_gatt_char(self, *_args: Any, **_kwargs: Any) -> bytes:
         """Provide a fixed empty-bytes response for any GATT characteristic read.
 
         Returns
@@ -458,7 +458,7 @@ class DummyClient:
         """
         return self.isConnected()
 
-    def disconnect(self, *_args, **_kwargs):
+    def disconnect(self, *_args: Any, **_kwargs: Any) -> None:
         """Record a disconnect invocation and optionally raise a configured exception.
 
         Increments the instance's `disconnect_calls` counter. If `disconnect_exception` is set, that exception is raised instead of returning normally.
@@ -472,14 +472,14 @@ class DummyClient:
         if self.disconnect_exception:
             raise self.disconnect_exception
 
-    def close(self):
+    def close(self) -> None:
         """Record that the client was closed.
 
         Increments the internal `close_calls` counter so tests can assert how many times `close()` was invoked.
         """
         self.close_calls += 1
 
-    def _get_services(self):
+    def _get_services(self) -> SimpleNamespace:
         """Stub for _get_services."""
         return self.services
 

--- a/tests/test_ble_interface_fixtures.py
+++ b/tests/test_ble_interface_fixtures.py
@@ -106,6 +106,7 @@ def mock_publishing_thread(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
 
     Returns
     -------
+    types.ModuleType
         The mocked publishingThread module inserted into sys.modules.
     """
     publishing_thread_module: Any = types.ModuleType("publishingThread")
@@ -186,7 +187,7 @@ def mock_bleak(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
         is_connected()
         """
 
-        def __init__(self, address=None, **_kwargs):
+        def __init__(self, address: str | None = None, **_kwargs: Any) -> None:
             """Initialize a minimal test BLE client with an associated address and a lightweight services shim.
 
             Parameters
@@ -203,7 +204,7 @@ def mock_bleak(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
             self.address = address
             self.services = SimpleNamespace(get_characteristic=lambda _specifier: None)
 
-        async def connect(self, **_kwargs):
+        async def connect(self, **_kwargs: Any) -> None:
             """Stub connect used in tests that ignores any keyword arguments.
 
             This no-op implementation accepts arbitrary keyword arguments and performs no action.
@@ -220,18 +221,18 @@ def mock_bleak(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
             """
             return None
 
-        async def disconnect(self, **_kwargs):
+        async def disconnect(self, **_kwargs: Any) -> None:
             """No-op disconnect that ignores any provided keyword arguments."""
             return None
 
-        async def start_notify(self, *_args, **_kwargs):
+        async def start_notify(self, *_args: Any, **_kwargs: Any) -> None:
             """Compatibility shim for the bleak start_notify API.
 
             Accepts and ignores positional and keyword arguments typically passed to `start_notify` (char_specifier, callback, *args, **kwargs) and performs no action.
             """
             return None
 
-        async def read_gatt_char(self, *_args, **_kwargs):
+        async def read_gatt_char(self, *_args: Any, **_kwargs: Any) -> bytes:
             """Provide an empty value for any GATT characteristic read.
 
             Returns
@@ -241,11 +242,11 @@ def mock_bleak(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
             """
             return b""
 
-        async def write_gatt_char(self, *_args, **_kwargs):
+        async def write_gatt_char(self, *_args: Any, **_kwargs: Any) -> None:
             """Accept any positional and keyword arguments and perform no action."""
             return None
 
-        def is_connected(self):
+        def is_connected(self) -> bool:
             """Report whether the client is connected.
 
             This dummy implementation always reports the client as disconnected.
@@ -257,7 +258,7 @@ def mock_bleak(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
             """
             return False
 
-    async def _stub_discover(**_kwargs):
+    async def _stub_discover(**_kwargs: Any) -> list[Any]:
         """Simulate BLE device discovery for tests when no devices are present.
 
         Parameters
@@ -275,7 +276,9 @@ def mock_bleak(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     class _StubBLEDevice:
         """Minimal BLEDevice test double."""
 
-        def __init__(self, address=None, name=None):
+        def __init__(
+            self, address: str | None = None, name: str | None = None
+        ) -> None:
             """Create a minimal BLE device representation with an optional address and name.
 
             Parameters
@@ -291,11 +294,11 @@ def mock_bleak(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     class _StubBleakScanner:
         """Minimal BleakScanner test double."""
 
-        def __init__(self):
+        def __init__(self) -> None:
             """Initialize a BleakScanner stub that reports no BLE devices."""
 
         @staticmethod
-        async def discover(**_kwargs):
+        async def discover(**_kwargs: Any) -> list[Any]:
             """Simulate BLE device discovery.
 
             Returns
@@ -407,14 +410,14 @@ class DummyClient:
         """
         return False
 
-    def start_notify(self, *_args, **_kwargs):
+    def start_notify(self, *_args: Any, **_kwargs: Any) -> None:
         """Simulate subscribing to a BLE characteristic notification for tests.
 
         Accepts any arguments and performs no action.
         """
         return None
 
-    def stopNotify(self, *args, **_kwargs):
+    def stopNotify(self, *args: Any, **_kwargs: Any) -> None:
         """Simulate unsubscribing from BLE notifications during tests.
 
         When a positional characteristic argument is provided, appends the first positional argument to the instance's stop_notify_calls list for later inspection.
@@ -423,7 +426,7 @@ class DummyClient:
             self.stop_notify_calls.append(args[0])
         return None
 
-    def stop_notify(self, *args, **kwargs):
+    def stop_notify(self, *args: Any, **kwargs: Any) -> None:
         """Backward-compatible snake_case alias for stopNotify."""
         return self.stopNotify(*args, **kwargs)
 

--- a/tests/test_ble_naming_compatibility.py
+++ b/tests/test_ble_naming_compatibility.py
@@ -4,7 +4,11 @@ import asyncio
 import warnings
 from unittest.mock import MagicMock
 
+import pytest
+
 from meshtastic.interfaces.ble import BLEClient, BLEInterface
+
+pytestmark = pytest.mark.unit
 
 
 def test_ble_interface_naming_compatibility() -> None:

--- a/tests/test_ble_runner.py
+++ b/tests/test_ble_runner.py
@@ -16,6 +16,8 @@ from meshtastic.interfaces.ble.runner import (
     get_zombie_runner_count,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def _fake_submit_completed_none(
     coro: Any, _loop: asyncio.AbstractEventLoop
@@ -168,7 +170,7 @@ class TestBLECoroutineRunner:
         runner = BLECoroutineRunner()
         observed_exc_info: list[object] = []
 
-        class _LoopStub:
+        class _ExceptionHandlerLoopStub:
             def __init__(self) -> None:
                 self.seen_contexts: list[dict[str, Any]] = []
 
@@ -183,7 +185,7 @@ class TestBLECoroutineRunner:
         monkeypatch.setattr(
             "meshtastic.interfaces.ble.runner.logger.error", _capture_error
         )
-        loop = _LoopStub()
+        loop = _ExceptionHandlerLoopStub()
 
         runner._handle_loop_exception(
             cast(Any, loop), {"message": "test error", "exception": None}

--- a/tests/test_ble_state_manager.py
+++ b/tests/test_ble_state_manager.py
@@ -20,6 +20,8 @@ from hypothesis import strategies as st
 
 from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
 
+pytestmark = pytest.mark.unit
+
 
 @contextmanager
 def _suppress_ble_debug_logs() -> Generator[None, None, None]:

--- a/tests/test_ble_utils.py
+++ b/tests/test_ble_utils.py
@@ -1,4 +1,5 @@
 """Targeted tests for BLE utility wrappers and error branches."""
+
 # pylint: disable=wrong-import-position
 
 import asyncio

--- a/tests/tuntest.py
+++ b/tests/tuntest.py
@@ -19,17 +19,17 @@ import threading
 
 from pytap2 import TapDevice
 
-# A list of chatty UDP services we should never accidentally
+# A set of chatty UDP services we should never accidentally
 # forward to our slow network.
 UDP_BLACKLIST: set[int] = {
     1900,  # SSDP
     5353,  # multicast DNS
 }
 
-# A list of TCP services to block.
+# A set of TCP services to block.
 TCP_BLACKLIST: set[int] = set()
 
-# A list of protocols we ignore.
+# A set of protocols we ignore.
 PROTOCOL_BLACKLIST: set[int] = {
     0x02,  # IGMP
     0x80,  # Service-Specific Connection-Oriented Protocol in a Multilink and Connectionless Environment
@@ -99,7 +99,13 @@ def _internet_checksum(payload: bytes) -> int:
 
 
 def _readtest(tap: TapDevice) -> None:
-    """Read packets from a TapDevice and log/filter protocol details."""
+    """Read packets from a TapDevice and log/filter protocol details.
+
+    Parameters
+    ----------
+    tap : TapDevice
+        The TUN/TAP device to read packets from.
+    """
     while True:
         p = bytes(tap.read())
         if len(p) < 20:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Overview

This PR centralizes compatibility/deprecation governance into COMPATIBILITY.md, expands and hardens tests (notably mesh_interface), and applies a set of linting, modernization, and robustness improvements across scripts, examples, and tests. Most production-code changes are non‑breaking shims, safer initialization, or synchronization fixes; the largest surface-area change is expanded test coverage.

Key changes

Features
- Documentation
  - Add COMPATIBILITY.md as the canonical compatibility/deprecation inventory and policy (baselines, alias/shim rules, warn-once semantics, maintenance checklist).
  - Update CONTRIBUTING.md, AGENTS.md, REFACTOR_PROGRAM.md, and copilot-instructions.md to reference COMPATIBILITY.md and require updating it when compatibility behavior changes.
- Compatibility shims / aliases
  - Add preference-field normalization aliases in meshtastic.__main__ to accept historical spellings of preference keys.
  - Restore meshtastic.serial as an alias to the third‑party pyserial module (canonical serial symbol).
- Convenience helpers
  - Add camelCase private aliases in meshtastic/mesh_interface.py:
    - _sendPacket(...) → delegates to _send_packet(...)
    - _generatePacketId() → delegates to _generate_packet_id(...)

Fixes
- Thread-safety
  - Make deprecation-warning emission thread-safe using a shared module-level lock in meshtastic/util.py (and related warning paths) to avoid duplicate warnings under concurrency.
- Scripts and build robustness
  - Guard Poetry virtualenv activation and improve quoting/guards in bin/build-bin.sh and bin/regen-protobufs.sh; improve macOS sed handling and tmpdir usage.
  - Make upload script safer (shebang, set -e, robust rm invocation).
- Tests and typing
  - Substantially expand unit tests (very large additions in meshtastic/tests/test_mesh_interface.py).
  - Add or strengthen type annotations across many BLE test fixtures and helpers.
- CI
  - Add a Python 3.13 CI job that validates COMPAT_STABLE_SHIM / COMPAT_DEPRECATE markers and runs a targeted pytest subset.

Refactors, tooling & minor changes
- Lint/config
  - Update trunk/trunk.yaml to ignore LICENSE and protobuf artifacts and tighten pylint scope; reflow .vscode settings.
- Examples and small API ergonomics
  - Refactor examples to use logging and explicit exit codes (e.g., tcp_gps_example), add __main__ guards, and tidy import/order/formatting across modules.
- Tests
  - Add pytest markers (pytest.mark.unit) to multiple BLE test modules and adjust various test import orders/formatting.

Notable code-surface changes (review recommended)
- meshtastic.__init__.py
  - Replace direct "from pubsub import pub" with runtime import_module("pubsub.pub") cast to Any; alters import/initialization semantics (lazy/dynamic import).
- meshtastic.slog package
  - Import order change in meshtastic/slog/__init__.py (swap of root_dir vs rootDir) — verify which symbol is exported.
- meshtastic/slog/slog.py and meshtastic/util.py
  - Switch to shared-lock usage for deprecation-warning paths (synchronization semantics changed).

Breaking changes / migration notes

- pub import semantics: The public symbol pub is now initialized via import_module at runtime rather than a direct import. Behavior should be equivalent at runtime, but code relying on import-time semantics, side effects, or static-type assumptions should be validated.
- meshtastic.slog exports: Verify downstream consumers that import rootDir or root_dir from meshtastic.slog to ensure the expected symbol remains available.
- COMPATIBILITY.md governance: COMPATIBILITY.md is now authoritative for compatibility aliases and deprecations—update it alongside any alias/deprecation changes.

Recommended actions before merge

- Review COMPATIBILITY.md and reconcile any pending compatibility/alias decisions with the centralized inventory.
- Run the expanded test suite (or CI) locally per the updated CONTRIBUTING.md guidance (including mypy --strict if desired).
- Validate downstream integrations that import meshtastic.pub or meshtastic.slog.rootDir/root_dir for expected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->