### PR TITLE
Enhance OTA module validation

### DIFF
--- a/REFACTOR_PROGRAM-2.md
+++ b/REFACTOR_PROGRAM-2.md
@@ -1,6 +1,6 @@
 # REFACTOR_PROGRAM-2.md
 
-## Meshtastic Python Refactor – Phase 2 Program Plan
+## Meshtastic Python Refactor – Phase 2/3 Program Plan
 
 Date: 2026-03-11  
 Base Branch: `develop`  
@@ -32,7 +32,7 @@ Because of this, we still should **not** merge `develop → master` directly.
 
 Instead, we perform **a few large, deliberate stabilization passes** based on `develop`.
 
-Phase 1 (BLE stabilization) is now complete and merged into `develop` (`#63`), and Phase 2 is the active execution stream.
+Phase 1 (BLE stabilization) is complete and merged into `develop` (`#63`), Phase 2 runtime stabilization is complete, and Phase 3 is now the active execution stream.
 
 ---
 
@@ -185,8 +185,8 @@ Instead of merging `develop → master` directly, the program continues through 
 ### Phase Status Snapshot
 
 - Phase 1 BLE stabilization: **Completed** (merged into `develop`, PR `#63`)
-- Phase 2 MeshInterface runtime stabilization: **In progress** on `meshinterface-pass`
-- Phase 3 Runtime boundary cleanup: Pending
+- Phase 2 MeshInterface runtime stabilization: **Completed** on `meshinterface-pass`
+- Phase 3 Runtime boundary cleanup: **In progress** on `runtime-boundary-cleanup`
 - Phase 4 CLI structural refactor: Future
 
 ---
@@ -208,9 +208,9 @@ Delivered outcomes:
 
 ---
 
-## Phase 2: MeshInterface Runtime Stabilization (Active)
+## Phase 2: MeshInterface Runtime Stabilization (Completed)
 
-Active branch:
+Execution branch:
 
 ```text
 meshinterface-pass
@@ -251,7 +251,7 @@ Execution checklist for this phase:
 
 ---
 
-## Phase 3: Runtime Boundary Cleanup
+## Phase 3: Runtime Boundary Cleanup (Active)
 
 Branch name suggestion:
 
@@ -339,7 +339,7 @@ main()
 
 ## 6. Merge Strategy
 
-The final merge into `master` will occur **after Phase 2 and Phase 3 are completed** (Phase 1 is already complete).
+The final merge into `master` will occur **after Phase 3 is completed** (Phases 1 and 2 are already complete).
 
 This allows:
 
@@ -378,18 +378,19 @@ To keep the refactor manageable:
 
 ## 8. Immediate Next Step
 
-Continue executing Phase 2 on the active branch:
+Start executing Phase 3 on the active branch:
 
 ```bash
-git checkout meshinterface-pass
+git checkout runtime-boundary-cleanup
 ```
 
 Immediate focus:
 
-- complete mesh runtime hardening in `mesh_interface.py` and `node.py`
-- run explicit backward-compatibility checks against `master`
-- validate compatibility inventory alignment in `COMPATIBILITY.md`
-- keep tests green with expanded targeted regression coverage
+- unify host/port parsing behavior across CLI and runtime code paths
+- improve runtime-facing error surfaces for OTA and transport failures
+- harden OTA destination validation and socket-failure diagnostics
+- improve configuration reliability and preference-sanitization paths
+- keep security-sensitive outputs redacted and validate request-id handling
 
 This work stream should produce the next major PRs for the refactor program.
 
@@ -404,8 +405,8 @@ The next work should not expand scope further.
 Instead, the project proceeds through **large stabilization passes**:
 
 1. BLE stabilization (completed)
-2. MeshInterface runtime stabilization (active)
-3. Runtime boundary cleanup (pending)
+2. MeshInterface runtime stabilization (completed)
+3. Runtime boundary cleanup (active)
 4. CLI modularization (future)
 
 Once these passes are complete, `develop` will be ready to merge into `master`.

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -877,7 +877,10 @@ def onConnected(interface: MeshInterface) -> None:
             ota_dest = LOCAL_ADDR if args.dest == BROADCAST_ADDR else args.dest
             waitForAckNak = False
 
-            ota = meshtastic.ota.ESP32WiFiOTA(args.ota_update, interface.hostname)
+            try:
+                ota = meshtastic.ota.ESP32WiFiOTA(args.ota_update, interface.hostname)
+            except meshtastic.ota.OTAError as e:
+                _cli_exit(f"OTA update failed: {e}")
 
             print(f"Triggering OTA update on {interface.hostname}...")
             interface.getNode(

--- a/meshtastic/ota.py
+++ b/meshtastic/ota.py
@@ -19,25 +19,30 @@ FIRMWARE_CHANGED_ERROR: str = (
     "Firmware file {filename} changed after OTA session initialization."
 )
 OTA_DESTINATION_ENV_LABEL: str = "OTA destination"
-INVALID_OTA_DESTINATION_ERROR: str = (
-    "Invalid OTA destination {destination!r}: {error}"
-)
-OTA_TRANSPORT_ERROR: str = (
-    "OTA transport to {host}:{port} failed during {stage}: {error}"
-)
+INVALID_OTA_DESTINATION_ERROR: str = "Invalid OTA destination {destination!r}: {error}"
+OTA_TRANSPORT_ERROR: str = "OTA transport to {endpoint} failed during {stage}: {error}"
+
+
+def _format_endpoint(host: str, port: int) -> str:
+    """Return a host:port string with IPv6 literals bracketed."""
+    if ":" in host and not host.startswith("["):
+        return f"[{host}]:{port}"
+    return f"{host}:{port}"
 
 
 class _SHA256Digest(Protocol):
     """Minimal digest protocol returned by hashlib.sha256()."""
 
-    def update(self, data: bytes) -> None:
+    def update(self, data: bytes, /) -> None:
         """Update the digest with bytes."""
 
     def digest(self) -> bytes:
         """Return raw digest bytes."""
+        ...
 
     def hexdigest(self) -> str:
         """Return digest as hexadecimal string."""
+        ...
 
 
 def _file_sha256(filename: str) -> _SHA256Digest:
@@ -254,8 +259,7 @@ class ESP32WiFiOTA:
         except (ConnectionError, OSError) as exc:
             raise OTATransportError(
                 OTA_TRANSPORT_ERROR.format(
-                    host=self._hostname,
-                    port=self._port,
+                    endpoint=_format_endpoint(self._hostname, self._port),
                     stage=transport_stage,
                     error=exc,
                 )

--- a/meshtastic/ota.py
+++ b/meshtastic/ota.py
@@ -5,6 +5,8 @@ import logging
 import socket
 from typing import Callable, Protocol
 
+from meshtastic.host_port import parseHostAndPort
+
 logger = logging.getLogger(__name__)
 OTA_SOCKET_TIMEOUT_SECONDS = 15
 OTA_CHUNK_SIZE_BYTES = 1024
@@ -16,7 +18,13 @@ READ_FIRMWARE_ERROR: str = "Unable to read firmware file {filename}: {error}"
 FIRMWARE_CHANGED_ERROR: str = (
     "Firmware file {filename} changed after OTA session initialization."
 )
-OTA_TRANSPORT_ERROR: str = "OTA transport to {host}:{port} failed: {error}"
+OTA_DESTINATION_ENV_LABEL = "OTA destination"
+INVALID_OTA_DESTINATION_ERROR: str = (
+    "Invalid OTA destination {destination!r}: {error}"
+)
+OTA_TRANSPORT_ERROR: str = (
+    "OTA transport to {host}:{port} failed during {stage}: {error}"
+)
 
 
 class _SHA256Digest(Protocol):
@@ -57,15 +65,33 @@ class ESP32WiFiOTA:
     """ESP32 WiFi Unified OTA updates."""
 
     def __init__(self, filename: str, hostname: str, port: int = 3232) -> None:
+        normalized_host, normalized_port = self._normalize_destination(hostname, port)
         self._filename = filename
-        self._hostname = hostname
-        self._port = port
+        self._hostname = normalized_host
+        self._port = normalized_port
         self._socket: socket.socket | None = None
 
         self._file_bytes: bytes = b""
         self._size = 0
         self._file_hash: _SHA256Digest = hashlib.sha256()
         self._refresh_firmware_metadata()
+
+    @staticmethod
+    def _normalize_destination(hostname: str, port: int) -> tuple[str, int]:
+        """Validate and normalize OTA destination host/port."""
+        try:
+            return parseHostAndPort(
+                hostname,
+                default_port=port,
+                env_var=OTA_DESTINATION_ENV_LABEL,
+            )
+        except ValueError as exc:
+            raise OTAError(
+                INVALID_OTA_DESTINATION_ERROR.format(
+                    destination=hostname,
+                    error=exc,
+                )
+            ) from exc
 
     def _refresh_firmware_metadata(self) -> tuple[int, _SHA256Digest]:
         """Refresh cached firmware size/hash from disk and validate non-empty file.
@@ -162,6 +188,7 @@ class ESP32WiFiOTA:
             file_hash.hexdigest(),
         )
 
+        transport_stage = "connect"
         try:
             self._socket = socket.create_connection(
                 (self._hostname, self._port),
@@ -170,9 +197,11 @@ class ESP32WiFiOTA:
             logger.debug("Connected to %s:%d", self._hostname, self._port)
 
             # Send start command
+            transport_stage = "send OTA start command"
             self._socket.sendall(f"OTA {size} {file_hash.hexdigest()}\n".encode())
 
             # Wait for OK from the device
+            transport_stage = "wait for OTA ready response"
             while True:
                 response = self._read_line()
                 if response == "OK":
@@ -187,6 +216,7 @@ class ESP32WiFiOTA:
 
             sent_bytes = 0
             for offset in range(0, size, OTA_CHUNK_SIZE_BYTES):
+                transport_stage = "send firmware chunk"
                 chunk = firmware_image[offset : offset + OTA_CHUNK_SIZE_BYTES]
                 self._socket.sendall(chunk)
                 sent_bytes += len(chunk)
@@ -209,6 +239,7 @@ class ESP32WiFiOTA:
                             next_progress_log_percent += OTA_PROGRESS_LOG_PERCENT_STEP
 
             # Wait for OK from device
+            transport_stage = "wait for OTA completion response"
             logger.info("Firmware sent, waiting for verification...")
             while True:
                 response = self._read_line()
@@ -225,6 +256,7 @@ class ESP32WiFiOTA:
                 OTA_TRANSPORT_ERROR.format(
                     host=self._hostname,
                     port=self._port,
+                    stage=transport_stage,
                     error=exc,
                 )
             ) from exc

--- a/meshtastic/ota.py
+++ b/meshtastic/ota.py
@@ -18,7 +18,7 @@ READ_FIRMWARE_ERROR: str = "Unable to read firmware file {filename}: {error}"
 FIRMWARE_CHANGED_ERROR: str = (
     "Firmware file {filename} changed after OTA session initialization."
 )
-OTA_DESTINATION_ENV_LABEL = "OTA destination"
+OTA_DESTINATION_ENV_LABEL: str = "OTA destination"
 INVALID_OTA_DESTINATION_ERROR: str = (
     "Invalid OTA destination {destination!r}: {error}"
 )

--- a/meshtastic/ota.py
+++ b/meshtastic/ota.py
@@ -38,11 +38,11 @@ class _SHA256Digest(Protocol):
 
     def digest(self) -> bytes:
         """Return raw digest bytes."""
-        ...
+        ...  # pylint: disable=unnecessary-ellipsis
 
     def hexdigest(self) -> str:
         """Return digest as hexadecimal string."""
-        ...
+        ...  # pylint: disable=unnecessary-ellipsis
 
 
 def _file_sha256(filename: str) -> _SHA256Digest:

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -4663,6 +4663,52 @@ def test_main_ota_update_fails_fast_on_non_transport_error(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+def test_main_ota_update_constructor_error_exits_gracefully(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--ota-update should exit gracefully when ESP32WiFiOTA constructor raises OTAError.
+
+    This tests the error handling for constructor failures (invalid destination,
+    missing firmware file, empty firmware, etc.) that occur before update() is called.
+    """
+    sys.argv = ["", "--host", "localhost", "--ota-update", "firmware.bin"]
+    mt_config.args = cast(Any, sys.argv)
+
+    node = MagicMock(autospec=Node)
+    get_node = MagicMock(return_value=node)
+
+    with (
+        patch(
+            "meshtastic.tcp_interface.TCPInterface",
+            _make_fake_tcp_interface(get_node=get_node),
+        ),
+        patch(
+            "meshtastic.ota.ESP32WiFiOTA",
+            side_effect=OTAError(
+                "Invalid OTA destination 'bad:port': malformed address"
+            ),
+        ) as ota_ctor_mock,
+        patch("meshtastic.__main__.time.sleep") as sleep_mock,
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        main()
+
+    _, err = capsys.readouterr()
+    assert (
+        "OTA update failed: Invalid OTA destination 'bad:port': malformed address"
+        in err
+    )
+    assert excinfo.value.code == 1
+    # Constructor was called with firmware path and hostname
+    ota_ctor_mock.assert_called_once_with("firmware.bin", "localhost")
+    # Should not reach sleep/retry logic since constructor failed
+    assert sleep_mock.call_args_list == []
+    # Should not call update or startOTA since constructor failed
+    node.startOTA.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
 def test_main_ota_update_succeeds_and_prints_completion(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/meshtastic/tests/test_ota.py
+++ b/meshtastic/tests/test_ota.py
@@ -1,8 +1,10 @@
 """Meshtastic unit tests for ota.py."""
 
+from collections.abc import Callable
 import hashlib
 import logging
 import os
+from pathlib import Path
 import tempfile
 from unittest.mock import MagicMock, patch
 
@@ -15,6 +17,21 @@ from meshtastic.ota import (
     OTATransportError,
     _file_sha256,
 )
+
+
+@pytest.fixture
+def firmware_file_factory(tmp_path: Path) -> Callable[[bytes], str]:
+    """Provide a helper that writes firmware bytes to a test-local file path."""
+    counter = 0
+
+    def _create_firmware_file(payload: bytes = b"fake firmware data") -> str:
+        nonlocal counter
+        firmware_path = tmp_path / f"firmware-{counter}.bin"
+        counter += 1
+        firmware_path.write_bytes(payload)
+        return str(firmware_path)
+
+    return _create_firmware_file
 
 
 @pytest.mark.unit
@@ -94,32 +111,22 @@ def test_esp32_wifi_ota_init_default_port() -> None:
 
 
 @pytest.mark.unit
-def test_esp32_wifi_ota_init_parses_host_port_destination() -> None:
+def test_esp32_wifi_ota_init_parses_host_port_destination(
+    firmware_file_factory: Callable[[bytes], str],
+) -> None:
     """ESP32WiFiOTA should normalize HOST:PORT destinations via shared parser."""
-    with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
-        f.write(b"fake firmware data")
-        temp_file = f.name
-
-    try:
-        ota = ESP32WiFiOTA(temp_file, "192.168.1.1:4545")
-        assert ota._hostname == "192.168.1.1"
-        assert ota._port == 4545
-    finally:
-        os.unlink(temp_file)
+    ota = ESP32WiFiOTA(firmware_file_factory(), "192.168.1.1:4545")
+    assert ota._hostname == "192.168.1.1"
+    assert ota._port == 4545
 
 
 @pytest.mark.unit
-def test_esp32_wifi_ota_init_rejects_invalid_destination() -> None:
+def test_esp32_wifi_ota_init_rejects_invalid_destination(
+    firmware_file_factory: Callable[[bytes], str],
+) -> None:
     """ESP32WiFiOTA should raise OTAError for malformed OTA destination values."""
-    with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
-        f.write(b"fake firmware data")
-        temp_file = f.name
-
-    try:
-        with pytest.raises(OTAError, match="Invalid OTA destination"):
-            ESP32WiFiOTA(temp_file, "[]:3232")
-    finally:
-        os.unlink(temp_file)
+    with pytest.raises(OTAError, match="Invalid OTA destination"):
+        ESP32WiFiOTA(firmware_file_factory(), "[]:3232")
 
 
 @pytest.mark.unit
@@ -566,22 +573,36 @@ def test_esp32_wifi_ota_update_socket_cleanup_on_error(
 @patch("meshtastic.ota.socket.create_connection")
 def test_esp32_wifi_ota_update_transport_error_includes_stage(
     mock_socket_class: MagicMock,
+    firmware_file_factory: Callable[[bytes], str],
 ) -> None:
     """OTATransportError should include transport stage context for connection failures."""
-    with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
-        f.write(b"firmware")
-        temp_file = f.name
+    mock_socket_class.side_effect = OSError("network unreachable")
+    ota = ESP32WiFiOTA(firmware_file_factory(b"firmware"), "192.168.1.1")
+    with pytest.raises(
+        OTATransportError,
+        match=r"failed during connect: network unreachable",
+    ):
+        ota.update()
 
-    try:
-        mock_socket_class.side_effect = OSError("network unreachable")
-        ota = ESP32WiFiOTA(temp_file, "192.168.1.1")
-        with pytest.raises(
-            OTATransportError,
-            match=r"failed during connect: network unreachable",
-        ):
-            ota.update()
-    finally:
-        os.unlink(temp_file)
+
+@pytest.mark.unit
+@patch("meshtastic.ota.socket.create_connection")
+def test_esp32_wifi_ota_update_transport_error_includes_send_stage(
+    mock_socket_class: MagicMock,
+    firmware_file_factory: Callable[[bytes], str],
+) -> None:
+    """OTATransportError should include non-connect stage context for send failures."""
+    mock_socket = MagicMock()
+    mock_socket.sendall.side_effect = OSError("network unreachable")
+    mock_socket_class.return_value = mock_socket
+
+    ota = ESP32WiFiOTA(firmware_file_factory(b"firmware"), "192.168.1.1")
+    with pytest.raises(
+        OTATransportError,
+        match=r"failed during send OTA start command: network unreachable",
+    ):
+        ota.update()
+    mock_socket.close.assert_called_once()
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_ota.py
+++ b/meshtastic/tests/test_ota.py
@@ -94,6 +94,35 @@ def test_esp32_wifi_ota_init_default_port() -> None:
 
 
 @pytest.mark.unit
+def test_esp32_wifi_ota_init_parses_host_port_destination() -> None:
+    """ESP32WiFiOTA should normalize HOST:PORT destinations via shared parser."""
+    with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
+        f.write(b"fake firmware data")
+        temp_file = f.name
+
+    try:
+        ota = ESP32WiFiOTA(temp_file, "192.168.1.1:4545")
+        assert ota._hostname == "192.168.1.1"
+        assert ota._port == 4545
+    finally:
+        os.unlink(temp_file)
+
+
+@pytest.mark.unit
+def test_esp32_wifi_ota_init_rejects_invalid_destination() -> None:
+    """ESP32WiFiOTA should raise OTAError for malformed OTA destination values."""
+    with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
+        f.write(b"fake firmware data")
+        temp_file = f.name
+
+    try:
+        with pytest.raises(OTAError, match="Invalid OTA destination"):
+            ESP32WiFiOTA(temp_file, "[]:3232")
+    finally:
+        os.unlink(temp_file)
+
+
+@pytest.mark.unit
 def test_esp32_wifi_ota_hash_bytes() -> None:
     """Test hash_bytes returns correct bytes."""
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
@@ -529,6 +558,28 @@ def test_esp32_wifi_ota_update_socket_cleanup_on_error(
         mock_socket.close.assert_called_once()
         assert ota._socket is None
 
+    finally:
+        os.unlink(temp_file)
+
+
+@pytest.mark.unit
+@patch("meshtastic.ota.socket.create_connection")
+def test_esp32_wifi_ota_update_transport_error_includes_stage(
+    mock_socket_class: MagicMock,
+) -> None:
+    """OTATransportError should include transport stage context for connection failures."""
+    with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
+        f.write(b"firmware")
+        temp_file = f.name
+
+    try:
+        mock_socket_class.side_effect = OSError("network unreachable")
+        ota = ESP32WiFiOTA(temp_file, "192.168.1.1")
+        with pytest.raises(
+            OTATransportError,
+            match=r"failed during connect: network unreachable",
+        ):
+            ota.update()
     finally:
         os.unlink(temp_file)
 

--- a/meshtastic/tests/test_ota.py
+++ b/meshtastic/tests/test_ota.py
@@ -20,7 +20,7 @@ from meshtastic.ota import (
 
 
 @pytest.fixture
-def firmware_file_factory(tmp_path: Path) -> Callable[[bytes], str]:
+def firmware_file_factory(tmp_path: Path) -> Callable[..., str]:
     """Provide a helper that writes firmware bytes to a test-local file path."""
     counter = 0
 
@@ -111,8 +111,9 @@ def test_esp32_wifi_ota_init_default_port() -> None:
 
 
 @pytest.mark.unit
+# pylint: disable=redefined-outer-name
 def test_esp32_wifi_ota_init_parses_host_port_destination(
-    firmware_file_factory: Callable[[bytes], str],
+    firmware_file_factory: Callable[..., str],
 ) -> None:
     """ESP32WiFiOTA should normalize HOST:PORT destinations via shared parser."""
     ota = ESP32WiFiOTA(firmware_file_factory(), "192.168.1.1:4545")
@@ -121,8 +122,9 @@ def test_esp32_wifi_ota_init_parses_host_port_destination(
 
 
 @pytest.mark.unit
+# pylint: disable=redefined-outer-name
 def test_esp32_wifi_ota_init_rejects_invalid_destination(
-    firmware_file_factory: Callable[[bytes], str],
+    firmware_file_factory: Callable[..., str],
 ) -> None:
     """ESP32WiFiOTA should raise OTAError for malformed OTA destination values."""
     with pytest.raises(OTAError, match="Invalid OTA destination"):
@@ -571,6 +573,7 @@ def test_esp32_wifi_ota_update_socket_cleanup_on_error(
 
 @pytest.mark.unit
 @patch("meshtastic.ota.socket.create_connection")
+# pylint: disable=redefined-outer-name
 def test_esp32_wifi_ota_update_transport_error_includes_stage(
     mock_socket_class: MagicMock,
     firmware_file_factory: Callable[[bytes], str],
@@ -587,6 +590,7 @@ def test_esp32_wifi_ota_update_transport_error_includes_stage(
 
 @pytest.mark.unit
 @patch("meshtastic.ota.socket.create_connection")
+# pylint: disable=redefined-outer-name
 def test_esp32_wifi_ota_update_transport_error_includes_send_stage(
     mock_socket_class: MagicMock,
     firmware_file_factory: Callable[[bytes], str],

--- a/meshtastic/tests/test_ota.py
+++ b/meshtastic/tests/test_ota.py
@@ -576,7 +576,7 @@ def test_esp32_wifi_ota_update_socket_cleanup_on_error(
 # pylint: disable=redefined-outer-name
 def test_esp32_wifi_ota_update_transport_error_includes_stage(
     mock_socket_class: MagicMock,
-    firmware_file_factory: Callable[[bytes], str],
+    firmware_file_factory: Callable[..., str],
 ) -> None:
     """OTATransportError should include transport stage context for connection failures."""
     mock_socket_class.side_effect = OSError("network unreachable")
@@ -593,7 +593,7 @@ def test_esp32_wifi_ota_update_transport_error_includes_stage(
 # pylint: disable=redefined-outer-name
 def test_esp32_wifi_ota_update_transport_error_includes_send_stage(
     mock_socket_class: MagicMock,
-    firmware_file_factory: Callable[[bytes], str],
+    firmware_file_factory: Callable[..., str],
 ) -> None:
     """OTATransportError should include non-connect stage context for send failures."""
     mock_socket = MagicMock()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This pull request refactors the OTA subsystem to centralize HOST:PORT parsing, add destination validation, and improve transport diagnostics. New unit tests cover the parsing and error paths and the CLI entrypoint now handles constructor-time OTA errors gracefully.

## Key Changes

**Features**
- Added OTA destination environment constant: OTA_DESTINATION_ENV_LABEL.
- Added explicit invalid-destination error constant: INVALID_OTA_DESTINATION_ERROR.
- onConnected in meshtastic/__main__.py now catches OTAError from the OTA constructor and exits with a clear error message (graceful failure path).

**Refactors**
- Unified host:port parsing by importing and using parseHostAndPort (meshtastic.host_port).
- Introduced ESP32WiFiOTA._normalize_destination(hostname, port) to validate and normalize destinations at construction time using the shared parser.
- Normalized host/port are stored on ESP32WiFiOTA instances rather than allowing raw/unchecked inputs.

**Error Handling & Diagnostics (Fixes / Improvements)**
- OTA transport errors now include the transport stage (e.g., "failed during connect", "failed during send OTA start command"), and transport-stage context is propagated into OTATransportError to improve debugging.
- Invalid OTA destination formats now raise OTAError at ESP32WiFiOTA initialization, preventing later, harder-to-diagnose failures.
- Socket cleanup on send failures is asserted by tests (ensures resources are closed on error).

**Tests**
- New tests in meshtastic/tests/test_ota.py:
  - HOST:PORT parsing correctness for ESP32WiFiOTA initialization.
  - Rejection of invalid destination formats (expect OTAError with "Invalid OTA destination").
  - OTATransportError messages include the transport stage for connection and send failures; socket close behavior verified.
  - Helper fixture firmware_file_factory added for creating test firmware files.
- New test in meshtastic/tests/test_main.py:
  - Verifies main() exits gracefully with SystemExit(1) and prints an OTA failure message when ESP32WiFiOTA constructor raises OTAError.

## Migration / Compatibility Notes

- Backwards compatible for valid host:port strings: existing valid configurations continue to work.
- Invalid or malformed destination strings that previously may have been tolerated will now raise OTAError during ESP32WiFiOTA construction. Call sites that instantiate ESP32WiFiOTA should be prepared to catch OTAError (the CLI already handles this). If you programmatically create ESP32WiFiOTA instances, consider adding error handling around construction to handle configuration validation failures early.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->