### PR TITLE
Add thread-safe metadata snapshot utilities to Node class

### DIFF
--- a/REFACTOR_PROGRAM-2.md
+++ b/REFACTOR_PROGRAM-2.md
@@ -20,19 +20,19 @@ The current `develop` branch represents a large structural modernization of the 
 - CI pipeline improvements
 - Async / concurrency correctness improvements
 
-`develop` is currently **two large commits ahead of `master`**, but those commits contain:
+`develop` is currently **seven commits ahead of `master`** (`master...develop = 0/7`), and the branch delta contains:
 
-- ~150 files changed
-- ~60k insertions
-- ~10k deletions
+- 153 files changed
+- 61,115 insertions
+- 10,739 deletions
 
 This is effectively a **platform-wide refactor**, not a typical incremental change.
 
-Because of this, the next phase should **not** merge `develop → master` directly.
+Because of this, we still should **not** merge `develop → master` directly.
 
-Instead, we will perform **a small number of large, deliberate stabilization passes** based on `develop`.
+Instead, we perform **a small number of large, deliberate stabilization passes** based on `develop`.
 
-These passes will become the next branches and PRs.
+Phase 1 (BLE stabilization) is now complete and merged into `develop` (`#63`), and Phase 2 is the active execution stream.
 
 ---
 
@@ -142,15 +142,13 @@ Despite the progress, several areas remain high risk:
 
 ### BLE Lifecycle Behavior
 
-BLE is the most complex subsystem and includes:
+Phase 1 delivered targeted BLE lifecycle hardening and timeout robustness. Remaining BLE risk is now primarily **regression risk**, not major architecture uncertainty.
 
-- async coordination
-- OS-specific behavior
-- reconnect logic
-- ownership / gating logic
-- management operations
+Residual focus areas:
 
-The architecture is improved, but lifecycle correctness must be stabilized.
+- cross-platform runtime behavior in real hardware environments
+- long-duration reconnect reliability
+- maintenance of compatibility semantics as future changes land
 
 ---
 
@@ -180,80 +178,45 @@ Compatibility shims exist but should be validated carefully to ensure:
 
 ---
 
-# 5. Next Phase Refactor Strategy
+# 5. Execution Status and Next-Phase Strategy
 
-Instead of merging `develop → master`, the next steps will consist of **three large stabilization branches**.
+Instead of merging `develop → master` directly, the program continues through themed stabilization passes.
 
-Each branch will be created from `develop`.
+### Phase Status Snapshot
+
+- Phase 1 BLE stabilization: **Completed** (merged into `develop`, PR `#63`)
+- Phase 2 MeshInterface runtime stabilization: **In progress** on `meshinterface-pass`
+- Phase 3 Runtime boundary cleanup: Pending
+- Phase 4 CLI structural refactor: Future
 
 ---
 
-# Phase 1: BLE Stabilization Pass
+# Phase 1: BLE Stabilization Pass (Completed)
 
-Branch name suggestion:
+Executed branch:
 
 ```
 ble-stabilization-pass
 ```
 
-This will be the **largest and most important stabilization phase**.
+Delivered outcomes:
 
-### Goals
-
-- finalize BLE lifecycle behavior
-- stabilize connect / disconnect / reconnect logic
-- verify state machine transitions
-- ensure safe shutdown
-- ensure compatibility with legacy BLE APIs
-
-### Areas of Work
-
-BLE lifecycle correctness
-
-- connection ownership rules
-- pairing / trust support
-- management operation tracking
-- reconnect timing behavior
-- shutdown ordering
-
-Concurrency review
-
-- locking order
-- race conditions
-- notification coordination
-- state synchronization
-
-Compatibility verification
-
-- historical callbacks
-- legacy method names
-- BLE public API exports
-
-Testing improvements
-
-- lifecycle edge cases
-- reconnect scenarios
-- partial connection failures
-- shutdown reliability
-
-### Explicitly Out of Scope
-
-- CLI refactor
-- mesh core restructuring
-- style cleanup unrelated to BLE
-- unrelated test rewrites
+- elapsed-time based management wait timeout accounting for connect/shutdown paths
+- hardened management operation accounting (underflow-safe behavior)
+- bounded spurious-wakeup regression tests to avoid suite hangs
+- compatibility-preserving fixes validated by expanded BLE lifecycle tests
 
 ---
 
-# Phase 2: MeshInterface Runtime Stabilization
+# Phase 2: MeshInterface Runtime Stabilization (Active)
 
-Branch name suggestion:
+Active branch:
 
 ```
-meshinterface-runtime-stabilization
+meshinterface-pass
 ```
 
-This phase focuses on correctness of the core networking behavior.
+This phase focuses on runtime correctness of request/wait behavior, callback handling, queue behavior, and shared-state safety.
 
 ### Goals
 
@@ -261,41 +224,30 @@ This phase focuses on correctness of the core networking behavior.
 - ensure deterministic callback handling
 - prevent late callback contamination
 - improve routing error propagation
+- enforce lock ownership discipline in mesh runtime paths
 
 ### Areas of Work
 
 ```
 meshtastic/mesh_interface.py
 meshtastic/node.py
+meshtastic/tests/test_mesh_interface.py
+meshtastic/tests/test_node.py
 ```
 
-Key improvements
+Execution checklist for this phase:
 
-- request-scoped wait tracking
-- retired wait request handling
-- response handler locking validation
-- atomic queue send behavior
-- routing error timing cleanup
-
-Testing
-
-```
-tests/test_mesh_interface.py
-```
-
-Add or refine tests covering:
-
-- multiple concurrent requests
-- late responses
-- cancellation behavior
-- transport error handling
+- verify behavior against `master` for backward compatibility and completeness
+- preserve documented compatibility aliases from `COMPATIBILITY.md`
+- enforce `AGENTS.md` lock-partitioning and shutdown contracts
+- harden wait/error bookkeeping for stale, late, and concurrent responses
+- add focused tests for real failure modes (timeouts, race windows, stale callbacks)
 
 ### Explicitly Out of Scope
 
-- BLE architecture
-- CLI behavior
-- host parsing
-- OTA logic
+- BLE architecture changes (unless required by critical regression)
+- CLI behavior or modularization
+- host parsing and OTA boundary cleanup work (Phase 3 scope)
 
 ---
 
@@ -387,13 +339,13 @@ main()
 
 # 6. Merge Strategy
 
-The final merge into `master` will occur **after phases 1–3 are completed**.
+The final merge into `master` will occur **after Phase 2 and Phase 3 are completed** (Phase 1 is already complete).
 
 This allows:
 
-- stabilization of BLE
-- stabilization of MeshInterface runtime behavior
-- stabilization of runtime behavior
+- finalized BLE stability from Phase 1
+- validated MeshInterface runtime stabilization from Phase 2
+- runtime boundary hardening from Phase 3
 
 Once these subsystems are stable, the refactor can be safely promoted to production.
 
@@ -426,22 +378,20 @@ To keep the refactor manageable:
 
 # 8. Immediate Next Step
 
-Create the first stabilization branch from `develop`.
+Continue executing Phase 2 on the active branch:
 
 ```
-git checkout develop
-git checkout -b ble-stabilization-pass
+git checkout meshinterface-pass
 ```
 
-Focus entirely on:
+Immediate focus:
 
-- BLE lifecycle correctness
-- reconnect logic
-- shutdown reliability
-- compatibility verification
-- lifecycle test coverage
+- complete mesh runtime hardening in `mesh_interface.py` and `node.py`
+- run explicit backward-compatibility checks against `master`
+- validate compatibility inventory alignment in `COMPATIBILITY.md`
+- keep tests green with expanded targeted regression coverage
 
-This will produce the **next major PR** in the refactor program.
+This work stream should produce the next major PRs for the refactor program.
 
 ---
 
@@ -451,11 +401,11 @@ The major architectural refactor is largely complete.
 
 The next work should not expand scope further.
 
-Instead, the project should proceed through **large stabilization passes**:
+Instead, the project proceeds through **large stabilization passes**:
 
-1. BLE stabilization
-2. MeshInterface runtime stabilization
-3. Runtime boundary cleanup
+1. BLE stabilization (completed)
+2. MeshInterface runtime stabilization (active)
+3. Runtime boundary cleanup (pending)
 4. CLI modularization (future)
 
 Once these passes are complete, `develop` will be ready to merge into `master`.

--- a/REFACTOR_PROGRAM-2.md
+++ b/REFACTOR_PROGRAM-2.md
@@ -1,4 +1,5 @@
 # REFACTOR_PROGRAM-2.md
+
 ### Meshtastic Python Refactor – Phase 2 Program Plan
 
 Date: 2026-03-11  
@@ -49,7 +50,7 @@ Going forward we will keep the advantages of automation but shift toward **inten
 
 • dozens of tiny PRs  
 • style-only churn mixed with behavior changes  
-• interleaving multiple subsystem refactors  
+• interleaving multiple subsystem refactors
 
 Each branch should represent **one engineering theme**.
 

--- a/bin/run-multinode-with-meshtasticd.sh
+++ b/bin/run-multinode-with-meshtasticd.sh
@@ -278,7 +278,9 @@ wait_for_log_pattern() {
 	local deadline=$((SECONDS + timeout_seconds))
 
 	while ((SECONDS < deadline)); do
-		if docker logs "${container}" 2>&1 | grep -Fq "${pattern}"; then
+		# Keep pipefail from treating docker's expected SIGPIPE (when grep -q
+		# exits early after a match) as a false-negative "pattern not found".
+		if (set +o pipefail; docker logs "${container}" 2>&1 | grep -Fq "${pattern}"); then
 			return 0
 		fi
 		if ! docker ps --format '{{.Names}}' | grep -Fxq "${container}"; then

--- a/meshtastic/interfaces/ble/client.py
+++ b/meshtastic/interfaces/ble/client.py
@@ -380,7 +380,9 @@ class BLEClient:
         bleak_client = self.bleak_client
         if bleak_client is None:
             raise self.BLEError(BLECLIENT_ERROR_CANNOT_CONNECT_NOT_INITIALIZED)
-        result = self._async_await(bleak_client.connect(**kwargs), timeout=await_timeout)
+        result = self._async_await(
+            bleak_client.connect(**kwargs), timeout=await_timeout
+        )
         self._sync_address_from_bleak()
         return result
 

--- a/meshtastic/interfaces/ble/constants.py
+++ b/meshtastic/interfaces/ble/constants.py
@@ -129,7 +129,9 @@ ERROR_ADDRESS_RESOLUTION_FAILED: str = "Address resolution failed, cannot create
 ERROR_INTERFACE_CLOSING: str = "Cannot connect while interface is closing"
 ERROR_CONNECTION_SUPPRESSED: str = "Connection suppressed: recently connected elsewhere"
 ERROR_NO_CLIENT_ESTABLISHED: str = "Connection failed: no BLE client established"
-ERROR_MANAGEMENT_ADDRESS_EMPTY: str = "Management operations require a non-empty address."
+ERROR_MANAGEMENT_ADDRESS_EMPTY: str = (
+    "Management operations require a non-empty address."
+)
 ERROR_MANAGEMENT_ADDRESS_REQUIRED: str = (
     "Management operations require an explicit address when no device is connected."
 )
@@ -176,7 +178,9 @@ UNREACHABLE_ADDRESSED_DEVICES_MSG: str = (
 
 # BLEClient-specific constants
 # Alias preserves legacy access while sourcing value from BLEConfig
-BLECLIENT_EVENT_THREAD_JOIN_TIMEOUT: float = BLEConfig.BLECLIENT_EVENT_THREAD_JOIN_TIMEOUT
+BLECLIENT_EVENT_THREAD_JOIN_TIMEOUT: float = (
+    BLEConfig.BLECLIENT_EVENT_THREAD_JOIN_TIMEOUT
+)
 BLECLIENT_ERROR_ASYNC_TIMEOUT: str = "Async operation timed out"
 BLECLIENT_ERROR_CANCELLED: str = "Async operation was cancelled"
 BLECLIENT_ERROR_CANNOT_PAIR_NOT_INITIALIZED: str = (

--- a/meshtastic/interfaces/ble/gating.py
+++ b/meshtastic/interfaces/ble/gating.py
@@ -211,11 +211,7 @@ def _cleanup_addr_lock(key: str | None) -> None:
         return
     with _REGISTRY_LOCK:
         holder_count = _LOCK_HOLDERS.get(key, 0)
-        if (
-            holder_count > 0
-            or key in _CONNECTED_ADDRS
-            or key in _CONNECTING_ADDRS
-        ):
+        if holder_count > 0 or key in _CONNECTED_ADDRS or key in _CONNECTING_ADDRS:
             logger.debug(
                 "Skipping cleanup of address lock for %s (holders: %d)",
                 key,
@@ -619,7 +615,9 @@ def _mark_disconnected(addr: str | None, owner: Any | None = None) -> None:
                     clear_connecting_claim = False
                 if provisional_owner is None:
                     provisional_owner_id = _CONNECTING_OWNER_IDS.get(key)
-                    if provisional_owner_id is None or provisional_owner_id != id(owner):
+                    if provisional_owner_id is None or provisional_owner_id != id(
+                        owner
+                    ):
                         logger.debug(
                             "Ignoring provisional disconnect mark for %s from non-owner instance.",
                             key,

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -1696,8 +1696,19 @@ class BLEInterface(MeshInterface):
         self._management_inflight += 1
 
     def _finish_management_operation(self) -> None:
-        """Mark a management operation complete and wake shutdown waiters."""
+        """
+        Mark completion of an in-flight management operation and notify any waiters when no operations remain.
+
+        If the internal in-flight counter is already zero or negative, reset it to zero, notify waiters, and log a warning; otherwise decrement the counter and notify waiters when it reaches zero.
+        """
         with self._management_lock:
+            if self._management_inflight <= 0:
+                logger.warning(
+                    "Management operation accounting underflow detected during finish(); resetting inflight count to zero."
+                )
+                self._management_inflight = 0
+                self._management_idle_condition.notify_all()
+                return
             self._management_inflight -= 1
             if self._management_inflight == 0:
                 self._management_idle_condition.notify_all()
@@ -2400,8 +2411,8 @@ class BLEInterface(MeshInterface):
                 )
                 if not lost_gate_ownership:
                     with self._state_lock:
-                        still_owned, is_closing = self._get_connected_client_status_locked(
-                            connected_client
+                        still_owned, is_closing = (
+                            self._get_connected_client_status_locked(connected_client)
                         )
                         if still_owned:
                             publish_candidate = True
@@ -2697,7 +2708,7 @@ class BLEInterface(MeshInterface):
         try:
             management_lock = self._management_lock
             management_idle_condition = self._management_idle_condition
-            management_wait_started = time.monotonic()
+            management_wait_started: float | None = None
             while True:
                 requested_identifier = address if address is not None else self.address
                 normalized_request = sanitize_address(requested_identifier)
@@ -2710,18 +2721,25 @@ class BLEInterface(MeshInterface):
                 with management_lock:
                     while self._management_inflight > 0:
                         self._validate_connection_preconditions()
-                        if not management_idle_condition.wait(
-                            timeout=_MANAGEMENT_CONNECT_WAIT_POLL_SECONDS
-                        ):
-                            self._validate_connection_preconditions()
-                            elapsed = time.monotonic() - management_wait_started
-                            if elapsed >= _MANAGEMENT_CONNECT_WAIT_TIMEOUT_SECONDS:
-                                logger.warning(
-                                    "Timed out waiting %.1fs for %d inflight management operation(s) before connect()",
-                                    elapsed,
-                                    self._management_inflight,
-                                )
-                                raise self.BLEError(ERROR_MANAGEMENT_CONNECTING)
+                        if management_wait_started is None:
+                            management_wait_started = time.monotonic()
+                        elapsed = time.monotonic() - management_wait_started
+                        if elapsed >= _MANAGEMENT_CONNECT_WAIT_TIMEOUT_SECONDS:
+                            logger.warning(
+                                "Timed out waiting %.1fs for %d inflight management operation(s) before connect()",
+                                elapsed,
+                                self._management_inflight,
+                            )
+                            raise self.BLEError(ERROR_MANAGEMENT_CONNECTING)
+                        remaining = _MANAGEMENT_CONNECT_WAIT_TIMEOUT_SECONDS - elapsed
+                        management_idle_condition.wait(
+                            timeout=min(
+                                _MANAGEMENT_CONNECT_WAIT_POLL_SECONDS, remaining
+                            )
+                        )
+                    # Reset timeout accounting once we are no longer blocked by
+                    # in-flight management operations so future waits start fresh.
+                    management_wait_started = None
 
                 # Recompute potentially discovery-backed target state after
                 # waiting for inflight management operations so retries do not
@@ -3224,6 +3242,7 @@ class BLEInterface(MeshInterface):
         # can observe _closed/_is_closing and abort, rather than forcing close()
         # to wait behind a long BLE connect attempt.
         management_wait_timed_out = False
+        management_wait_started = time.monotonic()
         with self._management_lock:
             # Use unified state lock
             with self._state_lock:
@@ -3246,15 +3265,19 @@ class BLEInterface(MeshInterface):
                 ):
                     self._state_manager._transition_to(ConnectionState.DISCONNECTING)
             while self._management_inflight > 0:
-                if not self._management_idle_condition.wait(
-                    timeout=_MANAGEMENT_SHUTDOWN_WAIT_TIMEOUT_SECONDS
-                ):
+                elapsed = time.monotonic() - management_wait_started
+                if elapsed >= _MANAGEMENT_SHUTDOWN_WAIT_TIMEOUT_SECONDS:
                     management_wait_timed_out = True
                     logger.warning(
-                        "Timed out waiting for %d inflight management operation(s) during shutdown",
+                        "Timed out waiting %.1fs for %d inflight management operation(s) during shutdown",
+                        elapsed,
                         self._management_inflight,
                     )
                     break
+                remaining = _MANAGEMENT_SHUTDOWN_WAIT_TIMEOUT_SECONDS - elapsed
+                self._management_idle_condition.wait(
+                    timeout=min(_MANAGEMENT_CONNECT_WAIT_POLL_SECONDS, remaining)
+                )
 
         try:
             # Release lock before calling MeshInterface.close() to avoid deadlock

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -17,6 +17,7 @@ from typing import (
     Callable,
     NoReturn,
     Sequence,
+    TypeVar,
     cast,
 )
 
@@ -70,6 +71,7 @@ FACTORY_RESET_REQUEST_VALUE: int = 1
 # Extra wait used only when getMetadata() runs under redirected stdout for
 # historical callers that parse printed metadata lines.
 METADATA_STDOUT_COMPAT_WAIT_SECONDS = 1.0
+_LockedCallResult = TypeVar("_LockedCallResult")
 
 
 class Node:
@@ -195,36 +197,38 @@ class Node:
         if metadata_stdout_event is not None:
             metadata_stdout_event.set()
 
-    def _get_metadata_snapshot(self) -> Any:
-        """Return a stable snapshot of ``iface.metadata`` under the node DB lock when available."""
+    def _execute_with_node_db_lock(
+        self, func: Callable[[], _LockedCallResult]
+    ) -> _LockedCallResult:
+        """Execute ``func`` while holding ``iface._node_db_lock`` when available."""
         node_db_lock = getattr(self.iface, "_node_db_lock", None)
         if (
             node_db_lock is None
             or not hasattr(node_db_lock, "__enter__")
             or not hasattr(node_db_lock, "__exit__")
         ):
+            return func()
+        with node_db_lock:
+            return func()
+
+    def _get_metadata_snapshot(self) -> mesh_pb2.DeviceMetadata | None:
+        """Return a stable snapshot of ``iface.metadata`` under the node DB lock when available."""
+        def _read_and_copy() -> mesh_pb2.DeviceMetadata | None:
             metadata = getattr(self.iface, "metadata", None)
-        else:
-            with node_db_lock:
-                metadata = getattr(self.iface, "metadata", None)
-        if isinstance(metadata, mesh_pb2.DeviceMetadata):
+            if not isinstance(metadata, mesh_pb2.DeviceMetadata):
+                return None
             metadata_snapshot = mesh_pb2.DeviceMetadata()
             metadata_snapshot.CopyFrom(metadata)
             return metadata_snapshot
-        return metadata
+
+        return self._execute_with_node_db_lock(_read_and_copy)
 
     def _set_metadata_snapshot(self, metadata_snapshot: mesh_pb2.DeviceMetadata) -> None:
         """Persist a metadata snapshot to ``iface.metadata`` under the node DB lock when available."""
-        node_db_lock = getattr(self.iface, "_node_db_lock", None)
-        if (
-            node_db_lock is None
-            or not hasattr(node_db_lock, "__enter__")
-            or not hasattr(node_db_lock, "__exit__")
-        ):
+        def _write() -> None:
             self.iface.metadata = metadata_snapshot
-            return
-        with node_db_lock:
-            self.iface.metadata = metadata_snapshot
+
+        self._execute_with_node_db_lock(_write)
 
     def _emit_cached_metadata_for_stdout(self) -> bool:
         """Emit metadata lines from ``self.iface.metadata`` for stdout parser compatibility."""

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -195,9 +195,40 @@ class Node:
         if metadata_stdout_event is not None:
             metadata_stdout_event.set()
 
+    def _get_metadata_snapshot(self) -> Any:
+        """Return a stable snapshot of ``iface.metadata`` under the node DB lock when available."""
+        node_db_lock = getattr(self.iface, "_node_db_lock", None)
+        if (
+            node_db_lock is None
+            or not hasattr(node_db_lock, "__enter__")
+            or not hasattr(node_db_lock, "__exit__")
+        ):
+            metadata = getattr(self.iface, "metadata", None)
+        else:
+            with node_db_lock:
+                metadata = getattr(self.iface, "metadata", None)
+        if isinstance(metadata, mesh_pb2.DeviceMetadata):
+            metadata_snapshot = mesh_pb2.DeviceMetadata()
+            metadata_snapshot.CopyFrom(metadata)
+            return metadata_snapshot
+        return metadata
+
+    def _set_metadata_snapshot(self, metadata_snapshot: mesh_pb2.DeviceMetadata) -> None:
+        """Persist a metadata snapshot to ``iface.metadata`` under the node DB lock when available."""
+        node_db_lock = getattr(self.iface, "_node_db_lock", None)
+        if (
+            node_db_lock is None
+            or not hasattr(node_db_lock, "__enter__")
+            or not hasattr(node_db_lock, "__exit__")
+        ):
+            self.iface.metadata = metadata_snapshot
+            return
+        with node_db_lock:
+            self.iface.metadata = metadata_snapshot
+
     def _emit_cached_metadata_for_stdout(self) -> bool:
         """Emit metadata lines from ``self.iface.metadata`` for stdout parser compatibility."""
-        metadata = getattr(self.iface, "metadata", None)
+        metadata = self._get_metadata_snapshot()
         firmware_version = getattr(metadata, "firmware_version", "")
         if not isinstance(firmware_version, str) or not firmware_version:
             return False
@@ -2116,7 +2147,7 @@ class Node:
         c = decoded["admin"]["raw"].get_device_metadata_response
         metadata_snapshot = mesh_pb2.DeviceMetadata()
         metadata_snapshot.CopyFrom(c)
-        self.iface.metadata = metadata_snapshot
+        self._set_metadata_snapshot(metadata_snapshot)
         self._timeout.reset()  # We made forward progress
         logger.debug("Received metadata %s", stripnl(c))
         self._emit_metadata_line(f"\nfirmware_version: {c.firmware_version}")

--- a/meshtastic/tests/test_examples.py
+++ b/meshtastic/tests/test_examples.py
@@ -29,7 +29,9 @@ def _require_mapping(value: object, *, label: str) -> dict[str, object]:
 
 def _require_int_strict(value: object, *, label: str) -> int:
     """Assert that `value` is an int (excluding bool) and return it."""
-    assert isinstance(value, int), f"{label} should be an int, got {type(value).__name__}"
+    assert isinstance(
+        value, int
+    ), f"{label} should be an int, got {type(value).__name__}"
     assert not isinstance(value, bool), f"{label} must not be a bool"
     return cast(int, value)
 
@@ -92,9 +94,9 @@ def test_examples_example_config_yaml_is_valid() -> None:
     assert isinstance(owner_short, str), "owner_short should be a string"
     assert owner_short.strip(), "owner_short should not be empty/whitespace"
     assert isinstance(channel_url, str), "channel_url should be a string"
-    assert channel_url.startswith("https://meshtastic.org/e/#"), (
-        f"channel_url should start with the Meshtastic share URL, got: {channel_url}"
-    )
+    assert channel_url.startswith(
+        "https://meshtastic.org/e/#"
+    ), f"channel_url should start with the Meshtastic share URL, got: {channel_url}"
     assert "ownerShort" not in config
     assert "channelUrl" not in config
 

--- a/meshtastic/tests/test_examples.py
+++ b/meshtastic/tests/test_examples.py
@@ -33,7 +33,7 @@ def _require_int_strict(value: object, *, label: str) -> int:
         value, int
     ), f"{label} should be an int, got {type(value).__name__}"
     assert not isinstance(value, bool), f"{label} must not be a bool"
-    return cast(int, value)
+    return value
 
 
 def _run_hello_world_serial(monkeypatch: pytest.MonkeyPatch, *args: str) -> None:

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -38,12 +38,12 @@ from meshtastic.__main__ import (
 
 # from ..ble_interface import BLEInterface
 from ..node import Node
-from ..protobuf import config_pb2, localonly_pb2
-from ..protobuf.channel_pb2 import Channel  # pylint: disable=E0611
 
 # from ..radioconfig_pb2 import UserPreferences
 # import meshtastic.config_pb2
 from ..ota import OTAError, OTATransportError
+from ..protobuf import config_pb2, localonly_pb2
+from ..protobuf.channel_pb2 import Channel  # pylint: disable=E0611
 from ..serial_interface import SerialInterface
 from ..tcp_interface import TCPInterface
 

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -61,6 +61,21 @@ class _DropChannelsOnEnterCountLock:
         return False
 
 
+class _TrackingLock:
+    """Lock stub that records how many times it was acquired."""
+
+    def __init__(self) -> None:
+        self.enter_count = 0
+
+    def __enter__(self) -> "_TrackingLock":
+        self.enter_count += 1
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> Literal[False]:
+        _ = (exc_type, exc, tb)
+        return False
+
+
 def _make_fake_send_admin(
     *,
     sent_messages: list[admin_pb2.AdminMessage] | None = None,
@@ -1711,6 +1726,34 @@ def test_onRequestGetMetadata_logs_valid_and_fallback_enum_values(
 
 
 @pytest.mark.unit
+def test_onRequestGetMetadata_updates_metadata_under_node_db_lock(
+    autospec_local_node_iface: Callable[[type[Any]], MagicMock],
+) -> None:
+    """onRequestGetMetadata should update iface.metadata while holding iface._node_db_lock."""
+    iface = autospec_local_node_iface(MeshInterface)
+    iface._acknowledgment = Acknowledgment()
+    iface._node_db_lock = _TrackingLock()
+    anode = Node(iface, "!12345678", noProto=True)
+    anode._timeout = MagicMock()
+
+    raw = admin_pb2.AdminMessage()
+    response = raw.get_device_metadata_response
+    response.firmware_version = "2.7.19"
+    response.device_state_version = 25
+    response.role = config_pb2.Config.DeviceConfig.Role.CLIENT
+    response.position_flags = 0
+    response.hw_model = mesh_pb2.HardwareModel.PORTDUINO
+    response.hasPKC = True
+
+    anode.onRequestGetMetadata(
+        {"decoded": {"portnum": "ADMIN_APP", "admin": {"raw": raw}}}
+    )
+
+    assert iface._node_db_lock.enter_count == 1
+    assert iface.metadata.firmware_version == "2.7.19"
+
+
+@pytest.mark.unit
 def test_onRequestGetMetadata_emits_stdout_when_redirected(
     autospec_local_node_iface: Callable[[type[Any]], MagicMock],
     capsys: CaptureFixture[str],
@@ -1774,6 +1817,31 @@ def test_emit_cached_metadata_uses_fallback_values_for_unknown_enums(
     assert "role: 999" in emitted
     assert "hw_model: 999" in emitted
     assert any(line.startswith("excluded_modules:") for line in emitted)
+
+
+@pytest.mark.unit
+def test_emit_cached_metadata_reads_metadata_under_node_db_lock(
+    autospec_local_node_iface: Callable[[type[Any]], MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_emit_cached_metadata_for_stdout should snapshot iface.metadata under iface._node_db_lock."""
+    iface = autospec_local_node_iface(MeshInterface)
+    iface._node_db_lock = _TrackingLock()
+    iface.metadata = mesh_pb2.DeviceMetadata(
+        firmware_version="2.7.18",
+        device_state_version=24,
+        role=config_pb2.Config.DeviceConfig.Role.CLIENT,
+        position_flags=0,
+        hw_model=mesh_pb2.HardwareModel.PORTDUINO,
+        hasPKC=True,
+    )
+    anode = Node(iface, "!12345678", noProto=True)
+    emitted: list[str] = []
+    monkeypatch.setattr(anode, "_emit_metadata_line", emitted.append)
+
+    assert anode._emit_cached_metadata_for_stdout() is True
+    assert iface._node_db_lock.enter_count == 1
+    assert any("firmware_version: 2.7.18" in line for line in emitted)
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -64,8 +64,9 @@ class _DropChannelsOnEnterCountLock:
 class _TrackingLock:
     """Lock stub that records how many times it was acquired."""
 
-    def __init__(self) -> None:
+    def __init__(self, on_exit: Callable[[], None] | None = None) -> None:
         self.enter_count = 0
+        self._on_exit = on_exit
 
     def __enter__(self) -> "_TrackingLock":
         self.enter_count += 1
@@ -73,6 +74,8 @@ class _TrackingLock:
 
     def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> Literal[False]:
         _ = (exc_type, exc, tb)
+        if self._on_exit is not None:
+            self._on_exit()
         return False
 
 
@@ -1824,9 +1827,8 @@ def test_emit_cached_metadata_reads_metadata_under_node_db_lock(
     autospec_local_node_iface: Callable[[type[Any]], MagicMock],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """_emit_cached_metadata_for_stdout should snapshot iface.metadata under iface._node_db_lock."""
+    """_emit_cached_metadata_for_stdout should snapshot metadata before lock release."""
     iface = autospec_local_node_iface(MeshInterface)
-    iface._node_db_lock = _TrackingLock()
     iface.metadata = mesh_pb2.DeviceMetadata(
         firmware_version="2.7.18",
         device_state_version=24,
@@ -1835,6 +1837,18 @@ def test_emit_cached_metadata_reads_metadata_under_node_db_lock(
         hw_model=mesh_pb2.HardwareModel.PORTDUINO,
         hasPKC=True,
     )
+
+    def _mutate_metadata_after_unlock() -> None:
+        iface.metadata = mesh_pb2.DeviceMetadata(
+            firmware_version="mutated-after-unlock",
+            device_state_version=99,
+            role=config_pb2.Config.DeviceConfig.Role.CLIENT_HIDDEN,
+            position_flags=0,
+            hw_model=mesh_pb2.HardwareModel.UNSET,
+            hasPKC=False,
+        )
+
+    iface._node_db_lock = _TrackingLock(on_exit=_mutate_metadata_after_unlock)
     anode = Node(iface, "!12345678", noProto=True)
     emitted: list[str] = []
     monkeypatch.setattr(anode, "_emit_metadata_line", emitted.append)
@@ -1842,6 +1856,20 @@ def test_emit_cached_metadata_reads_metadata_under_node_db_lock(
     assert anode._emit_cached_metadata_for_stdout() is True
     assert iface._node_db_lock.enter_count == 1
     assert any("firmware_version: 2.7.18" in line for line in emitted)
+    assert not any("firmware_version: mutated-after-unlock" in line for line in emitted)
+
+
+@pytest.mark.unit
+def test_get_metadata_snapshot_returns_none_for_non_proto_metadata(
+    autospec_local_node_iface: Callable[[type[Any]], MagicMock],
+) -> None:
+    """_get_metadata_snapshot should return None when iface.metadata is not DeviceMetadata."""
+    iface = autospec_local_node_iface(MeshInterface)
+    iface._node_db_lock = _TrackingLock()
+    iface.metadata = {"firmware_version": "not-a-protobuf"}
+    anode = Node(iface, "!12345678", noProto=True)
+
+    assert anode._get_metadata_snapshot() is None
 
 
 @pytest.mark.unit

--- a/tests/test_ble_client_edge_cases.py
+++ b/tests/test_ble_client_edge_cases.py
@@ -210,7 +210,9 @@ def test_bleclient_init_with_address_syncs_from_bleak(
 
 
 @pytest.mark.unit
-def test_bleclient_sync_address_noops_without_bleak_client(ble_client: BLEClient) -> None:
+def test_bleclient_sync_address_noops_without_bleak_client(
+    ble_client: BLEClient,
+) -> None:
     """Address sync should return early when the backend client is not initialized."""
     ble_client.address = "11:22:33:44:55:66"
     ble_client.bleak_client = None
@@ -227,7 +229,9 @@ def test_bleclient_management_call_reraises_non_notimplemented_bleerror() -> Non
     async def _noop_operation() -> None:
         return None
 
-    def _raise_bleerror(awaitable: Awaitable[object], timeout: float | None = None) -> NoReturn:
+    def _raise_bleerror(
+        awaitable: Awaitable[object], timeout: float | None = None
+    ) -> NoReturn:
         _ = timeout
         close_awaitable = getattr(awaitable, "close", None)
         if callable(close_awaitable):

--- a/tests/test_ble_connection_edge_cases.py
+++ b/tests/test_ble_connection_edge_cases.py
@@ -58,8 +58,12 @@ def test_is_device_not_found_error_matches_device_context_messages() -> None:
         is False
     )
     assert _is_device_not_found_error(Exception("Service not found")) is False
-    assert _is_device_not_found_error(Exception("Peripheral service not found")) is False
-    assert _is_device_not_found_error(Exception("Peripheral: service not found")) is False
+    assert (
+        _is_device_not_found_error(Exception("Peripheral service not found")) is False
+    )
+    assert (
+        _is_device_not_found_error(Exception("Peripheral: service not found")) is False
+    )
 
 
 @pytest.mark.unit
@@ -757,7 +761,9 @@ def test_connection_orchestrator_raises_when_connect_state_transition_fails() ->
         thread_coordinator=MagicMock(),
     )
 
-    with pytest.raises(MockBLEError, match="Already connected or connection in progress"):
+    with pytest.raises(
+        MockBLEError, match="Already connected or connection in progress"
+    ):
         orchestrator._establish_connection(
             address="AA:BB:CC:DD:EE:FF",
             current_address=None,

--- a/tests/test_ble_interface_advanced.py
+++ b/tests/test_ble_interface_advanced.py
@@ -830,9 +830,9 @@ def test_rapid_connect_disconnect_stress_test(
     ) -> tuple[list["StressTestClient"], list["StressTestClient"]]:
         """Wait until latest successful reconnect attempt owns iface.client."""
 
-        def _snapshot_stress_state() -> tuple[
-            object | None, list["StressTestClient"], list["StressTestClient"]
-        ]:
+        def _snapshot_stress_state() -> (
+            tuple[object | None, list["StressTestClient"], list["StressTestClient"]]
+        ):
             with iface._state_lock:
                 current_client = cast(object | None, iface.client)
                 attempts = list(
@@ -1030,7 +1030,9 @@ def test_rapid_connect_disconnect_stress_test(
                 bleak_client.is_connected_result = False
                 iface3._on_ble_disconnect(bleak_client)
                 time.sleep(0.01)
-            except Exception as exc:  # noqa: BLE001 - test records failure-path behavior
+            except (
+                Exception
+            ) as exc:  # noqa: BLE001 - test records failure-path behavior
                 failure_errors.append(exc)
 
         assert failure_errors == []

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -19,31 +19,50 @@ from bleak.exc import BleakDBusError, BleakError
 # Import meshtastic modules for use in tests
 import meshtastic.interfaces.ble as ble_mod
 import meshtastic.interfaces.ble.discovery as discovery_mod
-from meshtastic.interfaces.ble import (FROMNUM_UUID, LEGACY_LOGRADIO_UUID,
-                                       LOGRADIO_UUID, SERVICE_UUID, BLEClient,
-                                       BLEInterface)
+from meshtastic.interfaces.ble import (
+    FROMNUM_UUID,
+    LEGACY_LOGRADIO_UUID,
+    LOGRADIO_UUID,
+    SERVICE_UUID,
+    BLEClient,
+    BLEInterface,
+)
 from meshtastic.interfaces.ble.connection import ConnectionValidator
 from meshtastic.interfaces.ble.constants import (
     BLECLIENT_ERROR_CANNOT_PAIR_NOT_INITIALIZED,
     BLECLIENT_ERROR_CANNOT_UNPAIR_NOT_INITIALIZED,
-    CONNECTION_ERROR_LOST_OWNERSHIP, ERROR_CONNECTION_SUPPRESSED,
-    ERROR_INTERFACE_CLOSING, ERROR_MANAGEMENT_ADDRESS_EMPTY,
-    ERROR_MANAGEMENT_ADDRESS_REQUIRED, ERROR_MANAGEMENT_AWAIT_TIMEOUT_INVALID,
-    ERROR_MANAGEMENT_CONNECTING, ERROR_MANAGEMENT_TARGET_CHANGED,
-    ERROR_TRUST_ADDRESS_NOT_RESOLVED, ERROR_TRUST_BLUETOOTHCTL_MISSING,
-    ERROR_TRUST_COMMAND_FAILED, ERROR_TRUST_COMMAND_TIMEOUT,
-    ERROR_TRUST_INVALID_TIMEOUT)
+    CONNECTION_ERROR_LOST_OWNERSHIP,
+    ERROR_CONNECTION_SUPPRESSED,
+    ERROR_INTERFACE_CLOSING,
+    ERROR_MANAGEMENT_ADDRESS_EMPTY,
+    ERROR_MANAGEMENT_ADDRESS_REQUIRED,
+    ERROR_MANAGEMENT_AWAIT_TIMEOUT_INVALID,
+    ERROR_MANAGEMENT_CONNECTING,
+    ERROR_MANAGEMENT_TARGET_CHANGED,
+    ERROR_TRUST_ADDRESS_NOT_RESOLVED,
+    ERROR_TRUST_BLUETOOTHCTL_MISSING,
+    ERROR_TRUST_COMMAND_FAILED,
+    ERROR_TRUST_COMMAND_TIMEOUT,
+    ERROR_TRUST_INVALID_TIMEOUT,
+)
 from meshtastic.interfaces.ble.discovery import (
-    DiscoveryClientError, DiscoveryManager,
-    _close_discovery_client_best_effort, _filter_devices_for_target_identifier,
-    _looks_like_ble_address, _parse_scan_response)
-from meshtastic.interfaces.ble.reconnection import (ReconnectScheduler,
-                                                    ReconnectWorker)
+    DiscoveryClientError,
+    DiscoveryManager,
+    _close_discovery_client_best_effort,
+    _filter_devices_for_target_identifier,
+    _looks_like_ble_address,
+    _parse_scan_response,
+)
+from meshtastic.interfaces.ble.reconnection import ReconnectScheduler, ReconnectWorker
 from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
+
 # Import common fixtures
 from tests.test_ble_interface_fixtures import DummyClient, _build_interface
 
 pytestmark = pytest.mark.unit
+
+_MAX_SPURIOUS_CONNECT_WAIT_CALLS_BEFORE_FAIL = 10
+_MAX_SPURIOUS_CLOSE_WAIT_CALLS_BEFORE_FAIL = 50
 
 
 def _pin_trust_environment(
@@ -51,7 +70,13 @@ def _pin_trust_environment(
     *,
     run: Callable[..., object] | None = None,
 ) -> None:
-    """Pin trust() host dependencies so guard-path tests stay hermetic."""
+    """
+    Configure host-specific dependencies so tests of trust() run in a controlled Linux-like environment.
+
+    Parameters:
+        monkeypatch (pytest.MonkeyPatch): Fixture used to apply attribute patches.
+        run (Callable[..., object] | None): Optional replacement for subprocess.run used by trust(); if None, a sentinel callable is installed that raises AssertionError if invoked.
+    """
     monkeypatch.setattr("meshtastic.interfaces.ble.interface.sys.platform", "linux")
     monkeypatch.setattr(
         "meshtastic.interfaces.ble.interface.shutil.which",
@@ -1899,6 +1924,135 @@ def test_ble_interface_close_skips_management_gate_after_wait_timeout(
     assert disconnect_calls == [client]
 
 
+def test_ble_interface_close_bounds_wait_on_spurious_management_wakeups(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """close() should enforce shutdown timeout despite spurious management wakeups."""
+    client = DummyClient()
+    client.address = "AA:BB:CC:DD:EE:31"
+    client.bleak_client = SimpleNamespace(address=client.address)
+    iface = _build_interface(monkeypatch, client, start_receive_thread=False)
+    wait_calls: list[float | None] = []
+    gate_calls: list[str] = []
+    unsubscribe_calls: list[object] = []
+    disconnect_calls: list[object] = []
+    close_errors: list[Exception] = []
+    close_done = threading.Event()
+
+    with iface._management_lock:
+        iface._management_inflight = 1
+    with iface._state_lock:
+        iface._disconnect_notified = True
+
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.interface._MANAGEMENT_SHUTDOWN_WAIT_TIMEOUT_SECONDS",
+        0.05,
+    )
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.interface._MANAGEMENT_CONNECT_WAIT_POLL_SECONDS",
+        0.005,
+    )
+
+    def _spurious_wait(timeout: float | None = None) -> bool:
+        """
+        Simulate a spurious wait for tests and track each requested timeout.
+
+        Parameters:
+            timeout (float | None): The requested wait duration in seconds; if greater than zero the function sleeps for that duration.
+
+        Returns:
+            bool: `True` to indicate the wait condition remains satisfied.
+
+        Raises:
+            AssertionError: If the number of invocations exceeds the allowed spurious-wait budget, signals that shutdown waited past its timeout.
+        """
+        wait_calls.append(timeout)
+        if timeout is not None and timeout > 0:
+            time.sleep(timeout)
+        if len(wait_calls) > _MAX_SPURIOUS_CLOSE_WAIT_CALLS_BEFORE_FAIL:
+            close_done.set()
+            raise AssertionError(
+                "close() kept waiting past the shutdown timeout budget"
+            )
+        return True
+
+    monkeypatch.setattr(
+        iface._management_idle_condition,
+        "wait",
+        _spurious_wait,
+        raising=True,
+    )
+
+    def _management_gate(
+        address: str,
+    ) -> contextlib.AbstractContextManager[None]:
+        """
+        Context manager used in tests to record a requested management address and provide a no-op gate.
+
+        Parameters:
+            address (str): The management address being requested; the address is recorded for test inspection.
+
+        Returns:
+            contextmanager: A context manager that performs no gating and yields `None`.
+        """
+        gate_calls.append(address)
+        return contextlib.nullcontext()
+
+    monkeypatch.setattr(
+        iface, "_management_target_gate", _management_gate, raising=True
+    )
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.interface.MeshInterface.close",
+        lambda _self: None,
+    )
+    monkeypatch.setattr(
+        iface._notification_manager,
+        "_unsubscribe_all",
+        lambda active_client, timeout=None: unsubscribe_calls.append(active_client),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        iface,
+        "_disconnect_and_close_client",
+        lambda active_client: disconnect_calls.append(active_client),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        iface._notification_manager,
+        "_cleanup_all",
+        lambda: None,
+        raising=True,
+    )
+
+    def _run_close() -> None:
+        """
+        Attempt to close the interface and signal completion.
+
+        Calls iface.close(). If an exception is raised, appends it to the shared close_errors list. Always sets the close_done event when finished.
+        """
+        try:
+            iface.close()
+        except Exception as exc:  # pragma: no cover - captured for assertion
+            close_errors.append(exc)
+        finally:
+            close_done.set()
+
+    with caplog.at_level(logging.WARNING):
+        close_thread = threading.Thread(target=_run_close, daemon=True)
+        close_thread.start()
+        close_thread.join(timeout=1.0)
+
+    assert not close_thread.is_alive()
+    assert close_done.is_set() is True
+    assert close_errors == []
+    assert wait_calls
+    assert gate_calls == []
+    assert unsubscribe_calls == [client]
+    assert disconnect_calls == [client]
+    assert any("Timed out waiting" in record.message for record in caplog.records)
+
+
 def test_ble_interface_implicit_trust_holds_connect_lock_during_subprocess(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -2305,6 +2459,75 @@ def test_validate_connect_timeout_override_rejects_non_numeric_values() -> None:
         )
 
 
+def test_finish_management_operation_clamps_underflow(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """_finish_management_operation() should clamp negative accounting to zero."""
+    iface = _build_minimal_connect_test_interface()
+    with iface._management_lock:
+        iface._management_inflight = -1
+    notify_calls: list[bool] = []
+    monkeypatch.setattr(
+        iface._management_idle_condition,
+        "notify_all",
+        lambda: notify_calls.append(True),
+        raising=True,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        iface._finish_management_operation()
+
+    with iface._management_lock:
+        assert iface._management_inflight == 0
+    assert notify_calls == [True]
+    assert any("underflow" in record.message.lower() for record in caplog.records)
+
+
+def test_finish_management_operation_notifies_when_count_reaches_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_finish_management_operation() should notify waiters on zero transition."""
+    iface = _build_minimal_connect_test_interface()
+    with iface._management_lock:
+        iface._management_inflight = 1
+    notify_calls: list[bool] = []
+    monkeypatch.setattr(
+        iface._management_idle_condition,
+        "notify_all",
+        lambda: notify_calls.append(True),
+        raising=True,
+    )
+
+    iface._finish_management_operation()
+
+    with iface._management_lock:
+        assert iface._management_inflight == 0
+    assert notify_calls == [True]
+
+
+def test_finish_management_operation_does_not_notify_above_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_finish_management_operation() should not notify while inflight remains positive."""
+    iface = _build_minimal_connect_test_interface()
+    with iface._management_lock:
+        iface._management_inflight = 2
+    notify_calls: list[bool] = []
+    monkeypatch.setattr(
+        iface._management_idle_condition,
+        "notify_all",
+        lambda: notify_calls.append(True),
+        raising=True,
+    )
+
+    iface._finish_management_operation()
+
+    with iface._management_lock:
+        assert iface._management_inflight == 1
+    assert notify_calls == []
+
+
 @pytest.mark.unit
 def test_connect_rejects_non_bool_pair_override() -> None:
     """connect() should fail fast when `pair` is not explicitly bool/None."""
@@ -2419,6 +2642,202 @@ def test_connect_times_out_waiting_for_management_operations(
 
     with pytest.raises(BLEInterface.BLEError, match=ERROR_MANAGEMENT_CONNECTING):
         iface.connect("AA:BB:CC:DD:EE:10")
+
+
+def test_connect_times_out_on_spurious_management_wakeups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """connect() should enforce timeout even if management wait wakes spuriously."""
+    iface = _build_minimal_connect_test_interface()
+    iface._management_lock = threading.RLock()
+    iface._management_idle_condition = threading.Condition(iface._management_lock)
+    iface._management_inflight = 1
+    wait_calls: list[float | None] = []
+    fake_time = 0.0
+
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.interface._MANAGEMENT_CONNECT_WAIT_TIMEOUT_SECONDS",
+        0.03,
+    )
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.interface._MANAGEMENT_CONNECT_WAIT_POLL_SECONDS",
+        0.005,
+    )
+
+    def _monotonic() -> float:
+        """
+        Advance and return a test monotonic timestamp by 0.01 seconds.
+
+        Returns:
+            Current monotonic time in seconds; the returned value increases by 0.01 on each call.
+        """
+        nonlocal fake_time
+        fake_time += 0.01
+        return fake_time
+
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.interface.time.monotonic", _monotonic
+    )
+
+    def _spurious_wait(timeout: float | None = None) -> bool:
+        """
+        Record a spurious wait invocation and signal a wakeup.
+
+        Parameters:
+            timeout (float | None): The timeout value passed to the wait; may be None.
+
+        Returns:
+            bool: `True` to indicate a spurious wakeup.
+
+        Raises:
+            AssertionError: If the number of recorded wait calls exceeds the configured budget.
+        """
+        wait_calls.append(timeout)
+        if len(wait_calls) > _MAX_SPURIOUS_CONNECT_WAIT_CALLS_BEFORE_FAIL:
+            raise AssertionError("connect() kept waiting past the timeout budget")
+        return True
+
+    monkeypatch.setattr(
+        iface._management_idle_condition,
+        "wait",
+        _spurious_wait,
+        raising=True,
+    )
+    monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
+    monkeypatch.setattr(iface, "_get_existing_client_if_valid", lambda _request: None)
+
+    with pytest.raises(BLEInterface.BLEError, match=ERROR_MANAGEMENT_CONNECTING):
+        iface.connect("AA:BB:CC:DD:EE:10")
+
+    assert wait_calls
+
+
+def test_connect_management_wait_timeout_resets_between_wait_cycles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """connect() should restart timeout accounting after management drains."""
+    iface = _build_minimal_connect_test_interface()
+    iface._management_lock = threading.RLock()
+    iface._management_idle_condition = threading.Condition(iface._management_lock)
+    iface._management_inflight = 1
+    wait_calls: list[float | None] = []
+    duplicate_checks = 0
+    monotonic_values = iter([0.0, 0.1, 100.0, 100.1])
+    last_time = 100.1
+
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.interface._MANAGEMENT_CONNECT_WAIT_TIMEOUT_SECONDS",
+        1.0,
+    )
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.interface._MANAGEMENT_CONNECT_WAIT_POLL_SECONDS",
+        0.1,
+    )
+
+    def _monotonic() -> float:
+        """
+        Provide a monotonic timestamp for tests, advancing through a preset sequence and falling back to incremental steps when the sequence is exhausted.
+
+        Returns:
+            float: The current monotonic time value and updates the captured `last_time` variable.
+        """
+        nonlocal last_time
+        try:
+            last_time = next(monotonic_values)
+        except StopIteration:
+            last_time += 0.1
+        return last_time
+
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.interface.time.monotonic", _monotonic
+    )
+
+    def _wait_for_management(timeout: float | None = None) -> bool:
+        """
+        Simulate waiting for management operations to drain and record the requested timeout.
+
+        Parameters:
+            timeout (float | None): Maximum seconds to wait, or `None` to indicate an indefinite wait.
+
+        Behavior:
+            Appends the provided `timeout` value to the `wait_calls` list and sets
+            `iface._management_inflight` to 0 to indicate no inflight management operations.
+
+        Returns:
+            bool: `True` to indicate the wait condition was signaled.
+        """
+        wait_calls.append(timeout)
+        iface._management_inflight = 0
+        return True
+
+    def _raise_if_duplicate(_key: str | None) -> None:
+        """
+        Increment the duplicate-check counter and, on the second invocation, mark the interface as having one inflight management operation.
+
+        Parameters:
+            _key (str | None): Ignored; present to match the duplicate-check callback signature.
+        """
+        nonlocal duplicate_checks
+        duplicate_checks += 1
+        if duplicate_checks == 2:
+            iface._management_inflight = 1
+
+    monkeypatch.setattr(
+        iface._management_idle_condition,
+        "wait",
+        _wait_for_management,
+        raising=True,
+    )
+    monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
+    monkeypatch.setattr(iface, "_get_existing_client_if_valid", lambda _request: None)
+    monkeypatch.setattr(
+        iface,
+        "_resolve_target_address_for_connect",
+        lambda identifier: cast(str, identifier),
+    )
+    monkeypatch.setattr(iface, "_raise_if_duplicate_connect", _raise_if_duplicate)
+    monkeypatch.setattr(iface, "_finalize_connection_gates", lambda *_args: None)
+    monkeypatch.setattr(
+        iface,
+        "_verify_and_publish_connected",
+        lambda *_args, **_kwargs: None,
+    )
+
+    def _establish_stub(
+        _address: str | None,
+        _normalized_request: str | None,
+        _address_key: str | None,
+        *,
+        pair_on_connect: bool = False,
+        connect_timeout: float | None = None,
+    ) -> tuple[DummyClient, str | None, str | None]:
+        """
+        Create and attach a DummyClient to the test BLE interface and mark it as connected.
+
+        Parameters:
+            _address (str | None): Ignored; present to match the real establish signature.
+            _normalized_request (str | None): Ignored; present to match the real establish signature.
+            _address_key (str | None): Ignored; present to match the real establish signature.
+            pair_on_connect (bool): Accepted but ignored by this test stub.
+            connect_timeout (float | None): Accepted but ignored by this test stub.
+
+        Returns:
+            tuple[DummyClient, None, None]: The created DummyClient instance and two None placeholders (resolved address and resolved identifier).
+        """
+        _ = (pair_on_connect, connect_timeout)
+        client = DummyClient()
+        with iface._state_lock:
+            cast(Any, iface).client = client
+            iface.address = client.address
+            iface._state_manager._reset_to_disconnected()
+            assert iface._state_manager._transition_to(ConnectionState.CONNECTING)
+            assert iface._state_manager._transition_to(ConnectionState.CONNECTED)
+        return client, None, None
+
+    monkeypatch.setattr(iface, "_establish_and_update_client", _establish_stub)
+
+    assert isinstance(iface.connect("AA:BB:CC:DD:EE:10"), DummyClient)
+    assert len(wait_calls) == 2
 
 
 def test_connect_retries_when_management_becomes_inflight_inside_connect_lock(
@@ -3270,8 +3689,7 @@ def test_connect_marks_provisional_claims_before_gate_release(
 ) -> None:
     """connect() should publish provisional ownership before releasing the address gate."""
     _ = clear_registry
-    from meshtastic.interfaces.ble.gating import \
-        _is_currently_connected_elsewhere
+    from meshtastic.interfaces.ble.gating import _is_currently_connected_elsewhere
 
     target_identifier = "mesh-node"
     device_key = "aabbccddee30"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR refactors Node to centralize and enforce lock-protected metadata access when an interface-provided _node_db_lock exists. It adds a small locking helper and snapshot helpers so metadata reads/writes happen under the optional lock, updates call sites to use those helpers, and adds tests that verify the locking behavior. Documentation phase-planning text was updated and a minor test helper return simplification was made.

## Key changes

Refactors
- meshtastic/node.py
  - Added _execute_with_node_db_lock(self, func: Callable[[], _LockedCallResult]) -> _LockedCallResult to run a callable while holding iface._node_db_lock when available.
  - Added _get_metadata_snapshot(self) -> mesh_pb2.DeviceMetadata | None returning a deep-copied, stable snapshot of iface.metadata under the lock.
  - Added _set_metadata_snapshot(self, metadata_snapshot: mesh_pb2.DeviceMetadata) -> None to persist a metadata snapshot to iface.metadata under the lock.
  - Replaced direct iface.metadata access:
    - _emit_cached_metadata_for_stdout now reads via _get_metadata_snapshot().
    - onRequestGetMetadata now writes via _set_metadata_snapshot().
  - Introduced _LockedCallResult TypeVar and imported TypeVar for generic typing.

Tests
- meshtastic/tests/test_node.py
  - Added _TrackingLock test utility to record lock acquisitions.
  - Added tests asserting that metadata reads and writes occur while holding iface._node_db_lock (e.g., test_onRequestGetMetadata_updates_metadata_under_node_db_lock, test_emit_cached_metadata_reads_metadata_under_node_db_lock).
  - Added tests covering behavior when iface.metadata is not a DeviceMetadata protobuf (snapshot returns None).
- meshtastic/tests/test_examples.py
  - Simplified _require_int_strict to return the asserted int value directly instead of casting after isinstance checks.

Documentation
- REFACTOR_PROGRAM-2.md
  - Updated phase planning/status text to mark Phase 1 (BLE stabilization) completed, Phase 2 (MeshInterface runtime stabilization) active, and Phase 3 pending; adjusted branch/merge strategy and next-step wording.

## Breaking changes / migration notes
- No public API or exported signatures changed. This is an internal, backward-compatible refactor that improves thread-safety for metadata access. No migration steps required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->