### PR TITLE
Update dependencies and add tracking document

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
       - name: Summarize meshtasticd integration logs
         if: always()
         run: |
-          ./bin/summarize-meshtasticd-logs.sh \
+          bash ./bin/summarize-meshtasticd-logs.sh \
             "meshtasticd Integration Summary" \
             "./bin/run-smokevirt-with-meshtasticd.sh" \
             "${MESHTASTICD_LOG_DIR}" \
@@ -215,7 +215,7 @@ jobs:
       - name: Summarize meshtasticd multinode logs
         if: always()
         run: |
-          ./bin/summarize-meshtasticd-logs.sh \
+          bash ./bin/summarize-meshtasticd-logs.sh \
             "meshtasticd Multinode Summary" \
             "./bin/run-multinode-with-meshtasticd.sh" \
             "${MESHTASTICD_LOG_DIR}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,27 +175,11 @@ jobs:
       - name: Summarize meshtasticd integration logs
         if: always()
         run: |
-          {
-            echo "### meshtasticd Integration Summary"
-            echo ""
-            echo "- Runner script: \`./bin/run-smokevirt-with-meshtasticd.sh\`"
-            if [[ -d "${MESHTASTICD_LOG_DIR}" ]]; then
-              shopt -s nullglob
-              log_files=("${MESHTASTICD_LOG_DIR}"/*.log)
-              if (( ${#log_files[@]} == 0 )); then
-                echo "- Log files: none"
-              else
-                echo "- Log files:"
-                for log_file in "${log_files[@]}"; do
-                  line_count="$(wc -l <"${log_file}" || echo 0)"
-                  packetish_count="$(grep -E -c 'PACKET FROM PHONE|handleReceived|Forwarding to phone|FromRadio=STATE_SEND_PACKETS' "${log_file}" || true)"
-                  echo "  - \`$(basename "${log_file}")\`: ${line_count} lines, packet-ish lines=${packetish_count}"
-                done
-              fi
-            else
-              echo "- Log directory not found: \`${MESHTASTICD_LOG_DIR}\`"
-            fi
-          } >>"${GITHUB_STEP_SUMMARY}"
+          ./bin/summarize-meshtasticd-logs.sh \
+            "meshtasticd Integration Summary" \
+            "./bin/run-smokevirt-with-meshtasticd.sh" \
+            "${MESHTASTICD_LOG_DIR}" \
+            single >>"${GITHUB_STEP_SUMMARY}"
       - name: Upload meshtasticd integration logs
         if: always()
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
@@ -231,28 +215,11 @@ jobs:
       - name: Summarize meshtasticd multinode logs
         if: always()
         run: |
-          {
-            echo "### meshtasticd Multinode Summary"
-            echo ""
-            echo "- Runner script: \`./bin/run-multinode-with-meshtasticd.sh\`"
-            if [[ -d "${MESHTASTICD_LOG_DIR}" ]]; then
-              shopt -s nullglob
-              log_files=("${MESHTASTICD_LOG_DIR}"/*.log)
-              if (( ${#log_files[@]} == 0 )); then
-                echo "- Log files: none"
-              else
-                echo "- Log files:"
-                for log_file in "${log_files[@]}"; do
-                  line_count="$(wc -l <"${log_file}" || echo 0)"
-                  packetish_count="$(grep -E -c 'PACKET FROM PHONE|handleReceived|Forwarding to phone|FromRadio=STATE_SEND_PACKETS' "${log_file}" || true)"
-                  multicast_count="$(grep -F -c 'Start multicast thread' "${log_file}" || true)"
-                  echo "  - \`$(basename "${log_file}")\`: ${line_count} lines, packet-ish lines=${packetish_count}, multicast=${multicast_count}"
-                done
-              fi
-            else
-              echo "- Log directory not found: \`${MESHTASTICD_LOG_DIR}\`"
-            fi
-          } >>"${GITHUB_STEP_SUMMARY}"
+          ./bin/summarize-meshtasticd-logs.sh \
+            "meshtasticd Multinode Summary" \
+            "./bin/run-multinode-with-meshtasticd.sh" \
+            "${MESHTASTICD_LOG_DIR}" \
+            multinode >>"${GITHUB_STEP_SUMMARY}"
       - name: Upload meshtasticd multinode logs
         if: always()
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3

--- a/DEPENDENCY_UPDATE_TRACKER.md
+++ b/DEPENDENCY_UPDATE_TRACKER.md
@@ -3,7 +3,7 @@
 ## Scope
 
 This document is the high-level tracker for the follow-up dependency refresh
-workstream described in [REFACTOR_PROGRAM.md](/home/jeremiah/dev/meshtastic/python/REFACTOR_PROGRAM.md#L380).
+workstream described in [REFACTOR_PROGRAM.md](REFACTOR_PROGRAM.md#L380).
 
 Goals:
 
@@ -187,3 +187,13 @@ Result:
 - Consequence:
   - keep `pandas` and `pandas-stubs` on 2.x-compatible constraints,
   - do not force Python-marker split that changes effective support policy.
+
+### 2026-03-05 - Review-follow-up maintenance polish
+
+- Replaced local absolute link in this tracker with repo-relative link.
+- Declared `plotly` explicitly in `pyproject.toml` analysis optional dependencies
+  and added it to the `analysis` extra, removing transitive-only reliance.
+- Extracted duplicated GitHub Actions meshtasticd log-summary logic into
+  `bin/summarize-meshtasticd-logs.sh` and switched both CI jobs to call it.
+- Hardened `bin/test-release.sh` `dist` cleanup to remove nested and hidden
+  artifacts under `dist/`.

--- a/DEPENDENCY_UPDATE_TRACKER.md
+++ b/DEPENDENCY_UPDATE_TRACKER.md
@@ -197,3 +197,14 @@ Result:
   `bin/summarize-meshtasticd-logs.sh` and switched both CI jobs to call it.
 - Hardened `bin/test-release.sh` `dist` cleanup to remove nested and hidden
   artifacts under `dist/`.
+
+### 2026-03-05 - Dash 4 migration-risk note
+
+- Recorded explicit migration caveat for the `dash 2.x -> 4.x` major jump:
+  optional analysis UI behavior can still require downstream manual validation
+  even when dependency resolution and test/lint/type gates pass.
+- Confirmed this phase covers:
+  - lock/install resolution with `dash 4.0.0`,
+    `dash-bootstrap-components 2.0.4`, `plotly 6.6.0`,
+  - targeted analysis tests (`meshtastic/tests/test_analysis.py`),
+  - strict type checks.

--- a/DEPENDENCY_UPDATE_TRACKER.md
+++ b/DEPENDENCY_UPDATE_TRACKER.md
@@ -3,7 +3,7 @@
 ## Scope
 
 This document is the high-level tracker for the follow-up dependency refresh
-workstream described in [REFACTOR_PROGRAM.md](REFACTOR_PROGRAM.md#L380).
+workstream described in [REFACTOR_PROGRAM.md](REFACTOR_PROGRAM.md#15-planned-follow-up-dependency-refresh-and-security-updates).
 
 Goals:
 

--- a/DEPENDENCY_UPDATE_TRACKER.md
+++ b/DEPENDENCY_UPDATE_TRACKER.md
@@ -1,0 +1,189 @@
+# Dependency Update Tracker (Phase: `dependencies-update-1`)
+
+## Scope
+
+This document is the high-level tracker for the follow-up dependency refresh
+workstream described in [REFACTOR_PROGRAM.md](/home/jeremiah/dev/meshtastic/python/REFACTOR_PROGRAM.md#L380).
+
+Goals:
+
+1. Update dependencies toward current supported releases.
+2. Clear active advisories from `poetry.lock`.
+3. Record breakages/regressions caused by dependency updates.
+4. Track mitigation decisions when an update cannot be taken immediately.
+
+## Baseline Snapshot (2026-03-05)
+
+Branch: `dependencies-update-1` (from `develop`).
+
+### Baseline commands used
+
+1. `poetry show --top-level`
+2. `poetry show --outdated`
+3. `TRUNK_INTERACTIVE=0 .trunk/trunk check --filter=osv-scanner --show-existing --no-progress poetry.lock`
+
+### Baseline security findings (`poetry.lock`)
+
+Active advisory findings before this phase:
+
+1. `GHSA-68rp-wp8r-4726` (`flask` 3.0.3, low): patch target `>=3.1.3`.
+2. `GHSA-hgf8-39gv-g3f2` (`werkzeug` 3.0.6, medium): patch target `>=3.1.4`.
+3. `GHSA-87hc-h4r5-73f7` (`werkzeug` 3.0.6, medium): patch target `>=3.1.5`.
+4. `GHSA-29vq-49wr-vm6x` (`werkzeug` 3.0.6, medium): patch target `>=3.1.6`.
+
+## Upgrade Inventory (Outdated Packages)
+
+| Package                   | Current           | Latest            | Delta | Area                         | Initial Risk | Status                                  |
+| ------------------------- | ----------------- | ----------------- | ----- | ---------------------------- | ------------ | --------------------------------------- |
+| astroid                   | 3.3.11            | 4.1.1             | major | lint toolchain (pylint dep)  | Medium       | blocked (pylint constraint)             |
+| dash                      | 2.18.2            | 4.0.0             | major | analysis optional runtime    | High         | completed (Batch A)                     |
+| dash-bootstrap-components | 1.7.1             | 2.0.4             | major | analysis optional runtime    | High         | completed (Batch A)                     |
+| flask                     | 3.0.3             | 3.1.3             | minor | transitive (dash) + security | High         | completed (Batch A)                     |
+| isort                     | 6.1.0             | 8.0.1             | major | lint toolchain               | Medium       | completed (Batch C)                     |
+| mypy-protobuf             | 3.7.0             | 5.0.0             | major | typing codegen toolchain     | Medium       | completed (Batch C)                     |
+| packaging                 | 24.2              | 26.0              | major | runtime utility              | Medium       | completed (Batch B)                     |
+| pandas                    | 2.3.3             | 3.0.1             | major | analysis optional runtime    | High         | blocked (Python 3.10 support)           |
+| pandas-stubs              | 2.3.3.260113      | 3.0.0.260204      | major | analysis typing              | Medium       | blocked (Python 3.10 support)           |
+| pdoc3                     | 0.10.0            | 0.11.6            | minor | docs toolchain               | Low          | completed (Batch B)                     |
+| plotly                    | 6.5.2             | 6.6.0             | minor | analysis optional runtime    | Low          | completed (Batch B via dash resolution) |
+| pyinstaller-hooks-contrib | 2026.1            | 2026.2            | patch | build tooling                | Low          | completed (Batch B)                     |
+| pylint                    | 3.3.9             | 4.0.5             | major | lint toolchain               | High         | completed (Batch C)                     |
+| pytest                    | 8.4.2             | 9.0.2             | major | test toolchain               | High         | completed (Batch C)                     |
+| pytest-cov                | 5.0.0             | 7.0.0             | major | test toolchain               | Medium       | completed (Batch C)                     |
+| pytz                      | 2025.2            | 2026.1.post1      | patch | transitive                   | Low          | completed (Batch B)                     |
+| tabulate                  | 0.9.0             | 0.10.0            | major | runtime output formatting    | Medium       | completed (Batch B)                     |
+| types-pytz                | 2025.2.0.20251108 | 2026.1.1.20260304 | patch | typing                       | Low          | completed (Batch B)                     |
+| wcwidth                   | 0.2.14            | 0.6.0             | major | optional CLI extra           | Medium       | completed (Batch B)                     |
+| werkzeug                  | 3.0.6             | 3.1.6             | minor | transitive (dash) + security | High         | completed (Batch A)                     |
+
+## Planned Execution Batches
+
+### Batch A - Security and low-risk transitive remediation
+
+Target: remove `flask`/`werkzeug` advisories with minimal behavioral churn.
+
+Candidate approaches:
+
+1. Update `dash` within compatible range if possible and observe transitive lift.
+2. If needed, pin/raise transitive floor for `flask` + `werkzeug`.
+
+Result:
+
+- Completed by moving `dash` to `4.0.0` and `dash-bootstrap-components` to `2.0.4`.
+- `dash 2.18.2` was a hard blocker for advisory remediation because it requires
+  `flask <3.1` and `werkzeug <3.1`.
+- Advisory findings for `flask`/`werkzeug` are now cleared from `poetry.lock`.
+
+### Batch B - Non-breaking/low-risk tooling updates
+
+Examples: `pdoc3`, `plotly`, `pyinstaller-hooks-contrib`, `pytz`, `types-pytz`.
+
+Result:
+
+- Completed.
+- Updated:
+  - `packaging 24.2 -> 26.0`
+  - `pdoc3 0.10.0 -> 0.11.6`
+  - `tabulate 0.9.0 -> 0.10.0`
+  - `pyinstaller-hooks-contrib 2026.1 -> 2026.2`
+  - `plotly 6.5.2 -> 6.6.0`
+  - `pytz 2025.2 -> 2026.1.post1`
+  - `types-pytz 2025.2.0.20251108 -> 2026.1.1.20260304`
+  - `wcwidth 0.2.14 -> 0.6.0`
+
+### Batch C - Test/lint/type major toolchain upgrades
+
+Examples: `pytest`, `pytest-cov`, `pylint`, `astroid`, `isort`, `mypy-protobuf`.
+
+Result:
+
+- Completed for upgradable items.
+- Updated:
+  - `pytest 8.4.2 -> 9.0.2`
+  - `pytest-cov 5.0.0 -> 7.0.0`
+  - `pylint 3.3.9 -> 4.0.5`
+  - `isort 6.1.0 -> 8.0.1`
+  - `mypy-protobuf 3.7.0 -> 5.0.0`
+  - `astroid 3.3.11 -> 4.0.4`
+- Remaining `astroid` delta (`4.0.4 -> 4.1.1`) is blocked by current
+  `pylint 4.0.5` dependency constraint (`astroid <=4.1.dev0`).
+
+### Batch D - Analysis stack major upgrades
+
+Examples: `dash`, `dash-bootstrap-components`, `pandas`, `pandas-stubs`.
+
+Result:
+
+- Partially completed.
+- `dash`/`dash-bootstrap-components` upgraded in Batch A.
+- `pandas 3.x` and `pandas-stubs 3.x` are blocked while project Python support
+  remains `>=3.10`, because the `3.x` line requires Python `>=3.11`.
+
+## Validation Protocol Per Batch
+
+1. `poetry lock` (or targeted `poetry update ...`) and inspect lock diff.
+2. `TRUNK_INTERACTIVE=0 .trunk/trunk check --fix --show-existing --no-progress`
+3. Targeted checks first:
+   - impacted unit/integration tests
+   - `poetry run mypy meshtastic/`
+   - `poetry run pylint meshtastic examples/ --ignore-patterns ".*_pb2\\.pyi?$"`
+4. If the batch is broad enough, run `make ci-strict` once and then return to
+   targeted runs only for subsequent fixes.
+
+## Progress Log
+
+### 2026-03-05 - Baseline collection
+
+- Re-read `REFACTOR_PROGRAM.md` dependency follow-up section.
+- Captured outdated package set and advisory baseline.
+- Established execution batches and risk levels.
+- No dependency versions changed yet in this log entry.
+
+### 2026-03-05 - Batch A execution (security remediation)
+
+- Updated dependency constraints:
+  - `dash: ^2.17.1 -> ^4.0.0`
+  - `dash-bootstrap-components: ^1.6.0 -> ^2.0.4`
+- Resolved lock and synced environment:
+  - `dash 4.0.0`
+  - `dash-bootstrap-components 2.0.4`
+  - `flask 3.1.3`
+  - `werkzeug 3.1.6`
+- Validation outcomes:
+  - `make ci-strict` passed.
+  - `poetry run pytest meshtastic/tests/test_analysis.py` passed.
+  - `poetry run mypy meshtastic/analysis/__main__.py` passed.
+  - `osv-scanner` for `poetry.lock` reports no findings.
+
+### 2026-03-05 - Batch B execution (low-risk refresh)
+
+- Updated `packaging`, `pdoc3`, `tabulate`, and `pyinstaller-hooks-contrib`.
+- Additional transitive/extra updates landed during environment sync:
+  - `plotly`, `pytz`, `types-pytz`, `wcwidth`.
+- No code regressions observed from this batch.
+
+### 2026-03-05 - Batch C execution (test/lint/type majors)
+
+- Updated:
+  - `pytest`, `pytest-cov`, `pylint`, `isort`, `mypy-protobuf`, `astroid`.
+- Full gate run (`make ci-strict`) surfaced one strict-mypy regression:
+  - `meshtastic/analysis/__main__.py`: unused `type: ignore`.
+- Fix applied by removing stale `type: ignore` on `from dash import ...`.
+- Revalidated strict mypy:
+  - `poetry run mypy meshtastic/ --strict` passed.
+
+### 2026-03-05 - Batch D investigation (pandas 3 line)
+
+- Attempted upgrade to `pandas 3.0.1` and `pandas-stubs 3.0.0.260204`.
+- Resolver failure confirmed:
+  - `pandas 3.x` requires Python `>=3.11`.
+  - project currently supports Python `>=3.10,<3.15`.
+- Decision: keep current pandas 2.x line and record as blocked pending policy
+  change to drop Python 3.10 support.
+
+### 2026-03-05 - Policy confirmation
+
+- Confirmed project policy for this phase: keep minimum supported Python at 3.10.
+- Consequence:
+  - keep `pandas` and `pandas-stubs` on 2.x-compatible constraints,
+  - do not force Python-marker split that changes effective support policy.

--- a/bin/summarize-meshtasticd-logs.sh
+++ b/bin/summarize-meshtasticd-logs.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -lt 3 ]]; then
+	echo "Usage: $0 <title> <runner-script> <log-dir> [single|multinode]" >&2
+	exit 1
+fi
+
+TITLE=$1
+RUNNER_SCRIPT=$2
+LOG_DIR=$3
+MODE=${4:-single}
+
+echo "### ${TITLE}"
+echo ""
+echo "- Runner script: \`${RUNNER_SCRIPT}\`"
+
+if [[ -d ${LOG_DIR} ]]; then
+	shopt -s nullglob
+	log_files=("${LOG_DIR}"/*.log)
+	if ((${#log_files[@]} == 0)); then
+		echo "- Log files: none"
+		exit 0
+	fi
+
+	echo "- Log files:"
+	for log_file in "${log_files[@]}"; do
+		line_count="$(wc -l <"${log_file}" || echo 0)"
+		packetish_count="$(grep -E -c 'PACKET FROM PHONE|handleReceived|Forwarding to phone|FromRadio=STATE_SEND_PACKETS' "${log_file}" || true)"
+		if [[ ${MODE} == "multinode" ]]; then
+			multicast_count="$(grep -F -c 'Start multicast thread' "${log_file}" || true)"
+			echo "  - \`$(basename "${log_file}")\`: ${line_count} lines, packet-ish lines=${packetish_count}, multicast=${multicast_count}"
+		else
+			echo "  - \`$(basename "${log_file}")\`: ${line_count} lines, packet-ish lines=${packetish_count}"
+		fi
+	done
+else
+	echo "- Log directory not found: \`${LOG_DIR}\`"
+fi

--- a/bin/summarize-meshtasticd-logs.sh
+++ b/bin/summarize-meshtasticd-logs.sh
@@ -40,11 +40,11 @@ if [[ -d "${LOG_DIR}" ]]; then
 			' "${log_file}"
 		)"
 		read -r line_count packetish_count multicast_count <<<"${awk_counts}"
+		summary="  - \`$(basename "${log_file}")\`: ${line_count} lines, packet-ish lines=${packetish_count}"
 		if [[ ${MODE} == "multinode" ]]; then
-			echo "  - \`$(basename "${log_file}")\`: ${line_count} lines, packet-ish lines=${packetish_count}, multicast=${multicast_count}"
-		else
-			echo "  - \`$(basename "${log_file}")\`: ${line_count} lines, packet-ish lines=${packetish_count}"
+			summary+=", multicast=${multicast_count}"
 		fi
+		echo "${summary}"
 	done
 else
 	echo "- Log directory not found: \`${LOG_DIR}\`"

--- a/bin/summarize-meshtasticd-logs.sh
+++ b/bin/summarize-meshtasticd-logs.sh
@@ -32,10 +32,15 @@ if [[ -d "${LOG_DIR}" ]]; then
 
 	echo "- Log files:"
 	for log_file in "${log_files[@]}"; do
-		line_count="$(wc -l <"${log_file}" || echo 0)"
-		packetish_count="$(grep -E -c 'PACKET FROM PHONE|handleReceived|Forwarding to phone|FromRadio=STATE_SEND_PACKETS' "${log_file}" || true)"
+		awk_counts="$(
+			awk '
+				/PACKET FROM PHONE|handleReceived|Forwarding to phone|FromRadio=STATE_SEND_PACKETS/ { packet_count++ }
+				/Start multicast thread/ { multicast_count++ }
+				END { print NR + 0, packet_count + 0, multicast_count + 0 }
+			' "${log_file}"
+		)"
+		read -r line_count packetish_count multicast_count <<<"${awk_counts}"
 		if [[ ${MODE} == "multinode" ]]; then
-			multicast_count="$(grep -F -c 'Start multicast thread' "${log_file}" || true)"
 			echo "  - \`$(basename "${log_file}")\`: ${line_count} lines, packet-ish lines=${packetish_count}, multicast=${multicast_count}"
 		else
 			echo "  - \`$(basename "${log_file}")\`: ${line_count} lines, packet-ish lines=${packetish_count}"

--- a/bin/summarize-meshtasticd-logs.sh
+++ b/bin/summarize-meshtasticd-logs.sh
@@ -7,18 +7,24 @@ if [[ $# -lt 3 ]]; then
 	exit 1
 fi
 
-TITLE=$1
-RUNNER_SCRIPT=$2
-LOG_DIR=$3
-MODE=${4:-single}
+TITLE="$1"
+RUNNER_SCRIPT="$2"
+LOG_DIR="$3"
+MODE="${4:-single}"
+
+if [[ ${MODE} != "single" && ${MODE} != "multinode" ]]; then
+	echo "Invalid mode: ${MODE}. Expected 'single' or 'multinode'." >&2
+	exit 1
+fi
 
 echo "### ${TITLE}"
 echo ""
 echo "- Runner script: \`${RUNNER_SCRIPT}\`"
 
-if [[ -d ${LOG_DIR} ]]; then
+if [[ -d "${LOG_DIR}" ]]; then
 	shopt -s nullglob
 	log_files=("${LOG_DIR}"/*.log)
+	shopt -u nullglob
 	if ((${#log_files[@]} == 0)); then
 		echo "- Log files: none"
 		exit 0

--- a/bin/test-release.sh
+++ b/bin/test-release.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 if [[ -d dist ]]; then
-	rm -f dist/*
+	find dist -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
 fi
 
 bin/regen-docs.sh

--- a/meshtastic/analysis/__main__.py
+++ b/meshtastic/analysis/__main__.py
@@ -14,7 +14,7 @@ import pandas as pd
 import plotly.express as px  # type: ignore[import-untyped]
 import plotly.graph_objects as go  # type: ignore[import-untyped]
 import pyarrow as pa
-from dash import Dash, dcc, html  # type: ignore[import-untyped]
+from dash import Dash, dcc, html
 from pyarrow import feather
 
 from .. import mesh_pb2, powermon_pb2, util

--- a/poetry.lock
+++ b/poetry.lock
@@ -140,14 +140,14 @@ test = ["dateparser (==1.*)", "pre-commit", "pytest", "pytest-cov", "pytest-mock
 
 [[package]]
 name = "astroid"
-version = "3.3.11"
+version = "4.0.4"
 description = "An abstract syntax tree for Python with inference support."
 optional = false
-python-versions = ">=3.9.0"
+python-versions = ">=3.10.0"
 groups = ["dev"]
 files = [
-    {file = "astroid-3.3.11-py3-none-any.whl", hash = "sha256:54c760ae8322ece1abd213057c4b5bba7c49818853fc901ef09719a60dbf9dec"},
-    {file = "astroid-3.3.11.tar.gz", hash = "sha256:1e5a5011af2920c7c67a53f65d536d65bfa7116feeaf2354d8b94f29573bb0ce"},
+    {file = "astroid-4.0.4-py3-none-any.whl", hash = "sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753"},
+    {file = "astroid-4.0.4.tar.gz", hash = "sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0"},
 ]
 
 [package.dependencies]
@@ -914,96 +914,57 @@ tests = ["pytest", "pytest-cov", "pytest-xdist"]
 
 [[package]]
 name = "dash"
-version = "2.18.2"
+version = "4.0.0"
 description = "A Python framework for building reactive web-apps. Developed by Plotly."
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
 markers = "extra == \"analysis\""
 files = [
-    {file = "dash-2.18.2-py3-none-any.whl", hash = "sha256:0ce0479d1bc958e934630e2de7023b8a4558f23ce1f9f5a4b34b65eb3903a869"},
-    {file = "dash-2.18.2.tar.gz", hash = "sha256:20e8404f73d0fe88ce2eae33c25bbc513cbe52f30d23a401fa5f24dbb44296c8"},
+    {file = "dash-4.0.0-py3-none-any.whl", hash = "sha256:e36b4b4eae9e1fa4136bf4f1450ed14ef76063bc5da0b10f8ab07bd57a7cb1ab"},
+    {file = "dash-4.0.0.tar.gz", hash = "sha256:c5f2bca497af288f552aea3ae208f6a0cca472559003dac84ac21187a1c3a142"},
 ]
 
 [package.dependencies]
-dash-core-components = "2.0.0"
-dash-html-components = "2.0.0"
-dash-table = "5.0.0"
-Flask = ">=1.0.4,<3.1"
+Flask = ">=1.0.4,<3.2"
 importlib-metadata = "*"
 nest-asyncio = "*"
 plotly = ">=5.0.0"
 requests = "*"
 retrying = "*"
 setuptools = "*"
-typing-extensions = ">=4.1.1"
-Werkzeug = "<3.1"
+typing_extensions = ">=4.1.1"
+Werkzeug = "<3.2"
 
 [package.extras]
-celery = ["celery[redis] (>=5.1.2)", "redis (>=3.5.3)"]
-ci = ["black (==22.3.0)", "dash-dangerously-set-inner-html", "dash-flow-example (==0.0.5)", "flake8 (==7.0.0)", "flaky (==3.8.1)", "flask-talisman (==1.0.0)", "jupyterlab (<4.0.0)", "mimesis (<=11.1.0)", "mock (==4.0.3)", "numpy (<=1.26.3)", "openpyxl", "orjson (==3.10.3)", "pandas (>=1.4.0)", "pyarrow", "pylint (==3.0.3)", "pytest-mock", "pytest-rerunfailures", "pytest-sugar (==0.9.6)", "pyzmq (==25.1.2)", "xlrd (>=2.0.1)"]
+ag-grid = ["dash-ag-grid"]
+async = ["flask[async]"]
+celery = ["celery[redis] (>=5.1.2,<5.4.0)", "kombu (<5.4.0)", "redis (>=3.5.3,<=5.0.4)"]
+ci = ["black (==22.3.0)", "flake8 (==7.0.0)", "flaky (==3.8.1)", "flask-talisman (==1.0.0)", "ipython (<9.0.0)", "jupyterlab (<4.0.0)", "mimesis (<=11.1.0)", "mock (==4.0.3)", "mypy (==1.15.0) ; python_version >= \"3.12\"", "numpy (<=1.26.3)", "openpyxl", "orjson (>=3.10.11)", "pandas (>=1.4.0)", "pyarrow", "pylint (==3.0.3)", "pyright (==1.1.398) ; python_version >= \"3.7\"", "pytest-mock", "pytest-rerunfailures", "pytest-sugar (==1.1.1)", "pyzmq (>=26.0.0)", "xlrd (>=2.0.1)"]
+cloud = ["plotly-cloud"]
 compress = ["flask-compress"]
 dev = ["PyYAML (>=5.4.1)", "coloredlogs (>=15.0.1)", "fire (>=0.4.0)"]
 diskcache = ["diskcache (>=5.2.1)", "multiprocess (>=0.70.12)", "psutil (>=5.8.0)"]
-testing = ["beautifulsoup4 (>=4.8.2)", "cryptography", "dash-testing-stub (>=0.0.2)", "lxml (>=4.6.2)", "multiprocess (>=0.70.12)", "percy (>=2.0.2)", "psutil (>=5.8.0)", "pytest (>=6.0.2)", "requests[security] (>=2.21.0)", "selenium (>=3.141.0,<=4.2.0)", "waitress (>=1.4.4)"]
+testing = ["beautifulsoup4 (>=4.8.2)", "cryptography", "dash_testing_stub (>=0.0.2)", "lxml (>=4.6.2)", "multiprocess (>=0.70.12)", "percy (>=2.0.2)", "psutil (>=5.8.0)", "pytest (>=6.0.2)", "requests[security] (>=2.21.0)", "selenium (>=3.141.0,<=4.2.0)", "waitress (>=1.4.4)"]
 
 [[package]]
 name = "dash-bootstrap-components"
-version = "1.7.1"
+version = "2.0.4"
 description = "Bootstrap themed components for use in Plotly Dash"
 optional = true
-python-versions = "<4,>=3.9"
+python-versions = ">=3.9"
 groups = ["main"]
 markers = "extra == \"analysis\""
 files = [
-    {file = "dash_bootstrap_components-1.7.1-py3-none-any.whl", hash = "sha256:5e8eae7ee1d013f69e272c68c1015b53ab71802460152088f33fffa90d245199"},
-    {file = "dash_bootstrap_components-1.7.1.tar.gz", hash = "sha256:30d48340d6dc89831d6c06e400cd4236f0d5363562c05b2a922f21545695a082"},
+    {file = "dash_bootstrap_components-2.0.4-py3-none-any.whl", hash = "sha256:767cf0084586c1b2b614ccf50f79fe4525fdbbf8e3a161ed60016e584a14f5d1"},
+    {file = "dash_bootstrap_components-2.0.4.tar.gz", hash = "sha256:c3206c0923774bbc6a6ddaa7822b8d9aa5326b0d3c1e7cd795cc975025fe2484"},
 ]
 
 [package.dependencies]
-dash = ">=2.0.0"
+dash = ">=3.0.4"
 
 [package.extras]
 pandas = ["numpy (>=2.0.2)", "pandas (>=2.2.3)"]
-
-[[package]]
-name = "dash-core-components"
-version = "2.0.0"
-description = "Core component suite for Dash"
-optional = true
-python-versions = "*"
-groups = ["main"]
-markers = "extra == \"analysis\""
-files = [
-    {file = "dash_core_components-2.0.0-py3-none-any.whl", hash = "sha256:52b8e8cce13b18d0802ee3acbc5e888cb1248a04968f962d63d070400af2e346"},
-    {file = "dash_core_components-2.0.0.tar.gz", hash = "sha256:c6733874af975e552f95a1398a16c2ee7df14ce43fa60bb3718a3c6e0b63ffee"},
-]
-
-[[package]]
-name = "dash-html-components"
-version = "2.0.0"
-description = "Vanilla HTML components for Dash"
-optional = true
-python-versions = "*"
-groups = ["main"]
-markers = "extra == \"analysis\""
-files = [
-    {file = "dash_html_components-2.0.0-py3-none-any.whl", hash = "sha256:b42cc903713c9706af03b3f2548bda4be7307a7cf89b7d6eae3da872717d1b63"},
-    {file = "dash_html_components-2.0.0.tar.gz", hash = "sha256:8703a601080f02619a6390998e0b3da4a5daabe97a1fd7a9cebc09d015f26e50"},
-]
-
-[[package]]
-name = "dash-table"
-version = "5.0.0"
-description = "Dash table"
-optional = true
-python-versions = "*"
-groups = ["main"]
-markers = "extra == \"analysis\""
-files = [
-    {file = "dash_table-5.0.0-py3-none-any.whl", hash = "sha256:19036fa352bb1c11baf38068ec62d172f0515f73ca3276c79dee49b95ddc16c9"},
-    {file = "dash_table-5.0.0.tar.gz", hash = "sha256:18624d693d4c8ef2ddec99a6f167593437a7ea0bf153aa20f318c170c5bc7308"},
-]
 
 [[package]]
 name = "dbus-fast"
@@ -1197,23 +1158,24 @@ devel = ["colorama", "json-spec", "jsonschema", "pylint", "pytest", "pytest-benc
 
 [[package]]
 name = "flask"
-version = "3.0.3"
+version = "3.1.3"
 description = "A simple framework for building complex web applications."
 optional = true
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 markers = "extra == \"analysis\""
 files = [
-    {file = "flask-3.0.3-py3-none-any.whl", hash = "sha256:34e815dfaa43340d1d15a5c3a02b8476004037eb4840b34910c6e21679d288f3"},
-    {file = "flask-3.0.3.tar.gz", hash = "sha256:ceb27b0af3823ea2737928a4d99d125a06175b8512c445cbd9a9ce200ef76842"},
+    {file = "flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c"},
+    {file = "flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb"},
 ]
 
 [package.dependencies]
-blinker = ">=1.6.2"
+blinker = ">=1.9.0"
 click = ">=8.1.3"
-itsdangerous = ">=2.1.2"
-Jinja2 = ">=3.1.2"
-Werkzeug = ">=3.0.0"
+itsdangerous = ">=2.2.0"
+jinja2 = ">=3.1.2"
+markupsafe = ">=2.1.1"
+werkzeug = ">=3.1.0"
 
 [package.extras]
 async = ["asgiref (>=3.2)"]
@@ -1635,19 +1597,18 @@ arrow = ">=0.15.0"
 
 [[package]]
 name = "isort"
-version = "6.1.0"
+version = "8.0.1"
 description = "A Python utility / library to sort Python imports."
 optional = false
-python-versions = ">=3.9.0"
+python-versions = ">=3.10.0"
 groups = ["dev"]
 files = [
-    {file = "isort-6.1.0-py3-none-any.whl", hash = "sha256:58d8927ecce74e5087aef019f778d4081a3b6c98f15a80ba35782ca8a2097784"},
-    {file = "isort-6.1.0.tar.gz", hash = "sha256:9b8f96a14cfee0677e78e941ff62f03769a06d412aabb9e2a90487b3b7e8d481"},
+    {file = "isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75"},
+    {file = "isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d"},
 ]
 
 [package.extras]
 colors = ["colorama"]
-plugins = ["setuptools"]
 
 [[package]]
 name = "itsdangerous"
@@ -2596,14 +2557,14 @@ files = [
 
 [[package]]
 name = "mypy-protobuf"
-version = "3.7.0"
+version = "5.0.0"
 description = "Generate mypy stub files from protobuf specs"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "mypy_protobuf-3.7.0-py3-none-any.whl", hash = "sha256:85256e9d4da935722ce8fbaa8d19397e1a2989aa8075c96577987de9fe7cea4d"},
-    {file = "mypy_protobuf-3.7.0.tar.gz", hash = "sha256:912fb281f7c7b3e3a7c9b8695712618a716fddbab70f6ad63eaf68eda80c5efe"},
+    {file = "mypy_protobuf-5.0.0-py3-none-any.whl", hash = "sha256:3a7dd753ef3e3b8783a824eb51f07983f62812f9ec066e4fbb1b22d6c5dc36d0"},
+    {file = "mypy_protobuf-5.0.0.tar.gz", hash = "sha256:6fdd1cfdbb4419c713291d800a332d4bba6510dbd1341ed95e0bcc82fcadb6b5"},
 ]
 
 [package.dependencies]
@@ -2914,14 +2875,14 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "24.2"
+version = "26.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "analysis", "dev"]
 files = [
-    {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
-    {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
+    {file = "packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"},
+    {file = "packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4"},
 ]
 
 [[package]]
@@ -2993,8 +2954,8 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">=1.22.4", markers = "python_version < \"3.11\""},
-    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
     {version = ">=1.23.2", markers = "python_version == \"3.11\""},
+    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -3102,14 +3063,14 @@ tests = ["pytest (>=9)", "typing-extensions (>=4.15)"]
 
 [[package]]
 name = "pdoc3"
-version = "0.10.0"
+version = "0.11.6"
 description = "Auto-generate API documentation for Python projects."
 optional = false
-python-versions = ">= 3.6"
+python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "pdoc3-0.10.0-py3-none-any.whl", hash = "sha256:ba45d1ada1bd987427d2bf5cdec30b2631a3ff5fb01f6d0e77648a572ce6028b"},
-    {file = "pdoc3-0.10.0.tar.gz", hash = "sha256:5f22e7bcb969006738e1aa4219c75a32f34c2d62d46dc9d2fb2d3e0b0287e4b7"},
+    {file = "pdoc3-0.11.6-py3-none-any.whl", hash = "sha256:8b72723767bd48d899812d2aec8375fc1c3476e179455db0b4575e6dccb44b93"},
+    {file = "pdoc3-0.11.6.tar.gz", hash = "sha256:1ea5e84b87a754d191fb64bf5e517ca6c50d0d84a614c1efecf6b46d290ae387"},
 ]
 
 [package.dependencies]
@@ -3268,15 +3229,15 @@ files = [
 
 [[package]]
 name = "plotly"
-version = "6.5.2"
+version = "6.6.0"
 description = "An open-source interactive data visualization library for Python"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
 markers = "extra == \"analysis\""
 files = [
-    {file = "plotly-6.5.2-py3-none-any.whl", hash = "sha256:91757653bd9c550eeea2fa2404dba6b85d1e366d54804c340b2c874e5a7eb4a4"},
-    {file = "plotly-6.5.2.tar.gz", hash = "sha256:7478555be0198562d1435dee4c308268187553cc15516a2f4dd034453699e393"},
+    {file = "plotly-6.6.0-py3-none-any.whl", hash = "sha256:8d6daf0f87412e0c0bfe72e809d615217ab57cc715899a1e5145135a7800d1d0"},
+    {file = "plotly-6.6.0.tar.gz", hash = "sha256:b897f15f3b02028d69f755f236be890ba950d0a42d7dfc619b44e2d8cea8748c"},
 ]
 
 [package.dependencies]
@@ -3600,14 +3561,14 @@ hook-testing = ["execnet (>=1.5.0)", "psutil", "pytest (>=2.7.3)"]
 
 [[package]]
 name = "pyinstaller-hooks-contrib"
-version = "2026.1"
+version = "2026.2"
 description = "Community maintained hooks for PyInstaller"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "pyinstaller_hooks_contrib-2026.1-py3-none-any.whl", hash = "sha256:66ad4888ba67de6f3cfd7ef554f9dd1a4389e2eb19f84d7129a5a6818e3f2180"},
-    {file = "pyinstaller_hooks_contrib-2026.1.tar.gz", hash = "sha256:a5f0891a1e81e92406ab917d9e76adfd7a2b68415ee2e35c950a7b3910bc361b"},
+    {file = "pyinstaller_hooks_contrib-2026.2-py3-none-any.whl", hash = "sha256:fc29f0481b58adf78ce9c1d9cf135fe96f38c708f74b2aa0670ef93e59578ab9"},
+    {file = "pyinstaller_hooks_contrib-2026.2.tar.gz", hash = "sha256:cbd1eb00b5d13301b1cce602e1fffb17f0c531c0391f0a87a383d376be68a186"},
 ]
 
 [package.dependencies]
@@ -3616,25 +3577,25 @@ setuptools = ">=42.0.0"
 
 [[package]]
 name = "pylint"
-version = "3.3.9"
+version = "4.0.5"
 description = "python code static checker"
 optional = false
-python-versions = ">=3.9.0"
+python-versions = ">=3.10.0"
 groups = ["dev"]
 files = [
-    {file = "pylint-3.3.9-py3-none-any.whl", hash = "sha256:01f9b0462c7730f94786c283f3e52a1fbdf0494bbe0971a78d7277ef46a751e7"},
-    {file = "pylint-3.3.9.tar.gz", hash = "sha256:d312737d7b25ccf6b01cc4ac629b5dcd14a0fcf3ec392735ac70f137a9d5f83a"},
+    {file = "pylint-4.0.5-py3-none-any.whl", hash = "sha256:00f51c9b14a3b3ae08cff6b2cdd43f28165c78b165b628692e428fb1f8dc2cf2"},
+    {file = "pylint-4.0.5.tar.gz", hash = "sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c"},
 ]
 
 [package.dependencies]
-astroid = ">=3.3.8,<=3.4.0.dev0"
+astroid = ">=4.0.2,<=4.1.dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
     {version = ">=0.2", markers = "python_version < \"3.11\""},
+    {version = ">=0.3.6", markers = "python_version >= \"3.11\""},
     {version = ">=0.3.7", markers = "python_version >= \"3.12\""},
-    {version = ">=0.3.6", markers = "python_version == \"3.11\""},
 ]
-isort = ">=4.2.5,<5.13 || >5.13,<7"
+isort = ">=5,<5.13 || >5.13,<9"
 mccabe = ">=0.6,<0.8"
 platformdirs = ">=2.2"
 tomli = {version = ">=1.1", markers = "python_version < \"3.11\""}
@@ -3804,21 +3765,21 @@ files = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.2"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b"},
+    {file = "pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -3828,22 +3789,23 @@ dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests
 
 [[package]]
 name = "pytest-cov"
-version = "5.0.0"
+version = "7.0.0"
 description = "Pytest plugin for measuring coverage."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "pytest-cov-5.0.0.tar.gz", hash = "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857"},
-    {file = "pytest_cov-5.0.0-py3-none-any.whl", hash = "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652"},
+    {file = "pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861"},
+    {file = "pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1"},
 ]
 
 [package.dependencies]
-coverage = {version = ">=5.2.1", extras = ["toml"]}
-pytest = ">=4.6"
+coverage = {version = ">=7.10.6", extras = ["toml"]}
+pluggy = ">=1.2"
+pytest = ">=7"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
+testing = ["process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
 name = "python-dateutil"
@@ -3878,15 +3840,15 @@ dev = ["backports.zoneinfo ; python_version < \"3.9\"", "black", "build", "freez
 
 [[package]]
 name = "pytz"
-version = "2025.2"
+version = "2026.1.post1"
 description = "World timezone definitions, modern and historical"
 optional = true
 python-versions = "*"
 groups = ["main"]
 markers = "extra == \"analysis\""
 files = [
-    {file = "pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00"},
-    {file = "pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3"},
+    {file = "pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a"},
+    {file = "pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1"},
 ]
 
 [[package]]
@@ -4457,14 +4419,14 @@ tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 
 [[package]]
 name = "tabulate"
-version = "0.9.0"
+version = "0.10.0"
 description = "Pretty-print tabular data"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f"},
-    {file = "tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c"},
+    {file = "tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3"},
+    {file = "tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d"},
 ]
 
 [package.extras]
@@ -4633,15 +4595,15 @@ files = [
 
 [[package]]
 name = "types-pytz"
-version = "2025.2.0.20251108"
+version = "2026.1.1.20260304"
 description = "Typing stubs for pytz"
 optional = true
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 markers = "extra == \"analysis\""
 files = [
-    {file = "types_pytz-2025.2.0.20251108-py3-none-any.whl", hash = "sha256:0f1c9792cab4eb0e46c52f8845c8f77cf1e313cb3d68bf826aa867fe4717d91c"},
-    {file = "types_pytz-2025.2.0.20251108.tar.gz", hash = "sha256:fca87917836ae843f07129567b74c1929f1870610681b4c92cb86a3df5817bdb"},
+    {file = "types_pytz-2026.1.1.20260304-py3-none-any.whl", hash = "sha256:175332c1cf7bd6b1cc56b877f70bf02def1a3f75e5adcc05385ce2c3c70e6500"},
+    {file = "types_pytz-2026.1.1.20260304.tar.gz", hash = "sha256:0c3542d8e9b0160b424233440c52b83d6f58cae4b85333d54e4f961cf013e117"},
 ]
 
 [[package]]
@@ -4706,7 +4668,7 @@ files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
-markers = {main = "platform_system == \"Windows\" or extra == \"analysis\" or python_version < \"3.12\""}
+markers = {main = "python_version < \"3.12\" or platform_system == \"Windows\" or extra == \"analysis\""}
 
 [[package]]
 name = "tzdata"
@@ -4756,14 +4718,14 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
 name = "wcwidth"
-version = "0.2.14"
+version = "0.6.0"
 description = "Measures the displayed width of unicode strings in a terminal"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 groups = ["main", "analysis"]
 files = [
-    {file = "wcwidth-0.2.14-py2.py3-none-any.whl", hash = "sha256:a7bb560c8aee30f9957e5f9895805edd20602f2d7f720186dfd906e82b4982e1"},
-    {file = "wcwidth-0.2.14.tar.gz", hash = "sha256:4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605"},
+    {file = "wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad"},
+    {file = "wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159"},
 ]
 markers = {main = "extra == \"cli\""}
 
@@ -4810,19 +4772,19 @@ test = ["pytest", "websockets"]
 
 [[package]]
 name = "werkzeug"
-version = "3.0.6"
+version = "3.1.6"
 description = "The comprehensive WSGI web application library."
 optional = true
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 markers = "extra == \"analysis\""
 files = [
-    {file = "werkzeug-3.0.6-py3-none-any.whl", hash = "sha256:1bc0c2310d2fbb07b1dd1105eba2f7af72f322e1e455f2f93c993bee8c8a5f17"},
-    {file = "werkzeug-3.0.6.tar.gz", hash = "sha256:a8dd59d4de28ca70471a34cba79bed5f7ef2e036a76b3ab0835474246eb41f8d"},
+    {file = "werkzeug-3.1.6-py3-none-any.whl", hash = "sha256:7ddf3357bb9564e407607f988f683d72038551200c704012bb9a4c523d42f131"},
+    {file = "werkzeug-3.1.6.tar.gz", hash = "sha256:210c6bede5a420a913956b4791a7f4d6843a43b6fcee4dfa08a65e93007d0d25"},
 ]
 
 [package.dependencies]
-MarkupSafe = ">=2.1.1"
+markupsafe = ">=2.1.1"
 
 [package.extras]
 watchdog = ["watchdog (>=2.3)"]
@@ -5189,4 +5151,4 @@ tunnel = ["pytap2"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10,<3.15"
-content-hash = "2a3ec9b9d145c6b49dde58a14a213cd1ae1b27f90b3a83e8303a8bf24500ab60"
+content-hash = "776b80d52f364b231c05d454bb13db651faf006e3ef3378a50482611b1c3b6c1"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2954,8 +2954,8 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">=1.22.4", markers = "python_version < \"3.11\""},
-    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
     {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
+    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -3592,8 +3592,8 @@ astroid = ">=4.0.2,<=4.1.dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
     {version = ">=0.2", markers = "python_version < \"3.11\""},
-    {version = ">=0.3.6", markers = "python_version >= \"3.11\""},
     {version = ">=0.3.7", markers = "python_version >= \"3.12\""},
+    {version = ">=0.3.6", markers = "python_version == \"3.11\""},
 ]
 isort = ">=5,<5.13 || >5.13,<9"
 mccabe = ">=0.6,<0.8"
@@ -4668,7 +4668,7 @@ files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
-markers = {main = "python_version < \"3.12\" or platform_system == \"Windows\" or extra == \"analysis\""}
+markers = {main = "platform_system == \"Windows\" or extra == \"analysis\" or python_version < \"3.12\""}
 
 [[package]]
 name = "tzdata"
@@ -5144,11 +5144,11 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more_it
 type = ["pytest-mypy"]
 
 [extras]
-analysis = ["dash", "dash-bootstrap-components", "pandas", "pandas-stubs"]
+analysis = ["dash", "dash-bootstrap-components", "pandas", "pandas-stubs", "plotly"]
 cli = ["argcomplete", "dotmap", "print-color", "pyqrcode", "wcwidth"]
 tunnel = ["pytap2"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10,<3.15"
-content-hash = "776b80d52f364b231c05d454bb13db651faf006e3ef3378a50482611b1c3b6c1"
+content-hash = "f3219b9579b2df32d3aaf254aa98f8b4f159def281b3c4bb38c1cc2208ff8571"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,33 +13,33 @@ include = [{ path = "meshtastic/py.typed", format = ["sdist", "wheel"] }]
 python = "^3.10,<3.15"
 pyserial = "^3.5"
 protobuf = ">=4.21.12"
-tabulate = "^0.9.0"
+tabulate = "^0.10.0"
 requests = "^2.31.0"
 pyyaml = "^6.0.1"
 pypubsub = "^4.0.3"
 bleak = "^2.1.1"
-packaging = "^24.0"
+packaging = "^26.0"
 argcomplete = { version = "^3.5.2", optional = true }
 pyqrcode = { version = "^1.2.1", optional = true }
 dotmap = { version = "^1.3.30", optional = true }
 print-color = { version = "^0.4.6", optional = true }
-dash = { version = "^2.17.1", optional = true }
+dash = { version = "^4.0.0", optional = true }
 pytap2 = { version = "^2.3.0", optional = true }
-dash-bootstrap-components = { version = "^1.6.0", optional = true }
+dash-bootstrap-components = { version = "^2.0.4", optional = true }
 pandas = { version = "^2.2.2", optional = true }
 pandas-stubs = { version = "^2.3.3.260113", optional = true }
-wcwidth = { version = "^0.2.13", optional = true }
+wcwidth = { version = "^0.6.0", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 hypothesis = "^6.103.2"
-pytest = "^8.2.2"
-pytest-cov = "^5.0.0"
-pdoc3 = "^0.10.0"
+pytest = "^9.0.2"
+pytest-cov = "^7.0.0"
+pdoc3 = "^0.11.6"
 autopep8 = "^2.1.0"
-pylint = "^3.2.3"
+pylint = "^4.0.5"
 pyinstaller = "^6.10.0"
 mypy = "^1.10.0"
-mypy-protobuf = "^3.3.0"
+mypy-protobuf = "^5.0.0"
 types-protobuf = "^6.32.1.20250221"
 types-tabulate = "^0.9.0.20241207"
 types-requests = "^2.32.4.20260107"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ print-color = { version = "^0.4.6", optional = true }
 dash = { version = "^4.0.0", optional = true }
 pytap2 = { version = "^2.3.0", optional = true }
 dash-bootstrap-components = { version = "^2.0.4", optional = true }
+plotly = { version = "^6.6.0", optional = true }
 pandas = { version = "^2.2.2", optional = true }
 pandas-stubs = { version = "^2.3.3.260113", optional = true }
 wcwidth = { version = "^0.6.0", optional = true }
@@ -71,7 +72,13 @@ jupyterlab-widgets = "^3.0.11"
 [tool.poetry.extras]
 cli = ["pyqrcode", "print-color", "dotmap", "argcomplete", "wcwidth"]
 tunnel = ["pytap2"]
-analysis = ["dash", "dash-bootstrap-components", "pandas", "pandas-stubs"]
+analysis = [
+  "dash",
+  "dash-bootstrap-components",
+  "plotly",
+  "pandas",
+  "pandas-stubs",
+]
 
 [tool.poetry.scripts]
 meshtastic = "meshtastic.__main__:main"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This pull request updates multiple project and development dependencies to newer compatible versions and adds DEPENDENCY_UPDATE_TRACKER.md to formalize and track future dependency refreshes. Additional changes standardize CI log summarization with a new helper script and make a small import annotation cleanup. No behavioral changes to core application logic are expected, but the dash/dash-bootstrap-components major-version upgrades merit careful verification of UI-related code.

## Key Changes

- Features
  - Add DEPENDENCY_UPDATE_TRACKER.md: tracker with scope, baseline snapshot, upgrade inventory, planned execution batches, validation protocol, and progress log to coordinate dependency refresh work.
  - Add bin/summarize-meshtasticd-logs.sh: new CI helper script that produces concise Meshtastic daemon log summaries and is invoked from CI.

- Refactors / CI
  - .github/workflows/ci.yml: replace inline shell logic for meshtasticd log summarization with centralized calls to bin/summarize-meshtasticd-logs.sh for integration and multinode jobs (standardizes and simplifies workflow).
  - bin/test-release.sh: safer dist cleanup using find -exec rm -rf to remove top-level contents rather than rm -f dist/*.

- Dependency updates
  - Runtime / extras:
    - tabulate: ^0.9.0 → ^0.10.0
    - packaging: ^24.0 → ^26.0
    - dash: ^2.17.1 → ^4.0.0
    - dash-bootstrap-components: ^1.6.0 → ^2.0.4
    - wcwidth: ^0.2.13 → ^0.6.0
    - Added optional dependency: plotly
    - extras/analysis updated to include plotly (and formatting adjusted)
  - Development:
    - pytest: ^8.2.2 → ^9.0.2
    - pytest-cov: ^5.0.0 → ^7.0.0
    - pdoc3: ^0.10.0 → ^0.11.6
    - pylint: ^3.2.3 → ^4.0.5
    - mypy-protobuf: ^3.3.0 → ^5.0.0

- Minor cleanup
  - meshtastic/analysis/__main__.py: removed a type-ignore annotation on a dash import (no functional change).

## Breaking changes / migration notes

- dash (and dash-bootstrap-components): Upgraded from 2.x → 4.x (major bump). This may introduce breaking API or behavioral changes in Dash components and Bootstrap components. Action items:
  - Run UI and integration tests, and manually test dashboards/components that depend on Dash, dash-bootstrap-components, and plotly.
  - If incompatibilities are found, consider pinning to the previous major versions or addressing API changes in follow-up fixes.

## Other notes

- DEPENDENCY_UPDATE_TRACKER.md is documentation-only and does not change runtime behavior.
- No other public API or exported-entity changes were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->