### PR TITLE
Improve BLE timeout handling with elapsed-time checks and polling

### DIFF
--- a/REFACTOR_PROGRAM-2.md
+++ b/REFACTOR_PROGRAM-2.md
@@ -1,4 +1,5 @@
 # REFACTOR_PROGRAM-2.md
+
 ### Meshtastic Python Refactor – Phase 2 Program Plan
 
 Date: 2026-03-11  
@@ -49,7 +50,7 @@ Going forward we will keep the advantages of automation but shift toward **inten
 
 • dozens of tiny PRs  
 • style-only churn mixed with behavior changes  
-• interleaving multiple subsystem refactors  
+• interleaving multiple subsystem refactors
 
 Each branch should represent **one engineering theme**.
 

--- a/meshtastic/interfaces/ble/client.py
+++ b/meshtastic/interfaces/ble/client.py
@@ -380,7 +380,9 @@ class BLEClient:
         bleak_client = self.bleak_client
         if bleak_client is None:
             raise self.BLEError(BLECLIENT_ERROR_CANNOT_CONNECT_NOT_INITIALIZED)
-        result = self._async_await(bleak_client.connect(**kwargs), timeout=await_timeout)
+        result = self._async_await(
+            bleak_client.connect(**kwargs), timeout=await_timeout
+        )
         self._sync_address_from_bleak()
         return result
 

--- a/meshtastic/interfaces/ble/constants.py
+++ b/meshtastic/interfaces/ble/constants.py
@@ -129,7 +129,9 @@ ERROR_ADDRESS_RESOLUTION_FAILED: str = "Address resolution failed, cannot create
 ERROR_INTERFACE_CLOSING: str = "Cannot connect while interface is closing"
 ERROR_CONNECTION_SUPPRESSED: str = "Connection suppressed: recently connected elsewhere"
 ERROR_NO_CLIENT_ESTABLISHED: str = "Connection failed: no BLE client established"
-ERROR_MANAGEMENT_ADDRESS_EMPTY: str = "Management operations require a non-empty address."
+ERROR_MANAGEMENT_ADDRESS_EMPTY: str = (
+    "Management operations require a non-empty address."
+)
 ERROR_MANAGEMENT_ADDRESS_REQUIRED: str = (
     "Management operations require an explicit address when no device is connected."
 )
@@ -176,7 +178,9 @@ UNREACHABLE_ADDRESSED_DEVICES_MSG: str = (
 
 # BLEClient-specific constants
 # Alias preserves legacy access while sourcing value from BLEConfig
-BLECLIENT_EVENT_THREAD_JOIN_TIMEOUT: float = BLEConfig.BLECLIENT_EVENT_THREAD_JOIN_TIMEOUT
+BLECLIENT_EVENT_THREAD_JOIN_TIMEOUT: float = (
+    BLEConfig.BLECLIENT_EVENT_THREAD_JOIN_TIMEOUT
+)
 BLECLIENT_ERROR_ASYNC_TIMEOUT: str = "Async operation timed out"
 BLECLIENT_ERROR_CANCELLED: str = "Async operation was cancelled"
 BLECLIENT_ERROR_CANNOT_PAIR_NOT_INITIALIZED: str = (

--- a/meshtastic/interfaces/ble/gating.py
+++ b/meshtastic/interfaces/ble/gating.py
@@ -211,11 +211,7 @@ def _cleanup_addr_lock(key: str | None) -> None:
         return
     with _REGISTRY_LOCK:
         holder_count = _LOCK_HOLDERS.get(key, 0)
-        if (
-            holder_count > 0
-            or key in _CONNECTED_ADDRS
-            or key in _CONNECTING_ADDRS
-        ):
+        if holder_count > 0 or key in _CONNECTED_ADDRS or key in _CONNECTING_ADDRS:
             logger.debug(
                 "Skipping cleanup of address lock for %s (holders: %d)",
                 key,
@@ -619,7 +615,9 @@ def _mark_disconnected(addr: str | None, owner: Any | None = None) -> None:
                     clear_connecting_claim = False
                 if provisional_owner is None:
                     provisional_owner_id = _CONNECTING_OWNER_IDS.get(key)
-                    if provisional_owner_id is None or provisional_owner_id != id(owner):
+                    if provisional_owner_id is None or provisional_owner_id != id(
+                        owner
+                    ):
                         logger.debug(
                             "Ignoring provisional disconnect mark for %s from non-owner instance.",
                             key,

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -1696,7 +1696,11 @@ class BLEInterface(MeshInterface):
         self._management_inflight += 1
 
     def _finish_management_operation(self) -> None:
-        """Mark a management operation complete and wake shutdown waiters."""
+        """
+        Mark completion of an in-flight management operation and notify any waiters when no operations remain.
+        
+        If the internal in-flight counter is already zero or negative, reset it to zero, notify waiters, and log a warning; otherwise decrement the counter and notify waiters when it reaches zero.
+        """
         with self._management_lock:
             if self._management_inflight <= 0:
                 logger.warning(

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -3224,6 +3224,7 @@ class BLEInterface(MeshInterface):
         # can observe _closed/_is_closing and abort, rather than forcing close()
         # to wait behind a long BLE connect attempt.
         management_wait_timed_out = False
+        management_wait_started = time.monotonic()
         with self._management_lock:
             # Use unified state lock
             with self._state_lock:
@@ -3246,15 +3247,19 @@ class BLEInterface(MeshInterface):
                 ):
                     self._state_manager._transition_to(ConnectionState.DISCONNECTING)
             while self._management_inflight > 0:
-                if not self._management_idle_condition.wait(
-                    timeout=_MANAGEMENT_SHUTDOWN_WAIT_TIMEOUT_SECONDS
-                ):
+                elapsed = time.monotonic() - management_wait_started
+                if elapsed >= _MANAGEMENT_SHUTDOWN_WAIT_TIMEOUT_SECONDS:
                     management_wait_timed_out = True
                     logger.warning(
-                        "Timed out waiting for %d inflight management operation(s) during shutdown",
+                        "Timed out waiting %.1fs for %d inflight management operation(s) during shutdown",
+                        elapsed,
                         self._management_inflight,
                     )
                     break
+                remaining = _MANAGEMENT_SHUTDOWN_WAIT_TIMEOUT_SECONDS - elapsed
+                self._management_idle_condition.wait(
+                    timeout=min(_MANAGEMENT_CONNECT_WAIT_POLL_SECONDS, remaining)
+                )
 
         try:
             # Release lock before calling MeshInterface.close() to avoid deadlock

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -1698,7 +1698,7 @@ class BLEInterface(MeshInterface):
     def _finish_management_operation(self) -> None:
         """
         Mark completion of an in-flight management operation and notify any waiters when no operations remain.
-        
+
         If the internal in-flight counter is already zero or negative, reset it to zero, notify waiters, and log a warning; otherwise decrement the counter and notify waiters when it reaches zero.
         """
         with self._management_lock:
@@ -2411,8 +2411,8 @@ class BLEInterface(MeshInterface):
                 )
                 if not lost_gate_ownership:
                     with self._state_lock:
-                        still_owned, is_closing = self._get_connected_client_status_locked(
-                            connected_client
+                        still_owned, is_closing = (
+                            self._get_connected_client_status_locked(connected_client)
                         )
                         if still_owned:
                             publish_candidate = True
@@ -2733,7 +2733,9 @@ class BLEInterface(MeshInterface):
                             raise self.BLEError(ERROR_MANAGEMENT_CONNECTING)
                         remaining = _MANAGEMENT_CONNECT_WAIT_TIMEOUT_SECONDS - elapsed
                         management_idle_condition.wait(
-                            timeout=min(_MANAGEMENT_CONNECT_WAIT_POLL_SECONDS, remaining)
+                            timeout=min(
+                                _MANAGEMENT_CONNECT_WAIT_POLL_SECONDS, remaining
+                            )
                         )
                     # Reset timeout accounting once we are no longer blocked by
                     # in-flight management operations so future waits start fresh.

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -2704,7 +2704,7 @@ class BLEInterface(MeshInterface):
         try:
             management_lock = self._management_lock
             management_idle_condition = self._management_idle_condition
-            management_wait_started = time.monotonic()
+            management_wait_started: float | None = None
             while True:
                 requested_identifier = address if address is not None else self.address
                 normalized_request = sanitize_address(requested_identifier)
@@ -2717,6 +2717,8 @@ class BLEInterface(MeshInterface):
                 with management_lock:
                     while self._management_inflight > 0:
                         self._validate_connection_preconditions()
+                        if management_wait_started is None:
+                            management_wait_started = time.monotonic()
                         elapsed = time.monotonic() - management_wait_started
                         if elapsed >= _MANAGEMENT_CONNECT_WAIT_TIMEOUT_SECONDS:
                             logger.warning(
@@ -2729,6 +2731,9 @@ class BLEInterface(MeshInterface):
                         management_idle_condition.wait(
                             timeout=min(_MANAGEMENT_CONNECT_WAIT_POLL_SECONDS, remaining)
                         )
+                    # Reset timeout accounting once we are no longer blocked by
+                    # in-flight management operations so future waits start fresh.
+                    management_wait_started = None
 
                 # Recompute potentially discovery-backed target state after
                 # waiting for inflight management operations so retries do not

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -1698,6 +1698,13 @@ class BLEInterface(MeshInterface):
     def _finish_management_operation(self) -> None:
         """Mark a management operation complete and wake shutdown waiters."""
         with self._management_lock:
+            if self._management_inflight <= 0:
+                logger.warning(
+                    "Management operation accounting underflow detected during finish(); resetting inflight count to zero."
+                )
+                self._management_inflight = 0
+                self._management_idle_condition.notify_all()
+                return
             self._management_inflight -= 1
             if self._management_inflight == 0:
                 self._management_idle_condition.notify_all()
@@ -2710,18 +2717,18 @@ class BLEInterface(MeshInterface):
                 with management_lock:
                     while self._management_inflight > 0:
                         self._validate_connection_preconditions()
-                        if not management_idle_condition.wait(
-                            timeout=_MANAGEMENT_CONNECT_WAIT_POLL_SECONDS
-                        ):
-                            self._validate_connection_preconditions()
-                            elapsed = time.monotonic() - management_wait_started
-                            if elapsed >= _MANAGEMENT_CONNECT_WAIT_TIMEOUT_SECONDS:
-                                logger.warning(
-                                    "Timed out waiting %.1fs for %d inflight management operation(s) before connect()",
-                                    elapsed,
-                                    self._management_inflight,
-                                )
-                                raise self.BLEError(ERROR_MANAGEMENT_CONNECTING)
+                        elapsed = time.monotonic() - management_wait_started
+                        if elapsed >= _MANAGEMENT_CONNECT_WAIT_TIMEOUT_SECONDS:
+                            logger.warning(
+                                "Timed out waiting %.1fs for %d inflight management operation(s) before connect()",
+                                elapsed,
+                                self._management_inflight,
+                            )
+                            raise self.BLEError(ERROR_MANAGEMENT_CONNECTING)
+                        remaining = _MANAGEMENT_CONNECT_WAIT_TIMEOUT_SECONDS - elapsed
+                        management_idle_condition.wait(
+                            timeout=min(_MANAGEMENT_CONNECT_WAIT_POLL_SECONDS, remaining)
+                        )
 
                 # Recompute potentially discovery-backed target state after
                 # waiting for inflight management operations so retries do not

--- a/meshtastic/tests/test_examples.py
+++ b/meshtastic/tests/test_examples.py
@@ -29,7 +29,9 @@ def _require_mapping(value: object, *, label: str) -> dict[str, object]:
 
 def _require_int_strict(value: object, *, label: str) -> int:
     """Assert that `value` is an int (excluding bool) and return it."""
-    assert isinstance(value, int), f"{label} should be an int, got {type(value).__name__}"
+    assert isinstance(
+        value, int
+    ), f"{label} should be an int, got {type(value).__name__}"
     assert not isinstance(value, bool), f"{label} must not be a bool"
     return cast(int, value)
 
@@ -92,9 +94,9 @@ def test_examples_example_config_yaml_is_valid() -> None:
     assert isinstance(owner_short, str), "owner_short should be a string"
     assert owner_short.strip(), "owner_short should not be empty/whitespace"
     assert isinstance(channel_url, str), "channel_url should be a string"
-    assert channel_url.startswith("https://meshtastic.org/e/#"), (
-        f"channel_url should start with the Meshtastic share URL, got: {channel_url}"
-    )
+    assert channel_url.startswith(
+        "https://meshtastic.org/e/#"
+    ), f"channel_url should start with the Meshtastic share URL, got: {channel_url}"
     assert "ownerShort" not in config
     assert "channelUrl" not in config
 

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -38,12 +38,12 @@ from meshtastic.__main__ import (
 
 # from ..ble_interface import BLEInterface
 from ..node import Node
-from ..protobuf import config_pb2, localonly_pb2
-from ..protobuf.channel_pb2 import Channel  # pylint: disable=E0611
 
 # from ..radioconfig_pb2 import UserPreferences
 # import meshtastic.config_pb2
 from ..ota import OTAError, OTATransportError
+from ..protobuf import config_pb2, localonly_pb2
+from ..protobuf.channel_pb2 import Channel  # pylint: disable=E0611
 from ..serial_interface import SerialInterface
 from ..tcp_interface import TCPInterface
 

--- a/tests/test_ble_client_edge_cases.py
+++ b/tests/test_ble_client_edge_cases.py
@@ -210,7 +210,9 @@ def test_bleclient_init_with_address_syncs_from_bleak(
 
 
 @pytest.mark.unit
-def test_bleclient_sync_address_noops_without_bleak_client(ble_client: BLEClient) -> None:
+def test_bleclient_sync_address_noops_without_bleak_client(
+    ble_client: BLEClient,
+) -> None:
     """Address sync should return early when the backend client is not initialized."""
     ble_client.address = "11:22:33:44:55:66"
     ble_client.bleak_client = None
@@ -227,7 +229,9 @@ def test_bleclient_management_call_reraises_non_notimplemented_bleerror() -> Non
     async def _noop_operation() -> None:
         return None
 
-    def _raise_bleerror(awaitable: Awaitable[object], timeout: float | None = None) -> NoReturn:
+    def _raise_bleerror(
+        awaitable: Awaitable[object], timeout: float | None = None
+    ) -> NoReturn:
         _ = timeout
         close_awaitable = getattr(awaitable, "close", None)
         if callable(close_awaitable):

--- a/tests/test_ble_connection_edge_cases.py
+++ b/tests/test_ble_connection_edge_cases.py
@@ -58,8 +58,12 @@ def test_is_device_not_found_error_matches_device_context_messages() -> None:
         is False
     )
     assert _is_device_not_found_error(Exception("Service not found")) is False
-    assert _is_device_not_found_error(Exception("Peripheral service not found")) is False
-    assert _is_device_not_found_error(Exception("Peripheral: service not found")) is False
+    assert (
+        _is_device_not_found_error(Exception("Peripheral service not found")) is False
+    )
+    assert (
+        _is_device_not_found_error(Exception("Peripheral: service not found")) is False
+    )
 
 
 @pytest.mark.unit
@@ -757,7 +761,9 @@ def test_connection_orchestrator_raises_when_connect_state_transition_fails() ->
         thread_coordinator=MagicMock(),
     )
 
-    with pytest.raises(MockBLEError, match="Already connected or connection in progress"):
+    with pytest.raises(
+        MockBLEError, match="Already connected or connection in progress"
+    ):
         orchestrator._establish_connection(
             address="AA:BB:CC:DD:EE:FF",
             current_address=None,

--- a/tests/test_ble_interface_advanced.py
+++ b/tests/test_ble_interface_advanced.py
@@ -830,9 +830,9 @@ def test_rapid_connect_disconnect_stress_test(
     ) -> tuple[list["StressTestClient"], list["StressTestClient"]]:
         """Wait until latest successful reconnect attempt owns iface.client."""
 
-        def _snapshot_stress_state() -> tuple[
-            object | None, list["StressTestClient"], list["StressTestClient"]
-        ]:
+        def _snapshot_stress_state() -> (
+            tuple[object | None, list["StressTestClient"], list["StressTestClient"]]
+        ):
             with iface._state_lock:
                 current_client = cast(object | None, iface.client)
                 attempts = list(
@@ -1030,7 +1030,9 @@ def test_rapid_connect_disconnect_stress_test(
                 bleak_client.is_connected_result = False
                 iface3._on_ble_disconnect(bleak_client)
                 time.sleep(0.01)
-            except Exception as exc:  # noqa: BLE001 - test records failure-path behavior
+            except (
+                Exception
+            ) as exc:  # noqa: BLE001 - test records failure-path behavior
                 failure_errors.append(exc)
 
         assert failure_errors == []

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -45,6 +45,9 @@ from tests.test_ble_interface_fixtures import DummyClient, _build_interface
 
 pytestmark = pytest.mark.unit
 
+_MAX_SPURIOUS_CONNECT_WAIT_CALLS_BEFORE_FAIL = 10
+_MAX_SPURIOUS_CLOSE_WAIT_CALLS_BEFORE_FAIL = 50
+
 
 def _pin_trust_environment(
     monkeypatch: pytest.MonkeyPatch,
@@ -1931,6 +1934,13 @@ def test_ble_interface_close_bounds_wait_on_spurious_management_wakeups(
 
     def _spurious_wait(timeout: float | None = None) -> bool:
         wait_calls.append(timeout)
+        if timeout is not None and timeout > 0:
+            time.sleep(timeout)
+        if len(wait_calls) > _MAX_SPURIOUS_CLOSE_WAIT_CALLS_BEFORE_FAIL:
+            close_done.set()
+            raise AssertionError(
+                "close() kept waiting past the shutdown timeout budget"
+            )
         return True
 
     monkeypatch.setattr(
@@ -2569,7 +2579,7 @@ def test_connect_times_out_on_spurious_management_wakeups(
 
     def _spurious_wait(timeout: float | None = None) -> bool:
         wait_calls.append(timeout)
-        if len(wait_calls) > 10:
+        if len(wait_calls) > _MAX_SPURIOUS_CONNECT_WAIT_CALLS_BEFORE_FAIL:
             raise AssertionError("connect() kept waiting past the timeout budget")
         return True
 

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -19,27 +19,43 @@ from bleak.exc import BleakDBusError, BleakError
 # Import meshtastic modules for use in tests
 import meshtastic.interfaces.ble as ble_mod
 import meshtastic.interfaces.ble.discovery as discovery_mod
-from meshtastic.interfaces.ble import (FROMNUM_UUID, LEGACY_LOGRADIO_UUID,
-                                       LOGRADIO_UUID, SERVICE_UUID, BLEClient,
-                                       BLEInterface)
+from meshtastic.interfaces.ble import (
+    FROMNUM_UUID,
+    LEGACY_LOGRADIO_UUID,
+    LOGRADIO_UUID,
+    SERVICE_UUID,
+    BLEClient,
+    BLEInterface,
+)
 from meshtastic.interfaces.ble.connection import ConnectionValidator
 from meshtastic.interfaces.ble.constants import (
     BLECLIENT_ERROR_CANNOT_PAIR_NOT_INITIALIZED,
     BLECLIENT_ERROR_CANNOT_UNPAIR_NOT_INITIALIZED,
-    CONNECTION_ERROR_LOST_OWNERSHIP, ERROR_CONNECTION_SUPPRESSED,
-    ERROR_INTERFACE_CLOSING, ERROR_MANAGEMENT_ADDRESS_EMPTY,
-    ERROR_MANAGEMENT_ADDRESS_REQUIRED, ERROR_MANAGEMENT_AWAIT_TIMEOUT_INVALID,
-    ERROR_MANAGEMENT_CONNECTING, ERROR_MANAGEMENT_TARGET_CHANGED,
-    ERROR_TRUST_ADDRESS_NOT_RESOLVED, ERROR_TRUST_BLUETOOTHCTL_MISSING,
-    ERROR_TRUST_COMMAND_FAILED, ERROR_TRUST_COMMAND_TIMEOUT,
-    ERROR_TRUST_INVALID_TIMEOUT)
+    CONNECTION_ERROR_LOST_OWNERSHIP,
+    ERROR_CONNECTION_SUPPRESSED,
+    ERROR_INTERFACE_CLOSING,
+    ERROR_MANAGEMENT_ADDRESS_EMPTY,
+    ERROR_MANAGEMENT_ADDRESS_REQUIRED,
+    ERROR_MANAGEMENT_AWAIT_TIMEOUT_INVALID,
+    ERROR_MANAGEMENT_CONNECTING,
+    ERROR_MANAGEMENT_TARGET_CHANGED,
+    ERROR_TRUST_ADDRESS_NOT_RESOLVED,
+    ERROR_TRUST_BLUETOOTHCTL_MISSING,
+    ERROR_TRUST_COMMAND_FAILED,
+    ERROR_TRUST_COMMAND_TIMEOUT,
+    ERROR_TRUST_INVALID_TIMEOUT,
+)
 from meshtastic.interfaces.ble.discovery import (
-    DiscoveryClientError, DiscoveryManager,
-    _close_discovery_client_best_effort, _filter_devices_for_target_identifier,
-    _looks_like_ble_address, _parse_scan_response)
-from meshtastic.interfaces.ble.reconnection import (ReconnectScheduler,
-                                                    ReconnectWorker)
+    DiscoveryClientError,
+    DiscoveryManager,
+    _close_discovery_client_best_effort,
+    _filter_devices_for_target_identifier,
+    _looks_like_ble_address,
+    _parse_scan_response,
+)
+from meshtastic.interfaces.ble.reconnection import ReconnectScheduler, ReconnectWorker
 from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
+
 # Import common fixtures
 from tests.test_ble_interface_fixtures import DummyClient, _build_interface
 
@@ -56,7 +72,7 @@ def _pin_trust_environment(
 ) -> None:
     """
     Configure host-specific dependencies so tests of trust() run in a controlled Linux-like environment.
-    
+
     Parameters:
         monkeypatch (pytest.MonkeyPatch): Fixture used to apply attribute patches.
         run (Callable[..., object] | None): Optional replacement for subprocess.run used by trust(); if None, a sentinel callable is installed that raises AssertionError if invoked.
@@ -1941,13 +1957,13 @@ def test_ble_interface_close_bounds_wait_on_spurious_management_wakeups(
     def _spurious_wait(timeout: float | None = None) -> bool:
         """
         Simulate a spurious wait for tests and track each requested timeout.
-        
+
         Parameters:
             timeout (float | None): The requested wait duration in seconds; if greater than zero the function sleeps for that duration.
-        
+
         Returns:
             bool: `True` to indicate the wait condition remains satisfied.
-        
+
         Raises:
             AssertionError: If the number of invocations exceeds the allowed spurious-wait budget, signals that shutdown waited past its timeout.
         """
@@ -1973,17 +1989,19 @@ def test_ble_interface_close_bounds_wait_on_spurious_management_wakeups(
     ) -> contextlib.AbstractContextManager[None]:
         """
         Context manager used in tests to record a requested management address and provide a no-op gate.
-        
+
         Parameters:
             address (str): The management address being requested; the address is recorded for test inspection.
-        
+
         Returns:
             contextmanager: A context manager that performs no gating and yields `None`.
         """
         gate_calls.append(address)
         return contextlib.nullcontext()
 
-    monkeypatch.setattr(iface, "_management_target_gate", _management_gate, raising=True)
+    monkeypatch.setattr(
+        iface, "_management_target_gate", _management_gate, raising=True
+    )
     monkeypatch.setattr(
         "meshtastic.interfaces.ble.interface.MeshInterface.close",
         lambda _self: None,
@@ -2010,7 +2028,7 @@ def test_ble_interface_close_bounds_wait_on_spurious_management_wakeups(
     def _run_close() -> None:
         """
         Attempt to close the interface and signal completion.
-        
+
         Calls iface.close(). If an exception is raised, appends it to the shared close_errors list. Always sets the close_done event when finished.
         """
         try:
@@ -2649,7 +2667,7 @@ def test_connect_times_out_on_spurious_management_wakeups(
     def _monotonic() -> float:
         """
         Advance and return a test monotonic timestamp by 0.01 seconds.
-        
+
         Returns:
             Current monotonic time in seconds; the returned value increases by 0.01 on each call.
         """
@@ -2657,18 +2675,20 @@ def test_connect_times_out_on_spurious_management_wakeups(
         fake_time += 0.01
         return fake_time
 
-    monkeypatch.setattr("meshtastic.interfaces.ble.interface.time.monotonic", _monotonic)
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.interface.time.monotonic", _monotonic
+    )
 
     def _spurious_wait(timeout: float | None = None) -> bool:
         """
         Record a spurious wait invocation and signal a wakeup.
-        
+
         Parameters:
             timeout (float | None): The timeout value passed to the wait; may be None.
-        
+
         Returns:
             bool: `True` to indicate a spurious wakeup.
-        
+
         Raises:
             AssertionError: If the number of recorded wait calls exceeds the configured budget.
         """
@@ -2717,7 +2737,7 @@ def test_connect_management_wait_timeout_resets_between_wait_cycles(
     def _monotonic() -> float:
         """
         Provide a monotonic timestamp for tests, advancing through a preset sequence and falling back to incremental steps when the sequence is exhausted.
-        
+
         Returns:
             float: The current monotonic time value and updates the captured `last_time` variable.
         """
@@ -2728,19 +2748,21 @@ def test_connect_management_wait_timeout_resets_between_wait_cycles(
             last_time += 0.1
         return last_time
 
-    monkeypatch.setattr("meshtastic.interfaces.ble.interface.time.monotonic", _monotonic)
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.interface.time.monotonic", _monotonic
+    )
 
     def _wait_for_management(timeout: float | None = None) -> bool:
         """
         Simulate waiting for management operations to drain and record the requested timeout.
-        
+
         Parameters:
             timeout (float | None): Maximum seconds to wait, or `None` to indicate an indefinite wait.
-        
+
         Behavior:
             Appends the provided `timeout` value to the `wait_calls` list and sets
             `iface._management_inflight` to 0 to indicate no inflight management operations.
-        
+
         Returns:
             bool: `True` to indicate the wait condition was signaled.
         """
@@ -2751,7 +2773,7 @@ def test_connect_management_wait_timeout_resets_between_wait_cycles(
     def _raise_if_duplicate(_key: str | None) -> None:
         """
         Increment the duplicate-check counter and, on the second invocation, mark the interface as having one inflight management operation.
-        
+
         Parameters:
             _key (str | None): Ignored; present to match the duplicate-check callback signature.
         """
@@ -2791,14 +2813,14 @@ def test_connect_management_wait_timeout_resets_between_wait_cycles(
     ) -> tuple[DummyClient, str | None, str | None]:
         """
         Create and attach a DummyClient to the test BLE interface and mark it as connected.
-        
+
         Parameters:
             _address (str | None): Ignored; present to match the real establish signature.
             _normalized_request (str | None): Ignored; present to match the real establish signature.
             _address_key (str | None): Ignored; present to match the real establish signature.
             pair_on_connect (bool): Accepted but ignored by this test stub.
             connect_timeout (float | None): Accepted but ignored by this test stub.
-        
+
         Returns:
             tuple[DummyClient, None, None]: The created DummyClient instance and two None placeholders (resolved address and resolved identifier).
         """
@@ -3667,8 +3689,7 @@ def test_connect_marks_provisional_claims_before_gate_release(
 ) -> None:
     """connect() should publish provisional ownership before releasing the address gate."""
     _ = clear_registry
-    from meshtastic.interfaces.ble.gating import \
-        _is_currently_connected_elsewhere
+    from meshtastic.interfaces.ble.gating import _is_currently_connected_elsewhere
 
     target_identifier = "mesh-node"
     device_key = "aabbccddee30"

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -2406,7 +2406,7 @@ def test_finish_management_operation_clamps_underflow(
     """_finish_management_operation() should clamp negative accounting to zero."""
     iface = _build_minimal_connect_test_interface()
     with iface._management_lock:
-        iface._management_inflight = 0
+        iface._management_inflight = -1
     notify_calls: list[bool] = []
     monkeypatch.setattr(
         iface._management_idle_condition,
@@ -2569,6 +2569,8 @@ def test_connect_times_out_on_spurious_management_wakeups(
 
     def _spurious_wait(timeout: float | None = None) -> bool:
         wait_calls.append(timeout)
+        if len(wait_calls) > 10:
+            raise AssertionError("connect() kept waiting past the timeout budget")
         return True
 
     monkeypatch.setattr(
@@ -2584,6 +2586,94 @@ def test_connect_times_out_on_spurious_management_wakeups(
         iface.connect("AA:BB:CC:DD:EE:10")
 
     assert wait_calls
+
+
+def test_connect_management_wait_timeout_resets_between_wait_cycles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """connect() should restart timeout accounting after management drains."""
+    iface = _build_minimal_connect_test_interface()
+    iface._management_lock = threading.RLock()
+    iface._management_idle_condition = threading.Condition(iface._management_lock)
+    iface._management_inflight = 1
+    wait_calls: list[float | None] = []
+    duplicate_checks = 0
+    monotonic_values = iter([0.0, 0.1, 100.0, 100.1])
+    last_time = 100.1
+
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.interface._MANAGEMENT_CONNECT_WAIT_TIMEOUT_SECONDS",
+        1.0,
+    )
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.interface._MANAGEMENT_CONNECT_WAIT_POLL_SECONDS",
+        0.1,
+    )
+
+    def _monotonic() -> float:
+        nonlocal last_time
+        try:
+            last_time = next(monotonic_values)
+        except StopIteration:
+            last_time += 0.1
+        return last_time
+
+    monkeypatch.setattr("meshtastic.interfaces.ble.interface.time.monotonic", _monotonic)
+
+    def _wait_for_management(timeout: float | None = None) -> bool:
+        wait_calls.append(timeout)
+        iface._management_inflight = 0
+        return True
+
+    def _raise_if_duplicate(_key: str | None) -> None:
+        nonlocal duplicate_checks
+        duplicate_checks += 1
+        if duplicate_checks == 2:
+            iface._management_inflight = 1
+
+    monkeypatch.setattr(
+        iface._management_idle_condition,
+        "wait",
+        _wait_for_management,
+        raising=True,
+    )
+    monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
+    monkeypatch.setattr(iface, "_get_existing_client_if_valid", lambda _request: None)
+    monkeypatch.setattr(
+        iface,
+        "_resolve_target_address_for_connect",
+        lambda identifier: cast(str, identifier),
+    )
+    monkeypatch.setattr(iface, "_raise_if_duplicate_connect", _raise_if_duplicate)
+    monkeypatch.setattr(iface, "_finalize_connection_gates", lambda *_args: None)
+    monkeypatch.setattr(
+        iface,
+        "_verify_and_publish_connected",
+        lambda *_args, **_kwargs: None,
+    )
+
+    def _establish_stub(
+        _address: str | None,
+        _normalized_request: str | None,
+        _address_key: str | None,
+        *,
+        pair_on_connect: bool = False,
+        connect_timeout: float | None = None,
+    ) -> tuple[DummyClient, str | None, str | None]:
+        _ = (pair_on_connect, connect_timeout)
+        client = DummyClient()
+        with iface._state_lock:
+            cast(Any, iface).client = client
+            iface.address = client.address
+            iface._state_manager._reset_to_disconnected()
+            assert iface._state_manager._transition_to(ConnectionState.CONNECTING)
+            assert iface._state_manager._transition_to(ConnectionState.CONNECTED)
+        return client, None, None
+
+    monkeypatch.setattr(iface, "_establish_and_update_client", _establish_stub)
+
+    assert isinstance(iface.connect("AA:BB:CC:DD:EE:10"), DummyClient)
+    assert len(wait_calls) == 2
 
 
 def test_connect_retries_when_management_becomes_inflight_inside_connect_lock(

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -2399,6 +2399,31 @@ def test_validate_connect_timeout_override_rejects_non_numeric_values() -> None:
         )
 
 
+def test_finish_management_operation_clamps_underflow(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """_finish_management_operation() should clamp negative accounting to zero."""
+    iface = _build_minimal_connect_test_interface()
+    with iface._management_lock:
+        iface._management_inflight = 0
+    notify_calls: list[bool] = []
+    monkeypatch.setattr(
+        iface._management_idle_condition,
+        "notify_all",
+        lambda: notify_calls.append(True),
+        raising=True,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        iface._finish_management_operation()
+
+    with iface._management_lock:
+        assert iface._management_inflight == 0
+    assert notify_calls == [True]
+    assert any("underflow" in record.message.lower() for record in caplog.records)
+
+
 @pytest.mark.unit
 def test_connect_rejects_non_bool_pair_override() -> None:
     """connect() should fail fast when `pair` is not explicitly bool/None."""
@@ -2513,6 +2538,52 @@ def test_connect_times_out_waiting_for_management_operations(
 
     with pytest.raises(BLEInterface.BLEError, match=ERROR_MANAGEMENT_CONNECTING):
         iface.connect("AA:BB:CC:DD:EE:10")
+
+
+def test_connect_times_out_on_spurious_management_wakeups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """connect() should enforce timeout even if management wait wakes spuriously."""
+    iface = _build_minimal_connect_test_interface()
+    iface._management_lock = threading.RLock()
+    iface._management_idle_condition = threading.Condition(iface._management_lock)
+    iface._management_inflight = 1
+    wait_calls: list[float | None] = []
+    fake_time = 0.0
+
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.interface._MANAGEMENT_CONNECT_WAIT_TIMEOUT_SECONDS",
+        0.03,
+    )
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.interface._MANAGEMENT_CONNECT_WAIT_POLL_SECONDS",
+        0.005,
+    )
+
+    def _monotonic() -> float:
+        nonlocal fake_time
+        fake_time += 0.01
+        return fake_time
+
+    monkeypatch.setattr("meshtastic.interfaces.ble.interface.time.monotonic", _monotonic)
+
+    def _spurious_wait(timeout: float | None = None) -> bool:
+        wait_calls.append(timeout)
+        return True
+
+    monkeypatch.setattr(
+        iface._management_idle_condition,
+        "wait",
+        _spurious_wait,
+        raising=True,
+    )
+    monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
+    monkeypatch.setattr(iface, "_get_existing_client_if_valid", lambda _request: None)
+
+    with pytest.raises(BLEInterface.BLEError, match=ERROR_MANAGEMENT_CONNECTING):
+        iface.connect("AA:BB:CC:DD:EE:10")
+
+    assert wait_calls
 
 
 def test_connect_retries_when_management_becomes_inflight_inside_connect_lock(

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -2434,6 +2434,50 @@ def test_finish_management_operation_clamps_underflow(
     assert any("underflow" in record.message.lower() for record in caplog.records)
 
 
+def test_finish_management_operation_notifies_when_count_reaches_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_finish_management_operation() should notify waiters on zero transition."""
+    iface = _build_minimal_connect_test_interface()
+    with iface._management_lock:
+        iface._management_inflight = 1
+    notify_calls: list[bool] = []
+    monkeypatch.setattr(
+        iface._management_idle_condition,
+        "notify_all",
+        lambda: notify_calls.append(True),
+        raising=True,
+    )
+
+    iface._finish_management_operation()
+
+    with iface._management_lock:
+        assert iface._management_inflight == 0
+    assert notify_calls == [True]
+
+
+def test_finish_management_operation_does_not_notify_above_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_finish_management_operation() should not notify while inflight remains positive."""
+    iface = _build_minimal_connect_test_interface()
+    with iface._management_lock:
+        iface._management_inflight = 2
+    notify_calls: list[bool] = []
+    monkeypatch.setattr(
+        iface._management_idle_condition,
+        "notify_all",
+        lambda: notify_calls.append(True),
+        raising=True,
+    )
+
+    iface._finish_management_operation()
+
+    with iface._management_lock:
+        assert iface._management_inflight == 1
+    assert notify_calls == []
+
+
 @pytest.mark.unit
 def test_connect_rejects_non_bool_pair_override() -> None:
     """connect() should fail fast when `pair` is not explicitly bool/None."""

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -1899,6 +1899,100 @@ def test_ble_interface_close_skips_management_gate_after_wait_timeout(
     assert disconnect_calls == [client]
 
 
+def test_ble_interface_close_bounds_wait_on_spurious_management_wakeups(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """close() should enforce shutdown timeout despite spurious management wakeups."""
+    client = DummyClient()
+    client.address = "AA:BB:CC:DD:EE:31"
+    client.bleak_client = SimpleNamespace(address=client.address)
+    iface = _build_interface(monkeypatch, client, start_receive_thread=False)
+    wait_calls: list[float | None] = []
+    gate_calls: list[str] = []
+    unsubscribe_calls: list[object] = []
+    disconnect_calls: list[object] = []
+    close_errors: list[Exception] = []
+    close_done = threading.Event()
+
+    with iface._management_lock:
+        iface._management_inflight = 1
+    with iface._state_lock:
+        iface._disconnect_notified = True
+
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.interface._MANAGEMENT_SHUTDOWN_WAIT_TIMEOUT_SECONDS",
+        0.05,
+    )
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.interface._MANAGEMENT_CONNECT_WAIT_POLL_SECONDS",
+        0.005,
+    )
+
+    def _spurious_wait(timeout: float | None = None) -> bool:
+        wait_calls.append(timeout)
+        return True
+
+    monkeypatch.setattr(
+        iface._management_idle_condition,
+        "wait",
+        _spurious_wait,
+        raising=True,
+    )
+
+    def _management_gate(
+        address: str,
+    ) -> contextlib.AbstractContextManager[None]:
+        gate_calls.append(address)
+        return contextlib.nullcontext()
+
+    monkeypatch.setattr(iface, "_management_target_gate", _management_gate, raising=True)
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.interface.MeshInterface.close",
+        lambda _self: None,
+    )
+    monkeypatch.setattr(
+        iface._notification_manager,
+        "_unsubscribe_all",
+        lambda active_client, timeout=None: unsubscribe_calls.append(active_client),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        iface,
+        "_disconnect_and_close_client",
+        lambda active_client: disconnect_calls.append(active_client),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        iface._notification_manager,
+        "_cleanup_all",
+        lambda: None,
+        raising=True,
+    )
+
+    def _run_close() -> None:
+        try:
+            iface.close()
+        except Exception as exc:  # pragma: no cover - captured for assertion
+            close_errors.append(exc)
+        finally:
+            close_done.set()
+
+    with caplog.at_level(logging.WARNING):
+        close_thread = threading.Thread(target=_run_close, daemon=True)
+        close_thread.start()
+        close_thread.join(timeout=1.0)
+
+    assert not close_thread.is_alive()
+    assert close_done.is_set() is True
+    assert close_errors == []
+    assert wait_calls
+    assert gate_calls == []
+    assert unsubscribe_calls == [client]
+    assert disconnect_calls == [client]
+    assert any("Timed out waiting" in record.message for record in caplog.records)
+
+
 def test_ble_interface_implicit_trust_holds_connect_lock_during_subprocess(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -54,7 +54,13 @@ def _pin_trust_environment(
     *,
     run: Callable[..., object] | None = None,
 ) -> None:
-    """Pin trust() host dependencies so guard-path tests stay hermetic."""
+    """
+    Configure host-specific dependencies so tests of trust() run in a controlled Linux-like environment.
+    
+    Parameters:
+        monkeypatch (pytest.MonkeyPatch): Fixture used to apply attribute patches.
+        run (Callable[..., object] | None): Optional replacement for subprocess.run used by trust(); if None, a sentinel callable is installed that raises AssertionError if invoked.
+    """
     monkeypatch.setattr("meshtastic.interfaces.ble.interface.sys.platform", "linux")
     monkeypatch.setattr(
         "meshtastic.interfaces.ble.interface.shutil.which",
@@ -1933,6 +1939,18 @@ def test_ble_interface_close_bounds_wait_on_spurious_management_wakeups(
     )
 
     def _spurious_wait(timeout: float | None = None) -> bool:
+        """
+        Simulate a spurious wait for tests and track each requested timeout.
+        
+        Parameters:
+            timeout (float | None): The requested wait duration in seconds; if greater than zero the function sleeps for that duration.
+        
+        Returns:
+            bool: `True` to indicate the wait condition remains satisfied.
+        
+        Raises:
+            AssertionError: If the number of invocations exceeds the allowed spurious-wait budget, signals that shutdown waited past its timeout.
+        """
         wait_calls.append(timeout)
         if timeout is not None and timeout > 0:
             time.sleep(timeout)
@@ -1953,6 +1971,15 @@ def test_ble_interface_close_bounds_wait_on_spurious_management_wakeups(
     def _management_gate(
         address: str,
     ) -> contextlib.AbstractContextManager[None]:
+        """
+        Context manager used in tests to record a requested management address and provide a no-op gate.
+        
+        Parameters:
+            address (str): The management address being requested; the address is recorded for test inspection.
+        
+        Returns:
+            contextmanager: A context manager that performs no gating and yields `None`.
+        """
         gate_calls.append(address)
         return contextlib.nullcontext()
 
@@ -1981,6 +2008,11 @@ def test_ble_interface_close_bounds_wait_on_spurious_management_wakeups(
     )
 
     def _run_close() -> None:
+        """
+        Attempt to close the interface and signal completion.
+        
+        Calls iface.close(). If an exception is raised, appends it to the shared close_errors list. Always sets the close_done event when finished.
+        """
         try:
             iface.close()
         except Exception as exc:  # pragma: no cover - captured for assertion
@@ -2615,6 +2647,12 @@ def test_connect_times_out_on_spurious_management_wakeups(
     )
 
     def _monotonic() -> float:
+        """
+        Advance and return a test monotonic timestamp by 0.01 seconds.
+        
+        Returns:
+            Current monotonic time in seconds; the returned value increases by 0.01 on each call.
+        """
         nonlocal fake_time
         fake_time += 0.01
         return fake_time
@@ -2622,6 +2660,18 @@ def test_connect_times_out_on_spurious_management_wakeups(
     monkeypatch.setattr("meshtastic.interfaces.ble.interface.time.monotonic", _monotonic)
 
     def _spurious_wait(timeout: float | None = None) -> bool:
+        """
+        Record a spurious wait invocation and signal a wakeup.
+        
+        Parameters:
+            timeout (float | None): The timeout value passed to the wait; may be None.
+        
+        Returns:
+            bool: `True` to indicate a spurious wakeup.
+        
+        Raises:
+            AssertionError: If the number of recorded wait calls exceeds the configured budget.
+        """
         wait_calls.append(timeout)
         if len(wait_calls) > _MAX_SPURIOUS_CONNECT_WAIT_CALLS_BEFORE_FAIL:
             raise AssertionError("connect() kept waiting past the timeout budget")
@@ -2665,6 +2715,12 @@ def test_connect_management_wait_timeout_resets_between_wait_cycles(
     )
 
     def _monotonic() -> float:
+        """
+        Provide a monotonic timestamp for tests, advancing through a preset sequence and falling back to incremental steps when the sequence is exhausted.
+        
+        Returns:
+            float: The current monotonic time value and updates the captured `last_time` variable.
+        """
         nonlocal last_time
         try:
             last_time = next(monotonic_values)
@@ -2675,11 +2731,30 @@ def test_connect_management_wait_timeout_resets_between_wait_cycles(
     monkeypatch.setattr("meshtastic.interfaces.ble.interface.time.monotonic", _monotonic)
 
     def _wait_for_management(timeout: float | None = None) -> bool:
+        """
+        Simulate waiting for management operations to drain and record the requested timeout.
+        
+        Parameters:
+            timeout (float | None): Maximum seconds to wait, or `None` to indicate an indefinite wait.
+        
+        Behavior:
+            Appends the provided `timeout` value to the `wait_calls` list and sets
+            `iface._management_inflight` to 0 to indicate no inflight management operations.
+        
+        Returns:
+            bool: `True` to indicate the wait condition was signaled.
+        """
         wait_calls.append(timeout)
         iface._management_inflight = 0
         return True
 
     def _raise_if_duplicate(_key: str | None) -> None:
+        """
+        Increment the duplicate-check counter and, on the second invocation, mark the interface as having one inflight management operation.
+        
+        Parameters:
+            _key (str | None): Ignored; present to match the duplicate-check callback signature.
+        """
         nonlocal duplicate_checks
         duplicate_checks += 1
         if duplicate_checks == 2:
@@ -2714,6 +2789,19 @@ def test_connect_management_wait_timeout_resets_between_wait_cycles(
         pair_on_connect: bool = False,
         connect_timeout: float | None = None,
     ) -> tuple[DummyClient, str | None, str | None]:
+        """
+        Create and attach a DummyClient to the test BLE interface and mark it as connected.
+        
+        Parameters:
+            _address (str | None): Ignored; present to match the real establish signature.
+            _normalized_request (str | None): Ignored; present to match the real establish signature.
+            _address_key (str | None): Ignored; present to match the real establish signature.
+            pair_on_connect (bool): Accepted but ignored by this test stub.
+            connect_timeout (float | None): Accepted but ignored by this test stub.
+        
+        Returns:
+            tuple[DummyClient, None, None]: The created DummyClient instance and two None placeholders (resolved address and resolved identifier).
+        """
         _ = (pair_on_connect, connect_timeout)
         client = DummyClient()
         with iface._state_lock:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR improves BLE management wait logic to make connect() and close() robust against spurious condition-variable wakeups and prevents management in-flight accounting from underflowing. It replaces single-step waits with elapsed-time bounded polling, tightens shutdown/connect timeout enforcement, and adds unit tests that exercise the new behaviors.

## Key changes

Fixes
- Bound shutdown wait in close(): record start time, poll in short slices, enforce remaining timeout, and log elapsed time when the configured shutdown timeout is exceeded.
- Enforce connect timeout using elapsed-time accounting: replace unconditional waits with bounded polling that respects the remaining timeout; on timeout connect raises ERROR_MANAGEMENT_CONNECTING and logs elapsed-time details.
- Prevent management inflight underflow: _finish_management_operation() detects inflight <= 0, logs a warning, clamps _management_inflight to 0, notifies idle waiters, and returns instead of decrementing into negative values.
- Harden management wait liveness and accounting: adjustments to wait/unblock bookkeeping so management drains and wakeups do not allow timeouts to be extended by spurious wakes.

Refactor / consistency
- Unified wait pattern across connect() and close(): both methods now use elapsed-time tracking plus short polling intervals (capped by MANAGEMENT_CONNECT_WAIT_POLL_SECONDS) instead of single long condition.wait() calls.
- Logging improvements: timeout warnings now include elapsed-time to aid debugging.
- Minor non-functional formatting/unwrap changes in other BLE modules and tests (no API changes).

Tests
- Added/expanded unit tests validating behavior under spurious management wakeups and underflow conditions, including:
  - shutdown wait bounding during close()
  - connect() timeout behavior under spurious wakeups and reset of timeout accounting between drain cycles
  - _finish_management_operation() clamping and notification when inflight would go negative

Breaking changes / migration notes
- None. No public API or exported function signatures were changed; changes are internal to timing and bookkeeping to improve robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->