### PR TITLE
Harden mesh/node packet handling and make setURL(addOnly) transactional

### DIFF
--- a/REFACTOR_PROGRAM-2.md
+++ b/REFACTOR_PROGRAM-2.md
@@ -20,19 +20,19 @@ The current `develop` branch represents a large structural modernization of the 
 - CI pipeline improvements
 - Async / concurrency correctness improvements
 
-`develop` is currently **two large commits ahead of `master`**, but those commits contain:
+`develop` is currently **seven commits ahead of `master`** (`master...develop = 0/7`), and the branch delta contains:
 
-- ~150 files changed
-- ~60k insertions
-- ~10k deletions
+- 153 files changed
+- 61,115 insertions
+- 10,739 deletions
 
 This is effectively a **platform-wide refactor**, not a typical incremental change.
 
-Because of this, the next phase should **not** merge `develop → master` directly.
+Because of this, we still should **not** merge `develop → master` directly.
 
-Instead, we will perform **a small number of large, deliberate stabilization passes** based on `develop`.
+Instead, we perform **a small number of large, deliberate stabilization passes** based on `develop`.
 
-These passes will become the next branches and PRs.
+Phase 1 (BLE stabilization) is now complete and merged into `develop` (`#63`), and Phase 2 is the active execution stream.
 
 ---
 
@@ -142,15 +142,13 @@ Despite the progress, several areas remain high risk:
 
 ### BLE Lifecycle Behavior
 
-BLE is the most complex subsystem and includes:
+Phase 1 delivered targeted BLE lifecycle hardening and timeout robustness. Remaining BLE risk is now primarily **regression risk**, not major architecture uncertainty.
 
-- async coordination
-- OS-specific behavior
-- reconnect logic
-- ownership / gating logic
-- management operations
+Residual focus areas:
 
-The architecture is improved, but lifecycle correctness must be stabilized.
+- cross-platform runtime behavior in real hardware environments
+- long-duration reconnect reliability
+- maintenance of compatibility semantics as future changes land
 
 ---
 
@@ -180,80 +178,45 @@ Compatibility shims exist but should be validated carefully to ensure:
 
 ---
 
-# 5. Next Phase Refactor Strategy
+# 5. Execution Status and Next-Phase Strategy
 
-Instead of merging `develop → master`, the next steps will consist of **three large stabilization branches**.
+Instead of merging `develop → master` directly, the program continues through themed stabilization passes.
 
-Each branch will be created from `develop`.
+### Phase Status Snapshot
+
+- Phase 1 BLE stabilization: **Completed** (merged into `develop`, PR `#63`)
+- Phase 2 MeshInterface runtime stabilization: **In progress** on `meshinterface-pass`
+- Phase 3 Runtime boundary cleanup: Pending
+- Phase 4 CLI structural refactor: Future
 
 ---
 
-# Phase 1: BLE Stabilization Pass
+# Phase 1: BLE Stabilization Pass (Completed)
 
-Branch name suggestion:
+Executed branch:
 
 ```
 ble-stabilization-pass
 ```
 
-This will be the **largest and most important stabilization phase**.
+Delivered outcomes:
 
-### Goals
-
-- finalize BLE lifecycle behavior
-- stabilize connect / disconnect / reconnect logic
-- verify state machine transitions
-- ensure safe shutdown
-- ensure compatibility with legacy BLE APIs
-
-### Areas of Work
-
-BLE lifecycle correctness
-
-- connection ownership rules
-- pairing / trust support
-- management operation tracking
-- reconnect timing behavior
-- shutdown ordering
-
-Concurrency review
-
-- locking order
-- race conditions
-- notification coordination
-- state synchronization
-
-Compatibility verification
-
-- historical callbacks
-- legacy method names
-- BLE public API exports
-
-Testing improvements
-
-- lifecycle edge cases
-- reconnect scenarios
-- partial connection failures
-- shutdown reliability
-
-### Explicitly Out of Scope
-
-- CLI refactor
-- mesh core restructuring
-- style cleanup unrelated to BLE
-- unrelated test rewrites
+- elapsed-time based management wait timeout accounting for connect/shutdown paths
+- hardened management operation accounting (underflow-safe behavior)
+- bounded spurious-wakeup regression tests to avoid suite hangs
+- compatibility-preserving fixes validated by expanded BLE lifecycle tests
 
 ---
 
-# Phase 2: MeshInterface Runtime Stabilization
+# Phase 2: MeshInterface Runtime Stabilization (Active)
 
-Branch name suggestion:
+Active branch:
 
 ```
-meshinterface-runtime-stabilization
+meshinterface-pass
 ```
 
-This phase focuses on correctness of the core networking behavior.
+This phase focuses on runtime correctness of request/wait behavior, callback handling, queue behavior, and shared-state safety.
 
 ### Goals
 
@@ -261,41 +224,30 @@ This phase focuses on correctness of the core networking behavior.
 - ensure deterministic callback handling
 - prevent late callback contamination
 - improve routing error propagation
+- enforce lock ownership discipline in mesh runtime paths
 
 ### Areas of Work
 
 ```
 meshtastic/mesh_interface.py
 meshtastic/node.py
+meshtastic/tests/test_mesh_interface.py
+meshtastic/tests/test_node.py
 ```
 
-Key improvements
+Execution checklist for this phase:
 
-- request-scoped wait tracking
-- retired wait request handling
-- response handler locking validation
-- atomic queue send behavior
-- routing error timing cleanup
-
-Testing
-
-```
-tests/test_mesh_interface.py
-```
-
-Add or refine tests covering:
-
-- multiple concurrent requests
-- late responses
-- cancellation behavior
-- transport error handling
+- verify behavior against `master` for backward compatibility and completeness
+- preserve documented compatibility aliases from `COMPATIBILITY.md`
+- enforce `AGENTS.md` lock-partitioning and shutdown contracts
+- harden wait/error bookkeeping for stale, late, and concurrent responses
+- add focused tests for real failure modes (timeouts, race windows, stale callbacks)
 
 ### Explicitly Out of Scope
 
-- BLE architecture
-- CLI behavior
-- host parsing
-- OTA logic
+- BLE architecture changes (unless required by critical regression)
+- CLI behavior or modularization
+- host parsing and OTA boundary cleanup work (Phase 3 scope)
 
 ---
 
@@ -387,13 +339,13 @@ main()
 
 # 6. Merge Strategy
 
-The final merge into `master` will occur **after phases 1–3 are completed**.
+The final merge into `master` will occur **after Phase 2 and Phase 3 are completed** (Phase 1 is already complete).
 
 This allows:
 
-- stabilization of BLE
-- stabilization of MeshInterface runtime behavior
-- stabilization of runtime behavior
+- finalized BLE stability from Phase 1
+- validated MeshInterface runtime stabilization from Phase 2
+- runtime boundary hardening from Phase 3
 
 Once these subsystems are stable, the refactor can be safely promoted to production.
 
@@ -426,22 +378,20 @@ To keep the refactor manageable:
 
 # 8. Immediate Next Step
 
-Create the first stabilization branch from `develop`.
+Continue executing Phase 2 on the active branch:
 
 ```
-git checkout develop
-git checkout -b ble-stabilization-pass
+git checkout meshinterface-pass
 ```
 
-Focus entirely on:
+Immediate focus:
 
-- BLE lifecycle correctness
-- reconnect logic
-- shutdown reliability
-- compatibility verification
-- lifecycle test coverage
+- complete mesh runtime hardening in `mesh_interface.py` and `node.py`
+- run explicit backward-compatibility checks against `master`
+- validate compatibility inventory alignment in `COMPATIBILITY.md`
+- keep tests green with expanded targeted regression coverage
 
-This will produce the **next major PR** in the refactor program.
+This work stream should produce the next major PRs for the refactor program.
 
 ---
 
@@ -451,11 +401,11 @@ The major architectural refactor is largely complete.
 
 The next work should not expand scope further.
 
-Instead, the project should proceed through **large stabilization passes**:
+Instead, the project proceeds through **large stabilization passes**:
 
-1. BLE stabilization
-2. MeshInterface runtime stabilization
-3. Runtime boundary cleanup
+1. BLE stabilization (completed)
+2. MeshInterface runtime stabilization (active)
+3. Runtime boundary cleanup (pending)
 4. CLI modularization (future)
 
 Once these passes are complete, `develop` will be ready to merge into `master`.

--- a/REFACTOR_PROGRAM-2.md
+++ b/REFACTOR_PROGRAM-2.md
@@ -1,6 +1,6 @@
 # REFACTOR_PROGRAM-2.md
 
-### Meshtastic Python Refactor – Phase 2 Program Plan
+## Meshtastic Python Refactor – Phase 2 Program Plan
 
 Date: 2026-03-11  
 Base Branch: `develop`  
@@ -8,7 +8,7 @@ Comparison Baseline: `master` (eb964d78)
 
 ---
 
-# 1. Context
+## 1. Context
 
 The current `develop` branch represents a large structural modernization of the Meshtastic Python codebase. It includes:
 
@@ -36,7 +36,7 @@ Phase 1 (BLE stabilization) is now complete and merged into `develop` (`#63`), a
 
 ---
 
-# 2. Refactor Philosophy Going Forward
+## 2. Refactor Philosophy Going Forward
 
 Going forward we will keep the advantages of automation but shift toward **intentional large passes** that address a single subsystem at a time.
 
@@ -56,7 +56,7 @@ Each branch should represent **one engineering theme**.
 
 ---
 
-# 3. Current Refactor State
+## 3. Current Refactor State
 
 The repository now contains significant architectural improvements.
 
@@ -66,7 +66,7 @@ The repository now contains significant architectural improvements.
 
 The BLE implementation has been modularized into:
 
-```
+```text
 meshtastic/interfaces/ble/
     client.py
     connection.py
@@ -86,7 +86,7 @@ meshtastic/interfaces/ble/
 
 A compatibility shim remains at:
 
-```
+```text
 meshtastic/ble_interface.py
 ```
 
@@ -114,7 +114,7 @@ The CLI code received cleanup and better separation of responsibilities.
 
 However:
 
-```
+```text
 meshtastic/__main__.py
 ```
 
@@ -136,7 +136,7 @@ This dramatically improves safety for future refactors.
 
 ---
 
-# 4. Key Remaining Risks
+## 4. Key Remaining Risks
 
 Despite the progress, several areas remain high risk:
 
@@ -178,7 +178,7 @@ Compatibility shims exist but should be validated carefully to ensure:
 
 ---
 
-# 5. Execution Status and Next-Phase Strategy
+## 5. Execution Status and Next-Phase Strategy
 
 Instead of merging `develop → master` directly, the program continues through themed stabilization passes.
 
@@ -191,11 +191,11 @@ Instead of merging `develop → master` directly, the program continues through 
 
 ---
 
-# Phase 1: BLE Stabilization Pass (Completed)
+## Phase 1: BLE Stabilization Pass (Completed)
 
 Executed branch:
 
-```
+```text
 ble-stabilization-pass
 ```
 
@@ -208,17 +208,17 @@ Delivered outcomes:
 
 ---
 
-# Phase 2: MeshInterface Runtime Stabilization (Active)
+## Phase 2: MeshInterface Runtime Stabilization (Active)
 
 Active branch:
 
-```
+```text
 meshinterface-pass
 ```
 
 This phase focuses on runtime correctness of request/wait behavior, callback handling, queue behavior, and shared-state safety.
 
-### Goals
+### Phase 2 Goals
 
 - finalize request wait-state semantics
 - ensure deterministic callback handling
@@ -226,9 +226,9 @@ This phase focuses on runtime correctness of request/wait behavior, callback han
 - improve routing error propagation
 - enforce lock ownership discipline in mesh runtime paths
 
-### Areas of Work
+### Phase 2 Areas of Work
 
-```
+```text
 meshtastic/mesh_interface.py
 meshtastic/node.py
 meshtastic/tests/test_mesh_interface.py
@@ -251,28 +251,28 @@ Execution checklist for this phase:
 
 ---
 
-# Phase 3: Runtime Boundary Cleanup
+## Phase 3: Runtime Boundary Cleanup
 
 Branch name suggestion:
 
-```
+```text
 runtime-boundary-cleanup
 ```
 
 This phase improves system boundaries and runtime behavior.
 
-### Goals
+### Phase 3 Goals
 
 - unify host/port parsing
 - improve runtime error surfaces
 - improve OTA error handling
 - improve configuration reliability
 
-### Areas of Work
+### Phase 3 Areas of Work
 
 New module usage:
 
-```
+```text
 meshtastic/host_port.py
 ```
 
@@ -284,7 +284,7 @@ Responsibilities:
 
 OTA improvements
 
-```
+```text
 meshtastic/ota.py
 ```
 
@@ -302,13 +302,13 @@ Security improvements
 
 ---
 
-# Phase 4: CLI Structural Refactor (Future)
+## Phase 4: CLI Structural Refactor (Future)
 
 This phase should **not begin until runtime behavior is stable**.
 
 Branch name suggestion:
 
-```
+```text
 cli-modularization
 ```
 
@@ -318,7 +318,7 @@ Split `__main__.py` responsibilities into separate modules.
 
 Possible structure:
 
-```
+```text
 meshtastic/cli/
     commands.py
     connection.py
@@ -329,7 +329,7 @@ meshtastic/cli/
 
 The CLI entry point should eventually become minimal:
 
-```
+```text
 main()
   -> argument parsing
   -> command dispatch
@@ -337,7 +337,7 @@ main()
 
 ---
 
-# 6. Merge Strategy
+## 6. Merge Strategy
 
 The final merge into `master` will occur **after Phase 2 and Phase 3 are completed** (Phase 1 is already complete).
 
@@ -351,7 +351,7 @@ Once these subsystems are stable, the refactor can be safely promoted to product
 
 ---
 
-# 7. Development Rules For Next Phases
+## 7. Development Rules For Next Phases
 
 To keep the refactor manageable:
 
@@ -376,11 +376,11 @@ To keep the refactor manageable:
 
 ---
 
-# 8. Immediate Next Step
+## 8. Immediate Next Step
 
 Continue executing Phase 2 on the active branch:
 
-```
+```text
 git checkout meshinterface-pass
 ```
 
@@ -395,7 +395,7 @@ This work stream should produce the next major PRs for the refactor program.
 
 ---
 
-# 9. Summary
+## 9. Summary
 
 The major architectural refactor is largely complete.
 

--- a/REFACTOR_PROGRAM-2.md
+++ b/REFACTOR_PROGRAM-2.md
@@ -380,7 +380,7 @@ To keep the refactor manageable:
 
 Continue executing Phase 2 on the active branch:
 
-```text
+```bash
 git checkout meshinterface-pass
 ```
 

--- a/REFACTOR_PROGRAM-2.md
+++ b/REFACTOR_PROGRAM-2.md
@@ -201,7 +201,7 @@ ble-stabilization-pass
 
 Delivered outcomes:
 
-- elapsed-time based management wait timeout accounting for connect/shutdown paths
+- elapsed-time-based management wait timeout accounting for connect/shutdown paths
 - hardened management operation accounting (underflow-safe behavior)
 - bounded spurious-wakeup regression tests to avoid suite hangs
 - compatibility-preserving fixes validated by expanded BLE lifecycle tests

--- a/bin/run-multinode-with-meshtasticd.sh
+++ b/bin/run-multinode-with-meshtasticd.sh
@@ -278,7 +278,9 @@ wait_for_log_pattern() {
 	local deadline=$((SECONDS + timeout_seconds))
 
 	while ((SECONDS < deadline)); do
-		if docker logs "${container}" 2>&1 | grep -Fq "${pattern}"; then
+		# Keep pipefail from treating docker's expected SIGPIPE (when grep -q
+		# exits early after a match) as a false-negative "pattern not found".
+		if (set +o pipefail; docker logs "${container}" 2>&1 | grep -Fq "${pattern}"); then
 			return 0
 		fi
 		if ! docker ps --format '{{.Names}}' | grep -Fxq "${container}"; then

--- a/bin/run-multinode-with-meshtasticd.sh
+++ b/bin/run-multinode-with-meshtasticd.sh
@@ -281,6 +281,7 @@ wait_for_log_pattern() {
 		local log_output=""
 		if ! log_output="$(docker logs "${container}" 2>&1)"; then
 			echo "Failed to read logs from ${container}." >&2
+			printf '%s\n' "${log_output}" >&2
 			return 1
 		fi
 		if grep -Fq "${pattern}" <<<"${log_output}"; then

--- a/bin/run-multinode-with-meshtasticd.sh
+++ b/bin/run-multinode-with-meshtasticd.sh
@@ -278,9 +278,12 @@ wait_for_log_pattern() {
 	local deadline=$((SECONDS + timeout_seconds))
 
 	while ((SECONDS < deadline)); do
-		# Keep pipefail from treating docker's expected SIGPIPE (when grep -q
-		# exits early after a match) as a false-negative "pattern not found".
-		if (set +o pipefail; docker logs "${container}" 2>&1 | grep -Fq "${pattern}"); then
+		local log_output=""
+		if ! log_output="$(docker logs "${container}" 2>&1)"; then
+			echo "Failed to read logs from ${container}." >&2
+			return 1
+		fi
+		if grep -Fq "${pattern}" <<<"${log_output}"; then
 			return 0
 		fi
 		if ! docker ps --format '{{.Names}}' | grep -Fxq "${container}"; then

--- a/meshtastic/__init__.py
+++ b/meshtastic/__init__.py
@@ -373,6 +373,19 @@ def _on_position_receive(iface: Any, as_dict: dict[str, Any]) -> None:
     if "position" in decoded:
         _receive_info_update(iface, as_dict)
         p = decoded["position"]
+        if not isinstance(p, dict):
+            logger.debug(
+                "Skipping position update from=%s: unexpected payload type %s",
+                sender,
+                type(p).__name__,
+            )
+            return
+        if "error" in p:
+            logger.debug(
+                "Skipping position state update from=%s due to decode error payload",
+                sender,
+            )
+            return
         logger.debug("position payload received from=%s", sender)
         p = iface._fixup_position(p)
         logger.debug("position payload normalized from=%s", sender)
@@ -405,6 +418,19 @@ def _on_node_info_receive(iface: Any, as_dict: dict[str, Any]) -> None:
     if "user" in decoded:
         _receive_info_update(iface, as_dict)
         p = decoded["user"]
+        if not isinstance(p, dict):
+            logger.debug(
+                "Skipping user update from=%s: unexpected payload type %s",
+                sender,
+                type(p).__name__,
+            )
+            return
+        if "error" in p:
+            logger.debug(
+                "Skipping user state update from=%s due to decode error payload",
+                sender,
+            )
+            return
         # decode user protobufs and update nodedb, provide decoded version as "position" in the published msg
         # update node DB as needed
         n = iface._get_or_create_by_num(sender)

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -82,6 +82,7 @@ VALID_TELEMETRY_TYPES: tuple[TelemetryType, ...] = (
 VALID_TELEMETRY_TYPE_SET: frozenset[str] = frozenset(VALID_TELEMETRY_TYPES)
 UNKNOWN_SNR_QUARTER_DB = -128
 MISSING_NODE_NUM_ERROR_TEMPLATE = "NodeId {destination_id} has no numeric 'num' in DB"
+HEX_NODE_ID_TAIL_CHARS = frozenset("0123456789abcdefABCDEF")
 NO_RESPONSE_FIRMWARE_ERROR: str = (
     "No response from node. At least firmware 2.1.22 is required on the destination node."
 )
@@ -118,6 +119,12 @@ PayloadData: TypeAlias = bytes | bytearray | memoryview | _SerializablePayload
 def _format_missing_node_num_error(destination_id: int | str) -> str:
     """Return a consistent error message for nodes missing numeric IDs."""
     return MISSING_NODE_NUM_ERROR_TEMPLATE.format(destination_id=destination_id)
+
+
+def _looks_like_hex_node_id_tail(destination_id: str) -> bool:
+    """Return True when the last 8 characters look like a hex node identifier."""
+    tail = destination_id[-8:]
+    return len(destination_id) >= 8 and all(ch in HEX_NODE_ID_TAIL_CHARS for ch in tail)
 
 
 def _logger_has_visible_info_handler(target_logger: logging.Logger) -> bool:
@@ -2360,9 +2367,8 @@ class MeshInterface:  # pylint: disable=R0902
             else:
                 raise MeshInterface.MeshInterfaceError("No myInfo found.")
         # A simple hex style nodeid - we can parse this without needing the DB
-        elif isinstance(destinationId, str) and len(destinationId) >= 8:
-            # assuming some form of node id string such as !1234578 or 0x12345678
-            # always grab the last 8 items of the hexadecimal id str and parse to integer
+        elif isinstance(destinationId, str) and _looks_like_hex_node_id_tail(destinationId):
+            # Simple hex-style node id strings (for example !12345678 or 0x12345678).
             nodeNum = int(destinationId[-8:], 16)
         else:
             with self._node_db_lock:
@@ -3478,18 +3484,34 @@ class MeshInterface:  # pylint: disable=R0902
             p = None
             if handler is not None:
                 topic = f"meshtastic.receive.{handler.name}"
+                parse_failed = False
 
                 # Convert to protobuf if possible
                 if handler.protobufFactory is not None:
                     pb = handler.protobufFactory()
-                    pb.ParseFromString(meshPacket.decoded.payload)
-                    p = google.protobuf.json_format.MessageToDict(pb)
-                    asDict["decoded"][handler.name] = p
-                    # Also provide the protobuf raw
-                    asDict["decoded"][handler.name]["raw"] = pb
+                    try:
+                        pb.ParseFromString(meshPacket.decoded.payload)
+                    except (protobuf_message.DecodeError, TypeError, ValueError) as exc:
+                        parse_failed = True
+                        logger.warning(
+                            "Failed to decode %s payload for packet id=%s from=%s to=%s: %s",
+                            handler.name,
+                            getattr(meshPacket, "id", 0),
+                            asDict.get("from"),
+                            asDict.get("to"),
+                            exc,
+                        )
+                        asDict["decoded"][handler.name] = {
+                            "error": f"decode-failed: {exc}"
+                        }
+                    else:
+                        p = google.protobuf.json_format.MessageToDict(pb)
+                        asDict["decoded"][handler.name] = p
+                        # Also provide the protobuf raw
+                        asDict["decoded"][handler.name]["raw"] = pb
 
                 # Call specialized onReceive if necessary
-                if handler.onReceive is not None:
+                if handler.onReceive is not None and not parse_failed:
                     handler.onReceive(self, asDict)
 
             # Is this message in response to a request, if so, look for a handler

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -3540,7 +3540,12 @@ class MeshInterface:  # pylint: disable=R0902
                     pb = handler.protobufFactory()
                     try:
                         pb.ParseFromString(meshPacket.decoded.payload)
+                        p = google.protobuf.json_format.MessageToDict(pb)
+                        asDict["decoded"][handler.name] = p
+                        # Also provide the protobuf raw
+                        asDict["decoded"][handler.name]["raw"] = pb
                     except (protobuf_message.DecodeError, TypeError, ValueError) as exc:
+                        decode_error = f"decode-failed: {exc}"
                         logger.warning(
                             "Failed to decode %s payload for packet id=%s from=%s to=%s: %s",
                             handler.name,
@@ -3549,14 +3554,9 @@ class MeshInterface:  # pylint: disable=R0902
                             asDict.get("to"),
                             exc,
                         )
-                        asDict["decoded"][handler.name] = {
-                            "error": f"decode-failed: {exc}"
-                        }
-                    else:
-                        p = google.protobuf.json_format.MessageToDict(pb)
-                        asDict["decoded"][handler.name] = p
-                        # Also provide the protobuf raw
-                        asDict["decoded"][handler.name]["raw"] = pb
+                        asDict["decoded"][handler.name] = {"error": decode_error}
+                        if handler.name == "routing":
+                            asDict["decoded"][handler.name]["errorReason"] = decode_error
 
                 # Call specialized onReceive if necessary
                 if handler.onReceive is not None:

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -2373,7 +2373,12 @@ class MeshInterface:  # pylint: disable=R0902
         # A simple hex style nodeid - we can parse this without needing the DB
         elif isinstance(destinationId, str) and _looks_like_hex_node_id_tail(destinationId):
             # Simple hex-style node id strings (for example !12345678 or 0x12345678).
-            nodeNum = int(destinationId[-8:], 16)
+            if destinationId.startswith("!"):
+                nodeNum = int(destinationId[1:], 16)
+            elif destinationId.startswith(("0x", "0X")):
+                nodeNum = int(destinationId[2:], 16)
+            else:
+                nodeNum = int(destinationId, 16)
         else:
             with self._node_db_lock:
                 node = self.nodes.get(destinationId) if self.nodes else None

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -121,14 +121,23 @@ def _format_missing_node_num_error(destination_id: int | str) -> str:
     return MISSING_NODE_NUM_ERROR_TEMPLATE.format(destination_id=destination_id)
 
 
-def _looks_like_hex_node_id_tail(destination_id: str) -> bool:
-    """Return True when the whole string is a supported compact hex node identifier."""
+def _extract_hex_node_id_body(destination_id: str) -> str | None:
+    """Return compact hex node-id body when `destination_id` matches supported formats."""
     candidate = destination_id
     if destination_id.startswith("!"):
         candidate = destination_id[1:]
     elif destination_id.startswith(("0x", "0X")):
         candidate = destination_id[2:]
-    return len(candidate) == 8 and all(ch in HEX_NODE_ID_TAIL_CHARS for ch in candidate)
+    if len(candidate) != 8:
+        return None
+    if not all(ch in HEX_NODE_ID_TAIL_CHARS for ch in candidate):
+        return None
+    return candidate
+
+
+def _looks_like_hex_node_id_tail(destination_id: str) -> bool:
+    """Return True when the whole string is a supported compact hex node identifier."""
+    return _extract_hex_node_id_body(destination_id) is not None
 
 
 def _logger_has_visible_info_handler(target_logger: logging.Logger) -> bool:
@@ -2370,34 +2379,38 @@ class MeshInterface:  # pylint: disable=R0902
                 nodeNum = my_node_num
             else:
                 raise MeshInterface.MeshInterfaceError("No myInfo found.")
-        # A simple hex style nodeid - we can parse this without needing the DB
-        elif isinstance(destinationId, str) and _looks_like_hex_node_id_tail(destinationId):
-            # Simple hex-style node id strings (for example !12345678 or 0x12345678).
-            body = destinationId
-            if destinationId.startswith("!"):
-                body = destinationId[1:]
-            elif destinationId.startswith(("0x", "0X")):
-                body = destinationId[2:]
-            nodeNum = int(body, 16)
+        elif isinstance(destinationId, str):
+            # A simple hex style nodeid - we can parse this without needing the DB.
+            compact_hex_body = _extract_hex_node_id_body(destinationId)
+            if compact_hex_body is not None:
+                nodeNum = int(compact_hex_body, 16)
+            else:
+                with self._node_db_lock:
+                    node = self.nodes.get(destinationId) if self.nodes else None
+                    has_nodes = self.nodes is not None
+                    node_found = node is not None
+                    node_num = node.get("num") if isinstance(node, dict) else None
+                if node_found:
+                    if isinstance(node_num, int):
+                        nodeNum = node_num
+                    else:
+                        raise MeshInterface.MeshInterfaceError(
+                            _format_missing_node_num_error(destinationId)
+                        )
+                elif has_nodes:
+                    raise MeshInterface.MeshInterfaceError(
+                        f"NodeId {destinationId} not found in DB"
+                    )
+                else:
+                    logger.warning("Warning: There were no self.nodes.")
         else:
             with self._node_db_lock:
-                node = self.nodes.get(destinationId) if self.nodes else None
                 has_nodes = self.nodes is not None
-                node_found = node is not None
-                node_num = node.get("num") if isinstance(node, dict) else None
-            if node_found:
-                if isinstance(node_num, int):
-                    nodeNum = node_num
-                else:
-                    raise MeshInterface.MeshInterfaceError(
-                        _format_missing_node_num_error(destinationId)
-                    )
-            elif has_nodes:
+            if has_nodes:
                 raise MeshInterface.MeshInterfaceError(
                     f"NodeId {destinationId} not found in DB"
                 )
-            else:
-                logger.warning("Warning: There were no self.nodes.")
+            logger.warning("Warning: There were no self.nodes.")
 
         meshPacket.to = nodeNum
         meshPacket.want_ack = wantAck

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -122,9 +122,13 @@ def _format_missing_node_num_error(destination_id: int | str) -> str:
 
 
 def _looks_like_hex_node_id_tail(destination_id: str) -> bool:
-    """Return True when the last 8 characters look like a hex node identifier."""
-    tail = destination_id[-8:]
-    return len(destination_id) >= 8 and all(ch in HEX_NODE_ID_TAIL_CHARS for ch in tail)
+    """Return True when the whole string is a supported compact hex node identifier."""
+    candidate = destination_id
+    if destination_id.startswith("!"):
+        candidate = destination_id[1:]
+    elif destination_id.startswith(("0x", "0X")):
+        candidate = destination_id[2:]
+    return len(candidate) == 8 and all(ch in HEX_NODE_ID_TAIL_CHARS for ch in candidate)
 
 
 def _logger_has_visible_info_handler(target_logger: logging.Logger) -> bool:

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -122,7 +122,20 @@ def _format_missing_node_num_error(destination_id: int | str) -> str:
 
 
 def _extract_hex_node_id_body(destination_id: str) -> str | None:
-    """Return compact hex node-id body when `destination_id` matches supported formats."""
+    """Return a compact 8-hex node-id body when ``destination_id`` matches supported forms.
+
+    Parameters
+    ----------
+    destination_id : str
+        Candidate node identifier. Supported prefixed forms are ``!12345678``,
+        ``0x12345678``, and ``0X12345678``; bare ``12345678`` is also supported.
+
+    Returns
+    -------
+    str | None
+        The 8-character hexadecimal body if the full input is a supported compact
+        node-id format; otherwise ``None``.
+    """
     candidate = destination_id
     if destination_id.startswith("!"):
         candidate = destination_id[1:]
@@ -136,7 +149,18 @@ def _extract_hex_node_id_body(destination_id: str) -> str | None:
 
 
 def _looks_like_hex_node_id_tail(destination_id: str) -> bool:
-    """Return True when the whole string is a supported compact hex node identifier."""
+    """Return whether the full string is a supported compact hex node identifier.
+
+    Parameters
+    ----------
+    destination_id : str
+        Candidate node identifier string.
+
+    Returns
+    -------
+    bool
+        ``True`` when ``destination_id`` is exactly a supported compact hex node-id form.
+    """
     return _extract_hex_node_id_body(destination_id) is not None
 
 
@@ -2402,7 +2426,9 @@ class MeshInterface:  # pylint: disable=R0902
                         f"NodeId {destinationId} not found in DB"
                     )
                 else:
-                    logger.warning("Warning: There were no self.nodes.")
+                    raise MeshInterface.MeshInterfaceError(
+                        f"NodeId {destinationId} not found and node DB is unavailable"
+                    )
         else:
             with self._node_db_lock:
                 has_nodes = self.nodes is not None
@@ -2410,7 +2436,9 @@ class MeshInterface:  # pylint: disable=R0902
                 raise MeshInterface.MeshInterfaceError(
                     f"NodeId {destinationId} not found in DB"
                 )
-            logger.warning("Warning: There were no self.nodes.")
+            raise MeshInterface.MeshInterfaceError(
+                f"NodeId {destinationId} not found and node DB is unavailable"
+            )
 
         meshPacket.to = nodeNum
         meshPacket.want_ack = wantAck

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -3493,7 +3493,6 @@ class MeshInterface:  # pylint: disable=R0902
             p = None
             if handler is not None:
                 topic = f"meshtastic.receive.{handler.name}"
-                parse_failed = False
 
                 # Convert to protobuf if possible
                 if handler.protobufFactory is not None:
@@ -3501,7 +3500,6 @@ class MeshInterface:  # pylint: disable=R0902
                     try:
                         pb.ParseFromString(meshPacket.decoded.payload)
                     except (protobuf_message.DecodeError, TypeError, ValueError) as exc:
-                        parse_failed = True
                         logger.warning(
                             "Failed to decode %s payload for packet id=%s from=%s to=%s: %s",
                             handler.name,
@@ -3520,7 +3518,7 @@ class MeshInterface:  # pylint: disable=R0902
                         asDict["decoded"][handler.name]["raw"] = pb
 
                 # Call specialized onReceive if necessary
-                if handler.onReceive is not None and not parse_failed:
+                if handler.onReceive is not None:
                     handler.onReceive(self, asDict)
 
             # Is this message in response to a request, if so, look for a handler

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -2373,12 +2373,12 @@ class MeshInterface:  # pylint: disable=R0902
         # A simple hex style nodeid - we can parse this without needing the DB
         elif isinstance(destinationId, str) and _looks_like_hex_node_id_tail(destinationId):
             # Simple hex-style node id strings (for example !12345678 or 0x12345678).
+            body = destinationId
             if destinationId.startswith("!"):
-                nodeNum = int(destinationId[1:], 16)
+                body = destinationId[1:]
             elif destinationId.startswith(("0x", "0X")):
-                nodeNum = int(destinationId[2:], 16)
-            else:
-                nodeNum = int(destinationId, 16)
+                body = destinationId[2:]
+            nodeNum = int(body, 16)
         else:
             with self._node_db_lock:
                 node = self.nodes.get(destinationId) if self.nodes else None

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -1055,7 +1055,7 @@ class Node:
             self._raise_interface_error("There were no settings.")
         has_lora_update = channelSet.HasField("lora_config")
 
-        admin_write_node = self.iface.localNode if self.iface.localNode != self else self
+        admin_write_node = self.iface.localNode
         admin_index_for_write = admin_write_node._get_admin_channel_index()
         named_admin_index_for_write: int | None = None
         named_admin_getter = getattr(
@@ -1236,6 +1236,13 @@ class Node:
                 ch.index = i
                 ch.settings.CopyFrom(chs)
                 staged_channels.append(ch)
+            # Full-replace semantics: any channels not present in the URL should be
+            # explicitly disabled so stale secondaries/admin channels do not persist.
+            for i in range(len(staged_channels), max_channels):
+                disabled_channel = channel_pb2.Channel()
+                disabled_channel.index = i
+                disabled_channel.role = channel_pb2.Channel.Role.DISABLED
+                staged_channels.append(disabled_channel)
 
             deferred_admin_channel = None
             if named_admin_index_for_write is not None:
@@ -1248,41 +1255,55 @@ class Node:
                     None,
                 )
 
-            for staged_channel in staged_channels:
-                if (
-                    deferred_admin_channel is not None
-                    and staged_channel.index == deferred_admin_channel.index
-                ):
-                    continue
-                with self._channels_lock:
-                    channels = self.channels
-                    if channels is None:
-                        self._raise_interface_error("Config or channels not loaded")
-                    channels[staged_channel.index] = staged_channel
-                logger.debug(f"Channel i:{staged_channel.index} ch:{staged_channel}")
-                self.writeChannel(
-                    staged_channel.index, adminIndex=admin_index_for_write
-                )
+            try:
+                for staged_channel in staged_channels:
+                    if (
+                        deferred_admin_channel is not None
+                        and staged_channel.index == deferred_admin_channel.index
+                    ):
+                        continue
+                    logger.debug(f"Channel i:{staged_channel.index} ch:{staged_channel}")
+                    self._write_channel_snapshot(
+                        staged_channel,
+                        adminIndex=admin_index_for_write,
+                    )
+                    with self._channels_lock:
+                        channels = self.channels
+                        if channels is None:
+                            self._raise_interface_error("Config or channels not loaded")
+                        channels[staged_channel.index].CopyFrom(staged_channel)
 
-            if has_lora_update:
-                p = admin_pb2.AdminMessage()
-                p.set_config.lora.CopyFrom(channelSet.lora_config)
-                self.ensureSessionKey(adminIndex=admin_index_for_write)
-                self._send_admin(p, adminIndex=admin_index_for_write)
-                self.localConfig.lora.CopyFrom(channelSet.lora_config)
+                if has_lora_update:
+                    p = admin_pb2.AdminMessage()
+                    p.set_config.lora.CopyFrom(channelSet.lora_config)
+                    self.ensureSessionKey(adminIndex=admin_index_for_write)
+                    self._send_admin(p, adminIndex=admin_index_for_write)
+                    self.localConfig.lora.CopyFrom(channelSet.lora_config)
 
-            if deferred_admin_channel is not None:
+                if deferred_admin_channel is not None:
+                    logger.debug(
+                        f"Channel i:{deferred_admin_channel.index} ch:{deferred_admin_channel}"
+                    )
+                    self._write_channel_snapshot(
+                        deferred_admin_channel,
+                        adminIndex=admin_index_for_write,
+                    )
+                    with self._channels_lock:
+                        channels = self.channels
+                        if channels is None:
+                            self._raise_interface_error("Config or channels not loaded")
+                        channels[deferred_admin_channel.index].CopyFrom(
+                            deferred_admin_channel
+                        )
+            except Exception:
                 with self._channels_lock:
-                    channels = self.channels
-                    if channels is None:
-                        self._raise_interface_error("Config or channels not loaded")
-                    channels[deferred_admin_channel.index] = deferred_admin_channel
-                logger.debug(
-                    f"Channel i:{deferred_admin_channel.index} ch:{deferred_admin_channel}"
+                    self.channels = None
+                    self.partialChannels = []
+                logger.warning(
+                    "Failed while applying replace-all channel updates; invalidated local channel cache.",
+                    exc_info=True,
                 )
-                self.writeChannel(
-                    deferred_admin_channel.index, adminIndex=admin_index_for_write
-                )
+                raise
 
     def onResponseRequestRingtone(self, p: dict[str, Any]) -> None:
         """Process an admin response containing a ringtone fragment and cache it on the Node.

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -454,7 +454,9 @@ class Node:
                 config_values.CopyFrom(raw_config)
                 logger.info("%s:\n%s", camel_to_snake(field), config_values)
 
-    def requestConfig(self, configType: int | FieldDescriptor) -> None:
+    def requestConfig(
+        self, configType: int | FieldDescriptor, adminIndex: int = 0
+    ) -> None:
         """Request a configuration subset or the full configuration from this node.
 
         If `configType` is an int it is treated as a config index. If it is a protobuf
@@ -469,6 +471,9 @@ class Node:
         configType : int | FieldDescriptor
             Numeric config index or a
             protobuf field descriptor indicating which config field to fetch.
+        adminIndex : int
+            Admin channel index to use for sending; when 0 the node's configured
+            admin channel is used. (Default value = 0)
         """
         if self == self.iface.localNode:
             onResponse = None
@@ -490,7 +495,9 @@ class Node:
             else:
                 p.get_module_config_request = msg_index  # pyright: ignore[reportAttributeAccessIssue]
 
-        self._send_admin(p, wantResponse=True, onResponse=onResponse)
+        self._send_admin(
+            p, wantResponse=True, onResponse=onResponse, adminIndex=adminIndex
+        )
         if onResponse:
             self.iface.waitForAckNak()
 
@@ -658,7 +665,7 @@ class Node:
                 )
             channel_to_write = channel_pb2.Channel()
             channel_to_write.CopyFrom(channels[channelIndex])
-        self.ensureSessionKey()
+        self.ensureSessionKey(adminIndex=adminIndex)
         p = admin_pb2.AdminMessage()
         p.set_channel.CopyFrom(channel_to_write)
         self._send_admin(p, adminIndex=adminIndex)
@@ -758,7 +765,7 @@ class Node:
                 admin_index_for_write = self._get_admin_channel_index()
             else:
                 admin_index_for_write = self.iface.localNode.getAdminChannelIndex()
-            self.ensureSessionKey()
+            self.ensureSessionKey(adminIndex=admin_index_for_write)
             p = admin_pb2.AdminMessage()
             p.set_channel.CopyFrom(channel_snapshot)
             self._send_admin(p, adminIndex=admin_index_for_write)
@@ -1026,21 +1033,24 @@ class Node:
             ignored_channel_names: list[str] = []
             channels_to_write: list[tuple[int, str]] = []
             original_channels_by_index: dict[int, channel_pb2.Channel] = {}
-            # Snapshot admin channel path before staging writes so the first send
-            # does not depend on locally-mutated channel state.
+            # Snapshot admin channel path before staging writes so sends do not
+            # depend on locally-mutated channel state.
             admin_index_for_write = (
                 self.iface.localNode._get_admin_channel_index()
                 if self.iface.localNode != self
-                else None
+                else self._get_admin_channel_index()
             )
-            original_lora_config = config_pb2.Config.LoRaConfig()
-            original_lora_config.CopyFrom(self.localConfig.lora)
+            # Bootstrap admin session using the snapshotted path before staging.
+            self.ensureSessionKey(adminIndex=admin_index_for_write)
+            # Rollback should only use a verified local LoRa snapshot.
+            original_lora_config: config_pb2.Config.LoRaConfig | None = None
+            if self.localConfig.HasField("lora"):
+                original_lora_config = config_pb2.Config.LoRaConfig()
+                original_lora_config.CopyFrom(self.localConfig.lora)
             with self._channels_lock:
                 channels = self.channels
                 if channels is None:
                     self._raise_interface_error("Config or channels not loaded")
-                if admin_index_for_write is None:
-                    admin_index_for_write = self._get_admin_channel_index()
                 existing_names = {
                     c.settings.name for c in channels if c.settings and c.settings.name
                 }
@@ -1078,7 +1088,6 @@ class Node:
                 logger.info(
                     f'Ignoring existing or empty channel "{ignored_name}" from add URL'
                 )
-            assert admin_index_for_write is not None
             written_indices: list[int] = []
             try:
                 for channel_index, channel_name in channels_to_write:
@@ -1087,7 +1096,7 @@ class Node:
                     written_indices.append(channel_index)
                 set_lora = admin_pb2.AdminMessage()
                 set_lora.set_config.lora.CopyFrom(channelSet.lora_config)
-                self.ensureSessionKey()
+                self.ensureSessionKey(adminIndex=admin_index_for_write)
                 self._send_admin(set_lora, adminIndex=admin_index_for_write)
             # Intentionally broad: rollback should run for any send failure in this
             # transactional block. The original exception is re-raised.
@@ -1124,19 +1133,20 @@ class Node:
                             index,
                             exc_info=True,
                         )
-                rollback_lora = admin_pb2.AdminMessage()
-                rollback_lora.set_config.lora.CopyFrom(original_lora_config)
-                try:
-                    self._send_admin(
-                        rollback_lora,
-                        adminIndex=admin_index_for_write,
-                    )
-                # Best-effort rollback path; keep original failure semantics.
-                except Exception:
-                    logger.warning(
-                        "Rollback of LoRa config failed after addOnly partial failure.",
-                        exc_info=True,
-                    )
+                if original_lora_config is not None:
+                    rollback_lora = admin_pb2.AdminMessage()
+                    rollback_lora.set_config.lora.CopyFrom(original_lora_config)
+                    try:
+                        self._send_admin(
+                            rollback_lora,
+                            adminIndex=admin_index_for_write,
+                        )
+                    # Best-effort rollback path; keep original failure semantics.
+                    except Exception:
+                        logger.warning(
+                            "Rollback of LoRa config failed after addOnly partial failure.",
+                            exc_info=True,
+                        )
                 raise
         else:
             with self._channels_lock:
@@ -2446,11 +2456,17 @@ class Node:
             pkiEncrypted=True,
         )
 
-    def ensureSessionKey(self) -> None:
+    def ensureSessionKey(self, adminIndex: int = 0) -> None:
         """Ensure an admin session key exists for this node, requesting one if missing.
 
         If protocol use is disabled (`noProto`), no action is taken. Otherwise, if the node has no
         `adminSessionPassKey` recorded, a session-key request is sent.
+
+        Parameters
+        ----------
+        adminIndex : int
+            Admin channel index to use for the session key request; when 0 the
+            node's configured admin channel is used. (Default value = 0)
         """
         if self.noProto:
             logger.warning(
@@ -2463,7 +2479,10 @@ class Node:
                 )
                 is None
             ):
-                self.requestConfig(admin_pb2.AdminMessage.SESSIONKEY_CONFIG)
+                self.requestConfig(
+                    admin_pb2.AdminMessage.SESSIONKEY_CONFIG,
+                    adminIndex=adminIndex,
+                )
 
     def _get_channels_with_hash(self) -> list[dict[str, Any]]:
         """Return a list of channel descriptors containing index, role, name, and an optional hash.

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -1043,13 +1043,15 @@ class Node:
                 if self.iface.localNode != self
                 else self._get_admin_channel_index()
             )
+            # Rollback must have a local LoRa snapshot before transactional apply.
+            if not self.localConfig.HasField("lora"):
+                self._raise_interface_error(
+                    "LoRa config must be loaded before setURL(addOnly=True)"
+                )
+            original_lora_config = config_pb2.Config.LoRaConfig()
+            original_lora_config.CopyFrom(self.localConfig.lora)
             # Bootstrap admin session using the snapshotted path before staging.
             self.ensureSessionKey(adminIndex=admin_index_for_write)
-            # Rollback should only use a verified local LoRa snapshot.
-            original_lora_config: config_pb2.Config.LoRaConfig | None = None
-            if self.localConfig.HasField("lora"):
-                original_lora_config = config_pb2.Config.LoRaConfig()
-                original_lora_config.CopyFrom(self.localConfig.lora)
             with self._channels_lock:
                 channels = self.channels
                 if channels is None:
@@ -1092,6 +1094,7 @@ class Node:
                     f'Ignoring existing or empty channel "{ignored_name}" from add URL'
                 )
             written_indices: list[int] = []
+            lora_write_started = False
             try:
                 for channel_index, channel_name in channels_to_write:
                     logger.info(f"Adding new channel '{channel_name}' to device")
@@ -1100,6 +1103,7 @@ class Node:
                 set_lora = admin_pb2.AdminMessage()
                 set_lora.set_config.lora.CopyFrom(channelSet.lora_config)
                 self.ensureSessionKey(adminIndex=admin_index_for_write)
+                lora_write_started = True
                 self._send_admin(set_lora, adminIndex=admin_index_for_write)
                 self.localConfig.lora.CopyFrom(channelSet.lora_config)
             # Intentionally broad: rollback should run for any send failure in this
@@ -1146,7 +1150,7 @@ class Node:
                             ) in original_channels_by_index.items():
                                 if 0 <= index < len(channels):
                                     channels[index].CopyFrom(previous_channel)
-                if original_lora_config is not None:
+                if lora_write_started:
                     rollback_lora = admin_pb2.AdminMessage()
                     rollback_lora.set_config.lora.CopyFrom(original_lora_config)
                     try:

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -1049,19 +1049,18 @@ class Node:
         if len(channelSet.settings) == 0:
             self._raise_interface_error("There were no settings.")
 
+        admin_index_for_write = (
+            self.iface.localNode._get_admin_channel_index()
+            if self.iface.localNode != self
+            else self._get_admin_channel_index()
+        )
+
         if addOnly:
             # Add new channels with names not already present
             # Don't change existing channels
             ignored_channel_names: list[str] = []
             channels_to_write: list[tuple[channel_pb2.Channel, str]] = []
             original_channels_by_index: dict[int, channel_pb2.Channel] = {}
-            # Snapshot admin channel path before staging writes so sends do not
-            # depend on locally-mutated channel state.
-            admin_index_for_write = (
-                self.iface.localNode._get_admin_channel_index()
-                if self.iface.localNode != self
-                else self._get_admin_channel_index()
-            )
             # Rollback must have a local LoRa snapshot before transactional apply.
             if not self.localConfig.HasField("lora"):
                 self._raise_interface_error(
@@ -1129,19 +1128,6 @@ class Node:
                 self.ensureSessionKey(adminIndex=admin_index_for_write)
                 lora_write_started = True
                 self._send_admin(set_lora, adminIndex=admin_index_for_write)
-                with self._channels_lock:
-                    channels = self.channels
-                    if channels is None:
-                        self._raise_interface_error("Config or channels not loaded")
-                    for staged_channel, _channel_name in channels_to_write:
-                        if 0 <= staged_channel.index < len(channels):
-                            channels[staged_channel.index].CopyFrom(staged_channel)
-                        else:
-                            self._raise_interface_error(
-                                f"Channel index {staged_channel.index} out of range "
-                                f"(0-{len(channels) - 1})"
-                            )
-                self.localConfig.lora.CopyFrom(channelSet.lora_config)
             # Intentionally broad: rollback should run for any send failure in this
             # transactional block. The original exception is re-raised.
             except Exception:
@@ -1196,6 +1182,25 @@ class Node:
                             "LoRa config cache cleared after rollback failure; reload config before using localConfig.lora."
                         )
                 raise
+            with self._channels_lock:
+                channels = self.channels
+                if channels is None:
+                    logger.warning(
+                        "Channel cache unavailable after successful addOnly apply; reload channels to refresh local state."
+                    )
+                else:
+                    for staged_channel, _channel_name in channels_to_write:
+                        if 0 <= staged_channel.index < len(channels):
+                            channels[staged_channel.index].CopyFrom(staged_channel)
+                        else:
+                            logger.warning(
+                                "Channel index %s out of range during addOnly cache update; invalidating local channel cache.",
+                                staged_channel.index,
+                            )
+                            self.channels = None
+                            self.partialChannels = []
+                            break
+            self.localConfig.lora.CopyFrom(channelSet.lora_config)
         else:
             with self._channels_lock:
                 channels = self.channels
@@ -1223,13 +1228,13 @@ class Node:
                         self._raise_interface_error("Config or channels not loaded")
                     channels[ch.index] = ch
                 logger.debug(f"Channel i:{i} ch:{ch}")
-                self.writeChannel(ch.index)
+                self.writeChannel(ch.index, adminIndex=admin_index_for_write)
 
         if not addOnly:
             p = admin_pb2.AdminMessage()
             p.set_config.lora.CopyFrom(channelSet.lora_config)
-            self.ensureSessionKey()
-            self._send_admin(p)
+            self.ensureSessionKey(adminIndex=admin_index_for_write)
+            self._send_admin(p, adminIndex=admin_index_for_write)
             self.localConfig.lora.CopyFrom(channelSet.lora_config)
 
     def onResponseRequestRingtone(self, p: dict[str, Any]) -> None:

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -1022,7 +1022,7 @@ class Node:
             # Add new channels with names not already present
             # Don't change existing channels
             ignored_channel_names: list[str] = []
-            channels_to_write: list[tuple[int, str]] = []
+            channels_to_write: list[tuple[int, str, channel_pb2.ChannelSettings]] = []
             with self._channels_lock:
                 channels = self.channels
                 if channels is None:
@@ -1033,25 +1033,30 @@ class Node:
                 disabled_channels = [
                     c for c in channels if c.role == channel_pb2.Channel.Role.DISABLED
                 ]
-                disabled_channel_iter = iter(disabled_channels)
+                pending_new_settings: list[channel_pb2.ChannelSettings] = []
                 for chs in channelSet.settings:
                     channel_name = chs.name
                     if channel_name == "" or channel_name in existing_names:
                         ignored_channel_names.append(channel_name)
                         continue
-                    disabled_channel = next(disabled_channel_iter, None)
-                    if disabled_channel is None:
-                        self._raise_interface_error("No free channels were found")
-                    disabled_channel.settings.CopyFrom(chs)
-                    disabled_channel.role = channel_pb2.Channel.Role.SECONDARY
-                    channels_to_write.append((disabled_channel.index, channel_name))
+                    pending_new_settings.append(chs)
                     existing_names.add(channel_name)
+                if len(pending_new_settings) > len(disabled_channels):
+                    self._raise_interface_error("No free channels were found")
+                for disabled_channel, new_settings in zip(
+                    disabled_channels, pending_new_settings
+                ):
+                    disabled_channel.settings.CopyFrom(new_settings)
+                    disabled_channel.role = channel_pb2.Channel.Role.SECONDARY
+                    channels_to_write.append(
+                        (disabled_channel.index, new_settings.name, new_settings)
+                    )
 
             for ignored_name in ignored_channel_names:
                 logger.info(
                     f'Ignoring existing or empty channel "{ignored_name}" from add URL'
                 )
-            for channel_index, channel_name in channels_to_write:
+            for channel_index, channel_name, _ in channels_to_write:
                 logger.info(f"Adding new channel '{channel_name}' to device")
                 self.writeChannel(channel_index)
         else:

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -1095,8 +1095,8 @@ class Node:
             try:
                 for channel_index, channel_name in channels_to_write:
                     logger.info(f"Adding new channel '{channel_name}' to device")
-                    self.writeChannel(channel_index, adminIndex=admin_index_for_write)
                     written_indices.append(channel_index)
+                    self.writeChannel(channel_index, adminIndex=admin_index_for_write)
                 set_lora = admin_pb2.AdminMessage()
                 set_lora.set_config.lora.CopyFrom(channelSet.lora_config)
                 self.ensureSessionKey(adminIndex=admin_index_for_write)

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -1048,6 +1048,7 @@ class Node:
 
         if len(channelSet.settings) == 0:
             self._raise_interface_error("There were no settings.")
+        has_lora_update = channelSet.HasField("lora_config")
 
         admin_index_for_write = (
             self.iface.localNode._get_admin_channel_index()
@@ -1061,13 +1062,15 @@ class Node:
             ignored_channel_names: list[str] = []
             channels_to_write: list[tuple[channel_pb2.Channel, str]] = []
             original_channels_by_index: dict[int, channel_pb2.Channel] = {}
-            # Rollback must have a local LoRa snapshot before transactional apply.
-            if not self.localConfig.HasField("lora"):
-                self._raise_interface_error(
-                    "LoRa config must be loaded before setURL(addOnly=True)"
-                )
-            original_lora_config = config_pb2.Config.LoRaConfig()
-            original_lora_config.CopyFrom(self.localConfig.lora)
+            original_lora_config: config_pb2.Config.LoRaConfig | None = None
+            # Rollback needs a local LoRa snapshot only when this URL updates LoRa.
+            if has_lora_update:
+                if not self.localConfig.HasField("lora"):
+                    self._raise_interface_error(
+                        "LoRa config must be loaded before setURL(addOnly=True)"
+                    )
+                original_lora_config = config_pb2.Config.LoRaConfig()
+                original_lora_config.CopyFrom(self.localConfig.lora)
             # Bootstrap admin session using the snapshotted path before staging.
             self.ensureSessionKey(adminIndex=admin_index_for_write)
             with self._channels_lock:
@@ -1123,11 +1126,12 @@ class Node:
                         staged_channel,
                         adminIndex=admin_index_for_write,
                     )
-                set_lora = admin_pb2.AdminMessage()
-                set_lora.set_config.lora.CopyFrom(channelSet.lora_config)
-                self.ensureSessionKey(adminIndex=admin_index_for_write)
-                lora_write_started = True
-                self._send_admin(set_lora, adminIndex=admin_index_for_write)
+                if has_lora_update:
+                    set_lora = admin_pb2.AdminMessage()
+                    set_lora.set_config.lora.CopyFrom(channelSet.lora_config)
+                    self.ensureSessionKey(adminIndex=admin_index_for_write)
+                    lora_write_started = True
+                    self._send_admin(set_lora, adminIndex=admin_index_for_write)
             # Intentionally broad: rollback should run for any send failure in this
             # transactional block. The original exception is re-raised.
             except Exception:
@@ -1160,7 +1164,7 @@ class Node:
                     logger.warning(
                         "Channel rollback incomplete after addOnly failure; invalidated local channel cache."
                     )
-                if lora_write_started:
+                if lora_write_started and original_lora_config is not None:
                     rollback_lora = admin_pb2.AdminMessage()
                     rollback_lora.set_config.lora.CopyFrom(original_lora_config)
                     try:
@@ -1199,7 +1203,8 @@ class Node:
                             self.channels = None
                             self.partialChannels = []
                             break
-            self.localConfig.lora.CopyFrom(channelSet.lora_config)
+            if has_lora_update:
+                self.localConfig.lora.CopyFrom(channelSet.lora_config)
         else:
             with self._channels_lock:
                 channels = self.channels
@@ -1229,7 +1234,7 @@ class Node:
                 logger.debug(f"Channel i:{i} ch:{ch}")
                 self.writeChannel(ch.index, adminIndex=admin_index_for_write)
 
-        if not addOnly:
+        if not addOnly and has_lora_update:
             p = admin_pb2.AdminMessage()
             p.set_config.lora.CopyFrom(channelSet.lora_config)
             self.ensureSessionKey(adminIndex=admin_index_for_write)

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -213,6 +213,7 @@ class Node:
 
     def _get_metadata_snapshot(self) -> mesh_pb2.DeviceMetadata | None:
         """Return a stable snapshot of ``iface.metadata`` under the node DB lock when available."""
+
         def _read_and_copy() -> mesh_pb2.DeviceMetadata | None:
             metadata = getattr(self.iface, "metadata", None)
             if not isinstance(metadata, mesh_pb2.DeviceMetadata):
@@ -223,8 +224,11 @@ class Node:
 
         return self._execute_with_node_db_lock(_read_and_copy)
 
-    def _set_metadata_snapshot(self, metadata_snapshot: mesh_pb2.DeviceMetadata) -> None:
+    def _set_metadata_snapshot(
+        self, metadata_snapshot: mesh_pb2.DeviceMetadata
+    ) -> None:
         """Persist a metadata snapshot to ``iface.metadata`` under the node DB lock when available."""
+
         def _write() -> None:
             self.iface.metadata = metadata_snapshot
 
@@ -484,9 +488,7 @@ class Node:
                     f"{configType.name.upper()}_CONFIG"
                 )
             else:
-                p.get_module_config_request = (
-                    msg_index  # pyright: ignore[reportAttributeAccessIssue]
-                )
+                p.get_module_config_request = msg_index  # pyright: ignore[reportAttributeAccessIssue]
 
         self._send_admin(p, wantResponse=True, onResponse=onResponse)
         if onResponse:
@@ -1063,10 +1065,14 @@ class Node:
                 ):
                     previous_channel = channel_pb2.Channel()
                     previous_channel.CopyFrom(disabled_channel)
-                    original_channels_by_index[disabled_channel.index] = previous_channel
+                    original_channels_by_index[disabled_channel.index] = (
+                        previous_channel
+                    )
                     disabled_channel.settings.CopyFrom(new_settings)
                     disabled_channel.role = channel_pb2.Channel.Role.SECONDARY
-                    channels_to_write.append((disabled_channel.index, new_settings.name))
+                    channels_to_write.append(
+                        (disabled_channel.index, new_settings.name)
+                    )
 
             for ignored_name in ignored_channel_names:
                 logger.info(
@@ -1087,13 +1093,17 @@ class Node:
             # transactional block. The original exception is re-raised.
             except Exception:
                 logger.warning(
-                    "Failed while applying addOnly channel updates; restoring local channel state and attempting rollback for written channels and LoRa config.",
+                    "Failed while applying addOnly channel updates; restoring local channel state "
+                    "and attempting rollback for written channels and LoRa config.",
                     exc_info=True,
                 )
                 with self._channels_lock:
                     channels = self.channels
                     if channels is not None:
-                        for index, previous_channel in original_channels_by_index.items():
+                        for (
+                            index,
+                            previous_channel,
+                        ) in original_channels_by_index.items():
                             if 0 <= index < len(channels):
                                 channels[index].CopyFrom(previous_channel)
                 for index in written_indices:

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -17,6 +17,7 @@ from typing import (
     Callable,
     NoReturn,
     Sequence,
+    TypeVar,
     cast,
 )
 
@@ -70,6 +71,7 @@ FACTORY_RESET_REQUEST_VALUE: int = 1
 # Extra wait used only when getMetadata() runs under redirected stdout for
 # historical callers that parse printed metadata lines.
 METADATA_STDOUT_COMPAT_WAIT_SECONDS = 1.0
+_LockedCallResult = TypeVar("_LockedCallResult")
 
 
 class Node:
@@ -195,36 +197,38 @@ class Node:
         if metadata_stdout_event is not None:
             metadata_stdout_event.set()
 
-    def _get_metadata_snapshot(self) -> Any:
-        """Return a stable snapshot of ``iface.metadata`` under the node DB lock when available."""
+    def _execute_with_node_db_lock(
+        self, func: Callable[[], _LockedCallResult]
+    ) -> _LockedCallResult:
+        """Execute ``func`` while holding ``iface._node_db_lock`` when available."""
         node_db_lock = getattr(self.iface, "_node_db_lock", None)
         if (
             node_db_lock is None
             or not hasattr(node_db_lock, "__enter__")
             or not hasattr(node_db_lock, "__exit__")
         ):
+            return func()
+        with node_db_lock:
+            return func()
+
+    def _get_metadata_snapshot(self) -> mesh_pb2.DeviceMetadata | None:
+        """Return a stable snapshot of ``iface.metadata`` under the node DB lock when available."""
+        def _read_and_copy() -> mesh_pb2.DeviceMetadata | None:
             metadata = getattr(self.iface, "metadata", None)
-        else:
-            with node_db_lock:
-                metadata = getattr(self.iface, "metadata", None)
-        if isinstance(metadata, mesh_pb2.DeviceMetadata):
+            if not isinstance(metadata, mesh_pb2.DeviceMetadata):
+                return None
             metadata_snapshot = mesh_pb2.DeviceMetadata()
             metadata_snapshot.CopyFrom(metadata)
             return metadata_snapshot
-        return metadata
+
+        return self._execute_with_node_db_lock(_read_and_copy)
 
     def _set_metadata_snapshot(self, metadata_snapshot: mesh_pb2.DeviceMetadata) -> None:
         """Persist a metadata snapshot to ``iface.metadata`` under the node DB lock when available."""
-        node_db_lock = getattr(self.iface, "_node_db_lock", None)
-        if (
-            node_db_lock is None
-            or not hasattr(node_db_lock, "__enter__")
-            or not hasattr(node_db_lock, "__exit__")
-        ):
+        def _write() -> None:
             self.iface.metadata = metadata_snapshot
-            return
-        with node_db_lock:
-            self.iface.metadata = metadata_snapshot
+
+        self._execute_with_node_db_lock(_write)
 
     def _emit_cached_metadata_for_stdout(self) -> bool:
         """Emit metadata lines from ``self.iface.metadata`` for stdout parser compatibility."""

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -230,7 +230,9 @@ class Node:
         """Persist a metadata snapshot to ``iface.metadata`` under the node DB lock when available."""
 
         def _write() -> None:
-            self.iface.metadata = metadata_snapshot
+            stored_metadata = mesh_pb2.DeviceMetadata()
+            stored_metadata.CopyFrom(metadata_snapshot)
+            self.iface.metadata = stored_metadata
 
         self._execute_with_node_db_lock(_write)
 
@@ -1108,33 +1110,42 @@ class Node:
                     "and attempting rollback for written channels and LoRa config.",
                     exc_info=True,
                 )
-                with self._channels_lock:
-                    channels = self.channels
-                    if channels is not None:
-                        for (
-                            index,
-                            previous_channel,
-                        ) in original_channels_by_index.items():
-                            if 0 <= index < len(channels):
-                                channels[index].CopyFrom(previous_channel)
-                for index in written_indices:
-                    rollback_channel = original_channels_by_index.get(index)
-                    if rollback_channel is None:
-                        continue
-                    rollback_admin = admin_pb2.AdminMessage()
-                    rollback_admin.set_channel.CopyFrom(rollback_channel)
-                    try:
-                        self._send_admin(
-                            rollback_admin,
-                            adminIndex=admin_index_for_write,
-                        )
-                    # Best-effort rollback path; keep attempting remaining steps.
-                    except Exception:
-                        logger.warning(
-                            "Rollback of channel index %s failed after addOnly partial failure.",
-                            index,
-                            exc_info=True,
-                        )
+                rollback_failed = False
+                written_index_set = set(written_indices)
+                for index, rollback_channel in original_channels_by_index.items():
+                    if index in written_index_set:
+                        rollback_admin = admin_pb2.AdminMessage()
+                        rollback_admin.set_channel.CopyFrom(rollback_channel)
+                        try:
+                            self._send_admin(
+                                rollback_admin,
+                                adminIndex=admin_index_for_write,
+                            )
+                        # Best-effort rollback path; keep attempting remaining steps.
+                        except Exception:
+                            rollback_failed = True
+                            logger.warning(
+                                "Rollback of channel index %s failed after addOnly partial failure.",
+                                index,
+                                exc_info=True,
+                            )
+                if rollback_failed:
+                    with self._channels_lock:
+                        self.channels = None
+                        self.partialChannels = []
+                    logger.warning(
+                        "Channel rollback incomplete after addOnly failure; invalidated local channel cache."
+                    )
+                else:
+                    with self._channels_lock:
+                        channels = self.channels
+                        if channels is not None:
+                            for (
+                                index,
+                                previous_channel,
+                            ) in original_channels_by_index.items():
+                                if 0 <= index < len(channels):
+                                    channels[index].CopyFrom(previous_channel)
                 if original_lora_config is not None:
                     rollback_lora = admin_pb2.AdminMessage()
                     rollback_lora.set_config.lora.CopyFrom(original_lora_config)
@@ -1149,6 +1160,10 @@ class Node:
                         logger.warning(
                             "Rollback of LoRa config failed after addOnly partial failure.",
                             exc_info=True,
+                        )
+                        self.localConfig.ClearField("lora")
+                        logger.warning(
+                            "LoRa config cache cleared after rollback failure; reload config before using localConfig.lora."
                         )
                 raise
         else:

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -475,7 +475,8 @@ class Node:
             protobuf field descriptor indicating which config field to fetch.
         adminIndex : int | None
             Admin channel index to use for sending; when None the node's
-            configured admin channel is used. (Default value = None)
+            configured admin channel is used. Pass 0 to force channel 0.
+            (Default value = None)
         """
         if self == self.iface.localNode:
             onResponse = None
@@ -645,7 +646,17 @@ class Node:
         channel_to_write: channel_pb2.Channel,
         adminIndex: int | None = None,
     ) -> None:
-        """Write a pre-built channel snapshot to the device."""
+        """Write a pre-built channel snapshot to the device.
+
+        Parameters
+        ----------
+        channel_to_write : channel_pb2.Channel
+            Snapshot payload to send via `set_channel`.
+        adminIndex : int | None
+            Admin channel index to use for sending; when None the node's
+            configured admin channel is used. Pass 0 to force channel 0.
+            (Default value = None)
+        """
         self.ensureSessionKey(adminIndex=adminIndex)
         p = admin_pb2.AdminMessage()
         p.set_channel.CopyFrom(channel_to_write)
@@ -1091,10 +1102,10 @@ class Node:
                     original_channels_by_index[disabled_channel.index] = (
                         previous_channel
                     )
-                    disabled_channel.settings.CopyFrom(new_settings)
-                    disabled_channel.role = channel_pb2.Channel.Role.SECONDARY
                     staged_channel = channel_pb2.Channel()
                     staged_channel.CopyFrom(disabled_channel)
+                    staged_channel.settings.CopyFrom(new_settings)
+                    staged_channel.role = channel_pb2.Channel.Role.SECONDARY
                     channels_to_write.append(
                         (staged_channel, new_settings.name)
                     )
@@ -1118,13 +1129,25 @@ class Node:
                 self.ensureSessionKey(adminIndex=admin_index_for_write)
                 lora_write_started = True
                 self._send_admin(set_lora, adminIndex=admin_index_for_write)
+                with self._channels_lock:
+                    channels = self.channels
+                    if channels is None:
+                        self._raise_interface_error("Config or channels not loaded")
+                    for staged_channel, _channel_name in channels_to_write:
+                        if 0 <= staged_channel.index < len(channels):
+                            channels[staged_channel.index].CopyFrom(staged_channel)
+                        else:
+                            self._raise_interface_error(
+                                f"Channel index {staged_channel.index} out of range "
+                                f"(0-{len(channels) - 1})"
+                            )
                 self.localConfig.lora.CopyFrom(channelSet.lora_config)
             # Intentionally broad: rollback should run for any send failure in this
             # transactional block. The original exception is re-raised.
             except Exception:
                 logger.warning(
-                    "Failed while applying addOnly channel updates; restoring local channel state "
-                    "and attempting rollback for written channels and LoRa config.",
+                    "Failed while applying addOnly channel updates; attempting rollback "
+                    "for written channels and LoRa config.",
                     exc_info=True,
                 )
                 rollback_failed = False
@@ -1153,16 +1176,6 @@ class Node:
                     logger.warning(
                         "Channel rollback incomplete after addOnly failure; invalidated local channel cache."
                     )
-                else:
-                    with self._channels_lock:
-                        channels = self.channels
-                        if channels is not None:
-                            for (
-                                index,
-                                previous_channel,
-                            ) in original_channels_by_index.items():
-                                if 0 <= index < len(channels):
-                                    channels[index].CopyFrom(previous_channel)
                 if lora_write_started:
                     rollback_lora = admin_pb2.AdminMessage()
                     rollback_lora.set_config.lora.CopyFrom(original_lora_config)
@@ -2459,7 +2472,8 @@ class Node:
             Optional callback invoked with the received response packet. (Default value = None)
         adminIndex : int | None
             Channel index to use for the admin message; when None the node's
-            configured admin channel is used. (Default value = None)
+            configured admin channel is used. Pass 0 to force channel 0.
+            (Default value = None)
 
         Returns
         -------
@@ -2475,7 +2489,7 @@ class Node:
             return None
         if (
             adminIndex is None
-        ):  # unless a special channel index was used, we want to use the admin index
+        ):  # None means auto-detect; channel 0 remains an explicit valid index.
             adminIndex = self.iface.localNode._get_admin_channel_index()
         logger.debug(f"adminIndex:{adminIndex}")
         node_info = self.iface._get_or_create_by_num(self.nodeNum)
@@ -2503,7 +2517,8 @@ class Node:
         ----------
         adminIndex : int | None
             Admin channel index to use for the session key request; when None
-            the node's configured admin channel is used. (Default value = None)
+            the node's configured admin channel is used. Pass 0 to force
+            channel 0. (Default value = None)
         """
         if self.noProto:
             logger.warning(

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -1107,11 +1107,11 @@ class Node:
                             if 0 <= index < len(channels):
                                 channels[index].CopyFrom(previous_channel)
                 for index in written_indices:
-                    previous_channel = original_channels_by_index.get(index)
-                    if previous_channel is None:
+                    rollback_channel = original_channels_by_index.get(index)
+                    if rollback_channel is None:
                         continue
                     rollback_admin = admin_pb2.AdminMessage()
-                    rollback_admin.set_channel.CopyFrom(previous_channel)
+                    rollback_admin.set_channel.CopyFrom(rollback_channel)
                     try:
                         self._send_admin(
                             rollback_admin,

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -1140,11 +1140,9 @@ class Node:
                 written_index_set = set(written_indices)
                 for index, rollback_channel in original_channels_by_index.items():
                     if index in written_index_set:
-                        rollback_admin = admin_pb2.AdminMessage()
-                        rollback_admin.set_channel.CopyFrom(rollback_channel)
                         try:
-                            self._send_admin(
-                                rollback_admin,
+                            self._write_channel_snapshot(
+                                rollback_channel,
                                 adminIndex=admin_index_for_write,
                             )
                         # Best-effort rollback path; keep attempting remaining steps.
@@ -1166,6 +1164,7 @@ class Node:
                     rollback_lora = admin_pb2.AdminMessage()
                     rollback_lora.set_config.lora.CopyFrom(original_lora_config)
                     try:
+                        self.ensureSessionKey(adminIndex=admin_index_for_write)
                         self._send_admin(
                             rollback_lora,
                             adminIndex=admin_index_for_write,
@@ -1189,7 +1188,7 @@ class Node:
                         "Channel cache unavailable after successful addOnly apply; reload channels to refresh local state."
                     )
                 else:
-                    for staged_channel, _channel_name in channels_to_write:
+                    for staged_channel, _ in channels_to_write:
                         if 0 <= staged_channel.index < len(channels):
                             channels[staged_channel.index].CopyFrom(staged_channel)
                         else:

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -195,9 +195,40 @@ class Node:
         if metadata_stdout_event is not None:
             metadata_stdout_event.set()
 
+    def _get_metadata_snapshot(self) -> Any:
+        """Return a stable snapshot of ``iface.metadata`` under the node DB lock when available."""
+        node_db_lock = getattr(self.iface, "_node_db_lock", None)
+        if (
+            node_db_lock is None
+            or not hasattr(node_db_lock, "__enter__")
+            or not hasattr(node_db_lock, "__exit__")
+        ):
+            metadata = getattr(self.iface, "metadata", None)
+        else:
+            with node_db_lock:
+                metadata = getattr(self.iface, "metadata", None)
+        if isinstance(metadata, mesh_pb2.DeviceMetadata):
+            metadata_snapshot = mesh_pb2.DeviceMetadata()
+            metadata_snapshot.CopyFrom(metadata)
+            return metadata_snapshot
+        return metadata
+
+    def _set_metadata_snapshot(self, metadata_snapshot: mesh_pb2.DeviceMetadata) -> None:
+        """Persist a metadata snapshot to ``iface.metadata`` under the node DB lock when available."""
+        node_db_lock = getattr(self.iface, "_node_db_lock", None)
+        if (
+            node_db_lock is None
+            or not hasattr(node_db_lock, "__enter__")
+            or not hasattr(node_db_lock, "__exit__")
+        ):
+            self.iface.metadata = metadata_snapshot
+            return
+        with node_db_lock:
+            self.iface.metadata = metadata_snapshot
+
     def _emit_cached_metadata_for_stdout(self) -> bool:
         """Emit metadata lines from ``self.iface.metadata`` for stdout parser compatibility."""
-        metadata = getattr(self.iface, "metadata", None)
+        metadata = self._get_metadata_snapshot()
         firmware_version = getattr(metadata, "firmware_version", "")
         if not isinstance(firmware_version, str) or not firmware_version:
             return False
@@ -2116,7 +2147,7 @@ class Node:
         c = decoded["admin"]["raw"].get_device_metadata_response
         metadata_snapshot = mesh_pb2.DeviceMetadata()
         metadata_snapshot.CopyFrom(c)
-        self.iface.metadata = metadata_snapshot
+        self._set_metadata_snapshot(metadata_snapshot)
         self._timeout.reset()  # We made forward progress
         logger.debug("Received metadata %s", stripnl(c))
         self._emit_metadata_line(f"\nfirmware_version: {c.firmware_version}")

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -640,6 +640,18 @@ class Node:
             onResponse = self.onAckNak
         self._send_admin(p, onResponse=onResponse)
 
+    def _write_channel_snapshot(
+        self,
+        channel_to_write: channel_pb2.Channel,
+        adminIndex: int | None = None,
+    ) -> None:
+        """Write a pre-built channel snapshot to the device."""
+        self.ensureSessionKey(adminIndex=adminIndex)
+        p = admin_pb2.AdminMessage()
+        p.set_channel.CopyFrom(channel_to_write)
+        self._send_admin(p, adminIndex=adminIndex)
+        logger.debug(f"Wrote channel {channel_to_write.index}")
+
     def writeChannel(self, channelIndex: int, adminIndex: int | None = None) -> None:
         """Write the channel at the given index to the device.
 
@@ -668,11 +680,7 @@ class Node:
                 )
             channel_to_write = channel_pb2.Channel()
             channel_to_write.CopyFrom(channels[channelIndex])
-        self.ensureSessionKey(adminIndex=adminIndex)
-        p = admin_pb2.AdminMessage()
-        p.set_channel.CopyFrom(channel_to_write)
-        self._send_admin(p, adminIndex=adminIndex)
-        logger.debug(f"Wrote channel {channelIndex}")
+        self._write_channel_snapshot(channel_to_write, adminIndex=adminIndex)
 
     # COMPAT_STABLE_SHIM: historical channel lookup helpers return live Channel
     # objects for mutate-then-write workflows (get*() -> edit -> writeChannel()).
@@ -1034,7 +1042,7 @@ class Node:
             # Add new channels with names not already present
             # Don't change existing channels
             ignored_channel_names: list[str] = []
-            channels_to_write: list[tuple[int, str]] = []
+            channels_to_write: list[tuple[channel_pb2.Channel, str]] = []
             original_channels_by_index: dict[int, channel_pb2.Channel] = {}
             # Snapshot admin channel path before staging writes so sends do not
             # depend on locally-mutated channel state.
@@ -1085,8 +1093,10 @@ class Node:
                     )
                     disabled_channel.settings.CopyFrom(new_settings)
                     disabled_channel.role = channel_pb2.Channel.Role.SECONDARY
+                    staged_channel = channel_pb2.Channel()
+                    staged_channel.CopyFrom(disabled_channel)
                     channels_to_write.append(
-                        (disabled_channel.index, new_settings.name)
+                        (staged_channel, new_settings.name)
                     )
 
             for ignored_name in ignored_channel_names:
@@ -1096,10 +1106,13 @@ class Node:
             written_indices: list[int] = []
             lora_write_started = False
             try:
-                for channel_index, channel_name in channels_to_write:
+                for staged_channel, channel_name in channels_to_write:
                     logger.info(f"Adding new channel '{channel_name}' to device")
-                    written_indices.append(channel_index)
-                    self.writeChannel(channel_index, adminIndex=admin_index_for_write)
+                    written_indices.append(staged_channel.index)
+                    self._write_channel_snapshot(
+                        staged_channel,
+                        adminIndex=admin_index_for_write,
+                    )
                 set_lora = admin_pb2.AdminMessage()
                 set_lora.set_config.lora.CopyFrom(channelSet.lora_config)
                 self.ensureSessionKey(adminIndex=admin_index_for_write)

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -455,7 +455,7 @@ class Node:
                 logger.info("%s:\n%s", camel_to_snake(field), config_values)
 
     def requestConfig(
-        self, configType: int | FieldDescriptor, adminIndex: int = 0
+        self, configType: int | FieldDescriptor, adminIndex: int | None = None
     ) -> None:
         """Request a configuration subset or the full configuration from this node.
 
@@ -471,9 +471,9 @@ class Node:
         configType : int | FieldDescriptor
             Numeric config index or a
             protobuf field descriptor indicating which config field to fetch.
-        adminIndex : int
-            Admin channel index to use for sending; when 0 the node's configured
-            admin channel is used. (Default value = 0)
+        adminIndex : int | None
+            Admin channel index to use for sending; when None the node's
+            configured admin channel is used. (Default value = None)
         """
         if self == self.iface.localNode:
             onResponse = None
@@ -638,7 +638,7 @@ class Node:
             onResponse = self.onAckNak
         self._send_admin(p, onResponse=onResponse)
 
-    def writeChannel(self, channelIndex: int, adminIndex: int = 0) -> None:
+    def writeChannel(self, channelIndex: int, adminIndex: int | None = None) -> None:
         """Write the channel at the given index to the device.
 
         Sends the specified channel configuration to the node and ensures an admin session key is present before sending.
@@ -647,8 +647,9 @@ class Node:
         ----------
         channelIndex : int
             Index of the channel to write.
-        adminIndex : int
-            Admin channel index to use for sending. (Default value = 0)
+        adminIndex : int | None
+            Admin channel index to use for sending; when None the node's
+            configured admin channel is used. (Default value = None)
 
         Raises
         ------
@@ -1098,6 +1099,7 @@ class Node:
                 set_lora.set_config.lora.CopyFrom(channelSet.lora_config)
                 self.ensureSessionKey(adminIndex=admin_index_for_write)
                 self._send_admin(set_lora, adminIndex=admin_index_for_write)
+                self.localConfig.lora.CopyFrom(channelSet.lora_config)
             # Intentionally broad: rollback should run for any send failure in this
             # transactional block. The original exception is re-raised.
             except Exception:
@@ -1141,6 +1143,7 @@ class Node:
                             rollback_lora,
                             adminIndex=admin_index_for_write,
                         )
+                        self.localConfig.lora.CopyFrom(original_lora_config)
                     # Best-effort rollback path; keep original failure semantics.
                     except Exception:
                         logger.warning(
@@ -1182,6 +1185,7 @@ class Node:
             p.set_config.lora.CopyFrom(channelSet.lora_config)
             self.ensureSessionKey()
             self._send_admin(p)
+            self.localConfig.lora.CopyFrom(channelSet.lora_config)
 
     def onResponseRequestRingtone(self, p: dict[str, Any]) -> None:
         """Process an admin response containing a ringtone fragment and cache it on the Node.
@@ -2409,7 +2413,7 @@ class Node:
         p: admin_pb2.AdminMessage,
         wantResponse: bool = False,
         onResponse: Callable[[dict[str, Any]], Any] | None = None,
-        adminIndex: int = 0,
+        adminIndex: int | None = None,
     ) -> mesh_pb2.MeshPacket | None:
         """Send an AdminMessage to this Node's admin channel.
 
@@ -2421,8 +2425,9 @@ class Node:
             Request a response from the recipient when True. (Default value = False)
         onResponse : Callable[[dict[str, Any]], Any] | None
             Optional callback invoked with the received response packet. (Default value = None)
-        adminIndex : int
-            Channel index to use for the admin message; when 0 the node's configured admin channel is used. (Default value = 0)
+        adminIndex : int | None
+            Channel index to use for the admin message; when None the node's
+            configured admin channel is used. (Default value = None)
 
         Returns
         -------
@@ -2437,7 +2442,7 @@ class Node:
             )
             return None
         if (
-            adminIndex == 0
+            adminIndex is None
         ):  # unless a special channel index was used, we want to use the admin index
             adminIndex = self.iface.localNode._get_admin_channel_index()
         logger.debug(f"adminIndex:{adminIndex}")
@@ -2456,7 +2461,7 @@ class Node:
             pkiEncrypted=True,
         )
 
-    def ensureSessionKey(self, adminIndex: int = 0) -> None:
+    def ensureSessionKey(self, adminIndex: int | None = None) -> None:
         """Ensure an admin session key exists for this node, requesting one if missing.
 
         If protocol use is disabled (`noProto`), no action is taken. Otherwise, if the node has no
@@ -2464,9 +2469,9 @@ class Node:
 
         Parameters
         ----------
-        adminIndex : int
-            Admin channel index to use for the session key request; when 0 the
-            node's configured admin channel is used. (Default value = 0)
+        adminIndex : int | None
+            Admin channel index to use for the session key request; when None
+            the node's configured admin channel is used. (Default value = None)
         """
         if self.noProto:
             logger.warning(

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -661,7 +661,7 @@ class Node:
         p = admin_pb2.AdminMessage()
         p.set_channel.CopyFrom(channel_to_write)
         self._send_admin(p, adminIndex=adminIndex)
-        logger.debug(f"Wrote channel {channel_to_write.index}")
+        logger.debug("Wrote channel %s", channel_to_write.index)
 
     def writeChannel(self, channelIndex: int, adminIndex: int | None = None) -> None:
         """Write the channel at the given index to the device.
@@ -1122,13 +1122,14 @@ class Node:
 
             for ignored_name in ignored_channel_names:
                 logger.info(
-                    f'Ignoring existing or empty channel "{ignored_name}" from add URL'
+                    'Ignoring existing or empty channel "%s" from add URL',
+                    ignored_name,
                 )
             written_indices: list[int] = []
             lora_write_started = False
             try:
                 for staged_channel, channel_name in channels_to_write:
-                    logger.info(f"Adding new channel '{channel_name}' to device")
+                    logger.info("Adding new channel '%s' to device", channel_name)
                     written_indices.append(staged_channel.index)
                     self._write_channel_snapshot(
                         staged_channel,
@@ -1262,7 +1263,11 @@ class Node:
                         and staged_channel.index == deferred_admin_channel.index
                     ):
                         continue
-                    logger.debug(f"Channel i:{staged_channel.index} ch:{staged_channel}")
+                    logger.debug(
+                        "Channel i:%s ch:%s",
+                        staged_channel.index,
+                        staged_channel,
+                    )
                     self._write_channel_snapshot(
                         staged_channel,
                         adminIndex=admin_index_for_write,
@@ -1282,7 +1287,9 @@ class Node:
 
                 if deferred_admin_channel is not None:
                     logger.debug(
-                        f"Channel i:{deferred_admin_channel.index} ch:{deferred_admin_channel}"
+                        "Channel i:%s ch:%s",
+                        deferred_admin_channel.index,
+                        deferred_admin_channel,
                     )
                     self._write_channel_snapshot(
                         deferred_admin_channel,

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -1211,6 +1211,7 @@ class Node:
                 if channels is None:
                     self._raise_interface_error("Config or channels not loaded")
                 max_channels = len(channels)
+            staged_channels: list[channel_pb2.Channel] = []
             for i, chs in enumerate(channelSet.settings):
                 if i >= max_channels:
                     logger.warning(
@@ -1226,20 +1227,52 @@ class Node:
                 )
                 ch.index = i
                 ch.settings.CopyFrom(chs)
+                staged_channels.append(ch)
+
+            deferred_admin_channel = next(
+                (
+                    staged_channel
+                    for staged_channel in staged_channels
+                    if staged_channel.index == admin_index_for_write
+                ),
+                None,
+            )
+
+            for staged_channel in staged_channels:
+                if (
+                    deferred_admin_channel is not None
+                    and staged_channel.index == deferred_admin_channel.index
+                ):
+                    continue
                 with self._channels_lock:
                     channels = self.channels
                     if channels is None:
                         self._raise_interface_error("Config or channels not loaded")
-                    channels[ch.index] = ch
-                logger.debug(f"Channel i:{i} ch:{ch}")
-                self.writeChannel(ch.index, adminIndex=admin_index_for_write)
+                    channels[staged_channel.index] = staged_channel
+                logger.debug(f"Channel i:{staged_channel.index} ch:{staged_channel}")
+                self.writeChannel(
+                    staged_channel.index, adminIndex=admin_index_for_write
+                )
 
-        if not addOnly and has_lora_update:
-            p = admin_pb2.AdminMessage()
-            p.set_config.lora.CopyFrom(channelSet.lora_config)
-            self.ensureSessionKey(adminIndex=admin_index_for_write)
-            self._send_admin(p, adminIndex=admin_index_for_write)
-            self.localConfig.lora.CopyFrom(channelSet.lora_config)
+            if has_lora_update:
+                p = admin_pb2.AdminMessage()
+                p.set_config.lora.CopyFrom(channelSet.lora_config)
+                self.ensureSessionKey(adminIndex=admin_index_for_write)
+                self._send_admin(p, adminIndex=admin_index_for_write)
+                self.localConfig.lora.CopyFrom(channelSet.lora_config)
+
+            if deferred_admin_channel is not None:
+                with self._channels_lock:
+                    channels = self.channels
+                    if channels is None:
+                        self._raise_interface_error("Config or channels not loaded")
+                    channels[deferred_admin_channel.index] = deferred_admin_channel
+                logger.debug(
+                    f"Channel i:{deferred_admin_channel.index} ch:{deferred_admin_channel}"
+                )
+                self.writeChannel(
+                    deferred_admin_channel.index, adminIndex=admin_index_for_write
+                )
 
     def onResponseRequestRingtone(self, p: dict[str, Any]) -> None:
         """Process an admin response containing a ringtone fragment and cache it on the Node.

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -1031,6 +1031,8 @@ class Node:
                 if self.iface.localNode != self
                 else None
             )
+            original_lora_config = config_pb2.Config.LoRaConfig()
+            original_lora_config.CopyFrom(self.localConfig.lora)
             with self._channels_lock:
                 channels = self.channels
                 if channels is None:
@@ -1077,9 +1079,15 @@ class Node:
                     logger.info(f"Adding new channel '{channel_name}' to device")
                     self.writeChannel(channel_index, adminIndex=admin_index_for_write)
                     written_indices.append(channel_index)
+                set_lora = admin_pb2.AdminMessage()
+                set_lora.set_config.lora.CopyFrom(channelSet.lora_config)
+                self.ensureSessionKey()
+                self._send_admin(set_lora, adminIndex=admin_index_for_write)
+            # Intentionally broad: rollback should run for any send failure in this
+            # transactional block. The original exception is re-raised.
             except Exception:
                 logger.warning(
-                    "Failed while applying addOnly channel updates; restoring local channel state and attempting rollback for written channels.",
+                    "Failed while applying addOnly channel updates; restoring local channel state and attempting rollback for written channels and LoRa config.",
                     exc_info=True,
                 )
                 with self._channels_lock:
@@ -1099,12 +1107,26 @@ class Node:
                             rollback_admin,
                             adminIndex=admin_index_for_write,
                         )
+                    # Best-effort rollback path; keep attempting remaining steps.
                     except Exception:
                         logger.warning(
                             "Rollback of channel index %s failed after addOnly partial failure.",
                             index,
                             exc_info=True,
                         )
+                rollback_lora = admin_pb2.AdminMessage()
+                rollback_lora.set_config.lora.CopyFrom(original_lora_config)
+                try:
+                    self._send_admin(
+                        rollback_lora,
+                        adminIndex=admin_index_for_write,
+                    )
+                # Best-effort rollback path; keep original failure semantics.
+                except Exception:
+                    logger.warning(
+                        "Rollback of LoRa config failed after addOnly partial failure.",
+                        exc_info=True,
+                    )
                 raise
         else:
             with self._channels_lock:
@@ -1135,10 +1157,11 @@ class Node:
                 logger.debug(f"Channel i:{i} ch:{ch}")
                 self.writeChannel(ch.index)
 
-        p = admin_pb2.AdminMessage()
-        p.set_config.lora.CopyFrom(channelSet.lora_config)
-        self.ensureSessionKey()
-        self._send_admin(p)
+        if not addOnly:
+            p = admin_pb2.AdminMessage()
+            p.set_config.lora.CopyFrom(channelSet.lora_config)
+            self.ensureSessionKey()
+            self._send_admin(p)
 
     def onResponseRequestRingtone(self, p: dict[str, Any]) -> None:
         """Process an admin response containing a ringtone fragment and cache it on the Node.

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -1022,11 +1022,21 @@ class Node:
             # Add new channels with names not already present
             # Don't change existing channels
             ignored_channel_names: list[str] = []
-            channels_to_write: list[tuple[int, str, channel_pb2.ChannelSettings]] = []
+            channels_to_write: list[tuple[int, str]] = []
+            original_channels_by_index: dict[int, channel_pb2.Channel] = {}
+            # Snapshot admin channel path before staging writes so the first send
+            # does not depend on locally-mutated channel state.
+            admin_index_for_write = (
+                self.iface.localNode._get_admin_channel_index()
+                if self.iface.localNode != self
+                else None
+            )
             with self._channels_lock:
                 channels = self.channels
                 if channels is None:
                     self._raise_interface_error("Config or channels not loaded")
+                if admin_index_for_write is None:
+                    admin_index_for_write = self._get_admin_channel_index()
                 existing_names = {
                     c.settings.name for c in channels if c.settings and c.settings.name
                 }
@@ -1042,23 +1052,60 @@ class Node:
                     pending_new_settings.append(chs)
                     existing_names.add(channel_name)
                 if len(pending_new_settings) > len(disabled_channels):
-                    self._raise_interface_error("No free channels were found")
+                    self._raise_interface_error(
+                        "No free channels were found for all additions "
+                        f"(need {len(pending_new_settings)}, available {len(disabled_channels)})"
+                    )
                 for disabled_channel, new_settings in zip(
                     disabled_channels, pending_new_settings
                 ):
+                    previous_channel = channel_pb2.Channel()
+                    previous_channel.CopyFrom(disabled_channel)
+                    original_channels_by_index[disabled_channel.index] = previous_channel
                     disabled_channel.settings.CopyFrom(new_settings)
                     disabled_channel.role = channel_pb2.Channel.Role.SECONDARY
-                    channels_to_write.append(
-                        (disabled_channel.index, new_settings.name, new_settings)
-                    )
+                    channels_to_write.append((disabled_channel.index, new_settings.name))
 
             for ignored_name in ignored_channel_names:
                 logger.info(
                     f'Ignoring existing or empty channel "{ignored_name}" from add URL'
                 )
-            for channel_index, channel_name, _ in channels_to_write:
-                logger.info(f"Adding new channel '{channel_name}' to device")
-                self.writeChannel(channel_index)
+            assert admin_index_for_write is not None
+            written_indices: list[int] = []
+            try:
+                for channel_index, channel_name in channels_to_write:
+                    logger.info(f"Adding new channel '{channel_name}' to device")
+                    self.writeChannel(channel_index, adminIndex=admin_index_for_write)
+                    written_indices.append(channel_index)
+            except Exception:
+                logger.warning(
+                    "Failed while applying addOnly channel updates; restoring local channel state and attempting rollback for written channels.",
+                    exc_info=True,
+                )
+                with self._channels_lock:
+                    channels = self.channels
+                    if channels is not None:
+                        for index, previous_channel in original_channels_by_index.items():
+                            if 0 <= index < len(channels):
+                                channels[index].CopyFrom(previous_channel)
+                for index in written_indices:
+                    previous_channel = original_channels_by_index.get(index)
+                    if previous_channel is None:
+                        continue
+                    rollback_admin = admin_pb2.AdminMessage()
+                    rollback_admin.set_channel.CopyFrom(previous_channel)
+                    try:
+                        self._send_admin(
+                            rollback_admin,
+                            adminIndex=admin_index_for_write,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Rollback of channel index %s failed after addOnly partial failure.",
+                            index,
+                            exc_info=True,
+                        )
+                raise
         else:
             with self._channels_lock:
                 channels = self.channels

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -1072,7 +1072,7 @@ class Node:
                         f"(need {len(pending_new_settings)}, available {len(disabled_channels)})"
                     )
                 for disabled_channel, new_settings in zip(
-                    disabled_channels, pending_new_settings
+                    disabled_channels, pending_new_settings, strict=False
                 ):
                     previous_channel = channel_pb2.Channel()
                     previous_channel.CopyFrom(disabled_channel)

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -870,6 +870,14 @@ class Node:
         """Public accessor for the admin channel index on this node."""
         return self._get_admin_channel_index()
 
+    def _get_named_admin_channel_index(self) -> int | None:
+        """Return the index of a channel explicitly named ``admin``, if present."""
+        with self._channels_lock:
+            for channel in self.channels or []:
+                if channel.settings and channel.settings.name.lower() == "admin":
+                    return channel.index
+            return None
+
     def _get_admin_channel_index(self) -> int:
         """Get the index of the channel named "admin", or 0 if no such channel exists.
 
@@ -878,11 +886,8 @@ class Node:
         int
             Index of the admin channel, or 0 if no channel with name "admin" is present.
         """
-        with self._channels_lock:
-            for c in self.channels or []:
-                if c.settings and c.settings.name.lower() == "admin":
-                    return c.index
-            return 0
+        named_admin_index = self._get_named_admin_channel_index()
+        return 0 if named_admin_index is None else named_admin_index
 
     def setOwner(
         self,
@@ -1050,11 +1055,14 @@ class Node:
             self._raise_interface_error("There were no settings.")
         has_lora_update = channelSet.HasField("lora_config")
 
-        admin_index_for_write = (
-            self.iface.localNode._get_admin_channel_index()
-            if self.iface.localNode != self
-            else self._get_admin_channel_index()
+        admin_write_node = self.iface.localNode if self.iface.localNode != self else self
+        admin_index_for_write = admin_write_node._get_admin_channel_index()
+        named_admin_index_for_write: int | None = None
+        named_admin_getter = getattr(
+            admin_write_node, "_get_named_admin_channel_index", None
         )
+        if callable(named_admin_getter):
+            named_admin_index_for_write = named_admin_getter()
 
         if addOnly:
             # Add new channels with names not already present
@@ -1229,14 +1237,16 @@ class Node:
                 ch.settings.CopyFrom(chs)
                 staged_channels.append(ch)
 
-            deferred_admin_channel = next(
-                (
-                    staged_channel
-                    for staged_channel in staged_channels
-                    if staged_channel.index == admin_index_for_write
-                ),
-                None,
-            )
+            deferred_admin_channel = None
+            if named_admin_index_for_write is not None:
+                deferred_admin_channel = next(
+                    (
+                        staged_channel
+                        for staged_channel in staged_channels
+                        if staged_channel.index == admin_index_for_write
+                    ),
+                    None,
+                )
 
             for staged_channel in staged_channels:
                 if (

--- a/meshtastic/tests/test_examples.py
+++ b/meshtastic/tests/test_examples.py
@@ -33,7 +33,7 @@ def _require_int_strict(value: object, *, label: str) -> int:
         value, int
     ), f"{label} should be an int, got {type(value).__name__}"
     assert not isinstance(value, bool), f"{label} must not be a bool"
-    return cast(int, value)
+    return value
 
 
 def _run_hello_world_serial(monkeypatch: pytest.MonkeyPatch, *args: str) -> None:

--- a/meshtastic/tests/test_init.py
+++ b/meshtastic/tests/test_init.py
@@ -155,7 +155,7 @@ def test_init_on_node_info_receive_decode_error_updates_metadata_without_user_st
     baseline_node = iface._get_or_create_by_num(2468135790)
     with iface._node_db_lock:
         baseline_node["user"] = {"id": "baseline-user"}
-    packet = {
+    packet: dict[str, Any] = {
         "from": 2468135790,
         "decoded": {"user": {"error": "decode-failed: malformed"}},
     }

--- a/meshtastic/tests/test_init.py
+++ b/meshtastic/tests/test_init.py
@@ -98,6 +98,7 @@ def test_init_on_position_receive_decode_error_updates_metadata_without_position
     baseline_node = iface._get_or_create_by_num(1234567890)
     with iface._node_db_lock:
         baseline_node["position"] = {"latitudeI": 111111, "longitudeI": 222222}
+        baseline_position = dict(baseline_node["position"])
     packet: dict[str, Any] = {
         "from": 1234567890,
         "decoded": {"position": {"error": "decode-failed: malformed"}},
@@ -106,8 +107,7 @@ def test_init_on_position_receive_decode_error_updates_metadata_without_position
     _on_position_receive(iface, packet)
 
     node = iface._get_or_create_by_num(1234567890)
-    assert node["position"]["latitudeI"] == 111111
-    assert "error" not in node["position"]
+    assert node["position"] == baseline_position
     assert node["lastReceived"]["decoded"]["position"]["error"].startswith(
         "decode-failed:"
     )

--- a/meshtastic/tests/test_init.py
+++ b/meshtastic/tests/test_init.py
@@ -87,6 +87,33 @@ def test_init_on_position_receive_updates_node_position(
 
 
 @pytest.mark.unit
+def test_init_on_position_receive_decode_error_updates_metadata_without_position_state(
+    iface_with_nodes: MeshInterface,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Decode-error position payloads should update receive metadata but not overwrite position state."""
+    args = SimpleNamespace(camel_case=False)
+    monkeypatch.setattr(mt_config, "args", args)
+    iface = iface_with_nodes
+    baseline_node = iface._get_or_create_by_num(1234567890)
+    with iface._node_db_lock:
+        baseline_node["position"] = {"latitudeI": 111111, "longitudeI": 222222}
+    packet: dict[str, Any] = {
+        "from": 1234567890,
+        "decoded": {"position": {"error": "decode-failed: malformed"}},
+    }
+
+    _on_position_receive(iface, packet)
+
+    node = iface._get_or_create_by_num(1234567890)
+    assert node["position"]["latitudeI"] == 111111
+    assert "error" not in node["position"]
+    assert node["lastReceived"]["decoded"]["position"]["error"].startswith(
+        "decode-failed:"
+    )
+
+
+@pytest.mark.unit
 def test_init_on_node_info_receive(
     caplog: pytest.LogCaptureFixture,
     iface_with_nodes: MeshInterface,
@@ -114,6 +141,33 @@ def test_init_on_node_info_receive(
     assert iface.nodes is not None
     assert iface.nodes["bar"] is node
     assert node["lastReceived"]["decoded"]["user"]["id"] == "bar"
+
+
+@pytest.mark.unit
+def test_init_on_node_info_receive_decode_error_updates_metadata_without_user_state(
+    iface_with_nodes: MeshInterface,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Decode-error user payloads should update receive metadata but not overwrite user state."""
+    args = SimpleNamespace(camel_case=False)
+    monkeypatch.setattr(mt_config, "args", args)
+    iface = iface_with_nodes
+    baseline_node = iface._get_or_create_by_num(2468135790)
+    with iface._node_db_lock:
+        baseline_node["user"] = {"id": "baseline-user"}
+    packet = {
+        "from": 2468135790,
+        "decoded": {"user": {"error": "decode-failed: malformed"}},
+    }
+
+    _on_node_info_receive(iface, packet)
+
+    node = iface._get_or_create_by_num(2468135790)
+    assert node["user"]["id"] == "baseline-user"
+    assert "error" not in node["user"]
+    assert node["lastReceived"]["decoded"]["user"]["error"].startswith(
+        "decode-failed:"
+    )
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_init.py
+++ b/meshtastic/tests/test_init.py
@@ -1,5 +1,6 @@
 """Meshtastic unit tests for __init__.py."""
 
+import copy
 import logging
 import re
 from types import SimpleNamespace
@@ -154,7 +155,12 @@ def test_init_on_node_info_receive_decode_error_updates_metadata_without_user_st
     iface = iface_with_nodes
     baseline_node = iface._get_or_create_by_num(2468135790)
     with iface._node_db_lock:
-        baseline_node["user"] = {"id": "baseline-user"}
+        baseline_node["user"] = {
+            "id": "baseline-user",
+            "longName": "Baseline User",
+            "shortName": "BU",
+        }
+        baseline_user_snapshot = copy.deepcopy(baseline_node["user"])
     packet: dict[str, Any] = {
         "from": 2468135790,
         "decoded": {"user": {"error": "decode-failed: malformed"}},
@@ -163,8 +169,7 @@ def test_init_on_node_info_receive_decode_error_updates_metadata_without_user_st
     _on_node_info_receive(iface, packet)
 
     node = iface._get_or_create_by_num(2468135790)
-    assert node["user"]["id"] == "baseline-user"
-    assert "error" not in node["user"]
+    assert node["user"] == baseline_user_snapshot
     assert node["lastReceived"]["decoded"]["user"]["error"].startswith(
         "decode-failed:"
     )

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn, cast
 from unittest.mock import MagicMock, call, create_autospec, patch
 
+import google.protobuf.json_format
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
@@ -3782,3 +3783,128 @@ def test_handle_packet_from_radio_decode_failure_does_not_raise(
         )
         assert len(callback_calls) == 1
         assert 42 not in iface.responseHandlers
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_handle_packet_from_radio_routing_decode_failure_sets_error_reason(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Malformed ROUTING_APP payloads should surface decode errors via routing.errorReason."""
+    monkeypatch.setattr(
+        mesh_interface_module.publishingThread,  # type: ignore[attr-defined]
+        "queueWork",
+        lambda callback: callback(),
+    )
+
+    with MeshInterface(noProto=True) as iface:
+        fake_on_receive = MagicMock()
+        fake_protocol = types.SimpleNamespace(
+            name="routing",
+            protobufFactory=mesh_pb2.Routing,
+            onReceive=fake_on_receive,
+        )
+        monkeypatch.setattr(
+            mesh_interface_module,
+            "protocols",
+            {portnums_pb2.PortNum.ROUTING_APP: fake_protocol},
+        )
+
+        callback_calls: list[dict[str, Any]] = []
+
+        def _response_callback(packet: dict[str, Any]) -> None:
+            callback_calls.append(packet)
+
+        iface.responseHandlers[77] = ResponseHandler(
+            callback=_response_callback, ackPermitted=True
+        )
+
+        packet = mesh_pb2.MeshPacket()
+        setattr(packet, "from", 1)
+        packet.to = 2
+        packet.decoded.portnum = portnums_pb2.PortNum.ROUTING_APP
+        packet.decoded.request_id = 77
+        packet.decoded.payload = b"\xff\x00\xff\x00"
+
+        with caplog.at_level(logging.WARNING):
+            iface._handle_packet_from_radio(packet, hack=True)
+
+        assert "Failed to decode routing payload" in caplog.text
+        fake_on_receive.assert_called_once()
+        assert callback_calls
+        routing_payload = callback_calls[0]["decoded"]["routing"]
+        assert routing_payload["error"].startswith("decode-failed:")
+        assert routing_payload["errorReason"].startswith("decode-failed:")
+        assert 77 not in iface.responseHandlers
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_handle_packet_from_radio_message_to_dict_failure_does_not_raise(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """MessageToDict conversion failures should be handled as decode-failed payload errors."""
+    monkeypatch.setattr(
+        mesh_interface_module.publishingThread,  # type: ignore[attr-defined]
+        "queueWork",
+        lambda callback: callback(),
+    )
+
+    with MeshInterface(noProto=True) as iface:
+        fake_on_receive = MagicMock()
+        fake_protocol = types.SimpleNamespace(
+            name="position",
+            protobufFactory=mesh_pb2.Position,
+            onReceive=fake_on_receive,
+        )
+        monkeypatch.setattr(
+            mesh_interface_module,
+            "protocols",
+            {portnums_pb2.PortNum.POSITION_APP: fake_protocol},
+        )
+
+        callback_calls: list[dict[str, Any]] = []
+
+        def _response_callback(packet: dict[str, Any]) -> None:
+            callback_calls.append(packet)
+
+        iface.responseHandlers[88] = ResponseHandler(
+            callback=_response_callback, ackPermitted=True
+        )
+
+        original_message_to_dict = google.protobuf.json_format.MessageToDict
+
+        def _message_to_dict_with_position_failure(
+            message: Any,
+            *args: Any,
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            if isinstance(message, mesh_pb2.Position):
+                raise ValueError("position dict conversion failed")
+            return cast(dict[str, Any], original_message_to_dict(message, *args, **kwargs))
+
+        monkeypatch.setattr(
+            google.protobuf.json_format,
+            "MessageToDict",
+            _message_to_dict_with_position_failure,
+        )
+
+        packet = mesh_pb2.MeshPacket()
+        setattr(packet, "from", 1)
+        packet.to = 2
+        packet.decoded.portnum = portnums_pb2.PortNum.POSITION_APP
+        packet.decoded.request_id = 88
+        packet.decoded.payload = mesh_pb2.Position(latitude_i=1).SerializeToString()
+
+        with caplog.at_level(logging.WARNING):
+            iface._handle_packet_from_radio(packet, hack=True)
+
+        assert "Failed to decode position payload" in caplog.text
+        fake_on_receive.assert_called_once()
+        assert callback_calls
+        assert callback_calls[0]["decoded"]["position"]["error"].startswith(
+            "decode-failed:"
+        )
+        assert 88 not in iface.responseHandlers

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -955,6 +955,28 @@ def test_sendPacket_uses_numeric_num_from_node_record(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+@pytest.mark.parametrize(
+    ("destination_id", "expected_num"),
+    [
+        ("0x12345678", 0x12345678),
+        ("0X90ABCDEF", 0x90ABCDEF),
+        ("!89abcdef", 0x89ABCDEF),
+    ],
+)
+def test_sendPacket_parses_supported_hex_node_id_forms(
+    destination_id: str, expected_num: int
+) -> None:
+    """_send_packet should parse accepted compact hex destination ID forms."""
+    with MeshInterface(noProto=True) as iface:
+        mesh_packet = mesh_pb2.MeshPacket()
+
+        sent = iface._send_packet(mesh_packet, destinationId=destination_id)
+
+        assert sent.to == expected_num
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
 def test_sendPacket_with_non_hex_long_destination_falls_back_to_db_lookup(
     iface_with_nodes: MeshInterface,
 ) -> None:

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -3722,4 +3722,8 @@ def test_handle_packet_from_radio_decode_failure_does_not_raise(
 
         assert "Failed to decode position payload" in caplog.text
         fake_on_receive.assert_not_called()
+        assert callback_calls
+        assert callback_calls[0]["decoded"]["position"]["error"].startswith(
+            "decode-failed:"
+        )
         assert len(callback_calls) == 1

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -955,6 +955,21 @@ def test_sendPacket_uses_numeric_num_from_node_record(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+def test_sendPacket_with_non_hex_long_destination_falls_back_to_db_lookup(
+    iface_with_nodes: MeshInterface,
+) -> None:
+    """Non-hex destination strings of length >= 8 should not raise raw ValueError."""
+    iface = iface_with_nodes
+    mesh_packet = mesh_pb2.MeshPacket()
+    with pytest.raises(
+        MeshInterface.MeshInterfaceError,
+        match=r"NodeId nothexid1 not found in DB",
+    ):
+        iface._send_packet(mesh_packet, destinationId="nothexid1")
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
 def test_sendPacket_applies_explicit_hoplimit_and_pki_encrypted_flag() -> None:
     """_send_packet should honor explicit hopLimit and pkiEncrypted parameters."""
     with MeshInterface(noProto=True) as iface:
@@ -3658,3 +3673,53 @@ def test_handle_packet_from_radio_toid_warning_and_response_handler_paths(
     assert on_receive_calls == [1, 1, 1]
     assert on_ack_calls == [1]
     assert ack_permitted_calls == [1]
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_handle_packet_from_radio_decode_failure_does_not_raise(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Malformed known-protocol payloads should log and continue without crashing receive flow."""
+    monkeypatch.setattr(
+        mesh_interface_module.publishingThread,  # type: ignore[attr-defined]
+        "queueWork",
+        lambda callback: callback(),
+    )
+
+    with MeshInterface(noProto=True) as iface:
+        fake_on_receive = MagicMock()
+        fake_protocol = types.SimpleNamespace(
+            name="position",
+            protobufFactory=mesh_pb2.Position,
+            onReceive=fake_on_receive,
+        )
+        monkeypatch.setattr(
+            mesh_interface_module,
+            "protocols",
+            {portnums_pb2.PortNum.POSITION_APP: fake_protocol},
+        )
+
+        callback_calls: list[dict[str, Any]] = []
+
+        def _response_callback(packet: dict[str, Any]) -> None:
+            callback_calls.append(packet)
+
+        iface.responseHandlers[42] = ResponseHandler(
+            callback=_response_callback, ackPermitted=True
+        )
+
+        packet = mesh_pb2.MeshPacket()
+        setattr(packet, "from", 1)
+        packet.to = 2
+        packet.decoded.portnum = portnums_pb2.PortNum.POSITION_APP
+        packet.decoded.request_id = 42
+        packet.decoded.payload = b"\xff\x00\xff\x00"
+
+        with caplog.at_level(logging.WARNING):
+            iface._handle_packet_from_radio(packet, hack=True)
+
+        assert "Failed to decode position payload" in caplog.text
+        fake_on_receive.assert_not_called()
+        assert len(callback_calls) == 1

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -3761,9 +3761,10 @@ def test_handle_packet_from_radio_decode_failure_does_not_raise(
             iface._handle_packet_from_radio(packet, hack=True)
 
         assert "Failed to decode position payload" in caplog.text
-        fake_on_receive.assert_not_called()
+        fake_on_receive.assert_called_once()
         assert callback_calls
         assert callback_calls[0]["decoded"]["position"]["error"].startswith(
             "decode-failed:"
         )
         assert len(callback_calls) == 1
+        assert 42 not in iface.responseHandlers

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -970,6 +970,21 @@ def test_sendPacket_with_non_hex_long_destination_falls_back_to_db_lookup(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+def test_sendPacket_with_hex_suffix_only_string_still_uses_db_lookup(
+    iface_with_nodes: MeshInterface,
+) -> None:
+    """Arbitrary strings ending in hex should not be treated as direct node IDs."""
+    iface = iface_with_nodes
+    mesh_packet = mesh_pb2.MeshPacket()
+    with pytest.raises(
+        MeshInterface.MeshInterfaceError,
+        match=r"NodeId room-deadbeef not found in DB",
+    ):
+        iface._send_packet(mesh_packet, destinationId="room-deadbeef")
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
 def test_sendPacket_applies_explicit_hoplimit_and_pki_encrypted_flag() -> None:
     """_send_packet should honor explicit hopLimit and pkiEncrypted parameters."""
     with MeshInterface(noProto=True) as iface:

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -958,6 +958,7 @@ def test_sendPacket_uses_numeric_num_from_node_record(
 @pytest.mark.parametrize(
     ("destination_id", "expected_num"),
     [
+        ("12345678", 0x12345678),
         ("0x12345678", 0x12345678),
         ("0X90ABCDEF", 0x90ABCDEF),
         ("!89abcdef", 0x89ABCDEF),

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -977,17 +977,19 @@ def test_sendPacket_parses_supported_hex_node_id_forms(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+@pytest.mark.parametrize("destination_id", ["nothexid", "nothexid1"])
 def test_sendPacket_with_non_hex_long_destination_falls_back_to_db_lookup(
     iface_with_nodes: MeshInterface,
+    destination_id: str,
 ) -> None:
     """Non-hex destination strings of length >= 8 should not raise raw ValueError."""
     iface = iface_with_nodes
     mesh_packet = mesh_pb2.MeshPacket()
     with pytest.raises(
         MeshInterface.MeshInterfaceError,
-        match=r"NodeId nothexid1 not found in DB",
+        match=rf"NodeId {destination_id} not found in DB",
     ):
-        iface._send_packet(mesh_packet, destinationId="nothexid1")
+        iface._send_packet(mesh_packet, destinationId=destination_id)
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -836,18 +836,15 @@ def test_sendPacket_alias_with_destination_as_int(
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_sendPacket_with_destination_starting_with_a_bang(
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Verify that _send_packet ignores destination IDs that begin with '!' and logs the action.
-
-    Asserts that calling _send_packet with a destinationId starting with "!" results in a log entry containing "Not sending packet".
-
-    """
+    """Unsupported bang-prefixed IDs should raise when node DB lookup is unavailable."""
     with MeshInterface(noProto=True) as iface:
-        with caplog.at_level(logging.DEBUG):
-            meshPacket = mesh_pb2.MeshPacket()
-            iface._send_packet(meshPacket, destinationId="!1234")
-            assert re.search(r"Not sending packet", caplog.text, re.MULTILINE)
+        mesh_packet = mesh_pb2.MeshPacket()
+        with pytest.raises(
+            MeshInterface.MeshInterfaceError,
+            match=r"NodeId !1234 not found and node DB is unavailable",
+        ):
+            iface._send_packet(mesh_packet, destinationId="!1234")
 
 
 @pytest.mark.unit
@@ -910,16 +907,33 @@ def test_sendPacket_with_destination_is_blank_with_nodes(
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_sendPacket_with_destination_is_blank_without_nodes(
-    caplog: pytest.LogCaptureFixture,
     iface_with_nodes: MeshInterface,
 ) -> None:
-    """Test _send_packet() with '' as a destination with myInfo."""
+    """Test _send_packet() with '' as a destination raises when node DB is unavailable."""
     iface = iface_with_nodes
     iface.nodes = None
     meshPacket = mesh_pb2.MeshPacket()
-    with caplog.at_level(logging.WARNING):
+    with pytest.raises(
+        MeshInterface.MeshInterfaceError,
+        match=r"NodeId  not found and node DB is unavailable",
+    ):
         iface._send_packet(meshPacket, destinationId="")
-    assert re.search(r"Warning: There were no self.nodes.", caplog.text, re.MULTILINE)
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_sendPacket_with_unsupported_destination_type_without_nodes_raises(
+    iface_with_nodes: MeshInterface,
+) -> None:
+    """Unsupported destination types should raise when node DB is unavailable."""
+    iface = iface_with_nodes
+    iface.nodes = None
+    mesh_packet = mesh_pb2.MeshPacket()
+    with pytest.raises(
+        MeshInterface.MeshInterfaceError,
+        match=r"NodeId \[\] not found and node DB is unavailable",
+    ):
+        iface._send_packet(mesh_packet, destinationId=[])  # type: ignore[arg-type]
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -1950,7 +1950,9 @@ def test_onRequestGetMetadata_updates_metadata_under_node_db_lock() -> None:
     assert lock.enter_count == 1
     assert lock.is_held is False
     assert iface.metadata_assignment_lock_state is True
-    assert iface.metadata.firmware_version == "2.7.19"
+    metadata = iface.metadata
+    assert metadata is not None
+    assert metadata.firmware_version == "2.7.19"
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -1671,6 +1671,7 @@ def test_setURL_replace_pins_admin_index_for_channel_and_lora_writes(
     """setURL(addOnly=False) should pin admin path from pre-rewrite channel state."""
     iface = autospec_local_node_iface(MeshInterface)
     iface.localNode._get_admin_channel_index.return_value = 1
+    iface.localNode._get_named_admin_channel_index = MagicMock(return_value=1)  # type: ignore[attr-defined]
     iface._get_or_create_by_num.return_value = {"adminSessionPassKey": b"secret"}
     anode = Node(iface, "!12345678", noProto=False)
 
@@ -2429,11 +2430,13 @@ def test_emit_cached_metadata_reads_metadata_under_node_db_lock(
 
         @property
         def metadata(self) -> mesh_pb2.DeviceMetadata:
+            """Return stored metadata while recording lock-held state at read time."""
             metadata_read_lock_states.append(self._node_db_lock.is_held)
             return self._metadata
 
         @metadata.setter
         def metadata(self, value: mesh_pb2.DeviceMetadata) -> None:
+            """Update stored metadata for the probe interface."""
             self._metadata = value
 
     def _mutate_metadata_after_unlock() -> None:

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -61,6 +61,21 @@ class _DropChannelsOnEnterCountLock:
         return False
 
 
+class _TrackingLock:
+    """Lock stub that records how many times it was acquired."""
+
+    def __init__(self) -> None:
+        self.enter_count = 0
+
+    def __enter__(self) -> "_TrackingLock":
+        self.enter_count += 1
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> Literal[False]:
+        _ = (exc_type, exc, tb)
+        return False
+
+
 def _make_fake_send_admin(
     *,
     sent_messages: list[admin_pb2.AdminMessage] | None = None,
@@ -1711,6 +1726,34 @@ def test_onRequestGetMetadata_logs_valid_and_fallback_enum_values(
 
 
 @pytest.mark.unit
+def test_onRequestGetMetadata_updates_metadata_under_node_db_lock(
+    autospec_local_node_iface: Callable[[type[Any]], MagicMock],
+) -> None:
+    """onRequestGetMetadata should update iface.metadata while holding iface._node_db_lock."""
+    iface = autospec_local_node_iface(MeshInterface)
+    iface._acknowledgment = Acknowledgment()
+    iface._node_db_lock = _TrackingLock()
+    anode = Node(iface, "!12345678", noProto=True)
+    anode._timeout = MagicMock()
+
+    raw = admin_pb2.AdminMessage()
+    response = raw.get_device_metadata_response
+    response.firmware_version = "2.7.19"
+    response.device_state_version = 25
+    response.role = config_pb2.Config.DeviceConfig.Role.CLIENT
+    response.position_flags = 0
+    response.hw_model = mesh_pb2.HardwareModel.PORTDUINO
+    response.hasPKC = True
+
+    anode.onRequestGetMetadata(
+        {"decoded": {"portnum": "ADMIN_APP", "admin": {"raw": raw}}}
+    )
+
+    assert iface._node_db_lock.enter_count == 1
+    assert iface.metadata.firmware_version == "2.7.19"
+
+
+@pytest.mark.unit
 def test_onRequestGetMetadata_emits_stdout_when_redirected(
     autospec_local_node_iface: Callable[[type[Any]], MagicMock],
     capsys: CaptureFixture[str],
@@ -1774,6 +1817,31 @@ def test_emit_cached_metadata_uses_fallback_values_for_unknown_enums(
     assert "role: 999" in emitted
     assert "hw_model: 999" in emitted
     assert any(line.startswith("excluded_modules:") for line in emitted)
+
+
+@pytest.mark.unit
+def test_emit_cached_metadata_reads_metadata_under_node_db_lock(
+    autospec_local_node_iface: Callable[[type[Any]], MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_emit_cached_metadata_for_stdout should snapshot iface.metadata under iface._node_db_lock."""
+    iface = autospec_local_node_iface(MeshInterface)
+    iface._node_db_lock = _TrackingLock()
+    iface.metadata = mesh_pb2.DeviceMetadata(
+        firmware_version="2.7.18",
+        device_state_version=24,
+        role=config_pb2.Config.DeviceConfig.Role.CLIENT,
+        position_flags=0,
+        hw_model=mesh_pb2.HardwareModel.PORTDUINO,
+        hasPKC=True,
+    )
+    anode = Node(iface, "!12345678", noProto=True)
+    emitted: list[str] = []
+    monkeypatch.setattr(anode, "_emit_metadata_line", emitted.append)
+
+    assert anode._emit_cached_metadata_for_stdout() is True
+    assert iface._node_db_lock.enter_count == 1
+    assert any("firmware_version: 2.7.18" in line for line in emitted)
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -1257,7 +1257,7 @@ def test_setURL_add_only_adds_unique_named_channels(
     disabled = Channel(index=1, role=Channel.Role.DISABLED)
     anode.channels = [primary, disabled]
     anode.localConfig.lora.hop_limit = 3
-    anode.writeChannel = MagicMock()  # type: ignore[method-assign]
+    anode._send_admin = MagicMock(return_value=mesh_pb2.MeshPacket())  # type: ignore[method-assign]
 
     channel_set = apponly_pb2.ChannelSet()
     existing = channel_set.settings.add()
@@ -1279,7 +1279,14 @@ def test_setURL_add_only_adds_unique_named_channels(
     assert anode.channels[1].settings.name == "new-ch"
     assert anode.channels[1].role == Channel.Role.SECONDARY
     assert anode.localConfig.lora.hop_limit == 9
-    anode.writeChannel.assert_called_once_with(1, adminIndex=0)
+    send_calls = anode._send_admin.call_args_list
+    assert len(send_calls) == 2
+    assert send_calls[0].kwargs["adminIndex"] == 0
+    assert send_calls[0].args[0].HasField("set_channel")
+    assert send_calls[0].args[0].set_channel.index == 1
+    assert send_calls[1].kwargs["adminIndex"] == 0
+    assert send_calls[1].args[0].HasField("set_config")
+    assert send_calls[1].args[0].set_config.lora.hop_limit == 9
 
 
 @pytest.mark.unit
@@ -1346,7 +1353,7 @@ def test_setURL_add_only_is_transactional_when_slots_are_insufficient(
     disabled = Channel(index=2, role=Channel.Role.DISABLED)
     anode.channels = [primary, secondary, disabled]
     anode.localConfig.lora.hop_limit = 3
-    anode.writeChannel = MagicMock()  # type: ignore[method-assign]
+    anode._send_admin = MagicMock(return_value=mesh_pb2.MeshPacket())  # type: ignore[method-assign]
 
     before_snapshot = [channel.SerializeToString() for channel in anode.channels]
     before_lora = anode.localConfig.lora.SerializeToString()
@@ -1372,7 +1379,7 @@ def test_setURL_add_only_is_transactional_when_slots_are_insufficient(
     assert after_snapshot == before_snapshot
     after_lora = anode.localConfig.lora.SerializeToString()
     assert after_lora == before_lora
-    anode.writeChannel.assert_not_called()
+    anode._send_admin.assert_not_called()
 
 
 @pytest.mark.unit
@@ -1391,15 +1398,32 @@ def test_setURL_add_only_uses_snapshotted_admin_index_and_rolls_back_on_write_fa
     anode.localConfig.lora.hop_limit = 3
     before_snapshot = [channel.SerializeToString() for channel in anode.channels]
 
-    write_calls: list[tuple[int, int]] = []
+    staged_writes: list[tuple[int, str, int | None]] = []
+    rollback_writes: list[tuple[int, int | None]] = []
 
-    def _write_then_fail(channel_index: int, adminIndex: int = 0) -> None:  # noqa: N803
-        write_calls.append((channel_index, adminIndex))
-        if len(write_calls) == 2:
-            raise RuntimeError("write failed during addOnly batch")
+    def _send_admin_with_staged_write_failure(
+        msg: admin_pb2.AdminMessage,
+        wantResponse: bool = False,
+        onResponse: Callable[[dict[str, Any]], Any] | None = None,
+        adminIndex: int | None = None,
+    ) -> mesh_pb2.MeshPacket:
+        _ = (wantResponse, onResponse)
+        if msg.HasField("set_channel"):
+            if msg.set_channel.role == Channel.Role.SECONDARY:
+                staged_writes.append(
+                    (msg.set_channel.index, msg.set_channel.settings.name, adminIndex)
+                )
+                # Simulate a concurrent local mutation after staging to prove we
+                # send the staged snapshot, not a fresh read from self.channels.
+                if len(staged_writes) == 1 and anode.channels is not None:
+                    anode.channels[2].settings.name = "raced-name"
+                if len(staged_writes) == 2:
+                    raise RuntimeError("write failed during addOnly batch")
+            elif msg.set_channel.role == Channel.Role.DISABLED:
+                rollback_writes.append((msg.set_channel.index, adminIndex))
+        return mesh_pb2.MeshPacket()
 
-    anode.writeChannel = MagicMock(side_effect=_write_then_fail)  # type: ignore[method-assign]
-    anode._send_admin = MagicMock(return_value=mesh_pb2.MeshPacket())  # type: ignore[method-assign]
+    anode._send_admin = _send_admin_with_staged_write_failure  # type: ignore[method-assign,assignment]
 
     channel_set = apponly_pb2.ChannelSet()
     first = channel_set.settings.add()
@@ -1416,7 +1440,7 @@ def test_setURL_add_only_uses_snapshotted_admin_index_and_rolls_back_on_write_fa
 
     # Admin index is snapshotted before local mutation (0 fallback here),
     # even though a staged channel is named "admin".
-    assert write_calls == [(1, 0), (2, 0)]
+    assert staged_writes == [(1, "admin", 0), (2, "new-b", 0)]
 
     assert anode.channels is not None
     after_snapshot = [channel.SerializeToString() for channel in anode.channels]
@@ -1425,18 +1449,7 @@ def test_setURL_add_only_uses_snapshotted_admin_index_and_rolls_back_on_write_fa
     # Rollback should include the in-flight channel index as well, so both staged
     # channels are restored when writeChannel fails mid-send.
     # No LoRa rollback is attempted because the LoRa write never started.
-    rollback_calls = anode._send_admin.call_args_list
-    assert len(rollback_calls) == 2
-    rollback_channel_msg = rollback_calls[0].args[0]
-    assert isinstance(rollback_channel_msg, admin_pb2.AdminMessage)
-    assert rollback_channel_msg.set_channel.index == 1
-    assert rollback_channel_msg.set_channel.role == Channel.Role.DISABLED
-    assert rollback_calls[0].kwargs["adminIndex"] == 0
-    rollback_in_flight_msg = rollback_calls[1].args[0]
-    assert isinstance(rollback_in_flight_msg, admin_pb2.AdminMessage)
-    assert rollback_in_flight_msg.set_channel.index == 2
-    assert rollback_in_flight_msg.set_channel.role == Channel.Role.DISABLED
-    assert rollback_calls[1].kwargs["adminIndex"] == 0
+    assert rollback_writes == [(1, 0), (2, 0)]
 
 
 @pytest.mark.unit
@@ -1454,15 +1467,7 @@ def test_setURL_add_only_invalidates_channels_cache_on_partial_rollback_failure(
     anode.channels = [primary, disabled1, disabled2]
     anode.localConfig.lora.hop_limit = 3
 
-    write_calls = {"count": 0}
-
-    def _write_then_fail(channel_index: int, adminIndex: int | None = None) -> None:  # noqa: N803
-        _ = (channel_index, adminIndex)
-        write_calls["count"] += 1
-        if write_calls["count"] == 2:
-            raise RuntimeError("write failed during addOnly batch")
-
-    send_calls = {"count": 0}
+    send_calls = {"rollback_failures": 0, "stage_writes": 0}
 
     def _rollback_send_fails_once(
         msg: admin_pb2.AdminMessage,
@@ -1471,12 +1476,19 @@ def test_setURL_add_only_invalidates_channels_cache_on_partial_rollback_failure(
         adminIndex: int | None = None,
     ) -> mesh_pb2.MeshPacket:
         _ = (wantResponse, onResponse, adminIndex)
-        send_calls["count"] += 1
-        if msg.HasField("set_channel") and send_calls["count"] == 1:
-            raise OSError("channel rollback failed")
+        if msg.HasField("set_channel"):
+            if msg.set_channel.role == Channel.Role.SECONDARY:
+                send_calls["stage_writes"] += 1
+                if send_calls["stage_writes"] == 2:
+                    raise RuntimeError("write failed during addOnly batch")
+            elif (
+                msg.set_channel.role == Channel.Role.DISABLED
+                and send_calls["rollback_failures"] == 0
+            ):
+                send_calls["rollback_failures"] += 1
+                raise OSError("channel rollback failed")
         return mesh_pb2.MeshPacket()
 
-    anode.writeChannel = MagicMock(side_effect=_write_then_fail)  # type: ignore[method-assign]
     anode._send_admin = _rollback_send_fails_once  # type: ignore[method-assign,assignment]
 
     channel_set = apponly_pb2.ChannelSet()
@@ -1509,9 +1521,9 @@ def test_setURL_add_only_rolls_back_lora_when_lora_write_fails(
     anode.channels = [primary, disabled]
     before_snapshot = [channel.SerializeToString() for channel in anode.channels]
     anode.localConfig.lora.hop_limit = 3
-    anode.writeChannel = MagicMock()  # type: ignore[method-assign]
 
     failed_lora_send = {"seen": False}
+    staged_channel_writes: list[int] = []
     rollback_messages: list[admin_pb2.AdminMessage] = []
     admin_indexes: list[int | None] = []
 
@@ -1523,6 +1535,8 @@ def test_setURL_add_only_rolls_back_lora_when_lora_write_fails(
     ) -> mesh_pb2.MeshPacket:
         _ = (wantResponse, onResponse)
         admin_indexes.append(adminIndex)
+        if msg.HasField("set_channel") and msg.set_channel.role == Channel.Role.SECONDARY:
+            staged_channel_writes.append(msg.set_channel.index)
         if msg.HasField("set_config") and msg.set_config.HasField("lora"):
             if (
                 not failed_lora_send["seen"]
@@ -1550,17 +1564,24 @@ def test_setURL_add_only_rolls_back_lora_when_lora_write_fails(
     assert anode.channels is not None
     after_snapshot = [channel.SerializeToString() for channel in anode.channels]
     assert after_snapshot == before_snapshot
-    anode.writeChannel.assert_called_once_with(1, adminIndex=0)
+    assert staged_channel_writes == [1]
 
     # Rollback should include channel restoration and prior LoRa config.
-    assert len(rollback_messages) == 2
-    assert rollback_messages[0].HasField("set_channel")
-    assert rollback_messages[0].set_channel.index == 1
-    assert rollback_messages[0].set_channel.role == Channel.Role.DISABLED
-    assert rollback_messages[1].HasField("set_config")
-    assert rollback_messages[1].set_config.HasField("lora")
-    assert rollback_messages[1].set_config.lora.hop_limit == 3
-    assert admin_indexes == [0, 0, 0]
+    rollback_channel_messages = [
+        msg
+        for msg in rollback_messages
+        if msg.HasField("set_channel") and msg.set_channel.role == Channel.Role.DISABLED
+    ]
+    rollback_lora_messages = [
+        msg
+        for msg in rollback_messages
+        if msg.HasField("set_config") and msg.set_config.HasField("lora")
+    ]
+    assert len(rollback_channel_messages) == 1
+    assert rollback_channel_messages[0].set_channel.index == 1
+    assert len(rollback_lora_messages) == 1
+    assert rollback_lora_messages[0].set_config.lora.hop_limit == 3
+    assert admin_indexes == [0, 0, 0, 0]
     assert anode.localConfig.lora.hop_limit == 3
 
 

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -1922,6 +1922,7 @@ def test_onRequestGetMetadata_updates_metadata_under_node_db_lock() -> None:
 
         @property
         def metadata(self) -> mesh_pb2.DeviceMetadata | None:
+            """Metadata property for testing lock state during assignment."""
             return self._metadata
 
         @metadata.setter

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -7,6 +7,7 @@ import logging
 import re
 import threading
 from collections.abc import Callable
+from types import TracebackType
 from typing import Any, Literal, Protocol, cast
 from unittest.mock import MagicMock, patch
 
@@ -56,7 +57,12 @@ class _DropChannelsOnEnterCountLock:
             self.node.channels = None
         return self
 
-    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> Literal[False]:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> Literal[False]:
         _ = (exc_type, exc, tb)
         return False
 
@@ -66,16 +72,24 @@ class _TrackingLock:
 
     def __init__(self, on_exit: Callable[[], None] | None = None) -> None:
         self.enter_count = 0
+        self.is_held = False
         self._on_exit = on_exit
 
     def __enter__(self) -> "_TrackingLock":
         self.enter_count += 1
+        self.is_held = True
         return self
 
-    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> Literal[False]:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> Literal[False]:
         _ = (exc_type, exc, tb)
         if self._on_exit is not None:
             self._on_exit()
+        self.is_held = False
         return False
 
 
@@ -1241,7 +1255,7 @@ def test_setURL_add_only_adds_unique_named_channels(
     assert anode.channels is not None
     assert anode.channels[1].settings.name == "new-ch"
     assert anode.channels[1].role == Channel.Role.SECONDARY
-    anode.writeChannel.assert_called_once_with(1)
+    anode.writeChannel.assert_called_once_with(1, adminIndex=0)
 
 
 @pytest.mark.unit
@@ -1303,6 +1317,64 @@ def test_setURL_add_only_is_transactional_when_slots_are_insufficient(
     after_snapshot = [channel.SerializeToString() for channel in anode.channels]
     assert after_snapshot == before_snapshot
     anode.writeChannel.assert_not_called()
+
+
+@pytest.mark.unit
+def test_setURL_add_only_uses_snapshotted_admin_index_and_rolls_back_on_write_failure(
+    autospec_local_node_iface: Callable[[type[Any]], MagicMock],
+) -> None:
+    """setURL(addOnly=True) should keep using the pre-mutation admin path and rollback local state on failure."""
+    anode = Node(autospec_local_node_iface(MeshInterface), "!12345678", noProto=True)
+
+    primary = Channel(index=0, role=Channel.Role.PRIMARY)
+    primary.settings.name = "primary"
+    primary.settings.psk = b"\x01"
+    disabled1 = Channel(index=1, role=Channel.Role.DISABLED)
+    disabled2 = Channel(index=2, role=Channel.Role.DISABLED)
+    anode.channels = [primary, disabled1, disabled2]
+    before_snapshot = [channel.SerializeToString() for channel in anode.channels]
+
+    write_calls: list[tuple[int, int]] = []
+
+    def _write_then_fail(channel_index: int, adminIndex: int = 0) -> None:  # noqa: N803
+        write_calls.append((channel_index, adminIndex))
+        if len(write_calls) == 2:
+            raise RuntimeError("write failed during addOnly batch")
+
+    anode.writeChannel = MagicMock(side_effect=_write_then_fail)  # type: ignore[method-assign]
+    anode._send_admin = MagicMock(return_value=mesh_pb2.MeshPacket())  # type: ignore[method-assign]
+
+    channel_set = apponly_pb2.ChannelSet()
+    first = channel_set.settings.add()
+    first.name = "admin"
+    first.psk = b"\x03"
+    second = channel_set.settings.add()
+    second.name = "new-b"
+    second.psk = b"\x04"
+    encoded = base64.urlsafe_b64encode(channel_set.SerializeToString()).decode("ascii")
+    url = f"https://meshtastic.org/e/#{encoded.rstrip('=')}"
+
+    with pytest.raises(RuntimeError, match="write failed during addOnly batch"):
+        anode.setURL(url, addOnly=True)
+
+    # Admin index is snapshotted before local mutation (0 fallback here),
+    # even though a staged channel is named "admin".
+    assert write_calls == [(1, 0), (2, 0)]
+
+    assert anode.channels is not None
+    after_snapshot = [channel.SerializeToString() for channel in anode.channels]
+    assert after_snapshot == before_snapshot
+
+    # First channel write was considered sent; rollback path should attempt
+    # to restore it using the same snapshotted admin path.
+    assert anode._send_admin.call_count == 1
+    rollback_call = anode._send_admin.call_args
+    assert rollback_call is not None
+    rollback_msg = rollback_call.args[0]
+    assert isinstance(rollback_msg, admin_pb2.AdminMessage)
+    assert rollback_msg.set_channel.index == 1
+    assert rollback_msg.set_channel.role == Channel.Role.DISABLED
+    assert rollback_call.kwargs["adminIndex"] == 0
 
 
 @pytest.mark.unit
@@ -1775,7 +1847,8 @@ def test_onRequestGetMetadata_updates_metadata_under_node_db_lock(
     """onRequestGetMetadata should update iface.metadata while holding iface._node_db_lock."""
     iface = autospec_local_node_iface(MeshInterface)
     iface._acknowledgment = Acknowledgment()
-    iface._node_db_lock = _TrackingLock()
+    lock = _TrackingLock()
+    iface._node_db_lock = lock
     anode = Node(iface, "!12345678", noProto=True)
     anode._timeout = MagicMock()
 
@@ -1788,11 +1861,20 @@ def test_onRequestGetMetadata_updates_metadata_under_node_db_lock(
     response.hw_model = mesh_pb2.HardwareModel.PORTDUINO
     response.hasPKC = True
 
+    def _assert_assignment_happened_while_locked() -> None:
+        assert lock.is_held
+        metadata = iface.metadata
+        assert isinstance(metadata, mesh_pb2.DeviceMetadata)
+        assert metadata.firmware_version == "2.7.19"
+
+    lock._on_exit = _assert_assignment_happened_while_locked
+
     anode.onRequestGetMetadata(
         {"decoded": {"portnum": "ADMIN_APP", "admin": {"raw": raw}}}
     )
 
-    assert iface._node_db_lock.enter_count == 1
+    assert lock.enter_count == 1
+    assert lock.is_held is False
     assert iface.metadata.firmware_version == "2.7.19"
 
 

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -39,7 +39,7 @@ class _FakeSendAdminProtocol(Protocol):
         msg: admin_pb2.AdminMessage,
         wantResponse: bool = False,
         onResponse: Callable[[dict[str, Any]], Any] | None = None,
-        adminIndex: int = 0,
+        adminIndex: int | None = None,
     ) -> mesh_pb2.MeshPacket | None: ...
 
 
@@ -87,9 +87,9 @@ class _TrackingLock:
         tb: TracebackType | None,
     ) -> Literal[False]:
         _ = (exc_type, exc, tb)
+        self.is_held = False
         if self._on_exit is not None:
             self._on_exit()
-        self.is_held = False
         return False
 
 
@@ -107,7 +107,7 @@ def _make_fake_send_admin(
         msg: admin_pb2.AdminMessage,
         wantResponse: bool = False,
         onResponse: Callable[[dict[str, Any]], Any] | None = None,
-        adminIndex: int = 0,
+        adminIndex: int | None = None,
     ) -> mesh_pb2.MeshPacket | None:
         if sent_messages is not None:
             sent_messages.append(msg)
@@ -221,7 +221,7 @@ def test_set_canned_message_sends_payload_and_invalidates_cache(
     anode.iface.localNode.nodeNum = 999
     on_response({"decoded": {"routing": {"errorReason": "NONE"}}, "from": 123})
     assert acknowledgment.receivedAck is True
-    assert captured["adminIndex"] == 0
+    assert captured["adminIndex"] is None
     assert anode.cannedPluginMessage is None
     assert anode.cannedPluginMessageMessages is None
 
@@ -1401,6 +1401,61 @@ def test_setURL_add_only_uses_snapshotted_admin_index_and_rolls_back_on_write_fa
 
 
 @pytest.mark.unit
+def test_setURL_add_only_invalidates_channels_cache_on_partial_rollback_failure(
+    autospec_local_node_iface: Callable[[type[Any]], MagicMock],
+) -> None:
+    """setURL(addOnly=True) should invalidate local channels if channel rollback is partial."""
+    anode = Node(autospec_local_node_iface(MeshInterface), "!12345678", noProto=True)
+
+    primary = Channel(index=0, role=Channel.Role.PRIMARY)
+    primary.settings.name = "primary"
+    primary.settings.psk = b"\x01"
+    disabled1 = Channel(index=1, role=Channel.Role.DISABLED)
+    disabled2 = Channel(index=2, role=Channel.Role.DISABLED)
+    anode.channels = [primary, disabled1, disabled2]
+
+    write_calls = {"count": 0}
+
+    def _write_then_fail(channel_index: int, adminIndex: int | None = None) -> None:  # noqa: N803
+        _ = (channel_index, adminIndex)
+        write_calls["count"] += 1
+        if write_calls["count"] == 2:
+            raise RuntimeError("write failed during addOnly batch")
+
+    send_calls = {"count": 0}
+
+    def _rollback_send_fails_once(
+        msg: admin_pb2.AdminMessage,
+        wantResponse: bool = False,
+        onResponse: Callable[[dict[str, Any]], Any] | None = None,
+        adminIndex: int | None = None,
+    ) -> mesh_pb2.MeshPacket:
+        _ = (wantResponse, onResponse, adminIndex)
+        send_calls["count"] += 1
+        if msg.HasField("set_channel") and send_calls["count"] == 1:
+            raise OSError("channel rollback failed")
+        return mesh_pb2.MeshPacket()
+
+    anode.writeChannel = MagicMock(side_effect=_write_then_fail)  # type: ignore[method-assign]
+    anode._send_admin = _rollback_send_fails_once  # type: ignore[method-assign,assignment]
+
+    channel_set = apponly_pb2.ChannelSet()
+    first = channel_set.settings.add()
+    first.name = "admin"
+    first.psk = b"\x03"
+    second = channel_set.settings.add()
+    second.name = "new-b"
+    second.psk = b"\x04"
+    encoded = base64.urlsafe_b64encode(channel_set.SerializeToString()).decode("ascii")
+    url = f"https://meshtastic.org/e/#{encoded.rstrip('=')}"
+
+    with pytest.raises(RuntimeError, match="write failed during addOnly batch"):
+        anode.setURL(url, addOnly=True)
+
+    assert anode.channels is None
+
+
+@pytest.mark.unit
 def test_setURL_add_only_rolls_back_lora_when_lora_write_fails(
     autospec_local_node_iface: Callable[[type[Any]], MagicMock],
 ) -> None:
@@ -1991,6 +2046,30 @@ def test_onRequestGetMetadata_updates_metadata_under_node_db_lock() -> None:
     metadata = iface.metadata
     assert metadata is not None
     assert metadata.firmware_version == "2.7.19"
+
+
+@pytest.mark.unit
+def test_set_metadata_snapshot_stores_detached_copy_under_lock(
+    autospec_local_node_iface: Callable[[type[Any]], MagicMock],
+) -> None:
+    """_set_metadata_snapshot should store a detached metadata copy while holding node DB lock."""
+    iface = autospec_local_node_iface(MeshInterface)
+    lock = _TrackingLock()
+    iface._node_db_lock = lock
+    anode = Node(iface, "!12345678", noProto=True)
+    metadata_snapshot = mesh_pb2.DeviceMetadata(
+        firmware_version="2.7.19",
+        device_state_version=25,
+    )
+
+    anode._set_metadata_snapshot(metadata_snapshot)
+
+    assert lock.enter_count == 1
+    assert isinstance(iface.metadata, mesh_pb2.DeviceMetadata)
+    assert iface.metadata is not metadata_snapshot
+    assert iface.metadata.firmware_version == "2.7.19"
+    metadata_snapshot.firmware_version = "mutated-locally"
+    assert iface.metadata.firmware_version == "2.7.19"
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -1266,6 +1266,46 @@ def test_setURL_add_only_raises_when_no_disabled_slot_available(
 
 
 @pytest.mark.unit
+def test_setURL_add_only_is_transactional_when_slots_are_insufficient(
+    autospec_local_node_iface: Callable[[type[Any]], MagicMock],
+) -> None:
+    """setURL(addOnly=True) should not partially mutate channels when it fails for capacity."""
+    anode = Node(autospec_local_node_iface(MeshInterface), "!12345678", noProto=True)
+
+    primary = Channel(index=0, role=Channel.Role.PRIMARY)
+    primary.settings.name = "primary"
+    primary.settings.psk = b"\x01"
+    secondary = Channel(index=1, role=Channel.Role.SECONDARY)
+    secondary.settings.name = "existing"
+    secondary.settings.psk = b"\x02"
+    disabled = Channel(index=2, role=Channel.Role.DISABLED)
+    anode.channels = [primary, secondary, disabled]
+    anode.writeChannel = MagicMock()  # type: ignore[method-assign]
+
+    before_snapshot = [channel.SerializeToString() for channel in anode.channels]
+
+    channel_set = apponly_pb2.ChannelSet()
+    first = channel_set.settings.add()
+    first.name = "new-a"
+    first.psk = b"\x03"
+    second = channel_set.settings.add()
+    second.name = "new-b"
+    second.psk = b"\x04"
+    encoded = base64.urlsafe_b64encode(channel_set.SerializeToString()).decode("ascii")
+    url = f"https://meshtastic.org/e/#{encoded.rstrip('=')}"
+
+    with pytest.raises(
+        MeshInterface.MeshInterfaceError, match="No free channels were found"
+    ):
+        anode.setURL(url, addOnly=True)
+
+    assert anode.channels is not None
+    after_snapshot = [channel.SerializeToString() for channel in anode.channels]
+    assert after_snapshot == before_snapshot
+    anode.writeChannel.assert_not_called()
+
+
+@pytest.mark.unit
 def test_setURL_replace_raises_if_channels_disappear_during_assignment(
     autospec_local_node_iface: Callable[[type[Any]], MagicMock],
 ) -> None:

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -1321,6 +1321,8 @@ def test_setURL_add_only_requires_loaded_lora_config(
     primary.settings.name = "primary"
     disabled = Channel(index=1, role=Channel.Role.DISABLED)
     anode.channels = [primary, disabled]
+    before_snapshot = [channel.SerializeToString() for channel in anode.channels]
+    anode._send_admin = MagicMock()  # type: ignore[method-assign]
 
     channel_set = apponly_pb2.ChannelSet()
     new_channel = channel_set.settings.add()
@@ -1335,6 +1337,11 @@ def test_setURL_add_only_requires_loaded_lora_config(
         match=re.escape("LoRa config must be loaded before setURL(addOnly=True)"),
     ):
         anode.setURL(url, addOnly=True)
+
+    assert anode.channels is not None
+    after_snapshot = [channel.SerializeToString() for channel in anode.channels]
+    assert after_snapshot == before_snapshot
+    anode._send_admin.assert_not_called()
 
 
 @pytest.mark.unit
@@ -1508,6 +1515,8 @@ def test_setURL_add_only_invalidates_channels_cache_on_partial_rollback_failure(
     with pytest.raises(RuntimeError, match="write failed during addOnly batch"):
         anode.setURL(url, addOnly=True)
 
+    assert send_calls["stage_writes"] == 2
+    assert send_calls["rollback_failures"] == 1
     assert anode.channels is None
 
 
@@ -1587,6 +1596,63 @@ def test_setURL_add_only_rolls_back_lora_when_lora_write_fails(
     assert rollback_lora_messages[0].set_config.lora.hop_limit == 3
     assert admin_indexes == [0, 0, 0, 0]
     assert anode.localConfig.lora.hop_limit == 3
+
+
+@pytest.mark.unit
+def test_setURL_replace_pins_admin_index_for_channel_and_lora_writes(
+    autospec_local_node_iface: Callable[[type[Any]], MagicMock],
+) -> None:
+    """setURL(addOnly=False) should pin admin path from pre-rewrite channel state."""
+    iface = autospec_local_node_iface(MeshInterface)
+    iface.localNode._get_admin_channel_index.return_value = 1
+    anode = Node(iface, "!12345678", noProto=False)
+
+    primary = Channel(index=0, role=Channel.Role.PRIMARY)
+    primary.settings.name = "primary"
+    legacy_admin = Channel(index=1, role=Channel.Role.SECONDARY)
+    legacy_admin.settings.name = "admin"
+    anode.channels = [primary, legacy_admin]
+    anode.ensureSessionKey = MagicMock()  # type: ignore[method-assign]
+
+    sent_messages: list[admin_pb2.AdminMessage] = []
+    admin_indexes: list[int | None] = []
+
+    def _capture_admin_index(
+        msg: admin_pb2.AdminMessage,
+        wantResponse: bool = False,
+        onResponse: Callable[[dict[str, Any]], Any] | None = None,
+        adminIndex: int | None = None,
+    ) -> mesh_pb2.MeshPacket:
+        _ = (wantResponse, onResponse)
+        sent_messages.append(msg)
+        admin_indexes.append(adminIndex)
+        return mesh_pb2.MeshPacket()
+
+    anode._send_admin = _capture_admin_index  # type: ignore[method-assign,assignment]
+
+    channel_set = apponly_pb2.ChannelSet()
+    first = channel_set.settings.add()
+    first.name = "new-primary"
+    first.psk = b"\x11"
+    second = channel_set.settings.add()
+    second.name = "new-secondary"
+    second.psk = b"\x12"
+    channel_set.lora_config.hop_limit = 9
+    encoded = base64.urlsafe_b64encode(channel_set.SerializeToString()).decode("ascii")
+    url = f"https://meshtastic.org/e/#{encoded.rstrip('=')}"
+
+    anode.setURL(url, addOnly=False)
+
+    assert len(sent_messages) == 3
+    assert admin_indexes == [1, 1, 1]
+    assert sent_messages[0].HasField("set_channel")
+    assert sent_messages[0].set_channel.index == 0
+    assert sent_messages[1].HasField("set_channel")
+    assert sent_messages[1].set_channel.index == 1
+    assert sent_messages[2].HasField("set_config")
+    assert sent_messages[2].set_config.HasField("lora")
+    assert sent_messages[2].set_config.lora.hop_limit == 9
+    assert anode.localConfig.lora.hop_limit == 9
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -635,6 +635,25 @@ def test_writeChannel_with_no_channels_raises_mesh_error(
 
 
 @pytest.mark.unit
+def test_writeChannel_forwards_admin_index_to_session_key_bootstrap(
+    autospec_local_node_iface: Callable[[type[Any]], MagicMock],
+) -> None:
+    """writeChannel should use the same admin index for session bootstrap and channel write."""
+    anode = Node(autospec_local_node_iface(MeshInterface), "!12345678", noProto=True)
+    primary = Channel(index=0, role=Channel.Role.PRIMARY)
+    primary.settings.name = "primary"
+    primary.settings.psk = b"\x01"
+    anode.channels = [primary]
+    anode.ensureSessionKey = MagicMock()  # type: ignore[method-assign]
+    anode._send_admin = MagicMock(return_value=mesh_pb2.MeshPacket())  # type: ignore[method-assign]
+
+    anode.writeChannel(0, adminIndex=4)
+
+    anode.ensureSessionKey.assert_called_once_with(adminIndex=4)
+    assert anode._send_admin.call_args.kwargs["adminIndex"] == 4
+
+
+@pytest.mark.unit
 def test_writeConfig_traffic_management(
     autospec_local_node_iface: Callable[[type[Any]], MagicMock],
 ) -> None:
@@ -1323,7 +1342,7 @@ def test_setURL_add_only_is_transactional_when_slots_are_insufficient(
 def test_setURL_add_only_uses_snapshotted_admin_index_and_rolls_back_on_write_failure(
     autospec_local_node_iface: Callable[[type[Any]], MagicMock],
 ) -> None:
-    """setURL(addOnly=True) should keep using the pre-mutation admin path and rollback local state on failure."""
+    """setURL(addOnly=True) should keep using pre-mutation admin path and rollback local channel state."""
     anode = Node(autospec_local_node_iface(MeshInterface), "!12345678", noProto=True)
 
     primary = Channel(index=0, role=Channel.Role.PRIMARY)
@@ -1366,20 +1385,15 @@ def test_setURL_add_only_uses_snapshotted_admin_index_and_rolls_back_on_write_fa
     assert after_snapshot == before_snapshot
 
     # First channel write was considered sent; rollback path should attempt
-    # to restore that channel and the previous LoRa config using the same
-    # snapshotted admin path.
+    # to restore that channel using the same snapshotted admin path.
+    # No LoRa rollback is attempted because no verified local LoRa snapshot exists.
     rollback_calls = anode._send_admin.call_args_list
-    assert len(rollback_calls) == 2
+    assert len(rollback_calls) == 1
     rollback_channel_msg = rollback_calls[0].args[0]
-    rollback_lora_msg = rollback_calls[1].args[0]
     assert isinstance(rollback_channel_msg, admin_pb2.AdminMessage)
     assert rollback_channel_msg.set_channel.index == 1
     assert rollback_channel_msg.set_channel.role == Channel.Role.DISABLED
     assert rollback_calls[0].kwargs["adminIndex"] == 0
-    assert isinstance(rollback_lora_msg, admin_pb2.AdminMessage)
-    assert rollback_lora_msg.HasField("set_config")
-    assert rollback_lora_msg.set_config.HasField("lora")
-    assert rollback_calls[1].kwargs["adminIndex"] == 0
 
 
 @pytest.mark.unit
@@ -1632,15 +1646,15 @@ def test_send_admin_uses_session_passkey_and_selected_admin_index(
 def test_ensureSessionKey_requests_only_when_missing(
     autospec_local_node_iface: Callable[[type[Any]], MagicMock],
 ) -> None:
-    """EnsureSessionKey should request a key only if one is not already cached."""
+    """EnsureSessionKey should request only when missing and forward the selected admin index."""
     iface = autospec_local_node_iface(MeshInterface)
     anode = Node(iface, 555, noProto=False)
     anode.requestConfig = MagicMock()  # type: ignore[method-assign]
 
     iface._get_or_create_by_num.return_value = {}
-    anode.ensureSessionKey()
+    anode.ensureSessionKey(adminIndex=6)
     anode.requestConfig.assert_called_once_with(
-        admin_pb2.AdminMessage.SESSIONKEY_CONFIG
+        admin_pb2.AdminMessage.SESSIONKEY_CONFIG, adminIndex=6
     )
 
     anode.requestConfig.reset_mock()

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -2053,7 +2053,7 @@ def test_ensureSessionKey_requests_only_when_missing(
         _get_mock_call_arg(
             request_config_call,
             name="adminIndex",
-            positional_index=2,
+            positional_index=1,
         )
         == 6
     )

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -128,6 +128,13 @@ def _make_fake_send_admin(
     return _fake_send_admin
 
 
+def _get_mock_call_arg(call: Any, *, name: str, positional_index: int) -> Any:
+    """Resolve a mock call argument regardless of positional/keyword call style."""
+    if len(call.args) > positional_index:
+        return call.args[positional_index]
+    return call.kwargs.get(name)
+
+
 @pytest.mark.unit
 def test_tracking_lock_rejects_nested_acquisition() -> None:
     """_TrackingLock should fail on nested acquisition attempts."""
@@ -665,8 +672,22 @@ def test_writeChannel_forwards_admin_index_to_session_key_bootstrap(
 
     anode.writeChannel(0, adminIndex=4)
 
-    anode.ensureSessionKey.assert_called_once_with(adminIndex=4)
-    assert anode._send_admin.call_args.kwargs["adminIndex"] == 4
+    assert (
+        _get_mock_call_arg(
+            anode.ensureSessionKey.call_args,
+            name="adminIndex",
+            positional_index=0,
+        )
+        == 4
+    )
+    assert (
+        _get_mock_call_arg(
+            anode._send_admin.call_args,
+            name="adminIndex",
+            positional_index=3,
+        )
+        == 4
+    )
 
 
 @pytest.mark.unit
@@ -1155,7 +1176,8 @@ def test_deleteChannel_rewrites_following_channels_and_updates_admin_index(
     assert len(anode.channels) == CHANNEL_LIMIT
     assert anode._send_admin.call_count == CHANNEL_LIMIT - 1
     assert all(
-        call.kwargs["adminIndex"] == 0 for call in anode._send_admin.call_args_list
+        _get_mock_call_arg(call, name="adminIndex", positional_index=3) == 0
+        for call in anode._send_admin.call_args_list
     )
 
 
@@ -1295,10 +1317,10 @@ def test_setURL_add_only_adds_unique_named_channels(
     assert anode.localConfig.lora.hop_limit == 9
     send_calls = anode._send_admin.call_args_list
     assert len(send_calls) == 2
-    assert send_calls[0].kwargs["adminIndex"] == 0
+    assert _get_mock_call_arg(send_calls[0], name="adminIndex", positional_index=3) == 0
     assert send_calls[0].args[0].HasField("set_channel")
     assert send_calls[0].args[0].set_channel.index == 1
-    assert send_calls[1].kwargs["adminIndex"] == 0
+    assert _get_mock_call_arg(send_calls[1], name="adminIndex", positional_index=3) == 0
     assert send_calls[1].args[0].HasField("set_config")
     assert send_calls[1].args[0].set_config.lora.hop_limit == 9
 
@@ -1366,6 +1388,7 @@ def test_setURL_add_only_requires_loaded_lora_config(
     disabled = Channel(index=1, role=Channel.Role.DISABLED)
     anode.channels = [primary, disabled]
     before_snapshot = [channel.SerializeToString() for channel in anode.channels]
+    before_local_config = anode.localConfig.SerializeToString()
     anode._send_admin = MagicMock()  # type: ignore[method-assign]
 
     channel_set = apponly_pb2.ChannelSet()
@@ -1385,6 +1408,7 @@ def test_setURL_add_only_requires_loaded_lora_config(
     assert anode.channels is not None
     after_snapshot = [channel.SerializeToString() for channel in anode.channels]
     assert after_snapshot == before_snapshot
+    assert anode.localConfig.SerializeToString() == before_local_config
     anode._send_admin.assert_not_called()
 
 
@@ -1493,7 +1517,7 @@ def test_setURL_add_only_uses_snapshotted_admin_index_and_rolls_back_on_write_fa
 
     assert ensure_session_key_spy.call_args_list
     assert all(
-        call.kwargs.get("adminIndex") == 0
+        _get_mock_call_arg(call, name="adminIndex", positional_index=0) == 0
         for call in ensure_session_key_spy.call_args_list
     )
 
@@ -1571,7 +1595,7 @@ def test_setURL_add_only_invalidates_channels_cache_on_partial_rollback_failure(
 
     assert ensure_session_key_spy.call_args_list
     assert all(
-        call.kwargs.get("adminIndex") == 0
+        _get_mock_call_arg(call, name="adminIndex", positional_index=0) == 0
         for call in ensure_session_key_spy.call_args_list
     )
     assert send_calls["stage_writes"] == 2
@@ -1637,7 +1661,7 @@ def test_setURL_add_only_rolls_back_lora_when_lora_write_fails(
 
     assert ensure_session_key_spy.call_args_list
     assert all(
-        call.kwargs.get("adminIndex") == 0
+        _get_mock_call_arg(call, name="adminIndex", positional_index=0) == 0
         for call in ensure_session_key_spy.call_args_list
     )
     assert anode.channels is not None
@@ -1714,7 +1738,7 @@ def test_setURL_replace_pins_admin_index_for_channel_and_lora_writes(
 
     assert ensure_session_key_spy.call_args_list
     assert all(
-        call.kwargs.get("adminIndex") == 1
+        _get_mock_call_arg(call, name="adminIndex", positional_index=0) == 1
         for call in ensure_session_key_spy.call_args_list
     )
     assert len(sent_messages) == 3
@@ -1758,6 +1782,53 @@ def test_setURL_replace_channel_only_url_skips_lora_write_and_cache_update(
     assert len(send_calls) == 2
     assert all(call.args[0].HasField("set_channel") for call in send_calls)
     assert anode.localConfig.lora.hop_limit == 3
+
+
+@pytest.mark.unit
+def test_setURL_replace_disables_channels_omitted_from_url(
+    autospec_local_node_iface: Callable[[type[Any]], MagicMock],
+) -> None:
+    """setURL(addOnly=False) should disable stale channels not present in the replacement URL."""
+    anode = Node(autospec_local_node_iface(MeshInterface), "!12345678", noProto=True)
+    anode.iface.localNode = anode
+
+    primary = Channel(index=0, role=Channel.Role.PRIMARY)
+    primary.settings.name = "primary"
+    admin_secondary = Channel(index=1, role=Channel.Role.SECONDARY)
+    admin_secondary.settings.name = "admin"
+    stale_secondary_a = Channel(index=2, role=Channel.Role.SECONDARY)
+    stale_secondary_a.settings.name = "stale-a"
+    stale_secondary_b = Channel(index=3, role=Channel.Role.SECONDARY)
+    stale_secondary_b.settings.name = "stale-b"
+    anode.channels = [primary, admin_secondary, stale_secondary_a, stale_secondary_b]
+    anode._send_admin = MagicMock(return_value=mesh_pb2.MeshPacket())  # type: ignore[method-assign]
+
+    channel_set = apponly_pb2.ChannelSet()
+    first = channel_set.settings.add()
+    first.name = "new-primary"
+    first.psk = b"\x11"
+    encoded = base64.urlsafe_b64encode(channel_set.SerializeToString()).decode("ascii")
+    url = f"https://meshtastic.org/e/#{encoded.rstrip('=')}"
+
+    anode.setURL(url, addOnly=False)
+
+    assert anode.channels is not None
+    assert anode.channels[0].settings.name == "new-primary"
+    for channel_index in (1, 2, 3):
+        assert anode.channels[channel_index].role == Channel.Role.DISABLED
+        assert anode.channels[channel_index].settings.name == ""
+
+    channel_writes = [
+        call.args[0].set_channel
+        for call in anode._send_admin.call_args_list
+        if call.args[0].HasField("set_channel")
+    ]
+    assert {channel.index for channel in channel_writes} == {0, 1, 2, 3}
+    assert {
+        channel.index
+        for channel in channel_writes
+        if channel.role == Channel.Role.DISABLED
+    } == {1, 2, 3}
 
 
 @pytest.mark.unit
@@ -1975,8 +2046,16 @@ def test_ensureSessionKey_requests_only_when_missing(
 
     iface._get_or_create_by_num.return_value = {}
     anode.ensureSessionKey(adminIndex=6)
-    anode.requestConfig.assert_called_once_with(
-        admin_pb2.AdminMessage.SESSIONKEY_CONFIG, adminIndex=6
+    assert anode.requestConfig.call_count == 1
+    request_config_call = anode.requestConfig.call_args
+    assert request_config_call.args[0] == admin_pb2.AdminMessage.SESSIONKEY_CONFIG
+    assert (
+        _get_mock_call_arg(
+            request_config_call,
+            name="adminIndex",
+            positional_index=2,
+        )
+        == 6
     )
 
     anode.requestConfig.reset_mock()

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -1256,6 +1256,7 @@ def test_setURL_add_only_adds_unique_named_channels(
     primary.settings.name = "existing"
     disabled = Channel(index=1, role=Channel.Role.DISABLED)
     anode.channels = [primary, disabled]
+    anode.localConfig.lora.hop_limit = 3
     anode.writeChannel = MagicMock()  # type: ignore[method-assign]
 
     channel_set = apponly_pb2.ChannelSet()
@@ -1288,6 +1289,7 @@ def test_setURL_add_only_raises_when_no_disabled_slot_available(
     """setURL(addOnly=True) should fail if no DISABLED channels remain."""
     anode = Node(autospec_local_node_iface(MeshInterface), "!12345678", noProto=True)
     anode.channels = [Channel(index=i, role=Channel.Role.SECONDARY) for i in range(2)]
+    anode.localConfig.lora.hop_limit = 3
 
     channel_set = apponly_pb2.ChannelSet()
     new_channel = channel_set.settings.add()
@@ -1298,6 +1300,32 @@ def test_setURL_add_only_raises_when_no_disabled_slot_available(
 
     with pytest.raises(
         MeshInterface.MeshInterfaceError, match="No free channels were found"
+    ):
+        anode.setURL(url, addOnly=True)
+
+
+@pytest.mark.unit
+def test_setURL_add_only_requires_loaded_lora_config(
+    autospec_local_node_iface: Callable[[type[Any]], MagicMock],
+) -> None:
+    """setURL(addOnly=True) should require cached LoRa config so rollback is possible."""
+    anode = Node(autospec_local_node_iface(MeshInterface), "!12345678", noProto=True)
+    primary = Channel(index=0, role=Channel.Role.PRIMARY)
+    primary.settings.name = "primary"
+    disabled = Channel(index=1, role=Channel.Role.DISABLED)
+    anode.channels = [primary, disabled]
+
+    channel_set = apponly_pb2.ChannelSet()
+    new_channel = channel_set.settings.add()
+    new_channel.name = "new-ch"
+    new_channel.psk = b"\x03"
+    channel_set.lora_config.hop_limit = 9
+    encoded = base64.urlsafe_b64encode(channel_set.SerializeToString()).decode("ascii")
+    url = f"https://meshtastic.org/e/#{encoded.rstrip('=')}"
+
+    with pytest.raises(
+        MeshInterface.MeshInterfaceError,
+        match=re.escape("LoRa config must be loaded before setURL(addOnly=True)"),
     ):
         anode.setURL(url, addOnly=True)
 
@@ -1360,6 +1388,7 @@ def test_setURL_add_only_uses_snapshotted_admin_index_and_rolls_back_on_write_fa
     disabled1 = Channel(index=1, role=Channel.Role.DISABLED)
     disabled2 = Channel(index=2, role=Channel.Role.DISABLED)
     anode.channels = [primary, disabled1, disabled2]
+    anode.localConfig.lora.hop_limit = 3
     before_snapshot = [channel.SerializeToString() for channel in anode.channels]
 
     write_calls: list[tuple[int, int]] = []
@@ -1395,7 +1424,7 @@ def test_setURL_add_only_uses_snapshotted_admin_index_and_rolls_back_on_write_fa
 
     # Rollback should include the in-flight channel index as well, so both staged
     # channels are restored when writeChannel fails mid-send.
-    # No LoRa rollback is attempted because no verified local LoRa snapshot exists.
+    # No LoRa rollback is attempted because the LoRa write never started.
     rollback_calls = anode._send_admin.call_args_list
     assert len(rollback_calls) == 2
     rollback_channel_msg = rollback_calls[0].args[0]
@@ -1423,6 +1452,7 @@ def test_setURL_add_only_invalidates_channels_cache_on_partial_rollback_failure(
     disabled1 = Channel(index=1, role=Channel.Role.DISABLED)
     disabled2 = Channel(index=2, role=Channel.Role.DISABLED)
     anode.channels = [primary, disabled1, disabled2]
+    anode.localConfig.lora.hop_limit = 3
 
     write_calls = {"count": 0}
 
@@ -1877,6 +1907,7 @@ def test_setURL_add_only_rechecks_channels_before_addition(
     """SetURL(addOnly=True) should fail if channels disappear before add loop mutation."""
     anode = Node(autospec_local_node_iface(MeshInterface), "!12345678", noProto=True)
     anode.channels = [Channel(index=0, role=Channel.Role.DISABLED)]
+    anode.localConfig.lora.hop_limit = 3
     anode._channels_lock = _DropChannelsOnEnterCountLock(  # type: ignore[assignment]
         anode, trigger_enter=2
     )
@@ -2066,14 +2097,29 @@ def test_onRequestGetMetadata_updates_metadata_under_node_db_lock() -> None:
 
 
 @pytest.mark.unit
-def test_set_metadata_snapshot_stores_detached_copy_under_lock(
-    autospec_local_node_iface: Callable[[type[Any]], MagicMock],
-) -> None:
+def test_set_metadata_snapshot_stores_detached_copy_under_lock() -> None:
     """_set_metadata_snapshot should store a detached metadata copy while holding node DB lock."""
-    iface = autospec_local_node_iface(MeshInterface)
     lock = _TrackingLock()
-    iface._node_db_lock = lock
-    anode = Node(iface, "!12345678", noProto=True)
+
+    class _MetadataSnapshotProbeIface:
+        """Minimal interface stub that records lock state during metadata assignment."""
+
+        def __init__(self, node_db_lock: _TrackingLock) -> None:
+            self._node_db_lock = node_db_lock
+            self._metadata: mesh_pb2.DeviceMetadata | None = None
+            self.metadata_assignment_lock_state: bool | None = None
+
+        @property
+        def metadata(self) -> mesh_pb2.DeviceMetadata | None:
+            return self._metadata
+
+        @metadata.setter
+        def metadata(self, value: mesh_pb2.DeviceMetadata | None) -> None:
+            self.metadata_assignment_lock_state = self._node_db_lock.is_held
+            self._metadata = value
+
+    iface = _MetadataSnapshotProbeIface(lock)
+    anode = Node(cast(Any, iface), "!12345678", noProto=True)
     metadata_snapshot = mesh_pb2.DeviceMetadata(
         firmware_version="2.7.19",
         device_state_version=25,
@@ -2082,11 +2128,14 @@ def test_set_metadata_snapshot_stores_detached_copy_under_lock(
     anode._set_metadata_snapshot(metadata_snapshot)
 
     assert lock.enter_count == 1
-    assert isinstance(iface.metadata, mesh_pb2.DeviceMetadata)
-    assert iface.metadata is not metadata_snapshot
-    assert iface.metadata.firmware_version == "2.7.19"
+    assert lock.is_held is False
+    assert iface.metadata_assignment_lock_state is True
+    metadata = iface.metadata
+    assert isinstance(metadata, mesh_pb2.DeviceMetadata)
+    assert metadata is not metadata_snapshot
+    assert metadata.firmware_version == "2.7.19"
     metadata_snapshot.firmware_version = "mutated-locally"
-    assert iface.metadata.firmware_version == "2.7.19"
+    assert metadata.firmware_version == "2.7.19"
 
 
 @pytest.mark.unit
@@ -2160,7 +2209,7 @@ def test_emit_cached_metadata_reads_metadata_under_node_db_lock(
     autospec_local_node_iface: Callable[[type[Any]], MagicMock],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """_emit_cached_metadata_for_stdout should snapshot metadata before lock release."""
+    """_emit_cached_metadata_for_stdout should emit snapshot lines after lock release."""
     iface = autospec_local_node_iface(MeshInterface)
     original_metadata = mesh_pb2.DeviceMetadata(
         firmware_version="2.7.18",
@@ -2181,13 +2230,21 @@ def test_emit_cached_metadata_reads_metadata_under_node_db_lock(
 
     iface._node_db_lock = _TrackingLock(on_exit=_mutate_metadata_after_unlock)
     anode = Node(iface, "!12345678", noProto=True)
-    emitted: list[str] = []
-    monkeypatch.setattr(anode, "_emit_metadata_line", emitted.append)
+    emitted: list[tuple[str, bool]] = []
+
+    def _record_emit(line: str) -> None:
+        emitted.append((line, iface._node_db_lock.is_held))
+
+    monkeypatch.setattr(anode, "_emit_metadata_line", _record_emit)
 
     assert anode._emit_cached_metadata_for_stdout() is True
+    assert emitted
     assert iface._node_db_lock.enter_count == 1
-    assert any("firmware_version: 2.7.18" in line for line in emitted)
-    assert not any("firmware_version: mutated-after-unlock" in line for line in emitted)
+    assert all(not is_held for _line, is_held in emitted)
+    assert any("firmware_version: 2.7.18" in line for line, _ in emitted)
+    assert not any(
+        "firmware_version: mutated-after-unlock" in line for line, _ in emitted
+    )
     assert iface.metadata is original_metadata
     assert iface.metadata.firmware_version == "mutated-after-unlock"
 

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -1388,16 +1388,21 @@ def test_setURL_add_only_uses_snapshotted_admin_index_and_rolls_back_on_write_fa
     after_snapshot = [channel.SerializeToString() for channel in anode.channels]
     assert after_snapshot == before_snapshot
 
-    # First channel write was considered sent; rollback path should attempt
-    # to restore that channel using the same snapshotted admin path.
+    # Rollback should include the in-flight channel index as well, so both staged
+    # channels are restored when writeChannel fails mid-send.
     # No LoRa rollback is attempted because no verified local LoRa snapshot exists.
     rollback_calls = anode._send_admin.call_args_list
-    assert len(rollback_calls) == 1
+    assert len(rollback_calls) == 2
     rollback_channel_msg = rollback_calls[0].args[0]
     assert isinstance(rollback_channel_msg, admin_pb2.AdminMessage)
     assert rollback_channel_msg.set_channel.index == 1
     assert rollback_channel_msg.set_channel.role == Channel.Role.DISABLED
     assert rollback_calls[0].kwargs["adminIndex"] == 0
+    rollback_in_flight_msg = rollback_calls[1].args[0]
+    assert isinstance(rollback_in_flight_msg, admin_pb2.AdminMessage)
+    assert rollback_in_flight_msg.set_channel.index == 2
+    assert rollback_in_flight_msg.set_channel.role == Channel.Role.DISABLED
+    assert rollback_calls[1].kwargs["adminIndex"] == 0
 
 
 @pytest.mark.unit
@@ -2020,7 +2025,7 @@ def test_onRequestGetMetadata_updates_metadata_under_node_db_lock() -> None:
 
         @metadata.setter
         def metadata(self, value: mesh_pb2.DeviceMetadata | None) -> None:
-            self.metadata_assignment_lock_state = lock.is_held
+            self.metadata_assignment_lock_state = self._node_db_lock.is_held
             self._metadata = value
 
     iface = _MetadataAssignmentProbeIface(lock)

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -1366,15 +1366,81 @@ def test_setURL_add_only_uses_snapshotted_admin_index_and_rolls_back_on_write_fa
     assert after_snapshot == before_snapshot
 
     # First channel write was considered sent; rollback path should attempt
-    # to restore it using the same snapshotted admin path.
-    assert anode._send_admin.call_count == 1
-    rollback_call = anode._send_admin.call_args
-    assert rollback_call is not None
-    rollback_msg = rollback_call.args[0]
-    assert isinstance(rollback_msg, admin_pb2.AdminMessage)
-    assert rollback_msg.set_channel.index == 1
-    assert rollback_msg.set_channel.role == Channel.Role.DISABLED
-    assert rollback_call.kwargs["adminIndex"] == 0
+    # to restore that channel and the previous LoRa config using the same
+    # snapshotted admin path.
+    rollback_calls = anode._send_admin.call_args_list
+    assert len(rollback_calls) == 2
+    rollback_channel_msg = rollback_calls[0].args[0]
+    rollback_lora_msg = rollback_calls[1].args[0]
+    assert isinstance(rollback_channel_msg, admin_pb2.AdminMessage)
+    assert rollback_channel_msg.set_channel.index == 1
+    assert rollback_channel_msg.set_channel.role == Channel.Role.DISABLED
+    assert rollback_calls[0].kwargs["adminIndex"] == 0
+    assert isinstance(rollback_lora_msg, admin_pb2.AdminMessage)
+    assert rollback_lora_msg.HasField("set_config")
+    assert rollback_lora_msg.set_config.HasField("lora")
+    assert rollback_calls[1].kwargs["adminIndex"] == 0
+
+
+@pytest.mark.unit
+def test_setURL_add_only_rolls_back_lora_when_lora_write_fails(
+    autospec_local_node_iface: Callable[[type[Any]], MagicMock],
+) -> None:
+    """setURL(addOnly=True) should rollback channels and LoRa when final LoRa write fails."""
+    anode = Node(autospec_local_node_iface(MeshInterface), "!12345678", noProto=True)
+
+    primary = Channel(index=0, role=Channel.Role.PRIMARY)
+    primary.settings.name = "primary"
+    primary.settings.psk = b"\x01"
+    disabled = Channel(index=1, role=Channel.Role.DISABLED)
+    anode.channels = [primary, disabled]
+    before_snapshot = [channel.SerializeToString() for channel in anode.channels]
+    anode.localConfig.lora.hop_limit = 3
+    anode.writeChannel = MagicMock()  # type: ignore[method-assign]
+
+    failed_lora_send = {"seen": False}
+    rollback_messages: list[admin_pb2.AdminMessage] = []
+
+    def _send_admin_with_lora_failure(
+        msg: admin_pb2.AdminMessage,
+        wantResponse: bool = False,
+        onResponse: Callable[[dict[str, Any]], Any] | None = None,
+        adminIndex: int = 0,
+    ) -> mesh_pb2.MeshPacket:
+        _ = (wantResponse, onResponse, adminIndex)
+        if msg.HasField("set_config") and msg.set_config.HasField("lora"):
+            if not failed_lora_send["seen"] and msg.set_config.lora.hop_limit == 9:
+                failed_lora_send["seen"] = True
+                raise OSError("LoRa write failed")
+        rollback_messages.append(msg)
+        return mesh_pb2.MeshPacket()
+
+    anode._send_admin = _send_admin_with_lora_failure  # type: ignore[method-assign,assignment]
+
+    channel_set = apponly_pb2.ChannelSet()
+    added = channel_set.settings.add()
+    added.name = "new-channel"
+    added.psk = b"\x03"
+    channel_set.lora_config.hop_limit = 9
+    encoded = base64.urlsafe_b64encode(channel_set.SerializeToString()).decode("ascii")
+    url = f"https://meshtastic.org/e/#{encoded.rstrip('=')}"
+
+    with pytest.raises(OSError, match="LoRa write failed"):
+        anode.setURL(url, addOnly=True)
+
+    assert anode.channels is not None
+    after_snapshot = [channel.SerializeToString() for channel in anode.channels]
+    assert after_snapshot == before_snapshot
+    anode.writeChannel.assert_called_once_with(1, adminIndex=0)
+
+    # Rollback should include channel restoration and prior LoRa config.
+    assert len(rollback_messages) == 2
+    assert rollback_messages[0].HasField("set_channel")
+    assert rollback_messages[0].set_channel.index == 1
+    assert rollback_messages[0].set_channel.role == Channel.Role.DISABLED
+    assert rollback_messages[1].HasField("set_config")
+    assert rollback_messages[1].set_config.HasField("lora")
+    assert rollback_messages[1].set_config.lora.hop_limit == 3
 
 
 @pytest.mark.unit
@@ -1841,15 +1907,30 @@ def test_onRequestGetMetadata_logs_valid_and_fallback_enum_values(
 
 
 @pytest.mark.unit
-def test_onRequestGetMetadata_updates_metadata_under_node_db_lock(
-    autospec_local_node_iface: Callable[[type[Any]], MagicMock],
-) -> None:
+def test_onRequestGetMetadata_updates_metadata_under_node_db_lock() -> None:
     """onRequestGetMetadata should update iface.metadata while holding iface._node_db_lock."""
-    iface = autospec_local_node_iface(MeshInterface)
-    iface._acknowledgment = Acknowledgment()
     lock = _TrackingLock()
-    iface._node_db_lock = lock
-    anode = Node(iface, "!12345678", noProto=True)
+
+    class _MetadataAssignmentProbeIface:
+        """Minimal interface stub that asserts metadata writes happen while lock is held."""
+
+        def __init__(self, node_db_lock: _TrackingLock) -> None:
+            self._node_db_lock = node_db_lock
+            self._acknowledgment = Acknowledgment()
+            self._metadata: mesh_pb2.DeviceMetadata | None = None
+            self.metadata_assignment_lock_state: bool | None = None
+
+        @property
+        def metadata(self) -> mesh_pb2.DeviceMetadata | None:
+            return self._metadata
+
+        @metadata.setter
+        def metadata(self, value: mesh_pb2.DeviceMetadata | None) -> None:
+            self.metadata_assignment_lock_state = lock.is_held
+            self._metadata = value
+
+    iface = _MetadataAssignmentProbeIface(lock)
+    anode = Node(cast(Any, iface), "!12345678", noProto=True)
     anode._timeout = MagicMock()
 
     raw = admin_pb2.AdminMessage()
@@ -1861,20 +1942,13 @@ def test_onRequestGetMetadata_updates_metadata_under_node_db_lock(
     response.hw_model = mesh_pb2.HardwareModel.PORTDUINO
     response.hasPKC = True
 
-    def _assert_assignment_happened_while_locked() -> None:
-        assert lock.is_held
-        metadata = iface.metadata
-        assert isinstance(metadata, mesh_pb2.DeviceMetadata)
-        assert metadata.firmware_version == "2.7.19"
-
-    lock._on_exit = _assert_assignment_happened_while_locked
-
     anode.onRequestGetMetadata(
         {"decoded": {"portnum": "ADMIN_APP", "admin": {"raw": raw}}}
     )
 
     assert lock.enter_count == 1
     assert lock.is_held is False
+    assert iface.metadata_assignment_lock_state is True
     assert iface.metadata.firmware_version == "2.7.19"
 
 

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -76,6 +76,8 @@ class _TrackingLock:
         self._on_exit = on_exit
 
     def __enter__(self) -> "_TrackingLock":
+        if self.is_held:
+            raise AssertionError("_TrackingLock does not allow nested acquisition")
         self.enter_count += 1
         self.is_held = True
         return self
@@ -124,6 +126,18 @@ def _make_fake_send_admin(
         return return_packet
 
     return _fake_send_admin
+
+
+@pytest.mark.unit
+def test_tracking_lock_rejects_nested_acquisition() -> None:
+    """_TrackingLock should fail on nested acquisition attempts."""
+    lock = _TrackingLock()
+    with lock:
+        with pytest.raises(
+            AssertionError, match="_TrackingLock does not allow nested acquisition"
+        ):
+            with lock:
+                pass
 
 
 @pytest.mark.unit
@@ -1706,11 +1720,11 @@ def test_setURL_replace_pins_admin_index_for_channel_and_lora_writes(
     assert admin_indexes == [1, 1, 1]
     assert sent_messages[0].HasField("set_channel")
     assert sent_messages[0].set_channel.index == 0
-    assert sent_messages[1].HasField("set_channel")
-    assert sent_messages[1].set_channel.index == 1
-    assert sent_messages[2].HasField("set_config")
-    assert sent_messages[2].set_config.HasField("lora")
-    assert sent_messages[2].set_config.lora.hop_limit == 9
+    assert sent_messages[1].HasField("set_config")
+    assert sent_messages[1].set_config.HasField("lora")
+    assert sent_messages[1].set_config.lora.hop_limit == 9
+    assert sent_messages[2].HasField("set_channel")
+    assert sent_messages[2].set_channel.index == 1
     assert anode.localConfig.lora.hop_limit == 9
 
 
@@ -2388,11 +2402,9 @@ def test_emit_cached_metadata_uses_fallback_values_for_unknown_enums(
 
 @pytest.mark.unit
 def test_emit_cached_metadata_reads_metadata_under_node_db_lock(
-    autospec_local_node_iface: Callable[[type[Any]], MagicMock],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """_emit_cached_metadata_for_stdout should emit snapshot lines after lock release."""
-    iface = autospec_local_node_iface(MeshInterface)
     original_metadata = mesh_pb2.DeviceMetadata(
         firmware_version="2.7.18",
         device_state_version=24,
@@ -2401,7 +2413,28 @@ def test_emit_cached_metadata_reads_metadata_under_node_db_lock(
         hw_model=mesh_pb2.HardwareModel.PORTDUINO,
         hasPKC=True,
     )
-    iface.metadata = original_metadata
+
+    metadata_read_lock_states: list[bool] = []
+
+    class _MetadataReadProbeIface:
+        """Minimal interface stub that records lock state on metadata reads."""
+
+        def __init__(
+            self,
+            node_db_lock: _TrackingLock,
+            metadata: mesh_pb2.DeviceMetadata,
+        ) -> None:
+            self._node_db_lock = node_db_lock
+            self._metadata = metadata
+
+        @property
+        def metadata(self) -> mesh_pb2.DeviceMetadata:
+            metadata_read_lock_states.append(self._node_db_lock.is_held)
+            return self._metadata
+
+        @metadata.setter
+        def metadata(self, value: mesh_pb2.DeviceMetadata) -> None:
+            self._metadata = value
 
     def _mutate_metadata_after_unlock() -> None:
         original_metadata.firmware_version = "mutated-after-unlock"
@@ -2410,8 +2443,9 @@ def test_emit_cached_metadata_reads_metadata_under_node_db_lock(
         original_metadata.hw_model = mesh_pb2.HardwareModel.UNSET
         original_metadata.hasPKC = False
 
-    iface._node_db_lock = _TrackingLock(on_exit=_mutate_metadata_after_unlock)
-    anode = Node(iface, "!12345678", noProto=True)
+    lock = _TrackingLock(on_exit=_mutate_metadata_after_unlock)
+    iface = _MetadataReadProbeIface(lock, original_metadata)
+    anode = Node(cast(Any, iface), "!12345678", noProto=True)
     emitted: list[tuple[str, bool]] = []
 
     def _record_emit(line: str) -> None:
@@ -2421,6 +2455,8 @@ def test_emit_cached_metadata_reads_metadata_under_node_db_lock(
 
     assert anode._emit_cached_metadata_for_stdout() is True
     assert emitted
+    assert metadata_read_lock_states
+    assert any(metadata_read_lock_states)
     assert iface._node_db_lock.enter_count == 1
     assert all(not is_held for _line, is_held in emitted)
     assert any("firmware_version: 2.7.18" in line for line, _ in emitted)

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -2066,7 +2066,7 @@ def test_emit_cached_metadata_reads_metadata_under_node_db_lock(
 ) -> None:
     """_emit_cached_metadata_for_stdout should snapshot metadata before lock release."""
     iface = autospec_local_node_iface(MeshInterface)
-    iface.metadata = mesh_pb2.DeviceMetadata(
+    original_metadata = mesh_pb2.DeviceMetadata(
         firmware_version="2.7.18",
         device_state_version=24,
         role=config_pb2.Config.DeviceConfig.Role.CLIENT,
@@ -2074,16 +2074,14 @@ def test_emit_cached_metadata_reads_metadata_under_node_db_lock(
         hw_model=mesh_pb2.HardwareModel.PORTDUINO,
         hasPKC=True,
     )
+    iface.metadata = original_metadata
 
     def _mutate_metadata_after_unlock() -> None:
-        iface.metadata = mesh_pb2.DeviceMetadata(
-            firmware_version="mutated-after-unlock",
-            device_state_version=99,
-            role=config_pb2.Config.DeviceConfig.Role.CLIENT_HIDDEN,
-            position_flags=0,
-            hw_model=mesh_pb2.HardwareModel.UNSET,
-            hasPKC=False,
-        )
+        original_metadata.firmware_version = "mutated-after-unlock"
+        original_metadata.device_state_version = 99
+        original_metadata.role = config_pb2.Config.DeviceConfig.Role.CLIENT_HIDDEN
+        original_metadata.hw_model = mesh_pb2.HardwareModel.UNSET
+        original_metadata.hasPKC = False
 
     iface._node_db_lock = _TrackingLock(on_exit=_mutate_metadata_after_unlock)
     anode = Node(iface, "!12345678", noProto=True)
@@ -2094,6 +2092,8 @@ def test_emit_cached_metadata_reads_metadata_under_node_db_lock(
     assert iface._node_db_lock.enter_count == 1
     assert any("firmware_version: 2.7.18" in line for line in emitted)
     assert not any("firmware_version: mutated-after-unlock" in line for line in emitted)
+    assert iface.metadata is original_metadata
+    assert iface.metadata.firmware_version == "mutated-after-unlock"
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -475,6 +475,7 @@ def test_setURL_ignores_channels_over_device_limit(
         settings = channel_set.settings.add()
         settings.name = f"ch{i}"
         settings.psk = b"\x01"
+    channel_set.lora_config.hop_limit = 7
 
     encoded = base64.urlsafe_b64encode(channel_set.SerializeToString()).decode("ascii")
     encoded = encoded.replace("=", "")
@@ -491,6 +492,7 @@ def test_setURL_ignores_channels_over_device_limit(
     assert len(anode.channels) == CHANNEL_LIMIT
     assert anode.channels[0].settings.name == "ch0"
     assert anode.channels[CHANNEL_LIMIT - 1].settings.name == f"ch{CHANNEL_LIMIT - 1}"
+    assert anode.localConfig.lora.hop_limit == 7
 
 
 @pytest.mark.unit
@@ -1266,6 +1268,7 @@ def test_setURL_add_only_adds_unique_named_channels(
     new_channel = channel_set.settings.add()
     new_channel.name = "new-ch"
     new_channel.psk = b"\x03"
+    channel_set.lora_config.hop_limit = 9
     encoded = base64.urlsafe_b64encode(channel_set.SerializeToString()).decode("ascii")
     url = f"https://meshtastic.org/e/#{encoded.rstrip('=')}"
 
@@ -1274,6 +1277,7 @@ def test_setURL_add_only_adds_unique_named_channels(
     assert anode.channels is not None
     assert anode.channels[1].settings.name == "new-ch"
     assert anode.channels[1].role == Channel.Role.SECONDARY
+    assert anode.localConfig.lora.hop_limit == 9
     anode.writeChannel.assert_called_once_with(1, adminIndex=0)
 
 
@@ -1455,6 +1459,7 @@ def test_setURL_add_only_rolls_back_lora_when_lora_write_fails(
     assert rollback_messages[1].HasField("set_config")
     assert rollback_messages[1].set_config.HasField("lora")
     assert rollback_messages[1].set_config.lora.hop_limit == 3
+    assert anode.localConfig.lora.hop_limit == 3
 
 
 @pytest.mark.unit
@@ -1640,6 +1645,25 @@ def test_send_admin_uses_session_passkey_and_selected_admin_index(
     iface.sendData.assert_called_once()
     assert iface.sendData.call_args.kwargs["channelIndex"] == 3
     assert iface.sendData.call_args.kwargs["pkiEncrypted"] is True
+
+
+@pytest.mark.unit
+def test_send_admin_respects_explicit_channel_zero(
+    autospec_local_node_iface: Callable[[type[Any]], MagicMock],
+) -> None:
+    """_send_admin should treat channel 0 as explicit, not as auto-detect."""
+    iface = autospec_local_node_iface(MeshInterface)
+    iface.localNode._get_admin_channel_index.return_value = 3
+    iface._get_or_create_by_num.return_value = {"adminSessionPassKey": b"secret"}
+    packet = mesh_pb2.MeshPacket()
+    iface.sendData.return_value = packet
+    anode = Node(iface, 321, noProto=False)
+    msg = admin_pb2.AdminMessage()
+
+    result = anode._send_admin(msg, adminIndex=0)
+
+    assert result is packet
+    assert iface.sendData.call_args.kwargs["channelIndex"] == 0
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -1403,6 +1403,8 @@ def test_setURL_add_only_uses_snapshotted_admin_index_and_rolls_back_on_write_fa
     disabled2 = Channel(index=2, role=Channel.Role.DISABLED)
     anode.channels = [primary, disabled1, disabled2]
     anode.localConfig.lora.hop_limit = 3
+    ensure_session_key_spy = MagicMock(wraps=anode.ensureSessionKey)
+    anode.ensureSessionKey = ensure_session_key_spy  # type: ignore[method-assign]
     before_snapshot = [channel.SerializeToString() for channel in anode.channels]
 
     staged_writes: list[tuple[int, str, int | None]] = []
@@ -1445,6 +1447,12 @@ def test_setURL_add_only_uses_snapshotted_admin_index_and_rolls_back_on_write_fa
     with pytest.raises(RuntimeError, match="write failed during addOnly batch"):
         anode.setURL(url, addOnly=True)
 
+    assert ensure_session_key_spy.call_args_list
+    assert all(
+        call.kwargs.get("adminIndex") == 0
+        for call in ensure_session_key_spy.call_args_list
+    )
+
     # Admin index is snapshotted before local mutation (0 fallback here),
     # even though a staged channel is named "admin".
     assert staged_writes == [(1, "admin", 0), (2, "new-b", 0)]
@@ -1477,6 +1485,8 @@ def test_setURL_add_only_invalidates_channels_cache_on_partial_rollback_failure(
     disabled2 = Channel(index=2, role=Channel.Role.DISABLED)
     anode.channels = [primary, disabled1, disabled2]
     anode.localConfig.lora.hop_limit = 3
+    ensure_session_key_spy = MagicMock(wraps=anode.ensureSessionKey)
+    anode.ensureSessionKey = ensure_session_key_spy  # type: ignore[method-assign]
 
     send_calls = {"rollback_failures": 0, "stage_writes": 0}
 
@@ -1515,6 +1525,11 @@ def test_setURL_add_only_invalidates_channels_cache_on_partial_rollback_failure(
     with pytest.raises(RuntimeError, match="write failed during addOnly batch"):
         anode.setURL(url, addOnly=True)
 
+    assert ensure_session_key_spy.call_args_list
+    assert all(
+        call.kwargs.get("adminIndex") == 0
+        for call in ensure_session_key_spy.call_args_list
+    )
     assert send_calls["stage_writes"] == 2
     assert send_calls["rollback_failures"] == 1
     assert anode.channels is None
@@ -1534,6 +1549,8 @@ def test_setURL_add_only_rolls_back_lora_when_lora_write_fails(
     anode.channels = [primary, disabled]
     before_snapshot = [channel.SerializeToString() for channel in anode.channels]
     anode.localConfig.lora.hop_limit = 3
+    ensure_session_key_spy = MagicMock(wraps=anode.ensureSessionKey)
+    anode.ensureSessionKey = ensure_session_key_spy  # type: ignore[method-assign]
 
     failed_lora_send = {"seen": False}
     staged_channel_writes: list[int] = []
@@ -1574,6 +1591,11 @@ def test_setURL_add_only_rolls_back_lora_when_lora_write_fails(
     with pytest.raises(OSError, match="LoRa write failed"):
         anode.setURL(url, addOnly=True)
 
+    assert ensure_session_key_spy.call_args_list
+    assert all(
+        call.kwargs.get("adminIndex") == 0
+        for call in ensure_session_key_spy.call_args_list
+    )
     assert anode.channels is not None
     after_snapshot = [channel.SerializeToString() for channel in anode.channels]
     assert after_snapshot == before_snapshot
@@ -1612,7 +1634,8 @@ def test_setURL_replace_pins_admin_index_for_channel_and_lora_writes(
     legacy_admin = Channel(index=1, role=Channel.Role.SECONDARY)
     legacy_admin.settings.name = "admin"
     anode.channels = [primary, legacy_admin]
-    anode.ensureSessionKey = MagicMock()  # type: ignore[method-assign]
+    ensure_session_key_spy = MagicMock()
+    anode.ensureSessionKey = ensure_session_key_spy  # type: ignore[method-assign]
 
     sent_messages: list[admin_pb2.AdminMessage] = []
     admin_indexes: list[int | None] = []
@@ -1643,6 +1666,11 @@ def test_setURL_replace_pins_admin_index_for_channel_and_lora_writes(
 
     anode.setURL(url, addOnly=False)
 
+    assert ensure_session_key_spy.call_args_list
+    assert all(
+        call.kwargs.get("adminIndex") == 1
+        for call in ensure_session_key_spy.call_args_list
+    )
     assert len(sent_messages) == 3
     assert admin_indexes == [1, 1, 1]
     assert sent_messages[0].HasField("set_channel")

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -64,8 +64,9 @@ class _DropChannelsOnEnterCountLock:
 class _TrackingLock:
     """Lock stub that records how many times it was acquired."""
 
-    def __init__(self) -> None:
+    def __init__(self, on_exit: Callable[[], None] | None = None) -> None:
         self.enter_count = 0
+        self._on_exit = on_exit
 
     def __enter__(self) -> "_TrackingLock":
         self.enter_count += 1
@@ -73,6 +74,8 @@ class _TrackingLock:
 
     def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> Literal[False]:
         _ = (exc_type, exc, tb)
+        if self._on_exit is not None:
+            self._on_exit()
         return False
 
 
@@ -1824,9 +1827,8 @@ def test_emit_cached_metadata_reads_metadata_under_node_db_lock(
     autospec_local_node_iface: Callable[[type[Any]], MagicMock],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """_emit_cached_metadata_for_stdout should snapshot iface.metadata under iface._node_db_lock."""
+    """_emit_cached_metadata_for_stdout should snapshot metadata before lock release."""
     iface = autospec_local_node_iface(MeshInterface)
-    iface._node_db_lock = _TrackingLock()
     iface.metadata = mesh_pb2.DeviceMetadata(
         firmware_version="2.7.18",
         device_state_version=24,
@@ -1835,6 +1837,18 @@ def test_emit_cached_metadata_reads_metadata_under_node_db_lock(
         hw_model=mesh_pb2.HardwareModel.PORTDUINO,
         hasPKC=True,
     )
+
+    def _mutate_metadata_after_unlock() -> None:
+        iface.metadata = mesh_pb2.DeviceMetadata(
+            firmware_version="mutated-after-unlock",
+            device_state_version=99,
+            role=config_pb2.Config.DeviceConfig.Role.CLIENT_HIDDEN,
+            position_flags=0,
+            hw_model=mesh_pb2.HardwareModel.UNSET,
+            hasPKC=False,
+        )
+
+    iface._node_db_lock = _TrackingLock(on_exit=_mutate_metadata_after_unlock)
     anode = Node(iface, "!12345678", noProto=True)
     emitted: list[str] = []
     monkeypatch.setattr(anode, "_emit_metadata_line", emitted.append)
@@ -1842,6 +1856,20 @@ def test_emit_cached_metadata_reads_metadata_under_node_db_lock(
     assert anode._emit_cached_metadata_for_stdout() is True
     assert iface._node_db_lock.enter_count == 1
     assert any("firmware_version: 2.7.18" in line for line in emitted)
+    assert not any("firmware_version: mutated-after-unlock" in line for line in emitted)
+
+
+@pytest.mark.unit
+def test_get_metadata_snapshot_returns_none_for_non_proto_metadata(
+    autospec_local_node_iface: Callable[[type[Any]], MagicMock],
+) -> None:
+    """_get_metadata_snapshot should return None when iface.metadata is not DeviceMetadata."""
+    iface = autospec_local_node_iface(MeshInterface)
+    iface._node_db_lock = _TrackingLock()
+    iface.metadata = {"firmware_version": "not-a-protobuf"}
+    anode = Node(iface, "!12345678", noProto=True)
+
+    assert anode._get_metadata_snapshot() is None
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -1312,6 +1312,36 @@ def test_setURL_add_only_raises_when_no_disabled_slot_available(
 
 
 @pytest.mark.unit
+def test_setURL_add_only_channel_only_url_skips_lora_snapshot_and_write(
+    autospec_local_node_iface: Callable[[type[Any]], MagicMock],
+) -> None:
+    """setURL(addOnly=True) should allow channel-only URLs without requiring cached LoRa."""
+    anode = Node(autospec_local_node_iface(MeshInterface), "!12345678", noProto=True)
+    primary = Channel(index=0, role=Channel.Role.PRIMARY)
+    primary.settings.name = "primary"
+    disabled = Channel(index=1, role=Channel.Role.DISABLED)
+    anode.channels = [primary, disabled]
+    anode._send_admin = MagicMock(return_value=mesh_pb2.MeshPacket())  # type: ignore[method-assign]
+
+    channel_set = apponly_pb2.ChannelSet()
+    added = channel_set.settings.add()
+    added.name = "new-ch"
+    added.psk = b"\x03"
+    encoded = base64.urlsafe_b64encode(channel_set.SerializeToString()).decode("ascii")
+    url = f"https://meshtastic.org/e/#{encoded.rstrip('=')}"
+
+    anode.setURL(url, addOnly=True)
+
+    assert anode.channels is not None
+    assert anode.channels[1].settings.name == "new-ch"
+    assert anode.channels[1].role == Channel.Role.SECONDARY
+    assert anode.localConfig.HasField("lora") is False
+    send_calls = anode._send_admin.call_args_list
+    assert len(send_calls) == 1
+    assert send_calls[0].args[0].HasField("set_channel")
+
+
+@pytest.mark.unit
 def test_setURL_add_only_requires_loaded_lora_config(
     autospec_local_node_iface: Callable[[type[Any]], MagicMock],
 ) -> None:
@@ -1627,6 +1657,7 @@ def test_setURL_replace_pins_admin_index_for_channel_and_lora_writes(
     """setURL(addOnly=False) should pin admin path from pre-rewrite channel state."""
     iface = autospec_local_node_iface(MeshInterface)
     iface.localNode._get_admin_channel_index.return_value = 1
+    iface._get_or_create_by_num.return_value = {"adminSessionPassKey": b"secret"}
     anode = Node(iface, "!12345678", noProto=False)
 
     primary = Channel(index=0, role=Channel.Role.PRIMARY)
@@ -1634,7 +1665,7 @@ def test_setURL_replace_pins_admin_index_for_channel_and_lora_writes(
     legacy_admin = Channel(index=1, role=Channel.Role.SECONDARY)
     legacy_admin.settings.name = "admin"
     anode.channels = [primary, legacy_admin]
-    ensure_session_key_spy = MagicMock()
+    ensure_session_key_spy = MagicMock(wraps=anode.ensureSessionKey)
     anode.ensureSessionKey = ensure_session_key_spy  # type: ignore[method-assign]
 
     sent_messages: list[admin_pb2.AdminMessage] = []
@@ -1681,6 +1712,37 @@ def test_setURL_replace_pins_admin_index_for_channel_and_lora_writes(
     assert sent_messages[2].set_config.HasField("lora")
     assert sent_messages[2].set_config.lora.hop_limit == 9
     assert anode.localConfig.lora.hop_limit == 9
+
+
+@pytest.mark.unit
+def test_setURL_replace_channel_only_url_skips_lora_write_and_cache_update(
+    autospec_local_node_iface: Callable[[type[Any]], MagicMock],
+) -> None:
+    """setURL(addOnly=False) should not write LoRa when URL omits lora_config."""
+    anode = Node(autospec_local_node_iface(MeshInterface), "!12345678", noProto=True)
+    anode.channels = [
+        Channel(index=0, role=Channel.Role.DISABLED),
+        Channel(index=1, role=Channel.Role.DISABLED),
+    ]
+    anode.localConfig.lora.hop_limit = 3
+    anode._send_admin = MagicMock(return_value=mesh_pb2.MeshPacket())  # type: ignore[method-assign]
+
+    channel_set = apponly_pb2.ChannelSet()
+    first = channel_set.settings.add()
+    first.name = "new-primary"
+    first.psk = b"\x11"
+    second = channel_set.settings.add()
+    second.name = "new-secondary"
+    second.psk = b"\x12"
+    encoded = base64.urlsafe_b64encode(channel_set.SerializeToString()).decode("ascii")
+    url = f"https://meshtastic.org/e/#{encoded.rstrip('=')}"
+
+    anode.setURL(url, addOnly=False)
+
+    send_calls = anode._send_admin.call_args_list
+    assert len(send_calls) == 2
+    assert all(call.args[0].HasField("set_channel") for call in send_calls)
+    assert anode.localConfig.lora.hop_limit == 3
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -1444,7 +1444,11 @@ def test_setURL_add_only_uses_snapshotted_admin_index_and_rolls_back_on_write_fa
 
     assert anode.channels is not None
     after_snapshot = [channel.SerializeToString() for channel in anode.channels]
-    assert after_snapshot == before_snapshot
+    # The staged addOnly transaction should not overwrite concurrent live-channel
+    # mutations when it fails and rolls back device writes.
+    assert after_snapshot[0] == before_snapshot[0]
+    assert after_snapshot[1] == before_snapshot[1]
+    assert anode.channels[2].settings.name == "raced-name"
 
     # Rollback should include the in-flight channel index as well, so both staged
     # channels are restored when writeChannel fails mid-send.

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -2111,6 +2111,7 @@ def test_set_metadata_snapshot_stores_detached_copy_under_lock() -> None:
 
         @property
         def metadata(self) -> mesh_pb2.DeviceMetadata | None:
+            """Return the stored device metadata."""
             return self._metadata
 
         @metadata.setter

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -1317,9 +1317,11 @@ def test_setURL_add_only_is_transactional_when_slots_are_insufficient(
     secondary.settings.psk = b"\x02"
     disabled = Channel(index=2, role=Channel.Role.DISABLED)
     anode.channels = [primary, secondary, disabled]
+    anode.localConfig.lora.hop_limit = 3
     anode.writeChannel = MagicMock()  # type: ignore[method-assign]
 
     before_snapshot = [channel.SerializeToString() for channel in anode.channels]
+    before_lora = anode.localConfig.lora.SerializeToString()
 
     channel_set = apponly_pb2.ChannelSet()
     first = channel_set.settings.add()
@@ -1328,6 +1330,7 @@ def test_setURL_add_only_is_transactional_when_slots_are_insufficient(
     second = channel_set.settings.add()
     second.name = "new-b"
     second.psk = b"\x04"
+    channel_set.lora_config.hop_limit = 9
     encoded = base64.urlsafe_b64encode(channel_set.SerializeToString()).decode("ascii")
     url = f"https://meshtastic.org/e/#{encoded.rstrip('=')}"
 
@@ -1339,6 +1342,8 @@ def test_setURL_add_only_is_transactional_when_slots_are_insufficient(
     assert anode.channels is not None
     after_snapshot = [channel.SerializeToString() for channel in anode.channels]
     assert after_snapshot == before_snapshot
+    after_lora = anode.localConfig.lora.SerializeToString()
+    assert after_lora == before_lora
     anode.writeChannel.assert_not_called()
 
 
@@ -1478,16 +1483,22 @@ def test_setURL_add_only_rolls_back_lora_when_lora_write_fails(
 
     failed_lora_send = {"seen": False}
     rollback_messages: list[admin_pb2.AdminMessage] = []
+    admin_indexes: list[int | None] = []
 
     def _send_admin_with_lora_failure(
         msg: admin_pb2.AdminMessage,
         wantResponse: bool = False,
         onResponse: Callable[[dict[str, Any]], Any] | None = None,
-        adminIndex: int = 0,
+        adminIndex: int | None = None,
     ) -> mesh_pb2.MeshPacket:
-        _ = (wantResponse, onResponse, adminIndex)
+        _ = (wantResponse, onResponse)
+        admin_indexes.append(adminIndex)
         if msg.HasField("set_config") and msg.set_config.HasField("lora"):
-            if not failed_lora_send["seen"] and msg.set_config.lora.hop_limit == 9:
+            if (
+                not failed_lora_send["seen"]
+                and adminIndex == 0
+                and msg.set_config.lora.hop_limit == 9
+            ):
                 failed_lora_send["seen"] = True
                 raise OSError("LoRa write failed")
         rollback_messages.append(msg)
@@ -1497,7 +1508,7 @@ def test_setURL_add_only_rolls_back_lora_when_lora_write_fails(
 
     channel_set = apponly_pb2.ChannelSet()
     added = channel_set.settings.add()
-    added.name = "new-channel"
+    added.name = "admin"
     added.psk = b"\x03"
     channel_set.lora_config.hop_limit = 9
     encoded = base64.urlsafe_b64encode(channel_set.SerializeToString()).decode("ascii")
@@ -1519,6 +1530,7 @@ def test_setURL_add_only_rolls_back_lora_when_lora_write_fails(
     assert rollback_messages[1].HasField("set_config")
     assert rollback_messages[1].set_config.HasField("lora")
     assert rollback_messages[1].set_config.lora.hop_limit == 3
+    assert admin_indexes == [0, 0, 0]
     assert anode.localConfig.lora.hop_limit == 3
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR hardens mesh/node packet handling, improves metadata persistence under the node-DB lock, makes setURL(addOnly=True) transactional with best-effort rollback on partial failures, threads an optional adminIndex through admin/session APIs for explicit channel selection, and treats protobuf decode errors from the radio as non-fatal (logged and represented as decode-failed markers). It also adds extensive unit tests, tightens handler defensiveness, and includes a small script robustness change.

## Key changes

Features
- Hex node-id parsing
  - Add HEX_NODE_ID_TAIL_CHARS and helpers (_extract_hex_node_id_body, _looks_like_hex_node_id_tail) to parse compact hex node-id forms (supports optional "!" and "0x"/"0X" prefixes) and decode them to numeric destination IDs in _send_packet.
- Node metadata locking and snapshots
  - Add Node._execute_with_node_db_lock to centralize node DB lock usage.
  - Add _get_metadata_snapshot() and _set_metadata_snapshot() to read/write DeviceMetadata under the node DB lock; _emit_cached_metadata_for_stdout uses snapshot-backed reads.
- Admin-index propagation
  - Thread optional adminIndex through Node APIs (requestConfig, writeChannel, _send_admin, ensureSessionKey, etc.) so callers can select which admin channel/session to use.
  - Add _get_named_admin_channel_index() and prefer named "admin" channel when present.
- Transactional setURL(addOnly=True)
  - Implement snapshot-and-stage flow: capture LoRa and per-channel snapshots, boot an admin session via the snapshotted path, stage per-channel writes atomically, apply LoRa changes on success, and attempt best-effort rollback on partial failures with logging and cache invalidation.

Fixes
- Robust protobuf decoding for radio payloads
  - Wrap ParseFromString/MessageToDict in try/except; on decode failure log a warning and attach {"error": "decode-failed: ..."} into decoded results instead of raising or delivering malformed payloads to handlers.
  - For ROUTING_APP, set routing.errorReason on decode failure instead of crashing handlers.
- Defensive handler behavior
  - _on_position_receive and _on_node_info_receive validate decoded payload shape (must be a dict and not contain "error") before mutating state.
- Script robustness
  - bin/run-multinode-with-meshtasticd.sh captures docker logs into a variable and handles read failures explicitly for more reliable readiness checks.

Refactors
- Snapshot-backed metadata access replaces some direct iface.metadata reads/writes for thread-safety and deterministic stdout emission.
- Consolidated node-DB lock handling into Node._execute_with_node_db_lock to reduce duplication and clarify locking semantics.
- Separated rollback handling for channel writes vs LoRa config and made adminIndex propagation explicit across session bootstrap, channel writes, and admin send paths.
- Typing updates: add TypeVar _LockedCallResult and update signatures to reflect adminIndex optionality.

Tests
- Large test additions/adjustments (+797/-11 in tests) covering:
  - Transactional setURL(addOnly=True), partial-failure rollback, and adminIndex forwarding.
  - Malformed protobuf payload handling and handler behavior on decode failures.
  - Metadata locking semantics via a new _TrackingLock test helper.
  - Hex node-id parsing and DB-lookup fallback behaviors.
  - Test helpers updated to accept adminIndex: int | None.

Docs & scripts
- REFACTOR_PROGRAM-2.md: formatting and content refinements.
- bin/run-multinode-with-meshtasticd.sh: improved docker log-read/grep error handling.

Breaking changes / migration notes
- Several Node methods now accept an optional adminIndex parameter (requestConfig, writeChannel, _send_admin, ensureSessionKey, etc.). This parameter is optional and backward-compatible; pass adminIndex when selecting a specific admin channel/session is required.
- Protobuf decode failures from the radio are now non-fatal: they are logged and represented as {"error": "decode-failed: ..."} in decoded payloads. Handlers should ignore payloads containing an "error" key (the code now guards for this).
- setURL(addOnly=True) attempts atomic behavior with rollback on partial failure; callers may observe rollback attempts and additional logging on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->