### PR TITLE
Code cleanup and formatting pass

### DIFF
--- a/.github/workflows/cleanup_artifacts.yml
+++ b/.github/workflows/cleanup_artifacts.yml
@@ -3,7 +3,7 @@ name: Remove old artifacts
 on:
   schedule:
     # Every day at 1am
-    - cron: "0 1 * * *"
+    - cron: 0 1 * * *
 
   workflow_dispatch: {}
 
@@ -20,5 +20,5 @@ jobs:
         # v1.4.0
         uses: c-hive/gha-remove-artifacts@44fc7acaf1b3d0987da0e8d4707a989d80e9554b
         with:
-          age: "1 month"
+          age: 1 month
           skip-tags: true

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -112,17 +112,17 @@ Semantic deprecation:
 
 ### Utility and Config
 
-| Module            | Compatibility symbol      | Canonical symbol       |
-| ----------------- | ------------------------- | ---------------------- |
-| `meshtastic.host_port` | `parse_host_and_port()` | `parseHostAndPort()` |
-| `meshtastic.util` | `blacklistVids`           | `BLACKLIST_VIDS`       |
-| `meshtastic.util` | `whitelistVids`           | `WHITELIST_VIDS`       |
-| `meshtastic.util` | `our_exit()`              | `ourExit()`            |
-| `meshtastic.util` | `remove_keys_from_dict()` | `removeKeysFromDict()` |
-| `meshtastic.util` | `detect_windows_port()`   | `detectWindowsPort()`  |
-| `meshtastic.util` | `message_to_json()`       | `messageToJson()`      |
-| `meshtastic.util` | `to_node_num()`           | `toNodeNum()`          |
-| `meshtastic.util` | `flags_to_list()`         | `flagsToList()`        |
+| Module                 | Compatibility symbol      | Canonical symbol       |
+| ---------------------- | ------------------------- | ---------------------- |
+| `meshtastic.host_port` | `parse_host_and_port()`   | `parseHostAndPort()`   |
+| `meshtastic.util`      | `blacklistVids`           | `BLACKLIST_VIDS`       |
+| `meshtastic.util`      | `whitelistVids`           | `WHITELIST_VIDS`       |
+| `meshtastic.util`      | `our_exit()`              | `ourExit()`            |
+| `meshtastic.util`      | `remove_keys_from_dict()` | `removeKeysFromDict()` |
+| `meshtastic.util`      | `detect_windows_port()`   | `detectWindowsPort()`  |
+| `meshtastic.util`      | `message_to_json()`       | `messageToJson()`      |
+| `meshtastic.util`      | `to_node_num()`           | `toNodeNum()`          |
+| `meshtastic.util`      | `flags_to_list()`         | `flagsToList()`        |
 
 ### Node and Tunnel
 

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -1265,7 +1265,9 @@ class Node:
                             rollback_succeeded = True
                             break
                         # Best-effort rollback path; keep attempting remaining steps.
-                        except Exception as rollback_error:  # noqa: BLE001 - best-effort rollback must continue on any rollback send failure
+                        except (
+                            Exception
+                        ) as rollback_error:  # noqa: BLE001 - best-effort rollback must continue on any rollback send failure
                             last_rollback_error = rollback_error
                     if not rollback_succeeded:
                         rollback_failed = True
@@ -1560,7 +1562,9 @@ class Node:
                             )
                             rollback_succeeded = True
                             break
-                        except Exception as rollback_error:  # noqa: BLE001 - best-effort rollback must continue on any rollback send failure
+                        except (
+                            Exception
+                        ) as rollback_error:  # noqa: BLE001 - best-effort rollback must continue on any rollback send failure
                             replace_last_rollback_error = rollback_error
                     if not rollback_succeeded:
                         rollback_failed = True

--- a/meshtastic/ota.py
+++ b/meshtastic/ota.py
@@ -85,7 +85,9 @@ class ESP32WiFiOTA:
                     image.extend(block)
                     file_hash.update(block)
         except FileNotFoundError as exc:
-            raise OTAError(MISSING_FIRMWARE_ERROR.format(filename=self._filename)) from exc
+            raise OTAError(
+                MISSING_FIRMWARE_ERROR.format(filename=self._filename)
+            ) from exc
         except OSError as exc:
             raise OTAError(
                 READ_FIRMWARE_ERROR.format(filename=self._filename, error=exc)

--- a/meshtastic/tests/test_meshtasticd_tcp_interface_ci.py
+++ b/meshtastic/tests/test_meshtasticd_tcp_interface_ci.py
@@ -99,8 +99,8 @@ def test_parse_host_and_port_accepts_bracketed_ipv6_with_port() -> None:
 def test_parse_host_and_port_snake_case_alias_matches_canonical_name() -> None:
     """The snake_case host parser alias should delegate to the canonical camelCase name."""
     from meshtastic.host_port import (  # pylint: disable=import-outside-toplevel
-        parseHostAndPort,
         parse_host_and_port,
+        parseHostAndPort,
     )
 
     assert parse_host_and_port(

--- a/meshtastic/tests/test_ota.py
+++ b/meshtastic/tests/test_ota.py
@@ -212,9 +212,7 @@ def test_esp32_wifi_ota_update_success(mock_socket_class: MagicMock) -> None:
             ota.update()
 
             # Verify socket connection was created.
-            mock_socket_class.assert_called_once_with(
-                ("192.168.1.1", 3232), timeout=15
-            )
+            mock_socket_class.assert_called_once_with(("192.168.1.1", 3232), timeout=15)
 
             # Verify start command was sent
             start_cmd = f"OTA {len(test_data)} {ota.hash_hex()}\n".encode("utf-8")

--- a/meshtastic/tests/test_smoke1.py
+++ b/meshtastic/tests/test_smoke1.py
@@ -485,12 +485,13 @@ def restore_smoke1_module_config() -> Iterator[None]:
         _assert_connected(ready_output)
         restore_succeeded = True
     finally:
-        keep_backup_on_restore_failure = (
-            os.getenv(KEEP_BACKUP_ON_RESTORE_FAILURE_ENV_VAR, "").strip().lower()
-            in {"1", "true", "yes", "on"}
-        )
+        keep_backup_on_restore_failure = os.getenv(
+            KEEP_BACKUP_ON_RESTORE_FAILURE_ENV_VAR, ""
+        ).strip().lower() in {"1", "true", "yes", "on"}
         should_keep_backup = (
-            keep_backup_on_restore_failure and export_succeeded and not restore_succeeded
+            keep_backup_on_restore_failure
+            and export_succeeded
+            and not restore_succeeded
         )
         if not should_keep_backup:
             with contextlib.suppress(FileNotFoundError):
@@ -766,7 +767,8 @@ def test_smoke1_ch_values(preset_cmd: str, expected_preset: str) -> None:
 
     info_out = _wait_for_mutation_to_settle(
         predicate=lambda output: (
-            (block := _channel_info_block(output)) is not None and expected_preset in block
+            (block := _channel_info_block(output)) is not None
+            and expected_preset in block
         )
     )
     channel_zero = _channel_info_block(info_out)

--- a/meshtastic/tests/test_tunnel.py
+++ b/meshtastic/tests/test_tunnel.py
@@ -147,7 +147,9 @@ def test_tunnel_creates_tap_device_when_proto_enabled(
         "meshtastic.tunnel.pub.unsubscribe",
         lambda *_args, **_kwargs: None,
     )
-    monkeypatch.setattr("meshtastic.tunnel.pub.subscribe", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        "meshtastic.tunnel.pub.subscribe", lambda *_args, **_kwargs: None
+    )
 
     with _managed_tunnel(iface) as tun:
         assert tun.tun is not None

--- a/poetry.lock
+++ b/poetry.lock
@@ -4545,24 +4545,22 @@ files = [
 
 [[package]]
 name = "tornado"
-version = "6.5.4"
+version = "6.5.5"
 description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
 optional = false
 python-versions = ">=3.9"
 groups = ["analysis"]
 files = [
-    {file = "tornado-6.5.4-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:d6241c1a16b1c9e4cc28148b1cda97dd1c6cb4fb7068ac1bedc610768dff0ba9"},
-    {file = "tornado-6.5.4-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2d50f63dda1d2cac3ae1fa23d254e16b5e38153758470e9956cbc3d813d40843"},
-    {file = "tornado-6.5.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d1cf66105dc6acb5af613c054955b8137e34a03698aa53272dbda4afe252be17"},
-    {file = "tornado-6.5.4-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:50ff0a58b0dc97939d29da29cd624da010e7f804746621c78d14b80238669335"},
-    {file = "tornado-6.5.4-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e5fb5e04efa54cf0baabdd10061eb4148e0be137166146fff835745f59ab9f7f"},
-    {file = "tornado-6.5.4-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9c86b1643b33a4cd415f8d0fe53045f913bf07b4a3ef646b735a6a86047dda84"},
-    {file = "tornado-6.5.4-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:6eb82872335a53dd063a4f10917b3efd28270b56a33db69009606a0312660a6f"},
-    {file = "tornado-6.5.4-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6076d5dda368c9328ff41ab5d9dd3608e695e8225d1cd0fd1e006f05da3635a8"},
-    {file = "tornado-6.5.4-cp39-abi3-win32.whl", hash = "sha256:1768110f2411d5cd281bac0a090f707223ce77fd110424361092859e089b38d1"},
-    {file = "tornado-6.5.4-cp39-abi3-win_amd64.whl", hash = "sha256:fa07d31e0cd85c60713f2b995da613588aa03e1303d75705dca6af8babc18ddc"},
-    {file = "tornado-6.5.4-cp39-abi3-win_arm64.whl", hash = "sha256:053e6e16701eb6cbe641f308f4c1a9541f91b6261991160391bfc342e8a551a1"},
-    {file = "tornado-6.5.4.tar.gz", hash = "sha256:a22fa9047405d03260b483980635f0b041989d8bcc9a313f8fe18b411d84b1d7"},
+    {file = "tornado-6.5.5-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:487dc9cc380e29f58c7ab88f9e27cdeef04b2140862e5076a66fb6bb68bb1bfa"},
+    {file = "tornado-6.5.5-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:65a7f1d46d4bb41df1ac99f5fcb685fb25c7e61613742d5108b010975a9a6521"},
+    {file = "tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e74c92e8e65086b338fd56333fb9a68b9f6f2fe7ad532645a290a464bcf46be5"},
+    {file = "tornado-6.5.5-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:435319e9e340276428bbdb4e7fa732c2d399386d1de5686cb331ec8eee754f07"},
+    {file = "tornado-6.5.5-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3f54aa540bdbfee7b9eb268ead60e7d199de5021facd276819c193c0fb28ea4e"},
+    {file = "tornado-6.5.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:36abed1754faeb80fbd6e64db2758091e1320f6bba74a4cf8c09cd18ccce8aca"},
+    {file = "tornado-6.5.5-cp39-abi3-win32.whl", hash = "sha256:dd3eafaaeec1c7f2f8fdcd5f964e8907ad788fe8a5a32c4426fbbdda621223b7"},
+    {file = "tornado-6.5.5-cp39-abi3-win_amd64.whl", hash = "sha256:6443a794ba961a9f619b1ae926a2e900ac20c34483eea67be4ed8f1e58d3ef7b"},
+    {file = "tornado-6.5.5-cp39-abi3-win_arm64.whl", hash = "sha256:2c9a876e094109333f888539ddb2de4361743e5d21eece20688e3e351e4990a6"},
+    {file = "tornado-6.5.5.tar.gz", hash = "sha256:192b8f3ea91bd7f1f50c06955416ed76c6b72f96779b962f07f911b91e8d30e9"},
 ]
 
 [[package]]

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -73,7 +73,8 @@ def _pin_trust_environment(
     """
     Configure host-specific dependencies so tests of trust() run in a controlled Linux-like environment.
 
-    Parameters:
+    Parameters
+    ----------
         monkeypatch (pytest.MonkeyPatch): Fixture used to apply attribute patches.
         run (Callable[..., object] | None): Optional replacement for subprocess.run used by trust(); if None, a sentinel callable is installed that raises AssertionError if invoked.
     """
@@ -1958,13 +1959,16 @@ def test_ble_interface_close_bounds_wait_on_spurious_management_wakeups(
         """
         Simulate a spurious wait for tests and track each requested timeout.
 
-        Parameters:
+        Parameters
+        ----------
             timeout (float | None): The requested wait duration in seconds; if greater than zero the function sleeps for that duration.
 
-        Returns:
+        Returns
+        -------
             bool: `True` to indicate the wait condition remains satisfied.
 
-        Raises:
+        Raises
+        ------
             AssertionError: If the number of invocations exceeds the allowed spurious-wait budget, signals that shutdown waited past its timeout.
         """
         wait_calls.append(timeout)
@@ -1990,10 +1994,12 @@ def test_ble_interface_close_bounds_wait_on_spurious_management_wakeups(
         """
         Context manager used in tests to record a requested management address and provide a no-op gate.
 
-        Parameters:
+        Parameters
+        ----------
             address (str): The management address being requested; the address is recorded for test inspection.
 
-        Returns:
+        Returns
+        -------
             contextmanager: A context manager that performs no gating and yields `None`.
         """
         gate_calls.append(address)
@@ -2668,7 +2674,8 @@ def test_connect_times_out_on_spurious_management_wakeups(
         """
         Advance and return a test monotonic timestamp by 0.01 seconds.
 
-        Returns:
+        Returns
+        -------
             Current monotonic time in seconds; the returned value increases by 0.01 on each call.
         """
         nonlocal fake_time
@@ -2683,13 +2690,16 @@ def test_connect_times_out_on_spurious_management_wakeups(
         """
         Record a spurious wait invocation and signal a wakeup.
 
-        Parameters:
+        Parameters
+        ----------
             timeout (float | None): The timeout value passed to the wait; may be None.
 
-        Returns:
+        Returns
+        -------
             bool: `True` to indicate a spurious wakeup.
 
-        Raises:
+        Raises
+        ------
             AssertionError: If the number of recorded wait calls exceeds the configured budget.
         """
         wait_calls.append(timeout)
@@ -2738,7 +2748,8 @@ def test_connect_management_wait_timeout_resets_between_wait_cycles(
         """
         Provide a monotonic timestamp for tests, advancing through a preset sequence and falling back to incremental steps when the sequence is exhausted.
 
-        Returns:
+        Returns
+        -------
             float: The current monotonic time value and updates the captured `last_time` variable.
         """
         nonlocal last_time
@@ -2756,14 +2767,16 @@ def test_connect_management_wait_timeout_resets_between_wait_cycles(
         """
         Simulate waiting for management operations to drain and record the requested timeout.
 
-        Parameters:
+        Parameters
+        ----------
             timeout (float | None): Maximum seconds to wait, or `None` to indicate an indefinite wait.
 
         Behavior:
             Appends the provided `timeout` value to the `wait_calls` list and sets
             `iface._management_inflight` to 0 to indicate no inflight management operations.
 
-        Returns:
+        Returns
+        -------
             bool: `True` to indicate the wait condition was signaled.
         """
         wait_calls.append(timeout)
@@ -2774,7 +2787,8 @@ def test_connect_management_wait_timeout_resets_between_wait_cycles(
         """
         Increment the duplicate-check counter and, on the second invocation, mark the interface as having one inflight management operation.
 
-        Parameters:
+        Parameters
+        ----------
             _key (str | None): Ignored; present to match the duplicate-check callback signature.
         """
         nonlocal duplicate_checks
@@ -2814,14 +2828,16 @@ def test_connect_management_wait_timeout_resets_between_wait_cycles(
         """
         Create and attach a DummyClient to the test BLE interface and mark it as connected.
 
-        Parameters:
+        Parameters
+        ----------
             _address (str | None): Ignored; present to match the real establish signature.
             _normalized_request (str | None): Ignored; present to match the real establish signature.
             _address_key (str | None): Ignored; present to match the real establish signature.
             pair_on_connect (bool): Accepted but ignored by this test stub.
             connect_timeout (float | None): Accepted but ignored by this test stub.
 
-        Returns:
+        Returns
+        -------
             tuple[DummyClient, None, None]: The created DummyClient instance and two None placeholders (resolved address and resolved identifier).
         """
         _ = (pair_on_connect, connect_timeout)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This pull request applies code formatting and style fixes across the meshtastic-python codebase. The changes include normalizing exception handler syntax, reformatting test assertions and expressions, updating documentation strings to NumPy/Sphinx conventions, and adjusting YAML configuration and table formatting. All changes are stylistic and do not alter runtime behavior or public APIs.

## Changes by Category

**Code Formatting & Style**
- Reformatted exception handlers in `meshtastic/node.py` to use parenthesized exception groups across multiple lines for improved readability
- Reformatted OTA error raise statement in `meshtastic/ota.py` to span multiple lines instead of single-line expression
- Reflowed test assertion in `meshtastic/tests/test_ota.py` from multi-line to single-line format
- Reindented and split long logical expressions in `meshtastic/tests/test_smoke1.py` for better readability
- Reflowed monkeypatch call arguments in `meshtastic/tests/test_tunnel.py` across multiple lines

**Documentation & Configuration**
- Converted docstring format in `tests/test_ble_interface_core.py` from basic "Parameters/Returns/Raises" to NumPy/Sphinx-style format with explicit section underlines
- Normalized table formatting and alignment in `COMPATIBILITY.md`
- Removed unnecessary quotes from cron expression and age values in `.github/workflows/cleanup_artifacts.yml`
- Reordered imports in `meshtastic/tests/test_meshtasticd_tcp_interface_ci.py`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->