### PR TITLE
Expand COMPATIBILITY.md with module symbol mappings

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -162,8 +162,8 @@ Semantic deprecation:
 | `meshtastic.interfaces.ble.client`                | `stop_notify()`                      | `stopNotify()`                |
 | `meshtastic.interfaces.ble.client`                | `async_await()`                      | `_async_await()`              |
 | `meshtastic.interfaces.ble.client`                | `async_run()`                        | `_async_run()`                |
-| `meshtastic.interfaces.ble.errors`                | `safe_execute()`                     | `_safe_execute()`             |
-| `meshtastic.interfaces.ble.errors`                | `safe_cleanup()`                     | `_safe_cleanup()`             |
+| `meshtastic.interfaces.ble.errors`                | `BLEErrorHandler.safe_execute()`     | `BLEErrorHandler._safe_execute()` |
+| `meshtastic.interfaces.ble.errors`                | `BLEErrorHandler.safe_cleanup()`     | `BLEErrorHandler._safe_cleanup()` |
 | `meshtastic.interfaces.ble.compatibility_service` | `publish_connection_status_legacy()` | `publish_connection_status()` |
 | `meshtastic.interfaces.ble.interface`             | `find_device()`                      | `findDevice()`                |
 | `meshtastic.interfaces.ble.interface`             | `from_num_handler()`                 | `_from_num_handler()`         |

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -46,27 +46,27 @@ remain callable and silent.
 
 Additional approved BLE compatibility and promotions:
 
-| Symbol                                    | Status               | Warning policy | Notes                                          |
-| ----------------------------------------- | -------------------- | -------------- | ---------------------------------------------- |
-| `BLEClient.find_device`                   | `COMPAT_STABLE_SHIM` | Silent         | Historical snake_case.                         |
-| `BLEClient.findDevice`                    | `PRIMARY`            | Silent         | Approved promoted camelCase name.              |
-| `BLEClient.is_connected`                  | `COMPAT_STABLE_SHIM` | Silent         | Shim for `isConnected`.                        |
-| `BLEClient.isConnected`                   | `PRIMARY`            | Silent         | Approved promoted camelCase name.              |
-| `BLEClient.stop_notify`                   | `COMPAT_STABLE_SHIM` | Silent         | Shim for `stopNotify`.                         |
-| `BLEClient.stopNotify`                    | `PRIMARY`            | Silent         | Approved promoted camelCase name.              |
-| `BLEErrorHandler.safe_execute`            | `COMPAT_STABLE_SHIM` | Silent         | Wrapper alias for `_safe_execute`.             |
-| `BLEErrorHandler.safe_cleanup`            | `COMPAT_STABLE_SHIM` | Silent         | Wrapper alias for `_safe_cleanup`.             |
-| `BLECompatibilityEventService.publish_connection_status_legacy` | `COMPAT_STABLE_SHIM` | Silent | Wrapper alias for `publish_connection_status`. |
-| `BLEInterface.find_device`                | `COMPAT_STABLE_SHIM` | Silent         | Historical snake_case wrapper.                 |
-| `BLEInterface.findDevice`                 | `PRIMARY`            | Silent         | Approved promoted camelCase name.              |
-| `BLEClient._discover`                     | `COMPAT_STABLE_SHIM` | Silent         | Historical internal discovery entrypoint.      |
-| `BLEStateManager.is_connecting()`         | `COMPAT_STABLE_SHIM` | Silent         | Public alias for `_is_connecting()`.           |
-| `BLEStateManager._lock`                   | `INTERNAL_COMPAT`    | Silent         | Alias to `lock` property for legacy internals. |
-| `meshtastic.ble_interface.BleakClient`    | `COMPAT_STABLE_SHIM` | Silent         | Legacy module-level import compatibility.      |
-| `meshtastic.ble_interface.BleakScanner`   | `COMPAT_STABLE_SHIM` | Silent         | Legacy module-level import compatibility.      |
-| `meshtastic.ble_interface.BLEDevice`      | `COMPAT_STABLE_SHIM` | Silent         | Legacy module-level import compatibility.      |
-| `meshtastic.ble_interface.BleakError`     | `COMPAT_STABLE_SHIM` | Silent         | Legacy module-level import compatibility.      |
-| `meshtastic.ble_interface.BleakDBusError` | `COMPAT_STABLE_SHIM` | Silent         | Legacy module-level import compatibility.      |
+| Symbol                                                          | Status               | Warning policy | Notes                                          |
+| --------------------------------------------------------------- | -------------------- | -------------- | ---------------------------------------------- |
+| `BLEClient.find_device`                                         | `COMPAT_STABLE_SHIM` | Silent         | Historical snake_case.                         |
+| `BLEClient.findDevice`                                          | `PRIMARY`            | Silent         | Approved promoted camelCase name.              |
+| `BLEClient.is_connected`                                        | `COMPAT_STABLE_SHIM` | Silent         | Shim for `isConnected`.                        |
+| `BLEClient.isConnected`                                         | `PRIMARY`            | Silent         | Approved promoted camelCase name.              |
+| `BLEClient.stop_notify`                                         | `COMPAT_STABLE_SHIM` | Silent         | Shim for `stopNotify`.                         |
+| `BLEClient.stopNotify`                                          | `PRIMARY`            | Silent         | Approved promoted camelCase name.              |
+| `BLEErrorHandler.safe_execute`                                  | `COMPAT_STABLE_SHIM` | Silent         | Wrapper alias for `_safe_execute`.             |
+| `BLEErrorHandler.safe_cleanup`                                  | `COMPAT_STABLE_SHIM` | Silent         | Wrapper alias for `_safe_cleanup`.             |
+| `BLECompatibilityEventService.publish_connection_status_legacy` | `COMPAT_STABLE_SHIM` | Silent         | Wrapper alias for `publish_connection_status`. |
+| `BLEInterface.find_device`                                      | `COMPAT_STABLE_SHIM` | Silent         | Historical snake_case wrapper.                 |
+| `BLEInterface.findDevice`                                       | `PRIMARY`            | Silent         | Approved promoted camelCase name.              |
+| `BLEClient._discover`                                           | `COMPAT_STABLE_SHIM` | Silent         | Historical internal discovery entrypoint.      |
+| `BLEStateManager.is_connecting()`                               | `COMPAT_STABLE_SHIM` | Silent         | Public alias for `_is_connecting()`.           |
+| `BLEStateManager._lock`                                         | `INTERNAL_COMPAT`    | Silent         | Alias to `lock` property for legacy internals. |
+| `meshtastic.ble_interface.BleakClient`                          | `COMPAT_STABLE_SHIM` | Silent         | Legacy module-level import compatibility.      |
+| `meshtastic.ble_interface.BleakScanner`                         | `COMPAT_STABLE_SHIM` | Silent         | Legacy module-level import compatibility.      |
+| `meshtastic.ble_interface.BLEDevice`                            | `COMPAT_STABLE_SHIM` | Silent         | Legacy module-level import compatibility.      |
+| `meshtastic.ble_interface.BleakError`                           | `COMPAT_STABLE_SHIM` | Silent         | Legacy module-level import compatibility.      |
+| `meshtastic.ble_interface.BleakDBusError`                       | `COMPAT_STABLE_SHIM` | Silent         | Legacy module-level import compatibility.      |
 
 Approved BLE deprecation:
 
@@ -155,23 +155,23 @@ Semantic deprecation:
 
 ### BLE and Related Exports
 
-| Module                                            | Compatibility symbol                 | Canonical symbol                  |
-| ------------------------------------------------- | ------------------------------------ | --------------------------------- |
-| `meshtastic.interfaces.ble.client`                | `find_device()`                      | `findDevice()`                    |
-| `meshtastic.interfaces.ble.client`                | `_discover()`                        | `discover()`                      |
-| `meshtastic.interfaces.ble.client`                | `is_connected()`                     | `isConnected()`                   |
-| `meshtastic.interfaces.ble.client`                | `stop_notify()`                      | `stopNotify()`                    |
-| `meshtastic.interfaces.ble.client`                | `async_await()`                      | `_async_await()`                  |
-| `meshtastic.interfaces.ble.client`                | `async_run()`                        | `_async_run()`                    |
-| `meshtastic.interfaces.ble.errors`                | `BLEErrorHandler.safe_execute()`     | `BLEErrorHandler._safe_execute()` |
-| `meshtastic.interfaces.ble.errors`                | `BLEErrorHandler.safe_cleanup()`     | `BLEErrorHandler._safe_cleanup()` |
+| Module                                            | Compatibility symbol                                              | Canonical symbol                                           |
+| ------------------------------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------- |
+| `meshtastic.interfaces.ble.client`                | `find_device()`                                                   | `findDevice()`                                             |
+| `meshtastic.interfaces.ble.client`                | `_discover()`                                                     | `discover()`                                               |
+| `meshtastic.interfaces.ble.client`                | `is_connected()`                                                  | `isConnected()`                                            |
+| `meshtastic.interfaces.ble.client`                | `stop_notify()`                                                   | `stopNotify()`                                             |
+| `meshtastic.interfaces.ble.client`                | `async_await()`                                                   | `_async_await()`                                           |
+| `meshtastic.interfaces.ble.client`                | `async_run()`                                                     | `_async_run()`                                             |
+| `meshtastic.interfaces.ble.errors`                | `BLEErrorHandler.safe_execute()`                                  | `BLEErrorHandler._safe_execute()`                          |
+| `meshtastic.interfaces.ble.errors`                | `BLEErrorHandler.safe_cleanup()`                                  | `BLEErrorHandler._safe_cleanup()`                          |
 | `meshtastic.interfaces.ble.compatibility_service` | `BLECompatibilityEventService.publish_connection_status_legacy()` | `BLECompatibilityEventService.publish_connection_status()` |
-| `meshtastic.interfaces.ble.interface`             | `find_device()`                      | `findDevice()`                    |
-| `meshtastic.interfaces.ble.interface`             | `from_num_handler()`                 | `_from_num_handler()`             |
-| `meshtastic.interfaces.ble.interface`             | `log_radio_handler()`                | `_log_radio_handler()`            |
-| `meshtastic.interfaces.ble.interface`             | `legacy_log_radio_handler()`         | `_legacy_log_radio_handler()`     |
-| `meshtastic.interfaces.ble.state`                 | `is_connecting()`                    | `_is_connecting()`                |
-| `meshtastic.interfaces.ble.state`                 | `_lock` property                     | `lock` property                   |
+| `meshtastic.interfaces.ble.interface`             | `find_device()`                                                   | `findDevice()`                                             |
+| `meshtastic.interfaces.ble.interface`             | `from_num_handler()`                                              | `_from_num_handler()`                                      |
+| `meshtastic.interfaces.ble.interface`             | `log_radio_handler()`                                             | `_log_radio_handler()`                                     |
+| `meshtastic.interfaces.ble.interface`             | `legacy_log_radio_handler()`                                      | `_legacy_log_radio_handler()`                              |
+| `meshtastic.interfaces.ble.state`                 | `is_connecting()`                                                 | `_is_connecting()`                                         |
+| `meshtastic.interfaces.ble.state`                 | `_lock` property                                                  | `lock` property                                            |
 
 ### Powermon and Slog
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -154,23 +154,23 @@ Semantic deprecation:
 
 ### BLE and Related Exports
 
-| Module                                | Compatibility symbol         | Canonical symbol              |
-| ------------------------------------- | ---------------------------- | ----------------------------- |
-| `meshtastic.interfaces.ble.client`    | `find_device()`              | `findDevice()`                |
-| `meshtastic.interfaces.ble.client`    | `_discover()`                | `discover()`                  |
-| `meshtastic.interfaces.ble.client`    | `is_connected()`             | `isConnected()`               |
-| `meshtastic.interfaces.ble.client`    | `stop_notify()`              | `stopNotify()`                |
-| `meshtastic.interfaces.ble.client`    | `async_await()`              | `_async_await()`              |
-| `meshtastic.interfaces.ble.client`    | `async_run()`                | `_async_run()`                |
-| `meshtastic.interfaces.ble.errors`    | `safe_execute()`             | `_safe_execute()`             |
-| `meshtastic.interfaces.ble.errors`    | `safe_cleanup()`             | `_safe_cleanup()`             |
+| Module                                            | Compatibility symbol                 | Canonical symbol              |
+| ------------------------------------------------- | ------------------------------------ | ----------------------------- |
+| `meshtastic.interfaces.ble.client`                | `find_device()`                      | `findDevice()`                |
+| `meshtastic.interfaces.ble.client`                | `_discover()`                        | `discover()`                  |
+| `meshtastic.interfaces.ble.client`                | `is_connected()`                     | `isConnected()`               |
+| `meshtastic.interfaces.ble.client`                | `stop_notify()`                      | `stopNotify()`                |
+| `meshtastic.interfaces.ble.client`                | `async_await()`                      | `_async_await()`              |
+| `meshtastic.interfaces.ble.client`                | `async_run()`                        | `_async_run()`                |
+| `meshtastic.interfaces.ble.errors`                | `safe_execute()`                     | `_safe_execute()`             |
+| `meshtastic.interfaces.ble.errors`                | `safe_cleanup()`                     | `_safe_cleanup()`             |
 | `meshtastic.interfaces.ble.compatibility_service` | `publish_connection_status_legacy()` | `publish_connection_status()` |
-| `meshtastic.interfaces.ble.interface` | `find_device()`              | `findDevice()`                |
-| `meshtastic.interfaces.ble.interface` | `from_num_handler()`         | `_from_num_handler()`         |
-| `meshtastic.interfaces.ble.interface` | `log_radio_handler()`        | `_log_radio_handler()`        |
-| `meshtastic.interfaces.ble.interface` | `legacy_log_radio_handler()` | `_legacy_log_radio_handler()` |
-| `meshtastic.interfaces.ble.state`     | `is_connecting` property     | `_is_connecting` property     |
-| `meshtastic.interfaces.ble.state`     | `_lock` property             | `lock` property               |
+| `meshtastic.interfaces.ble.interface`             | `find_device()`                      | `findDevice()`                |
+| `meshtastic.interfaces.ble.interface`             | `from_num_handler()`                 | `_from_num_handler()`         |
+| `meshtastic.interfaces.ble.interface`             | `log_radio_handler()`                | `_log_radio_handler()`        |
+| `meshtastic.interfaces.ble.interface`             | `legacy_log_radio_handler()`         | `_legacy_log_radio_handler()` |
+| `meshtastic.interfaces.ble.state`                 | `is_connecting` property             | `_is_connecting` property     |
+| `meshtastic.interfaces.ble.state`                 | `_lock` property                     | `lock` property               |
 
 ### Powermon and Slog
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -154,23 +154,23 @@ Semantic deprecation:
 
 ### BLE and Related Exports
 
-| Module                                            | Compatibility symbol                 | Canonical symbol              |
-| ------------------------------------------------- | ------------------------------------ | ----------------------------- |
-| `meshtastic.interfaces.ble.client`                | `find_device()`                      | `findDevice()`                |
-| `meshtastic.interfaces.ble.client`                | `_discover()`                        | `discover()`                  |
-| `meshtastic.interfaces.ble.client`                | `is_connected()`                     | `isConnected()`               |
-| `meshtastic.interfaces.ble.client`                | `stop_notify()`                      | `stopNotify()`                |
-| `meshtastic.interfaces.ble.client`                | `async_await()`                      | `_async_await()`              |
-| `meshtastic.interfaces.ble.client`                | `async_run()`                        | `_async_run()`                |
+| Module                                            | Compatibility symbol                 | Canonical symbol                  |
+| ------------------------------------------------- | ------------------------------------ | --------------------------------- |
+| `meshtastic.interfaces.ble.client`                | `find_device()`                      | `findDevice()`                    |
+| `meshtastic.interfaces.ble.client`                | `_discover()`                        | `discover()`                      |
+| `meshtastic.interfaces.ble.client`                | `is_connected()`                     | `isConnected()`                   |
+| `meshtastic.interfaces.ble.client`                | `stop_notify()`                      | `stopNotify()`                    |
+| `meshtastic.interfaces.ble.client`                | `async_await()`                      | `_async_await()`                  |
+| `meshtastic.interfaces.ble.client`                | `async_run()`                        | `_async_run()`                    |
 | `meshtastic.interfaces.ble.errors`                | `BLEErrorHandler.safe_execute()`     | `BLEErrorHandler._safe_execute()` |
 | `meshtastic.interfaces.ble.errors`                | `BLEErrorHandler.safe_cleanup()`     | `BLEErrorHandler._safe_cleanup()` |
-| `meshtastic.interfaces.ble.compatibility_service` | `publish_connection_status_legacy()` | `publish_connection_status()` |
-| `meshtastic.interfaces.ble.interface`             | `find_device()`                      | `findDevice()`                |
-| `meshtastic.interfaces.ble.interface`             | `from_num_handler()`                 | `_from_num_handler()`         |
-| `meshtastic.interfaces.ble.interface`             | `log_radio_handler()`                | `_log_radio_handler()`        |
-| `meshtastic.interfaces.ble.interface`             | `legacy_log_radio_handler()`         | `_legacy_log_radio_handler()` |
-| `meshtastic.interfaces.ble.state`                 | `is_connecting` property             | `_is_connecting` property     |
-| `meshtastic.interfaces.ble.state`                 | `_lock` property                     | `lock` property               |
+| `meshtastic.interfaces.ble.compatibility_service` | `publish_connection_status_legacy()` | `publish_connection_status()`     |
+| `meshtastic.interfaces.ble.interface`             | `find_device()`                      | `findDevice()`                    |
+| `meshtastic.interfaces.ble.interface`             | `from_num_handler()`                 | `_from_num_handler()`             |
+| `meshtastic.interfaces.ble.interface`             | `log_radio_handler()`                | `_log_radio_handler()`            |
+| `meshtastic.interfaces.ble.interface`             | `legacy_log_radio_handler()`         | `_legacy_log_radio_handler()`     |
+| `meshtastic.interfaces.ble.state`                 | `is_connecting` property             | `_is_connecting` property         |
+| `meshtastic.interfaces.ble.state`                 | `_lock` property                     | `lock` property                   |
 
 ### Powermon and Slog
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -164,7 +164,7 @@ Semantic deprecation:
 | `meshtastic.interfaces.ble.client`                | `async_run()`                        | `_async_run()`                    |
 | `meshtastic.interfaces.ble.errors`                | `BLEErrorHandler.safe_execute()`     | `BLEErrorHandler._safe_execute()` |
 | `meshtastic.interfaces.ble.errors`                | `BLEErrorHandler.safe_cleanup()`     | `BLEErrorHandler._safe_cleanup()` |
-| `meshtastic.interfaces.ble.compatibility_service` | `publish_connection_status_legacy()` | `publish_connection_status()`     |
+| `meshtastic.interfaces.ble.compatibility_service` | `BLECompatibilityEventService.publish_connection_status_legacy()` | `BLECompatibilityEventService.publish_connection_status()` |
 | `meshtastic.interfaces.ble.interface`             | `find_device()`                      | `findDevice()`                    |
 | `meshtastic.interfaces.ble.interface`             | `from_num_handler()`                 | `_from_num_handler()`             |
 | `meshtastic.interfaces.ble.interface`             | `log_radio_handler()`                | `_log_radio_handler()`            |

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -56,10 +56,11 @@ Additional approved BLE compatibility and promotions:
 | `BLEClient.stopNotify`                    | `PRIMARY`            | Silent         | Approved promoted camelCase name.              |
 | `BLEErrorHandler.safe_execute`            | `COMPAT_STABLE_SHIM` | Silent         | Wrapper alias for `_safe_execute`.             |
 | `BLEErrorHandler.safe_cleanup`            | `COMPAT_STABLE_SHIM` | Silent         | Wrapper alias for `_safe_cleanup`.             |
+| `BLECompatibilityEventService.publish_connection_status_legacy` | `COMPAT_STABLE_SHIM` | Silent | Wrapper alias for `publish_connection_status`. |
 | `BLEInterface.find_device`                | `COMPAT_STABLE_SHIM` | Silent         | Historical snake_case wrapper.                 |
 | `BLEInterface.findDevice`                 | `PRIMARY`            | Silent         | Approved promoted camelCase name.              |
 | `BLEClient._discover`                     | `COMPAT_STABLE_SHIM` | Silent         | Historical internal discovery entrypoint.      |
-| `BLEStateManager.is_connecting`           | `COMPAT_STABLE_SHIM` | Silent         | Public alias for `_is_connecting`.             |
+| `BLEStateManager.is_connecting()`         | `COMPAT_STABLE_SHIM` | Silent         | Public alias for `_is_connecting()`.           |
 | `BLEStateManager._lock`                   | `INTERNAL_COMPAT`    | Silent         | Alias to `lock` property for legacy internals. |
 | `meshtastic.ble_interface.BleakClient`    | `COMPAT_STABLE_SHIM` | Silent         | Legacy module-level import compatibility.      |
 | `meshtastic.ble_interface.BleakScanner`   | `COMPAT_STABLE_SHIM` | Silent         | Legacy module-level import compatibility.      |
@@ -169,7 +170,7 @@ Semantic deprecation:
 | `meshtastic.interfaces.ble.interface`             | `from_num_handler()`                 | `_from_num_handler()`             |
 | `meshtastic.interfaces.ble.interface`             | `log_radio_handler()`                | `_log_radio_handler()`            |
 | `meshtastic.interfaces.ble.interface`             | `legacy_log_radio_handler()`         | `_legacy_log_radio_handler()`     |
-| `meshtastic.interfaces.ble.state`                 | `is_connecting` property             | `_is_connecting` property         |
+| `meshtastic.interfaces.ble.state`                 | `is_connecting()`                    | `_is_connecting()`                |
 | `meshtastic.interfaces.ble.state`                 | `_lock` property                     | `lock` property                   |
 
 ### Powermon and Slog

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -60,8 +60,8 @@ Additional approved BLE compatibility and promotions:
 | `BLEInterface.find_device`                                      | `COMPAT_STABLE_SHIM` | Silent         | Historical snake_case wrapper.                 |
 | `BLEInterface.findDevice`                                       | `PRIMARY`            | Silent         | Approved promoted camelCase name.              |
 | `BLEClient._discover`                                           | `COMPAT_STABLE_SHIM` | Silent         | Historical internal discovery entrypoint.      |
-| `BLEStateManager.is_connecting()`                               | `COMPAT_STABLE_SHIM` | Silent         | Public alias for `_is_connecting()`.           |
-| `BLEStateManager._lock`                                         | `INTERNAL_COMPAT`    | Silent         | Alias to `lock` property for legacy internals. |
+| `BLEStateManager.is_connecting`                                 | `COMPAT_STABLE_SHIM` | Silent         | Public alias for `_is_connecting()`.           |
+| `BLEStateManager._lock`                                         | `INTERNAL_COMPAT`    | Silent         | Legacy alias for `lock` property.              |
 | `meshtastic.ble_interface.BleakClient`                          | `COMPAT_STABLE_SHIM` | Silent         | Legacy module-level import compatibility.      |
 | `meshtastic.ble_interface.BleakScanner`                         | `COMPAT_STABLE_SHIM` | Silent         | Legacy module-level import compatibility.      |
 | `meshtastic.ble_interface.BLEDevice`                            | `COMPAT_STABLE_SHIM` | Silent         | Legacy module-level import compatibility.      |

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -170,7 +170,7 @@ Semantic deprecation:
 | `meshtastic.interfaces.ble.interface`             | `from_num_handler()`                                              | `_from_num_handler()`                                      |
 | `meshtastic.interfaces.ble.interface`             | `log_radio_handler()`                                             | `_log_radio_handler()`                                     |
 | `meshtastic.interfaces.ble.interface`             | `legacy_log_radio_handler()`                                      | `_legacy_log_radio_handler()`                              |
-| `meshtastic.interfaces.ble.state`                 | `is_connecting()`                                                 | `_is_connecting()`                                         |
+| `meshtastic.interfaces.ble.state`                 | `is_connecting`                                                   | `_is_connecting()`                                         |
 | `meshtastic.interfaces.ble.state`                 | `_lock` property                                                  | `lock` property                                            |
 
 ### Powermon and Slog

--- a/meshtastic/interfaces/ble/client.py
+++ b/meshtastic/interfaces/ble/client.py
@@ -567,15 +567,11 @@ class BLEClient:
         """
 
         def operation() -> Coroutine[Any, Any, object]:
-            from typing import cast as typing_cast
-
             bleak_client = self._require_bleak_client(not_initialized_error)
             method = getattr(bleak_client, method_name, None)
             if not callable(method) or _is_unconfigured_mock_callable(method):
                 raise self.BLEError(unsupported_error)
-            return typing_cast(
-                Coroutine[Any, Any, object], method(**(call_kwargs or {}))
-            )
+            return cast(Coroutine[Any, Any, object], method(**(call_kwargs or {})))
 
         self._run_management_call(
             operation,

--- a/meshtastic/interfaces/ble/client.py
+++ b/meshtastic/interfaces/ble/client.py
@@ -565,12 +565,17 @@ class BLEClient:
         None
             Management operation is performed for side effects only.
         """
+
         def operation() -> Coroutine[Any, Any, object]:
+            from typing import cast as typing_cast
+
             bleak_client = self._require_bleak_client(not_initialized_error)
             method = getattr(bleak_client, method_name, None)
             if not callable(method) or _is_unconfigured_mock_callable(method):
                 raise self.BLEError(unsupported_error)
-            return method(**(call_kwargs or {}))
+            return typing_cast(
+                Coroutine[Any, Any, object], method(**(call_kwargs or {}))
+            )
 
         self._run_management_call(
             operation,

--- a/meshtastic/interfaces/ble/compatibility_service.py
+++ b/meshtastic/interfaces/ble/compatibility_service.py
@@ -11,11 +11,7 @@ from meshtastic.interfaces.ble.constants import (
 )
 from meshtastic.interfaces.ble.utils import (
     _is_unconfigured_mock_callable,
-)
-from meshtastic.interfaces.ble.utils import (
     _resolve_safe_execute as _resolve_safe_execute_hook,
-)
-from meshtastic.interfaces.ble.utils import (
     _safe_execute_through_adapter,
 )
 

--- a/meshtastic/interfaces/ble/compatibility_service.py
+++ b/meshtastic/interfaces/ble/compatibility_service.py
@@ -11,7 +11,11 @@ from meshtastic.interfaces.ble.constants import (
 )
 from meshtastic.interfaces.ble.utils import (
     _is_unconfigured_mock_callable,
+)
+from meshtastic.interfaces.ble.utils import (
     _resolve_safe_execute as _resolve_safe_execute_hook,
+)
+from meshtastic.interfaces.ble.utils import (
     _safe_execute_through_adapter,
 )
 

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -1582,7 +1582,11 @@ class ConnectionOrchestrator:
             prior_ever_connected = (
                 False
                 if _is_unconfigured_mock_member(raw_ever_connected)
-                else raw_ever_connected if isinstance(raw_ever_connected, bool) else False
+                else (
+                    raw_ever_connected
+                    if isinstance(raw_ever_connected, bool)
+                    else False
+                )
             )
             on_connected_func()
             if prior_ever_connected:

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -111,12 +111,16 @@ def _run_safe_cleanup(
         ``False``.
     """
     cleanup_ran = False
+    cleanup_invoked = False
 
     def _tracked_cleanup() -> object:
-        nonlocal cleanup_ran
+        nonlocal cleanup_invoked, cleanup_ran
+        cleanup_invoked = True
+        result = func()
         cleanup_ran = True
-        return func()
+        return result
 
+    handled = False
     if safe_cleanup_hook is not None:
         try:
             handled = bool(
@@ -134,23 +138,22 @@ def _run_safe_cleanup(
                         cleanup_name,
                         exc_info=True,
                     )
-                    return cleanup_ran
             else:
                 logger.debug(
                     "Error running safe_cleanup hook for %s",
                     cleanup_name,
                     exc_info=True,
                 )
-                return cleanup_ran
         except Exception:  # noqa: BLE001 - cleanup path must stay best-effort
             logger.debug(
                 "Error running safe_cleanup hook for %s",
                 cleanup_name,
                 exc_info=True,
             )
-            return cleanup_ran
         if handled or cleanup_ran:
             return True
+        if cleanup_invoked:
+            return False
     if cleanup_ran:
         return True
     try:

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -154,8 +154,6 @@ def _run_safe_cleanup(
             return True
         if cleanup_invoked:
             return False
-    if cleanup_ran:
-        return True
     try:
         _tracked_cleanup()
     except Exception:  # noqa: BLE001 - cleanup path must stay best-effort
@@ -814,27 +812,36 @@ class ConnectionOrchestrator:
         AttributeError
             If no supported member exists and no default is provided.
         """
+        # Use the function's own default sentinel rather than module globals so
+        # behavior remains stable even if this module is reloaded in tests.
+        dispatch_kwdefaults = (
+            self._dispatch_public_or_underscore.__func__.__kwdefaults__ or {}
+        )
+        missing_sentinel = cast(
+            object,
+            dispatch_kwdefaults.get("default_if_missing", _DISPATCH_MISSING),
+        )
         kwargs = {} if kwargs is None else kwargs
-        public_member = getattr(target, public_name, _DISPATCH_MISSING)
-        underscore_member = getattr(target, underscore_name, _DISPATCH_MISSING)
+        public_member = getattr(target, public_name, missing_sentinel)
+        underscore_member = getattr(target, underscore_name, missing_sentinel)
 
         if not call_member:
             if _is_unconfigured_mock_member(public_member):
-                public_member = _DISPATCH_MISSING
+                public_member = missing_sentinel
             if _is_unconfigured_mock_member(underscore_member):
-                underscore_member = _DISPATCH_MISSING
+                underscore_member = missing_sentinel
         else:
             if _is_unconfigured_mock_callable(public_member):
-                public_member = _DISPATCH_MISSING
+                public_member = missing_sentinel
             if _is_unconfigured_mock_callable(underscore_member):
-                underscore_member = _DISPATCH_MISSING
+                underscore_member = missing_sentinel
 
         if (
             prefer_instance_type is not None
             and isinstance(target, prefer_instance_type)
             and not _is_mock_instance(target)
         ):
-            if public_member is _DISPATCH_MISSING:
+            if public_member is missing_sentinel:
                 raise AttributeError(
                     f"{type(target).__name__} is missing required member '{public_name}'"
                 )
@@ -852,18 +859,18 @@ class ConnectionOrchestrator:
             if callable(underscore_member):
                 return underscore_member(*args, **kwargs)
         else:
-            if public_member is not _DISPATCH_MISSING:
+            if public_member is not missing_sentinel:
                 if underscore_attr_type is None or isinstance(
                     public_member, underscore_attr_type
                 ):
                     return public_member
-            if underscore_member is not _DISPATCH_MISSING and (
+            if underscore_member is not missing_sentinel and (
                 underscore_attr_type is None
                 or isinstance(underscore_member, underscore_attr_type)
             ):
                 return underscore_member
 
-        if default_if_missing is not _DISPATCH_MISSING:
+        if default_if_missing is not missing_sentinel:
             return default_if_missing
 
         raise AttributeError(

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -8,7 +8,6 @@ import sys
 from collections.abc import Callable
 from threading import Event, RLock
 from typing import TYPE_CHECKING, cast
-from unittest.mock import Mock, NonCallableMock
 
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakDBusError, BleakDeviceNotFoundError, BleakError
@@ -69,6 +68,98 @@ def _is_device_not_found_error(err: Exception) -> bool:
     return bool(message) and _DEVICE_NOT_FOUND_MESSAGE_RE.search(message) is not None
 
 
+def _is_mock_instance(target: object) -> bool:
+    """Return whether ``target`` is a unittest mock instance.
+
+    Parameters
+    ----------
+    target : object
+        Candidate object inspected for mock-instance type.
+
+    Returns
+    -------
+    bool
+        ``True`` when ``target`` is a ``Mock`` or ``NonCallableMock``.
+    """
+    try:
+        from unittest.mock import Mock, NonCallableMock
+    except Exception:  # pragma: no cover - stdlib import should always exist
+        return False
+    return isinstance(target, (Mock, NonCallableMock))
+
+
+def _run_safe_cleanup(
+    func: Callable[[], object],
+    cleanup_name: str,
+    safe_cleanup_hook: Callable[..., object] | None,
+) -> bool:
+    """Run cleanup through hook when available, otherwise inline best effort.
+
+    Parameters
+    ----------
+    func : Callable[[], object]
+        Cleanup callable to execute.
+    cleanup_name : str
+        Cleanup operation label used in debug logs.
+    safe_cleanup_hook : Callable[..., object] | None
+        Optional hook resolved from error-handler compatibility surface.
+
+    Returns
+    -------
+    bool
+        ``True`` when cleanup was handled/executed successfully, otherwise
+        ``False``.
+    """
+    cleanup_ran = False
+
+    def _tracked_cleanup() -> object:
+        nonlocal cleanup_ran
+        cleanup_ran = True
+        return func()
+
+    if safe_cleanup_hook is not None:
+        try:
+            handled = bool(
+                safe_cleanup_hook(func=_tracked_cleanup, cleanup_name=cleanup_name)
+            )
+        except TypeError as exc:
+            if _is_unexpected_keyword_error(
+                exc, "func"
+            ) or _is_unexpected_keyword_error(exc, "cleanup_name"):
+                try:
+                    handled = bool(safe_cleanup_hook(_tracked_cleanup, cleanup_name))
+                except Exception:  # noqa: BLE001 - cleanup path must stay best-effort
+                    logger.debug(
+                        "Error running safe_cleanup hook for %s",
+                        cleanup_name,
+                        exc_info=True,
+                    )
+                    return cleanup_ran
+            else:
+                logger.debug(
+                    "Error running safe_cleanup hook for %s",
+                    cleanup_name,
+                    exc_info=True,
+                )
+                return cleanup_ran
+        except Exception:  # noqa: BLE001 - cleanup path must stay best-effort
+            logger.debug(
+                "Error running safe_cleanup hook for %s",
+                cleanup_name,
+                exc_info=True,
+            )
+            return cleanup_ran
+        if handled or cleanup_ran:
+            return True
+    if cleanup_ran:
+        return True
+    try:
+        _tracked_cleanup()
+    except Exception:  # noqa: BLE001 - cleanup path must stay best-effort
+        return False
+    return True
+
+
 class ConnectionValidator:
     """Encapsulate connection pre-checks and reuse logic."""
 
@@ -112,7 +203,7 @@ class ConnectionValidator:
                 raise self.BLEError(BLECLIENT_ERROR_ALREADY_CONNECTED)
 
     def validate_connection_request(self) -> None:
-        # COMPAT_STABLE_SHIM: Public compatibility alias; delegates to _validate_connection_request.
+        # Internal adapter alias for collaborator migration; delegates to _validate_connection_request.
         """Validate whether a BLE connection request may proceed.
 
         Parameters
@@ -212,7 +303,7 @@ class ConnectionValidator:
         normalized_request: str | None,
         last_connection_request: str | None,
     ) -> bool:
-        # COMPAT_STABLE_SHIM: Public compatibility alias; delegates to _check_existing_client.
+        # Internal adapter alias for collaborator migration; delegates to _check_existing_client.
         """Check whether an existing client still matches the requested target.
 
         Parameters
@@ -388,7 +479,7 @@ class ClientManager:
         pair_on_connect: bool = False,
         connect_timeout: float | None = None,
     ) -> BLEClient:
-        # COMPAT_STABLE_SHIM: Public compatibility alias; delegates to _create_client.
+        # Internal adapter alias for collaborator migration; delegates to _create_client.
         """Create a BLE client through the compatibility wrapper surface.
 
         Parameters
@@ -456,7 +547,7 @@ class ClientManager:
             client._get_services()
 
     def connect_client(self, client: BLEClient, timeout: float | None = None) -> None:
-        # COMPAT_STABLE_SHIM: Public compatibility alias; delegates to _connect_client.
+        # Internal adapter alias for collaborator migration; delegates to _connect_client.
         """Connect a BLE client and ensure service readiness.
 
         Parameters
@@ -540,7 +631,7 @@ class ClientManager:
         new_client: BLEClient,
         old_client: BLEClient | None,
     ) -> None:
-        # COMPAT_STABLE_SHIM: Public compatibility alias; delegates to _update_client_reference.
+        # Internal adapter alias for collaborator migration; delegates to _update_client_reference.
         """Update active-client reference and schedule old-client cleanup.
 
         Parameters
@@ -585,83 +676,29 @@ class ClientManager:
         ):
             safe_cleanup_hook = None
 
-        def run_safe_cleanup(func: Callable[[], object], cleanup_name: str) -> bool:
-            """Run cleanup through hook when available, otherwise inline best effort."""
-            cleanup_ran = False
-
-            def _tracked_cleanup() -> object:
-                nonlocal cleanup_ran
-                cleanup_ran = True
-                return func()
-
-            if safe_cleanup_hook is not None:
-                try:
-                    handled = bool(
-                        safe_cleanup_hook(
-                            func=_tracked_cleanup, cleanup_name=cleanup_name
-                        )
-                    )
-                except TypeError as exc:
-                    if _is_unexpected_keyword_error(
-                        exc, "func"
-                    ) or _is_unexpected_keyword_error(exc, "cleanup_name"):
-                        try:
-                            handled = bool(
-                                safe_cleanup_hook(_tracked_cleanup, cleanup_name)
-                            )
-                        except Exception:  # noqa: BLE001 - cleanup path must stay best-effort
-                            logger.debug(
-                                "Error running safe_cleanup hook for %s",
-                                cleanup_name,
-                                exc_info=True,
-                            )
-                            return cleanup_ran
-                    else:
-                        logger.debug(
-                            "Error running safe_cleanup hook for %s",
-                            cleanup_name,
-                            exc_info=True,
-                        )
-                        return cleanup_ran
-                except Exception:  # noqa: BLE001 - cleanup path must stay best-effort
-                    logger.debug(
-                        "Error running safe_cleanup hook for %s",
-                        cleanup_name,
-                        exc_info=True,
-                    )
-                    return cleanup_ran
-                if handled or cleanup_ran:
-                    return True
-            if cleanup_ran:
-                return True
-            try:
-                _tracked_cleanup()
-            except Exception:  # noqa: BLE001 - cleanup path must stay best-effort
-                return False
-            return True
-
         if (
             not skip_disconnect
             and not getattr(client, "_closed", False)
             and getattr(client, "bleak_client", None)
         ):
-            run_safe_cleanup(
+            _run_safe_cleanup(
                 lambda: client.disconnect(await_timeout=DISCONNECT_TIMEOUT_SECONDS),
                 "client disconnect",
+                safe_cleanup_hook,
             )
         elif skip_disconnect:
             logger.debug(
                 "Skipping BLE client disconnect during interpreter finalization."
             )
         if not skip_disconnect:
-            run_safe_cleanup(client.close, "client close")
+            _run_safe_cleanup(client.close, "client close", safe_cleanup_hook)
         else:
             logger.debug("Skipping BLE client close during interpreter finalization.")
         if event:
             event.set()
 
     def safe_close_client(self, client: BLEClient, event: Event | None = None) -> None:
-        # COMPAT_STABLE_SHIM: Public compatibility alias; delegates to _safe_close_client.
+        # Internal adapter alias for collaborator migration; delegates to _safe_close_client.
         """Close a BLE client using best-effort shutdown semantics.
 
         Parameters
@@ -683,8 +720,8 @@ class ClientManager:
         """
         if event is None:
             self._safe_close_client(client)
-        else:
-            self._safe_close_client(client, event=event)
+            return
+        self._safe_close_client(client, event=event)
 
 
 class ConnectionOrchestrator:
@@ -792,7 +829,7 @@ class ConnectionOrchestrator:
         if (
             prefer_instance_type is not None
             and isinstance(target, prefer_instance_type)
-            and not isinstance(target, (Mock, NonCallableMock))
+            and not _is_mock_instance(target)
         ):
             if public_member is _DISPATCH_MISSING:
                 raise AttributeError(
@@ -1742,7 +1779,7 @@ class ConnectionOrchestrator:
         connect_timeout: float | None = None,
         emit_connected_side_effects: bool = True,
     ) -> BLEClient:
-        # COMPAT_STABLE_SHIM: Public compatibility alias; delegates to _establish_connection.
+        # Internal adapter alias for collaborator migration; delegates to _establish_connection.
         """Establish a BLE connection through the public compatibility surface.
 
         Parameters

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -815,7 +815,7 @@ class ConnectionOrchestrator:
         # Use the function's own default sentinel rather than module globals so
         # behavior remains stable even if this module is reloaded in tests.
         dispatch_kwdefaults = (
-            self._dispatch_public_or_underscore.__func__.__kwdefaults__ or {}
+            type(self)._dispatch_public_or_underscore.__kwdefaults__ or {}
         )
         missing_sentinel = cast(
             object,

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -83,7 +83,7 @@ def _is_mock_instance(target: object) -> bool:
     """
     try:
         from unittest.mock import Mock, NonCallableMock
-    except Exception:  # pragma: no cover - stdlib import should always exist
+    except ImportError:  # pragma: no cover - stdlib import should always exist
         return False
     return isinstance(target, (Mock, NonCallableMock))
 

--- a/meshtastic/interfaces/ble/discovery.py
+++ b/meshtastic/interfaces/ble/discovery.py
@@ -501,7 +501,10 @@ class DiscoveryManager:
             Callable[..., Any], self.client_factory or BLEClient
         )
         cached_candidate: (
-            BLEClient | DiscoveryClientProtocol | UnderscoreDiscoveryClientProtocol | None
+            BLEClient
+            | DiscoveryClientProtocol
+            | UnderscoreDiscoveryClientProtocol
+            | None
         ) = None
 
         def _probe_connected_state(candidate: object) -> bool | None:
@@ -539,10 +542,7 @@ class DiscoveryManager:
                 self._client = None
 
         with self._client_lock:
-            cached_candidate = cast(
-                BLEClient | DiscoveryClientProtocol | UnderscoreDiscoveryClientProtocol | None,
-                self._client,
-            )
+            cached_candidate = self._client
 
         discard_cached_candidate = False
         # Only discard the client if it was previously connected and has since

--- a/meshtastic/interfaces/ble/errors.py
+++ b/meshtastic/interfaces/ble/errors.py
@@ -187,8 +187,7 @@ class BLEErrorHandler:
     # COMPAT_STABLE_SHIM: Public compatibility alias; delegates to _safe_cleanup.
     @classmethod
     def safe_cleanup(
-        cls,
-        func: Callable[[], Any], cleanup_name: str = "cleanup operation"
+        cls, func: Callable[[], Any], cleanup_name: str = "cleanup operation"
     ) -> bool:
         """Run a cleanup callable and suppress non-fatal cleanup exceptions.
 

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -800,7 +800,9 @@ class BLEInterface(MeshInterface):
             ):
                 try:
                     handler(sender, data)
-                except Exception:  # noqa: BLE001 - notification callbacks must stay best effort
+                except (
+                    Exception
+                ):  # noqa: BLE001 - notification callbacks must stay best effort
                     _report_notification_error()
                 return
             self._invoke_safe_execute_compat(
@@ -1092,8 +1094,7 @@ class BLEInterface(MeshInterface):
             awaitable,
             timeout,
             label,
-            timeout_error_factory=lambda timeout_label,
-            timeout_seconds: BLEInterface.BLEError(
+            timeout_error_factory=lambda timeout_label, timeout_seconds: BLEInterface.BLEError(
                 ERROR_TIMEOUT.format(timeout_label, timeout_seconds)
             ),
         )
@@ -2090,16 +2091,15 @@ class BLEInterface(MeshInterface):
         AttributeError
             If no supported delay helper exists on ``policy``.
         """
-        return float(
-            BLEInterface._compat_dispatch_callable(
-                policy,
-                public_name="get_delay",
-                legacy_name="_get_delay",
-                fallback_attr_name=None,
-                error_message=ERROR_RETRY_POLICY_MISSING_GET_DELAY,
-                args=(attempt,),
-            )
+        result = BLEInterface._compat_dispatch_callable(
+            policy,
+            public_name="get_delay",
+            legacy_name="_get_delay",
+            fallback_attr_name=None,
+            error_message=ERROR_RETRY_POLICY_MISSING_GET_DELAY,
+            args=(attempt,),
         )
+        return float(result) if isinstance(result, (int, float)) else 0.0
 
     @property
     def _connection_state(self) -> ConnectionState:

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -137,6 +137,10 @@ ERROR_RETRY_POLICY_MISSING_SHOULD_RETRY: str = (
     "Retry policy missing should_retry/_should_retry"
 )
 ERROR_RETRY_POLICY_MISSING_GET_DELAY: str = "Retry policy missing get_delay/_get_delay"
+_SAFE_EXECUTE_POSITIONAL_SIGNATURE_MISMATCH_RE = re.compile(
+    r"positional.*argument|takes .* positional|missing required positional",
+    re.IGNORECASE,
+)
 ERROR_DISCOVERY_MANAGER_MISSING_DISCOVER_DEVICES: str = (
     "Discovery manager is missing discover_devices/_discover_devices"
 )
@@ -686,24 +690,38 @@ class BLEInterface(MeshInterface):
         None
             Returns ``None`` after invoking a compatible signature or fallback.
         """
+        executed = False
+
+        def _tracked_handler_thunk() -> None:
+            nonlocal executed
+            executed = True
+            handler_thunk()
+
+        def _fallback_if_not_executed() -> None:
+            if not executed:
+                fallback()
+
         try:
-            safe_execute(handler_thunk, error_msg=error_msg)
+            safe_execute(_tracked_handler_thunk, error_msg=error_msg)
             return
         except TypeError as exc:
             if not _is_unexpected_keyword_error(exc, "error_msg"):
-                fallback()
+                _fallback_if_not_executed()
                 return
         except Exception:  # noqa: BLE001 - notification callbacks must stay best effort
-            fallback()
+            _fallback_if_not_executed()
+            return
+
+        if executed:
             return
 
         try:
-            safe_execute(handler_thunk, error_msg)
+            safe_execute(_tracked_handler_thunk, error_msg)
             return
         except TypeError as exc:
             # Most TypeError cases here are compatibility signature mismatches.
             # Only probe callable-only when this looks like a signature mismatch.
-            if "positional argument" in str(exc):
+            if _SAFE_EXECUTE_POSITIONAL_SIGNATURE_MISMATCH_RE.search(str(exc)):
                 pass
             else:
                 logger.debug(
@@ -711,7 +729,7 @@ class BLEInterface(MeshInterface):
                     error_msg,
                     exc_info=True,
                 )
-                fallback()
+                _fallback_if_not_executed()
                 return
         except Exception:  # noqa: BLE001 - notification callbacks must stay best effort
             logger.debug(
@@ -719,14 +737,17 @@ class BLEInterface(MeshInterface):
                 error_msg,
                 exc_info=True,
             )
-            fallback()
+            _fallback_if_not_executed()
+            return
+
+        if executed:
             return
 
         try:
-            safe_execute(handler_thunk)
+            safe_execute(_tracked_handler_thunk)
             return
         except Exception:  # noqa: BLE001 - notification callbacks must stay best effort
-            fallback()
+            _fallback_if_not_executed()
 
     def _from_num_handler(self, _: Any, b: bytes | bytearray) -> None:
         """Process a FROMNUM characteristic notification and wake the receive loop.
@@ -2129,16 +2150,17 @@ class BLEInterface(MeshInterface):
             error_message=ERROR_RETRY_POLICY_MISSING_GET_DELAY,
             args=(attempt,),
         )
-        if (
-            isinstance(result, numbers.Real)
-            and not isinstance(result, bool)
-            and math.isfinite(result)
-            and float(result) >= 0
-        ):
-            return float(result)
+        if isinstance(result, numbers.Real) and not isinstance(result, bool):
+            try:
+                normalized_result = float(result)
+            except (TypeError, ValueError, OverflowError):
+                normalized_result = None
+            else:
+                if math.isfinite(normalized_result) and normalized_result >= 0:
+                    return normalized_result
         logger.debug(
-            "Retry policy get_delay returned non-numeric %r; defaulting to 0.0",
-            type(result).__name__,
+            "Retry policy get_delay returned invalid value %r; defaulting to 0.0",
+            result,
         )
         return 0.0
 

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -698,8 +698,21 @@ class BLEInterface(MeshInterface):
         try:
             safe_execute(handler_thunk, error_msg)
             return
+        except TypeError as exc:
+            # Most TypeError cases here are compatibility signature mismatches.
+            # Keep probing the callable-only variant before invoking fallback.
+            if "positional argument" not in str(exc):
+                logger.debug(
+                    "safe_execute positional probe raised TypeError for notification handler (%s); trying callable-only fallback.",
+                    error_msg,
+                    exc_info=True,
+                )
         except Exception:  # noqa: BLE001 - notification callbacks must stay best effort
-            pass
+            logger.debug(
+                "safe_execute positional probe failed for notification handler (%s); trying callable-only fallback.",
+                error_msg,
+                exc_info=True,
+            )
 
         try:
             safe_execute(handler_thunk)
@@ -2099,7 +2112,13 @@ class BLEInterface(MeshInterface):
             error_message=ERROR_RETRY_POLICY_MISSING_GET_DELAY,
             args=(attempt,),
         )
-        return float(result) if isinstance(result, (int, float)) else 0.0
+        if isinstance(result, (int, float)):
+            return float(result)
+        logger.debug(
+            "Retry policy get_delay returned non-numeric %r; defaulting to 0.0",
+            type(result).__name__,
+        )
+        return 0.0
 
     @property
     def _connection_state(self) -> ConnectionState:

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -851,9 +851,7 @@ class BLEInterface(MeshInterface):
             ):
                 try:
                     _invoke_handler()
-                except (
-                    Exception
-                ):  # noqa: BLE001 - notification callbacks must stay best effort
+                except Exception:  # noqa: BLE001 - notification callbacks must stay best effort
                     _report_notification_error()
                 return
             self._invoke_safe_execute_compat(
@@ -1145,7 +1143,8 @@ class BLEInterface(MeshInterface):
             awaitable,
             timeout,
             label,
-            timeout_error_factory=lambda timeout_label, timeout_seconds: BLEInterface.BLEError(
+            timeout_error_factory=lambda timeout_label,
+            timeout_seconds: BLEInterface.BLEError(
                 ERROR_TIMEOUT.format(timeout_label, timeout_seconds)
             ),
         )
@@ -2155,9 +2154,12 @@ class BLEInterface(MeshInterface):
                 normalized_result = float(result)
             except (TypeError, ValueError, OverflowError):
                 normalized_result = None
-            else:
-                if math.isfinite(normalized_result) and normalized_result >= 0:
-                    return normalized_result
+            if (
+                normalized_result is not None
+                and math.isfinite(normalized_result)
+                and normalized_result >= 0
+            ):
+                return normalized_result
         logger.debug(
             "Retry policy get_delay returned invalid value %r; defaulting to 0.0",
             result,

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -811,6 +811,15 @@ class BLEInterface(MeshInterface):
             def _report_notification_error() -> None:
                 self._report_notification_handler_error(error_msg)
 
+            def _invoke_handler() -> None:
+                handler(sender, data)
+
+            def _fallback_invoke_handler() -> None:
+                try:
+                    _invoke_handler()
+                except Exception:  # noqa: BLE001 - notification callbacks must stay best effort
+                    _report_notification_error()
+
             safe_execute = getattr(self.error_handler, "safe_execute", None)
             if not callable(safe_execute) or _is_unconfigured_mock_callable(
                 safe_execute
@@ -820,7 +829,7 @@ class BLEInterface(MeshInterface):
                 safe_execute
             ):
                 try:
-                    handler(sender, data)
+                    _invoke_handler()
                 except (
                     Exception
                 ):  # noqa: BLE001 - notification callbacks must stay best effort
@@ -828,9 +837,9 @@ class BLEInterface(MeshInterface):
                 return
             self._invoke_safe_execute_compat(
                 safe_execute,
-                lambda: handler(sender, data),
+                _invoke_handler,
                 error_msg=error_msg,
-                fallback=_report_notification_error,
+                fallback=_fallback_invoke_handler,
             )
 
         def _safe_legacy_handler(sender: Any, data: bytes | bytearray) -> None:

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -26,6 +26,8 @@ Threading model summary
 
 import atexit
 import contextlib
+import math
+import numbers
 import re
 import shutil
 import struct
@@ -700,19 +702,25 @@ class BLEInterface(MeshInterface):
             return
         except TypeError as exc:
             # Most TypeError cases here are compatibility signature mismatches.
-            # Keep probing the callable-only variant before invoking fallback.
-            if "positional argument" not in str(exc):
+            # Only probe callable-only when this looks like a signature mismatch.
+            if "positional argument" in str(exc):
+                pass
+            else:
                 logger.debug(
-                    "safe_execute positional probe raised TypeError for notification handler (%s); trying callable-only fallback.",
+                    "safe_execute positional probe raised TypeError for notification handler (%s); skipping callable-only probe to avoid duplicate handler execution.",
                     error_msg,
                     exc_info=True,
                 )
+                fallback()
+                return
         except Exception:  # noqa: BLE001 - notification callbacks must stay best effort
             logger.debug(
-                "safe_execute positional probe failed for notification handler (%s); trying callable-only fallback.",
+                "safe_execute positional probe failed for notification handler (%s); skipping callable-only probe to avoid duplicate handler execution.",
                 error_msg,
                 exc_info=True,
             )
+            fallback()
+            return
 
         try:
             safe_execute(handler_thunk)
@@ -2112,7 +2120,12 @@ class BLEInterface(MeshInterface):
             error_message=ERROR_RETRY_POLICY_MISSING_GET_DELAY,
             args=(attempt,),
         )
-        if isinstance(result, (int, float)) and not isinstance(result, bool):
+        if (
+            isinstance(result, numbers.Real)
+            and not isinstance(result, bool)
+            and math.isfinite(result)
+            and result >= 0
+        ):
             return float(result)
         logger.debug(
             "Retry policy get_delay returned non-numeric %r; defaulting to 0.0",

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -706,6 +706,12 @@ class BLEInterface(MeshInterface):
             return
         except TypeError as exc:
             if not _is_unexpected_keyword_error(exc, "error_msg"):
+                logger.debug(
+                    "safe_execute keyword probe raised TypeError for notification handler (%s): %s",
+                    error_msg,
+                    exc,
+                    exc_info=True,
+                )
                 _fallback_if_not_executed()
                 return
         except Exception as exc:  # noqa: BLE001 - notification callbacks must stay best effort
@@ -753,6 +759,11 @@ class BLEInterface(MeshInterface):
             safe_execute(_tracked_handler_thunk)
             return
         except Exception:  # noqa: BLE001 - notification callbacks must stay best effort
+            logger.debug(
+                "safe_execute callable-only probe failed for notification handler (%s).",
+                error_msg,
+                exc_info=True,
+            )
             _fallback_if_not_executed()
 
     def _from_num_handler(self, _: Any, b: bytes | bytearray) -> None:

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -708,7 +708,13 @@ class BLEInterface(MeshInterface):
             if not _is_unexpected_keyword_error(exc, "error_msg"):
                 _fallback_if_not_executed()
                 return
-        except Exception:  # noqa: BLE001 - notification callbacks must stay best effort
+        except Exception as exc:  # noqa: BLE001 - notification callbacks must stay best effort
+            logger.debug(
+                "safe_execute keyword probe failed for notification handler (%s): %s",
+                error_msg,
+                exc,
+                exc_info=True,
+            )
             _fallback_if_not_executed()
             return
 

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -287,6 +287,7 @@ class BLEInterface(MeshInterface):
         self._prior_publish_was_reconnect = False
         self._last_connect_pair_override: bool | None = None
         self._last_connect_timeout_override: float | None = None
+        self._publishing_thread_override: object | None = None
 
         # Error handling infrastructure
         self.error_handler = BLEErrorHandler()
@@ -627,6 +628,85 @@ class BLEInterface(MeshInterface):
                 )
                 self._malformed_notification_count = 0
 
+    def _report_notification_handler_error(self, error_msg: str) -> None:
+        """Report notification-handler failures through configured error hooks.
+
+        Parameters
+        ----------
+        error_msg : str
+            Message forwarded to unhandled-exception hooks and debug logging.
+
+        Returns
+        -------
+        None
+            Returns ``None`` after best-effort error reporting.
+        """
+        report_exception: Callable[[str], Any] | None = None
+        for hook_name in (
+            "handle_unhandled_exception",
+            "_handle_unhandled_exception",
+        ):
+            hook = getattr(self.error_handler, hook_name, None)
+            if callable(hook) and not _is_unconfigured_mock_callable(hook):
+                report_exception = cast(Callable[[str], Any], hook)
+                break
+        if report_exception is not None:
+            try:
+                report_exception(error_msg)
+            except Exception:  # noqa: BLE001 - callback error reporting is best effort
+                logger.debug(error_msg, exc_info=True)
+            return
+        logger.debug(error_msg, exc_info=True)
+
+    @staticmethod
+    def _invoke_safe_execute_compat(
+        safe_execute: Callable[..., Any],
+        handler_thunk: Callable[[], None],
+        *,
+        error_msg: str,
+        fallback: Callable[[], None],
+    ) -> None:
+        """Invoke ``safe_execute`` with compatibility fallbacks.
+
+        Parameters
+        ----------
+        safe_execute : Callable[..., Any]
+            Resolved safe-execute hook from the error handler.
+        handler_thunk : Callable[[], None]
+            Thunk that executes the notification handler.
+        error_msg : str
+            Error message used for keyword/positional dispatch.
+        fallback : Callable[[], None]
+            Callback invoked when no compatible hook signature succeeds.
+
+        Returns
+        -------
+        None
+            Returns ``None`` after invoking a compatible signature or fallback.
+        """
+        try:
+            safe_execute(handler_thunk, error_msg=error_msg)
+            return
+        except TypeError as exc:
+            if not _is_unexpected_keyword_error(exc, "error_msg"):
+                fallback()
+                return
+        except Exception:  # noqa: BLE001 - notification callbacks must stay best effort
+            fallback()
+            return
+
+        try:
+            safe_execute(handler_thunk, error_msg)
+            return
+        except Exception:  # noqa: BLE001 - notification callbacks must stay best effort
+            pass
+
+        try:
+            safe_execute(handler_thunk)
+            return
+        except Exception:  # noqa: BLE001 - notification callbacks must stay best effort
+            fallback()
+
     def _from_num_handler(self, _: Any, b: bytes | bytearray) -> None:
         """Process a FROMNUM characteristic notification and wake the receive loop.
 
@@ -708,22 +788,7 @@ class BLEInterface(MeshInterface):
             """
 
             def _report_notification_error() -> None:
-                report_exception: Callable[[str], Any] | None = None
-                for hook_name in (
-                    "handle_unhandled_exception",
-                    "_handle_unhandled_exception",
-                ):
-                    hook = getattr(self.error_handler, hook_name, None)
-                    if callable(hook) and not _is_unconfigured_mock_callable(hook):
-                        report_exception = cast(Callable[[str], Any], hook)
-                        break
-                if report_exception is not None:
-                    try:
-                        report_exception(error_msg)
-                    except Exception:  # noqa: BLE001 - callback error reporting is best effort
-                        logger.debug(error_msg, exc_info=True)
-                else:
-                    logger.debug(error_msg, exc_info=True)
+                self._report_notification_handler_error(error_msg)
 
             safe_execute = getattr(self.error_handler, "safe_execute", None)
             if not callable(safe_execute) or _is_unconfigured_mock_callable(
@@ -738,27 +803,12 @@ class BLEInterface(MeshInterface):
                 except Exception:  # noqa: BLE001 - notification callbacks must stay best effort
                     _report_notification_error()
                 return
-            try:
-                safe_execute(lambda: handler(sender, data), error_msg=error_msg)
-            except TypeError as exc:
-                if not _is_unexpected_keyword_error(exc, "error_msg"):
-                    _report_notification_error()
-                    return
-                try:
-                    safe_execute(lambda: handler(sender, data), error_msg)
-                except TypeError as positional_exc:
-                    # Some legacy hooks accept only the callable argument.
-                    if "positional argument" not in str(positional_exc):
-                        _report_notification_error()
-                        return
-                    try:
-                        safe_execute(lambda: handler(sender, data))
-                    except Exception:  # noqa: BLE001 - notification callbacks must stay best effort
-                        _report_notification_error()
-                except Exception:  # noqa: BLE001 - notification callbacks must stay best effort
-                    _report_notification_error()
-            except Exception:  # noqa: BLE001 - notification callbacks must stay best effort
-                _report_notification_error()
+            self._invoke_safe_execute_compat(
+                safe_execute,
+                lambda: handler(sender, data),
+                error_msg=error_msg,
+                fallback=_report_notification_error,
+            )
 
         def _safe_legacy_handler(sender: Any, data: bytes | bytearray) -> None:
             """Invoke the legacy log-radio notification handler for a BLE notification and suppress any exceptions raised by the handler.
@@ -1780,7 +1830,7 @@ class BLEInterface(MeshInterface):
                 discovery_manager,
                 public_name="discover_devices",
                 legacy_name="_discover_devices",
-                fallback_attr_name="discover_devices",
+                fallback_attr_name=None,
                 error_message=ERROR_DISCOVERY_MANAGER_MISSING_DISCOVER_DEVICES,
                 args=(address,),
             ),
@@ -2041,16 +2091,13 @@ class BLEInterface(MeshInterface):
             If no supported delay helper exists on ``policy``.
         """
         return float(
-            cast(
-                float,
-                BLEInterface._compat_dispatch_callable(
-                    policy,
-                    public_name="get_delay",
-                    legacy_name="_get_delay",
-                    fallback_attr_name=None,
-                    error_message=ERROR_RETRY_POLICY_MISSING_GET_DELAY,
-                    args=(attempt,),
-                ),
+            BLEInterface._compat_dispatch_callable(
+                policy,
+                public_name="get_delay",
+                legacy_name="_get_delay",
+                fallback_attr_name=None,
+                error_message=ERROR_RETRY_POLICY_MISSING_GET_DELAY,
+                args=(attempt,),
             )
         )
 
@@ -2890,6 +2937,19 @@ class BLEInterface(MeshInterface):
             management_wait_poll_seconds=_MANAGEMENT_CONNECT_WAIT_POLL_SECONDS,
         )
 
+    def _get_publishing_thread(self) -> object:
+        """Resolve the publishing-thread adapter used for compatibility events.
+
+        Returns
+        -------
+        object
+            Instance override when configured, otherwise module-level
+            ``publishingThread``.
+        """
+        if self._publishing_thread_override is not None:
+            return self._publishing_thread_override
+        return publishingThread
+
     def _wait_for_disconnect_notifications(self, timeout: float | None = None) -> None:
         """Wait up to timeout seconds for the publishing thread to flush pending publish callbacks.
 
@@ -2903,7 +2963,7 @@ class BLEInterface(MeshInterface):
         BLECompatibilityEventService.wait_for_disconnect_notifications(
             self,
             timeout,
-            publishing_thread=publishingThread,
+            publishing_thread=self._get_publishing_thread(),
         )
 
     def _disconnect_and_close_client(self, client: BLEClient) -> None:
@@ -2929,7 +2989,7 @@ class BLEInterface(MeshInterface):
         BLECompatibilityEventService.drain_publish_queue(
             self,
             flush_event,
-            publishing_thread=publishingThread,
+            publishing_thread=self._get_publishing_thread(),
         )
 
     def _publish_connection_status(self, *, connected: bool) -> None:
@@ -2948,7 +3008,7 @@ class BLEInterface(MeshInterface):
         BLECompatibilityEventService.publish_connection_status(
             self,
             connected=connected,
-            publishing_thread=publishingThread,
+            publishing_thread=self._get_publishing_thread(),
         )
 
     def _disconnected(self) -> None:

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -2124,7 +2124,7 @@ class BLEInterface(MeshInterface):
             isinstance(result, numbers.Real)
             and not isinstance(result, bool)
             and math.isfinite(result)
-            and result >= 0
+            and float(result) >= 0
         ):
             return float(result)
         logger.debug(

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -2112,7 +2112,7 @@ class BLEInterface(MeshInterface):
             error_message=ERROR_RETRY_POLICY_MISSING_GET_DELAY,
             args=(attempt,),
         )
-        if isinstance(result, (int, float)):
+        if isinstance(result, (int, float)) and not isinstance(result, bool):
             return float(result)
         logger.debug(
             "Retry policy get_delay returned non-numeric %r; defaulting to 0.0",

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -838,7 +838,9 @@ class BLEInterface(MeshInterface):
             def _fallback_invoke_handler() -> None:
                 try:
                     _invoke_handler()
-                except Exception:  # noqa: BLE001 - notification callbacks must stay best effort
+                except (
+                    Exception
+                ):  # noqa: BLE001 - notification callbacks must stay best effort
                     _report_notification_error()
 
             safe_execute = getattr(self.error_handler, "safe_execute", None)
@@ -851,7 +853,9 @@ class BLEInterface(MeshInterface):
             ):
                 try:
                     _invoke_handler()
-                except Exception:  # noqa: BLE001 - notification callbacks must stay best effort
+                except (
+                    Exception
+                ):  # noqa: BLE001 - notification callbacks must stay best effort
                     _report_notification_error()
                 return
             self._invoke_safe_execute_compat(
@@ -1143,8 +1147,7 @@ class BLEInterface(MeshInterface):
             awaitable,
             timeout,
             label,
-            timeout_error_factory=lambda timeout_label,
-            timeout_seconds: BLEInterface.BLEError(
+            timeout_error_factory=lambda timeout_label, timeout_seconds: BLEInterface.BLEError(
                 ERROR_TIMEOUT.format(timeout_label, timeout_seconds)
             ),
         )

--- a/meshtastic/interfaces/ble/lifecycle_service.py
+++ b/meshtastic/interfaces/ble/lifecycle_service.py
@@ -225,13 +225,17 @@ class BLELifecycleService:
                 if _is_unexpected_keyword_error(exc, "error_msg"):
                     try:
                         return safe_execute(_tracked_func, error_msg)
-                    except Exception:  # noqa: BLE001 - hook failures must not abort shutdown
+                    except (
+                        Exception
+                    ):  # noqa: BLE001 - hook failures must not abort shutdown
                         logger.debug(error_msg, exc_info=True)
                         if func_ran:
                             return None
                     try:
                         return safe_execute(_tracked_func)
-                    except Exception:  # noqa: BLE001 - hook failures must not abort shutdown
+                    except (
+                        Exception
+                    ):  # noqa: BLE001 - hook failures must not abort shutdown
                         logger.debug(error_msg, exc_info=True)
                         if func_ran:
                             return None
@@ -656,11 +660,15 @@ class BLELifecycleService:
             # Keep clear() under the state lock so reconnect scheduling starts a
             # fresh cycle against a non-signaled shutdown event.
             iface._shutdown_event.clear()
-        schedule_reconnect = getattr(iface._reconnect_scheduler, "schedule_reconnect", None)
+        schedule_reconnect = getattr(
+            iface._reconnect_scheduler, "schedule_reconnect", None
+        )
         if not callable(schedule_reconnect) or _is_unconfigured_mock_callable(
             schedule_reconnect
         ):
-            schedule_reconnect = getattr(iface._reconnect_scheduler, "_schedule_reconnect", None)
+            schedule_reconnect = getattr(
+                iface._reconnect_scheduler, "_schedule_reconnect", None
+            )
         if not callable(schedule_reconnect) or _is_unconfigured_mock_callable(
             schedule_reconnect
         ):
@@ -1213,8 +1221,8 @@ class BLELifecycleService:
                     if not BLELifecycleService._state_manager_reset_to_disconnected(
                         iface
                     ):
-                        current_state = BLELifecycleService._state_manager_current_state(
-                            iface
+                        current_state = (
+                            BLELifecycleService._state_manager_current_state(iface)
                         )
                         logger.error(
                             "Failed to reset state after invalidated connect result (alias=%s current=%s); forcing transition to %s.",
@@ -1707,7 +1715,11 @@ class BLELifecycleService:
                         )
                     )
                     disconnect_notified = iface._disconnect_notified
-                if not still_owned_after and disconnect_notified and not is_closing_after:
+                if (
+                    not still_owned_after
+                    and disconnect_notified
+                    and not is_closing_after
+                ):
                     logger.debug(
                         "Connected publication raced with disconnect; emitting compensating disconnect event."
                     )
@@ -1957,15 +1969,11 @@ class BLELifecycleService:
                     logger.debug(
                         "BLEInterface.close called while another shutdown is in progress; continuing with cleanup"
                     )
-                if (
-                    BLELifecycleService._state_manager_current_state(iface)
-                    not in (
-                        ConnectionState.DISCONNECTED,
-                        ConnectionState.DISCONNECTING,
-                    )
-                    and not BLELifecycleService._state_manager_transition_to(
-                        iface, ConnectionState.DISCONNECTING
-                    )
+                if BLELifecycleService._state_manager_current_state(iface) not in (
+                    ConnectionState.DISCONNECTED,
+                    ConnectionState.DISCONNECTING,
+                ) and not BLELifecycleService._state_manager_transition_to(
+                    iface, ConnectionState.DISCONNECTING
                 ):
                     current_state = BLELifecycleService._state_manager_current_state(
                         iface
@@ -1976,16 +1984,13 @@ class BLELifecycleService:
                         iface._connection_alias_key,
                         getattr(current_state, "value", current_state),
                     )
-                    if (
-                        not BLELifecycleService._state_manager_reset_to_disconnected(
-                            iface
-                        )
-                        and not BLELifecycleService._state_manager_transition_to(
-                            iface, ConnectionState.DISCONNECTED
-                        )
+                    if not BLELifecycleService._state_manager_reset_to_disconnected(
+                        iface
+                    ) and not BLELifecycleService._state_manager_transition_to(
+                        iface, ConnectionState.DISCONNECTED
                     ):
-                        fallback_state = BLELifecycleService._state_manager_current_state(
-                            iface
+                        fallback_state = (
+                            BLELifecycleService._state_manager_current_state(iface)
                         )
                         logger.error(
                             "Failed forced transition to %s during shutdown fallback (alias=%s current=%s).",
@@ -2276,11 +2281,10 @@ class BLELifecycleService:
                     iface._connection_alias_key,
                     getattr(current_state, "value", current_state),
                 )
-                if (
-                    not BLELifecycleService._state_manager_reset_to_disconnected(iface)
-                    and not BLELifecycleService._state_manager_transition_to(
-                        iface, ConnectionState.DISCONNECTED
-                    )
+                if not BLELifecycleService._state_manager_reset_to_disconnected(
+                    iface
+                ) and not BLELifecycleService._state_manager_transition_to(
+                    iface, ConnectionState.DISCONNECTED
                 ):
                     fallback_state = BLELifecycleService._state_manager_current_state(
                         iface

--- a/meshtastic/interfaces/ble/lifecycle_service.py
+++ b/meshtastic/interfaces/ble/lifecycle_service.py
@@ -225,17 +225,13 @@ class BLELifecycleService:
                 if _is_unexpected_keyword_error(exc, "error_msg"):
                     try:
                         return safe_execute(_tracked_func, error_msg)
-                    except (
-                        Exception
-                    ):  # noqa: BLE001 - hook failures must not abort shutdown
+                    except Exception:  # noqa: BLE001 - hook failures must not abort shutdown
                         logger.debug(error_msg, exc_info=True)
                         if func_ran:
                             return None
                     try:
                         return safe_execute(_tracked_func)
-                    except (
-                        Exception
-                    ):  # noqa: BLE001 - hook failures must not abort shutdown
+                    except Exception:  # noqa: BLE001 - hook failures must not abort shutdown
                         logger.debug(error_msg, exc_info=True)
                         if func_ran:
                             return None

--- a/meshtastic/interfaces/ble/lifecycle_service.py
+++ b/meshtastic/interfaces/ble/lifecycle_service.py
@@ -225,13 +225,17 @@ class BLELifecycleService:
                 if _is_unexpected_keyword_error(exc, "error_msg"):
                     try:
                         return safe_execute(_tracked_func, error_msg)
-                    except Exception:  # noqa: BLE001 - hook failures must not abort shutdown
+                    except (
+                        Exception
+                    ):  # noqa: BLE001 - hook failures must not abort shutdown
                         logger.debug(error_msg, exc_info=True)
                         if func_ran:
                             return None
                     try:
                         return safe_execute(_tracked_func)
-                    except Exception:  # noqa: BLE001 - hook failures must not abort shutdown
+                    except (
+                        Exception
+                    ):  # noqa: BLE001 - hook failures must not abort shutdown
                         logger.debug(error_msg, exc_info=True)
                         if func_ran:
                             return None

--- a/meshtastic/interfaces/ble/lifecycle_service.py
+++ b/meshtastic/interfaces/ble/lifecycle_service.py
@@ -225,17 +225,13 @@ class BLELifecycleService:
                 if _is_unexpected_keyword_error(exc, "error_msg"):
                     try:
                         return safe_execute(_tracked_func, error_msg)
-                    except (
-                        Exception
-                    ):  # noqa: BLE001 - hook failures must not abort shutdown
+                    except Exception:  # noqa: BLE001 - hook failures must not abort shutdown
                         logger.debug(error_msg, exc_info=True)
                         if func_ran:
                             return None
                     try:
                         return safe_execute(_tracked_func)
-                    except (
-                        Exception
-                    ):  # noqa: BLE001 - hook failures must not abort shutdown
+                    except Exception:  # noqa: BLE001 - hook failures must not abort shutdown
                         logger.debug(error_msg, exc_info=True)
                         if func_ran:
                             return None
@@ -585,9 +581,7 @@ class BLELifecycleService:
                 if iface._receiveThread is thread:
                     iface._receiveThread = None
             raise
-        except (
-            Exception
-        ):  # noqa: BLE001 - start failure must clear stale thread reference
+        except Exception:  # noqa: BLE001 - start failure must clear stale thread reference
             with iface._state_lock:
                 if iface._receiveThread is thread:
                     iface._receiveThread = None

--- a/meshtastic/interfaces/ble/lifecycle_service.py
+++ b/meshtastic/interfaces/ble/lifecycle_service.py
@@ -138,10 +138,9 @@ class BLELifecycleService:
         None
             Always returns ``None``.
 
-        Raises
-        ------
-        None
-            Exceptions are suppressed to preserve shutdown progress.
+        Notes
+        -----
+        Exceptions are suppressed to preserve shutdown progress.
         """
         safe_cleanup = BLELifecycleService._resolve_error_handler_hook(
             iface, "safe_cleanup", "_safe_cleanup"
@@ -201,10 +200,9 @@ class BLELifecycleService:
         object | None
             Callable return value on success; otherwise ``None``.
 
-        Raises
-        ------
-        None
-            Exceptions are suppressed to preserve shutdown progress.
+        Notes
+        -----
+        Exceptions are suppressed to preserve shutdown progress.
         """
         safe_execute = BLELifecycleService._resolve_error_handler_hook(
             iface, "safe_execute", "_safe_execute"
@@ -218,8 +216,12 @@ class BLELifecycleService:
 
         if safe_execute is not None:
             try:
+                # Preferred signature: safe_execute(func, error_msg=...)
                 return safe_execute(_tracked_func, error_msg=error_msg)
             except TypeError as exc:
+                # Compatibility fallbacks:
+                #   1) positional error_msg
+                #   2) callable-only legacy signature
                 if _is_unexpected_keyword_error(exc, "error_msg"):
                     try:
                         return safe_execute(_tracked_func, error_msg)
@@ -886,7 +888,24 @@ class BLELifecycleService:
     def _close_previous_client_async(
         iface: "BLEInterface", previous_client: "BLEClient | None"
     ) -> None:
-        """Close previous client asynchronously, with inline fallback on start failure."""
+        """Close a disconnected previous client asynchronously.
+
+        Parameters
+        ----------
+        iface : BLEInterface
+            Interface providing thread and cleanup helpers.
+        previous_client : BLEClient | None
+            Prior client to close. ``None`` is a no-op.
+
+        Returns
+        -------
+        None
+            Returns ``None`` after scheduling or inline cleanup.
+
+        Notes
+        -----
+        Falls back to inline cleanup when thread creation/start fails.
+        """
         if previous_client is None:
             return
 
@@ -931,7 +950,23 @@ class BLELifecycleService:
     def _execute_disconnect_side_effects(
         iface: "BLEInterface", *, plan: _DisconnectPlan, source: str
     ) -> bool:
-        """Execute disconnect side effects outside ``_disconnect_lock``."""
+        """Execute disconnect publication/cleanup side effects.
+
+        Parameters
+        ----------
+        iface : BLEInterface
+            Interface providing disconnect side-effect helpers.
+        plan : _DisconnectPlan
+            Disconnect plan produced by ``_resolve_disconnect_target``.
+        source : str
+            Disconnect-source label used in logging.
+
+        Returns
+        -------
+        bool
+            ``True`` when reconnect flow should continue; ``False`` when
+            disconnect handling should stop.
+        """
         disconnect_keys = list(plan.disconnect_keys)
         skip_side_effects = False
         stale_disconnect_keys: list[str] = []
@@ -996,7 +1031,26 @@ class BLELifecycleService:
         client: "BLEClient | None" = None,
         bleak_client: BleakRootClient | None = None,
     ) -> bool:
-        """Handle a BLE client disconnection and drive reconnect/shutdown orchestration."""
+        """Handle disconnect orchestration and reconnect decisions.
+
+        Parameters
+        ----------
+        iface : BLEInterface
+            Interface whose disconnect lifecycle is being processed.
+        source : str
+            Disconnect-source label used in logs and emitted metadata.
+        client : BLEClient | None
+            Optional client that triggered the disconnect callback.
+        bleak_client : BleakRootClient | None
+            Optional Bleak transport object used when the wrapped client is not
+            directly available.
+
+        Returns
+        -------
+        bool
+            ``True`` when reconnect processing should continue; ``False`` when
+            disconnect flow should stop.
+        """
         if not iface._disconnect_lock.acquire(blocking=False):
             # Another disconnect handler is active; mirror current reconnect
             # intent so callers can stop when reconnect is not expected.
@@ -1017,6 +1071,8 @@ class BLELifecycleService:
                     )
                 )
 
+        # We release `_disconnect_lock` before address-lock work. Track manual
+        # release so `finally` can safely release only when still owned here.
         disconnect_lock_released = False
         plan = _DisconnectPlan(early_return=False)
         try:
@@ -1048,7 +1104,20 @@ class BLELifecycleService:
     def _emit_verified_connection_side_effects(
         iface: "BLEInterface", connected_client: "BLEClient"
     ) -> None:
-        """Emit reconnect signaling/logging only after verified connect publish."""
+        """Emit reconnect wake signal and success logging after verified publish.
+
+        Parameters
+        ----------
+        iface : BLEInterface
+            Interface providing reconnect event coordination state.
+        connected_client : BLEClient
+            Connected client used for normalized success logging.
+
+        Returns
+        -------
+        None
+            Returns ``None`` after side effects are emitted.
+        """
         coordinator = getattr(iface, "thread_coordinator", None)
         if iface._prior_publish_was_reconnect and coordinator is not None:
             BLELifecycleService._thread_set_event(iface, RECONNECTED_EVENT)
@@ -1069,7 +1138,24 @@ class BLELifecycleService:
         restore_address: str | None = None,
         restore_last_connection_request: str | None = None,
     ) -> None:
-        """Best-effort cleanup for a connected client invalidated before return."""
+        """Clean up a client invalidated before connect publication completes.
+
+        Parameters
+        ----------
+        iface : BLEInterface
+            Interface providing state and client-close helpers.
+        client : BLEClient
+            Client to detach and close.
+        restore_address : str | None
+            Address restored when ownership remains local after invalidation.
+        restore_last_connection_request : str | None
+            Last-request value restored when ownership remains local.
+
+        Returns
+        -------
+        None
+            Returns ``None`` after best-effort cleanup.
+        """
         restored_address = (
             restore_address.strip()
             if restore_address is not None and restore_address.strip()
@@ -1289,7 +1375,20 @@ class BLELifecycleService:
     def _get_connected_client_status_locked(
         iface: "BLEInterface", client: "BLEClient"
     ) -> tuple[bool, bool]:
-        """Return owned/closing status for a connected client while holding state lock."""
+        """Return ownership and closing flags for ``client`` under state lock.
+
+        Parameters
+        ----------
+        iface : BLEInterface
+            Interface whose state is being evaluated.
+        client : BLEClient
+            Client candidate for ownership verification.
+
+        Returns
+        -------
+        tuple[bool, bool]
+            ``(is_owned, is_closing)`` for the current snapshot.
+        """
         is_closing = (
             BLELifecycleService._state_manager_is_closing(iface) or iface._closed
         )
@@ -1307,7 +1406,20 @@ class BLELifecycleService:
     def _get_connected_client_status(
         iface: "BLEInterface", client: "BLEClient"
     ) -> tuple[bool, bool]:
-        """Return whether interface owns `client` and whether shutdown has started."""
+        """Return ownership and closing flags with internal state locking.
+
+        Parameters
+        ----------
+        iface : BLEInterface
+            Interface whose state is being evaluated.
+        client : BLEClient
+            Client candidate for ownership verification.
+
+        Returns
+        -------
+        tuple[bool, bool]
+            ``(is_owned, is_closing)`` for the current snapshot.
+        """
         with iface._state_lock:
             return BLELifecycleService._get_connected_client_status_locked(
                 iface, client
@@ -1315,7 +1427,21 @@ class BLELifecycleService:
 
     @staticmethod
     def _has_lost_gate_ownership(iface: "BLEInterface", *keys: str | None) -> bool:
-        """Return whether any connected address key is now owned elsewhere."""
+        """Return whether any supplied address key is now owned elsewhere.
+
+        Parameters
+        ----------
+        iface : BLEInterface
+            Interface used as the ownership identity.
+        *keys : str | None
+            Address keys to probe for ownership loss.
+
+        Returns
+        -------
+        bool
+            ``True`` when any non-``None`` key is currently owned by another
+            interface; otherwise ``False``.
+        """
         return any(
             key is not None and _is_currently_connected_elsewhere(key, owner=iface)
             for key in keys
@@ -1333,7 +1459,38 @@ class BLELifecycleService:
         restore_address: str | None,
         restore_last_connection_request: str | None,
     ) -> None:
-        """Clean up a stale connect result and raise the appropriate BLEError."""
+        """Clean up invalidated connect result and raise the corresponding BLEError.
+
+        Parameters
+        ----------
+        iface : BLEInterface
+            Interface whose stale connect result is being rejected.
+        connected_client : BLEClient
+            Client produced by a stale connect result.
+        connected_device_key : str | None
+            Address key for the connected client candidate.
+        connection_alias_key : str | None
+            Alias key associated with the connect attempt.
+        is_closing : bool
+            Whether shutdown is active for this interface.
+        lost_gate_ownership : bool
+            Whether another interface claimed ownership of the target.
+        restore_address : str | None
+            Address restored when cleanup preserves local state.
+        restore_last_connection_request : str | None
+            Last-request value restored when cleanup preserves local state.
+
+        Returns
+        -------
+        None
+            This method always raises and does not return normally.
+
+        Raises
+        ------
+        BLEError
+            ``ERROR_INTERFACE_CLOSING`` when closing; otherwise
+            ``CONNECTION_ERROR_LOST_OWNERSHIP``.
+        """
         stale_keys = iface._sorted_address_keys(
             connected_device_key,
             connection_alias_key,
@@ -1367,7 +1524,25 @@ class BLELifecycleService:
         connected_device_key: str | None,
         connection_alias_key: str | None,
     ) -> _OwnershipSnapshot:
-        """Return a single ownership snapshot for connect-result verification."""
+        """Capture a connect-result ownership snapshot.
+
+        Parameters
+        ----------
+        iface : BLEInterface
+            Interface whose ownership is being verified.
+        connected_client : BLEClient
+            Client candidate for ownership verification.
+        connected_device_key : str | None
+            Address key for the connected client candidate.
+        connection_alias_key : str | None
+            Alias key associated with the connect attempt.
+
+        Returns
+        -------
+        _OwnershipSnapshot
+            Snapshot containing ownership, closing, gate-loss, and reconnect
+            publication context.
+        """
         lost_gate_ownership = iface._has_lost_gate_ownership(
             connected_device_key,
             connection_alias_key,
@@ -1415,7 +1590,33 @@ class BLELifecycleService:
         restore_address: str | None,
         restore_last_connection_request: str | None,
     ) -> None:
-        """Publish connected state only when ownership is still valid."""
+        """Publish connected state only when ownership is still valid.
+
+        Parameters
+        ----------
+        iface : BLEInterface
+            Interface owning the candidate connected client.
+        connected_client : BLEClient
+            Client candidate produced by connection orchestration.
+        connected_device_key : str | None
+            Address key for ownership validation.
+        connection_alias_key : str | None
+            Alias key for ownership validation.
+        restore_address : str | None
+            Address restored when invalidation cleanup is required.
+        restore_last_connection_request : str | None
+            Last-request value restored when invalidation cleanup is required.
+
+        Returns
+        -------
+        None
+            Returns ``None`` after publication or invalidation handling.
+
+        Raises
+        ------
+        BLEError
+            Raised when ownership is invalidated before or during publication.
+        """
 
         def _raise_invalidated(snapshot: _OwnershipSnapshot) -> None:
             iface._raise_for_invalidated_connect_result(
@@ -1517,7 +1718,18 @@ class BLELifecycleService:
 
     @staticmethod
     def _cleanup_thread_coordinator(iface: "BLEInterface") -> None:
-        """Run thread coordinator cleanup using public-first compatibility dispatch."""
+        """Run thread-coordinator cleanup via public/legacy compatibility hooks.
+
+        Parameters
+        ----------
+        iface : BLEInterface
+            Interface providing the thread coordinator.
+
+        Returns
+        -------
+        None
+            Returns ``None`` after best-effort cleanup.
+        """
         cleanup = getattr(iface.thread_coordinator, "cleanup", None)
         if callable(cleanup) and not _is_unconfigured_mock_callable(cleanup):
             try:
@@ -1598,7 +1810,24 @@ class BLELifecycleService:
         connected_device_key: str | None,
         connection_alias_key: str | None,
     ) -> None:
-        """Finalize post-connection gating and cleanup stale claims."""
+        """Finalize address-gate ownership after successful connection.
+
+        Parameters
+        ----------
+        iface : BLEInterface
+            Interface owning connection-gate state.
+        connected_client : BLEClient
+            Connected client candidate associated with the gate claim.
+        connected_device_key : str | None
+            Device key to mark connected/disconnected.
+        connection_alias_key : str | None
+            Alias key to mark connected/disconnected.
+
+        Returns
+        -------
+        None
+            Returns ``None`` after gate publication or stale-claim cleanup.
+        """
         still_active, is_closing = BLELifecycleService._get_connected_client_status(
             iface, connected_client
         )
@@ -1672,7 +1901,20 @@ class BLELifecycleService:
 
     @staticmethod
     def _is_owned_connected_client(iface: "BLEInterface", client: "BLEClient") -> bool:
-        """Return whether the interface still owns the provided connected client."""
+        """Return whether the interface still owns the provided connected client.
+
+        Parameters
+        ----------
+        iface : BLEInterface
+            Interface whose ownership state is being checked.
+        client : BLEClient
+            Client candidate for ownership verification.
+
+        Returns
+        -------
+        bool
+            ``True`` when the interface still owns ``client``.
+        """
         is_owned, _ = BLELifecycleService._get_connected_client_status(iface, client)
         return is_owned
 
@@ -1683,7 +1925,23 @@ class BLELifecycleService:
         management_shutdown_wait_timeout: float,
         management_wait_poll_seconds: float,
     ) -> bool | None:
-        """Mark interface as closed and wait for inflight management operations."""
+        """Mark interface as closed and wait for inflight management operations.
+
+        Parameters
+        ----------
+        iface : BLEInterface
+            Interface whose management in-flight counter is being awaited.
+        management_shutdown_wait_timeout : float
+            Maximum seconds to wait for in-flight management completion.
+        management_wait_poll_seconds : float
+            Poll interval used while waiting on the management idle condition.
+
+        Returns
+        -------
+        bool | None
+            ``True`` when waiting timed out, ``False`` when all operations
+            drained cleanly, or ``None`` when the interface was already closed.
+        """
         management_wait_timed_out = False
         management_wait_started = time.monotonic()
         with iface._management_lock:
@@ -1777,7 +2035,18 @@ class BLELifecycleService:
 
     @staticmethod
     def _shutdown_receive_thread(iface: "BLEInterface") -> None:
-        """Wake and join receive thread, then clear cached thread reference."""
+        """Wake and join receive thread, then clear cached thread reference.
+
+        Parameters
+        ----------
+        iface : BLEInterface
+            Interface providing receive-thread state and thread hooks.
+
+        Returns
+        -------
+        None
+            Returns ``None`` after best-effort receive-thread shutdown.
+        """
         BLELifecycleService._thread_wake_waiting_threads(
             iface, READ_TRIGGER_EVENT, RECONNECTED_EVENT
         )
@@ -1809,7 +2078,18 @@ class BLELifecycleService:
 
     @staticmethod
     def _close_mesh_interface(iface: "BLEInterface") -> None:
-        """Run mesh-interface close under safe execution wrapper."""
+        """Run ``MeshInterface.close`` through guarded error-handler execution.
+
+        Parameters
+        ----------
+        iface : BLEInterface
+            Interface instance forwarded to ``MeshInterface.close``.
+
+        Returns
+        -------
+        None
+            Returns ``None`` after guarded close execution.
+        """
         BLELifecycleService._error_handler_safe_execute(
             iface,
             lambda: MeshInterface.close(iface),
@@ -1818,7 +2098,18 @@ class BLELifecycleService:
 
     @staticmethod
     def _unregister_exit_handler(iface: "BLEInterface") -> None:
-        """Unregister process exit handler when present."""
+        """Unregister process exit handler when present.
+
+        Parameters
+        ----------
+        iface : BLEInterface
+            Interface containing optional ``_exit_handler`` state.
+
+        Returns
+        -------
+        None
+            Returns ``None`` after best-effort unregister.
+        """
         if iface._exit_handler:
             atexit.unregister(iface._exit_handler)
             iface._exit_handler = None
@@ -1827,7 +2118,18 @@ class BLELifecycleService:
     def _detach_client_for_shutdown(
         iface: "BLEInterface",
     ) -> tuple["BLEClient | None", bool]:
-        """Detach active client reference and return detached client plus publish state."""
+        """Detach active client reference and return detached client plus publish state.
+
+        Parameters
+        ----------
+        iface : BLEInterface
+            Interface whose client and publish-pending state are detached.
+
+        Returns
+        -------
+        tuple[BLEClient | None, bool]
+            ``(client, publish_pending)`` snapshot captured during detach.
+        """
         with iface._state_lock:
             client = iface.client
             publish_pending = iface._client_publish_pending
@@ -1837,7 +2139,18 @@ class BLELifecycleService:
 
     @staticmethod
     def _consume_disconnect_notification_state(iface: "BLEInterface") -> bool:
-        """Consume pending publish flags and return whether public disconnect should emit."""
+        """Consume pending publish flags and decide disconnect notification emission.
+
+        Parameters
+        ----------
+        iface : BLEInterface
+            Interface containing disconnect-publication state flags.
+
+        Returns
+        -------
+        bool
+            ``True`` when callers should emit a public disconnect event.
+        """
         notify = False
         with iface._state_lock:
             if iface._client_publish_pending:

--- a/meshtastic/interfaces/ble/management_service.py
+++ b/meshtastic/interfaces/ble/management_service.py
@@ -162,13 +162,12 @@ class BLEManagementCommandsService:
             operation token.
         """
         expected_implicit_binding: str | None = None
-        if address is None:
-            with iface._state_lock:
+        with iface._connect_lock, iface._management_lock, iface._state_lock:
+            iface._validate_management_preconditions()
+            if address is None:
                 expected_implicit_binding = (
                     iface._get_current_implicit_management_binding_locked()
                 )
-        with iface._connect_lock, iface._management_lock:
-            iface._validate_management_preconditions()
             iface._begin_management_operation_locked()
             try:
                 existing_client = iface._get_management_client_if_available(address)
@@ -224,21 +223,28 @@ class BLEManagementCommandsService:
 
         if start_context.use_existing_client_without_resolved_address:
             current_binding: str | None = None
-            with iface._connect_lock, iface._management_lock:
-                iface._validate_management_preconditions()
-                refreshed_existing_client = iface._get_management_client_if_available(
-                    address
-                )
-                if refreshed_existing_client is None:
-                    raise iface.BLEError(ERROR_MANAGEMENT_TARGET_CHANGED)
-                if address is None:
-                    with iface._state_lock:
-                        current_binding = (
-                            iface._get_current_implicit_management_binding_locked()
-                        )
+            if address is None:
+                with iface._connect_lock, iface._management_lock, iface._state_lock:
+                    iface._validate_management_preconditions()
+                    refreshed_existing_client = (
+                        iface._get_management_client_if_available(address)
+                    )
+                    if refreshed_existing_client is None:
+                        raise iface.BLEError(ERROR_MANAGEMENT_TARGET_CHANGED)
+                    current_binding = (
+                        iface._get_current_implicit_management_binding_locked()
+                    )
                     if sanitize_address(current_binding) != sanitize_address(
                         start_context.expected_implicit_binding
                     ):
+                        raise iface.BLEError(ERROR_MANAGEMENT_TARGET_CHANGED)
+            else:
+                with iface._connect_lock, iface._management_lock:
+                    iface._validate_management_preconditions()
+                    refreshed_existing_client = (
+                        iface._get_management_client_if_available(address)
+                    )
+                    if refreshed_existing_client is None:
                         raise iface.BLEError(ERROR_MANAGEMENT_TARGET_CHANGED)
 
             # Prefer a live address extracted from the refreshed client. If no

--- a/meshtastic/interfaces/ble/management_service.py
+++ b/meshtastic/interfaces/ble/management_service.py
@@ -162,7 +162,7 @@ class BLEManagementCommandsService:
             operation token.
         """
         expected_implicit_binding: str | None = None
-        with iface._connect_lock, iface._management_lock, iface._state_lock:
+        with iface._state_lock, iface._connect_lock, iface._management_lock:
             iface._validate_management_preconditions()
             if address is None:
                 expected_implicit_binding = (
@@ -226,7 +226,7 @@ class BLEManagementCommandsService:
             target_candidate: str | None = None
             use_refreshed_existing_client = True
             if address is None:
-                with iface._connect_lock, iface._management_lock, iface._state_lock:
+                with iface._state_lock, iface._connect_lock, iface._management_lock:
                     iface._validate_management_preconditions()
                     refreshed_existing_client = (
                         iface._get_management_client_if_available(address)
@@ -386,9 +386,7 @@ class BLEManagementCommandsService:
             if temporary_client is not None:
                 try:
                     iface._client_manager_safe_close_client(temporary_client)
-                except (
-                    Exception
-                ):  # noqa: BLE001 - best-effort cleanup must not mask command outcome
+                except Exception:  # noqa: BLE001 - best-effort cleanup must not mask command outcome
                     logger.debug(
                         "Failed to close temporary management client.",
                         exc_info=True,
@@ -756,9 +754,7 @@ class BLEManagementCommandsService:
                 check=False,
                 timeout=validated_timeout,
             )
-        except (
-            Exception
-        ) as exc:  # noqa: BLE001 - preserve injected module compatibility
+        except Exception as exc:  # noqa: BLE001 - preserve injected module compatibility
             if isinstance(exc, timeout_exc_type):
                 raise iface.BLEError(
                     ERROR_TRUST_COMMAND_TIMEOUT.format(

--- a/meshtastic/interfaces/ble/management_service.py
+++ b/meshtastic/interfaces/ble/management_service.py
@@ -162,7 +162,7 @@ class BLEManagementCommandsService:
             operation token.
         """
         expected_implicit_binding: str | None = None
-        with iface._state_lock, iface._connect_lock, iface._management_lock:
+        with iface._connect_lock, iface._management_lock, iface._state_lock:
             iface._validate_management_preconditions()
             if address is None:
                 expected_implicit_binding = (
@@ -226,7 +226,7 @@ class BLEManagementCommandsService:
             target_candidate: str | None = None
             use_refreshed_existing_client = True
             if address is None:
-                with iface._state_lock, iface._connect_lock, iface._management_lock:
+                with iface._connect_lock, iface._management_lock, iface._state_lock:
                     iface._validate_management_preconditions()
                     refreshed_existing_client = (
                         iface._get_management_client_if_available(address)

--- a/meshtastic/interfaces/ble/management_service.py
+++ b/meshtastic/interfaces/ble/management_service.py
@@ -162,15 +162,15 @@ class BLEManagementCommandsService:
             operation token.
         """
         expected_implicit_binding: str | None = None
+        if address is None:
+            with iface._state_lock:
+                expected_implicit_binding = (
+                    iface._get_current_implicit_management_binding_locked()
+                )
         with iface._connect_lock, iface._management_lock:
             iface._validate_management_preconditions()
             iface._begin_management_operation_locked()
             try:
-                if address is None:
-                    with iface._state_lock:
-                        expected_implicit_binding = (
-                            iface._get_current_implicit_management_binding_locked()
-                        )
                 existing_client = iface._get_management_client_if_available(address)
                 target_address = iface._extract_client_address(existing_client)
                 use_existing_client_without_resolved_address = (
@@ -224,6 +224,11 @@ class BLEManagementCommandsService:
 
         if start_context.use_existing_client_without_resolved_address:
             current_binding: str | None = None
+            if address is None:
+                with iface._state_lock:
+                    current_binding = (
+                        iface._get_current_implicit_management_binding_locked()
+                    )
             with iface._connect_lock, iface._management_lock:
                 iface._validate_management_preconditions()
                 refreshed_existing_client = iface._get_management_client_if_available(
@@ -231,16 +236,19 @@ class BLEManagementCommandsService:
                 )
                 if refreshed_existing_client is None:
                     raise iface.BLEError(ERROR_MANAGEMENT_TARGET_CHANGED)
-                if address is None:
-                    with iface._state_lock:
-                        current_binding = (
-                            iface._get_current_implicit_management_binding_locked()
-                        )
-                    if sanitize_address(current_binding) != sanitize_address(
-                        start_context.expected_implicit_binding
-                    ):
-                        raise iface.BLEError(ERROR_MANAGEMENT_TARGET_CHANGED)
-            target_candidate = address if address is not None else current_binding
+            if address is None and sanitize_address(current_binding) != sanitize_address(
+                start_context.expected_implicit_binding
+            ):
+                raise iface.BLEError(ERROR_MANAGEMENT_TARGET_CHANGED)
+
+            # Prefer a live address extracted from the refreshed client. If no
+            # address is present, attempt explicit resolution for identifier
+            # inputs before falling back to implicit binding snapshots.
+            target_candidate = iface._extract_client_address(refreshed_existing_client)
+            if target_candidate is None and address is not None:
+                target_candidate = iface._resolve_target_address_for_management(address)
+            if target_candidate is None:
+                target_candidate = current_binding
             if target_candidate is not None:
                 candidate = target_candidate.strip() or None
                 normalized_candidate = sanitize_address(candidate)

--- a/meshtastic/interfaces/ble/management_service.py
+++ b/meshtastic/interfaces/ble/management_service.py
@@ -223,6 +223,8 @@ class BLEManagementCommandsService:
 
         if start_context.use_existing_client_without_resolved_address:
             current_binding: str | None = None
+            target_candidate: str | None = None
+            use_refreshed_existing_client = True
             if address is None:
                 with iface._connect_lock, iface._management_lock, iface._state_lock:
                     iface._validate_management_preconditions()
@@ -238,6 +240,9 @@ class BLEManagementCommandsService:
                         start_context.expected_implicit_binding
                     ):
                         raise iface.BLEError(ERROR_MANAGEMENT_TARGET_CHANGED)
+                    target_candidate = iface._extract_client_address(
+                        refreshed_existing_client
+                    )
             else:
                 with iface._connect_lock, iface._management_lock:
                     iface._validate_management_preconditions()
@@ -246,13 +251,17 @@ class BLEManagementCommandsService:
                     )
                     if refreshed_existing_client is None:
                         raise iface.BLEError(ERROR_MANAGEMENT_TARGET_CHANGED)
+                    target_candidate = iface._extract_client_address(
+                        refreshed_existing_client
+                    )
+                    if target_candidate is None:
+                        target_candidate = iface._resolve_target_address_for_management(
+                            address
+                        )
+                        # Explicit re-resolution outside the refreshed client
+                        # can drift from the client binding; force reacquisition.
+                        use_refreshed_existing_client = False
 
-            # Prefer a live address extracted from the refreshed client. If no
-            # address is present, attempt explicit resolution for identifier
-            # inputs before falling back to implicit binding snapshots.
-            target_candidate = iface._extract_client_address(refreshed_existing_client)
-            if target_candidate is None and address is not None:
-                target_candidate = iface._resolve_target_address_for_management(address)
             if target_candidate is None:
                 target_candidate = current_binding
             if target_candidate is not None:
@@ -266,7 +275,10 @@ class BLEManagementCommandsService:
                     target_address = candidate
                 else:
                     target_address = None
-            return target_address, refreshed_existing_client
+            return (
+                target_address,
+                refreshed_existing_client if use_refreshed_existing_client else None,
+            )
 
         return target_address, None
 

--- a/meshtastic/interfaces/ble/management_service.py
+++ b/meshtastic/interfaces/ble/management_service.py
@@ -236,9 +236,9 @@ class BLEManagementCommandsService:
                 )
                 if refreshed_existing_client is None:
                     raise iface.BLEError(ERROR_MANAGEMENT_TARGET_CHANGED)
-            if address is None and sanitize_address(current_binding) != sanitize_address(
-                start_context.expected_implicit_binding
-            ):
+            if address is None and sanitize_address(
+                current_binding
+            ) != sanitize_address(start_context.expected_implicit_binding):
                 raise iface.BLEError(ERROR_MANAGEMENT_TARGET_CHANGED)
 
             # Prefer a live address extracted from the refreshed client. If no
@@ -368,7 +368,9 @@ class BLEManagementCommandsService:
             if temporary_client is not None:
                 try:
                     iface._client_manager_safe_close_client(temporary_client)
-                except Exception:  # noqa: BLE001 - best-effort cleanup must not mask command outcome
+                except (
+                    Exception
+                ):  # noqa: BLE001 - best-effort cleanup must not mask command outcome
                     logger.debug(
                         "Failed to close temporary management client.",
                         exc_info=True,

--- a/meshtastic/interfaces/ble/management_service.py
+++ b/meshtastic/interfaces/ble/management_service.py
@@ -224,11 +224,6 @@ class BLEManagementCommandsService:
 
         if start_context.use_existing_client_without_resolved_address:
             current_binding: str | None = None
-            if address is None:
-                with iface._state_lock:
-                    current_binding = (
-                        iface._get_current_implicit_management_binding_locked()
-                    )
             with iface._connect_lock, iface._management_lock:
                 iface._validate_management_preconditions()
                 refreshed_existing_client = iface._get_management_client_if_available(
@@ -236,10 +231,15 @@ class BLEManagementCommandsService:
                 )
                 if refreshed_existing_client is None:
                     raise iface.BLEError(ERROR_MANAGEMENT_TARGET_CHANGED)
-            if address is None and sanitize_address(
-                current_binding
-            ) != sanitize_address(start_context.expected_implicit_binding):
-                raise iface.BLEError(ERROR_MANAGEMENT_TARGET_CHANGED)
+                if address is None:
+                    with iface._state_lock:
+                        current_binding = (
+                            iface._get_current_implicit_management_binding_locked()
+                        )
+                    if sanitize_address(current_binding) != sanitize_address(
+                        start_context.expected_implicit_binding
+                    ):
+                        raise iface.BLEError(ERROR_MANAGEMENT_TARGET_CHANGED)
 
             # Prefer a live address extracted from the refreshed client. If no
             # address is present, attempt explicit resolution for identifier

--- a/meshtastic/interfaces/ble/receive_service.py
+++ b/meshtastic/interfaces/ble/receive_service.py
@@ -226,13 +226,7 @@ class BLEReceiveRecoveryService:
             timeout=wait_timeout,
         )
         poll_without_notify = False
-        raw_ever_connected = getattr(iface, "_ever_connected", False)
-        if _is_unconfigured_mock_member(raw_ever_connected):
-            ever_connected = False
-        elif isinstance(raw_ever_connected, bool):
-            ever_connected = raw_ever_connected
-        else:
-            ever_connected = False
+        ever_connected = BLELifecycleService._ever_connected_flag(iface)
         if not event_signaled:
             if (
                 ever_connected
@@ -791,7 +785,6 @@ class BLEReceiveRecoveryService:
             _sleep(iface._retry_policy_get_delay(transient_policy, attempt_index))
             return
         iface._read_retry_count = 0
-        logger.warning("Persistent BLE read error after retries", exc_info=True)
         raise iface.BLEError(ERROR_READING_BLE) from error
 
     @staticmethod

--- a/meshtastic/interfaces/ble/receive_service.py
+++ b/meshtastic/interfaces/ble/receive_service.py
@@ -20,6 +20,7 @@ from meshtastic.interfaces.ble.constants import (
     logger,
 )
 from meshtastic.interfaces.ble.errors import DecodeError
+from meshtastic.interfaces.ble.lifecycle_service import BLELifecycleService
 from meshtastic.interfaces.ble.utils import (
     _is_unconfigured_mock_callable,
     _is_unconfigured_mock_member,
@@ -226,11 +227,12 @@ class BLEReceiveRecoveryService:
         )
         poll_without_notify = False
         raw_ever_connected = getattr(iface, "_ever_connected", False)
-        ever_connected = (
-            False
-            if _is_unconfigured_mock_member(raw_ever_connected)
-            else raw_ever_connected if isinstance(raw_ever_connected, bool) else False
-        )
+        if _is_unconfigured_mock_member(raw_ever_connected):
+            ever_connected = False
+        elif isinstance(raw_ever_connected, bool):
+            ever_connected = raw_ever_connected
+        else:
+            ever_connected = False
         if not event_signaled:
             if (
                 ever_connected
@@ -267,8 +269,6 @@ class BLEReceiveRecoveryService:
         tuple[BLEClient | None, bool, bool, bool]
             ``(client, is_connecting, publish_pending, is_closing)``.
         """
-        from meshtastic.interfaces.ble.lifecycle_service import BLELifecycleService
-
         with iface._state_lock:
             client = iface.client
             state_is_connecting = getattr(iface._state_manager, "is_connecting", None)
@@ -789,7 +789,7 @@ class BLEReceiveRecoveryService:
             _sleep(iface._retry_policy_get_delay(transient_policy, attempt_index))
             return
         iface._read_retry_count = 0
-        logger.debug("Persistent BLE read error after retries", exc_info=True)
+        logger.warning("Persistent BLE read error after retries", exc_info=True)
         raise iface.BLEError(ERROR_READING_BLE) from error
 
     @staticmethod

--- a/meshtastic/interfaces/ble/receive_service.py
+++ b/meshtastic/interfaces/ble/receive_service.py
@@ -279,15 +279,17 @@ class BLEReceiveRecoveryService:
                 is_connecting = (
                     connecting_result if isinstance(connecting_result, bool) else False
                 )
-            elif not _is_unconfigured_mock_member(
-                state_is_connecting
-            ) and isinstance(state_is_connecting, bool):
+            elif not _is_unconfigured_mock_member(state_is_connecting) and isinstance(
+                state_is_connecting, bool
+            ):
                 is_connecting = state_is_connecting
             else:
-                legacy_is_connecting = getattr(iface._state_manager, "_is_connecting", None)
-                if callable(legacy_is_connecting) and not _is_unconfigured_mock_callable(
+                legacy_is_connecting = getattr(
+                    iface._state_manager, "_is_connecting", None
+                )
+                if callable(
                     legacy_is_connecting
-                ):
+                ) and not _is_unconfigured_mock_callable(legacy_is_connecting):
                     connecting_result = legacy_is_connecting()
                     is_connecting = (
                         connecting_result

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import contextlib
 from threading import Event, RLock
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Iterator
 from unittest.mock import MagicMock
 
 import pytest
@@ -28,9 +29,10 @@ class _TestBLEError(Exception):
     """Custom BLEError type for focused branch tests."""
 
 
+@contextlib.contextmanager
 def _make_orchestrator(
     monkeypatch: pytest.MonkeyPatch,
-) -> tuple[Any, ConnectionOrchestrator]:
+) -> Iterator[tuple[Any, ConnectionOrchestrator]]:
     iface = _build_interface(monkeypatch, DummyClient(), start_receive_thread=False)
     validator = ConnectionValidator(BLEStateManager(), RLock(), iface.BLEError)
     client_manager = ClientManager(
@@ -49,7 +51,10 @@ def _make_orchestrator(
         RLock(),
         SimpleNamespace(),
     )
-    return iface, orchestrator
+    try:
+        yield iface, orchestrator
+    finally:
+        iface.close()
 
 
 def test_connection_validator_client_is_connected_member_paths() -> None:
@@ -170,62 +175,64 @@ def test_connection_orchestrator_dispatch_set_event_and_kwarg_fallbacks(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Orchestrator dispatch helpers should cover missing/default and kwarg compatibility retries."""
-    iface, orchestrator = _make_orchestrator(monkeypatch)
-
-    assert (
-        orchestrator._dispatch_public_or_underscore(
-            target=SimpleNamespace(),
-            public_name="missing",
-            underscore_name="_missing",
-            call_member=False,
-            default_if_missing="default",
+    with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
+        assert (
+            orchestrator._dispatch_public_or_underscore(
+                target=SimpleNamespace(),
+                public_name="missing",
+                underscore_name="_missing",
+                call_member=False,
+                default_if_missing="default",
+            )
+            == "default"
         )
-        == "default"
-    )
 
-    orchestrator.thread_coordinator = SimpleNamespace()
-    orchestrator._thread_set_event("reconnected_event")
+        orchestrator.thread_coordinator = SimpleNamespace()
+        orchestrator._thread_set_event("reconnected_event")
 
-    create_calls: list[dict[str, object]] = []
+        create_calls: list[dict[str, object]] = []
 
-    def _create_client(_device: object, _cb: object, **kwargs: object) -> DummyClient:
-        create_calls.append(dict(kwargs))
-        if "pair_on_connect" in kwargs:
-            raise TypeError("create_client() got an unexpected keyword argument 'pair_on_connect'")
-        if "connect_timeout" in kwargs:
-            raise TypeError("create_client() got an unexpected keyword argument 'connect_timeout'")
-        return DummyClient()
+        def _create_client(_device: object, _cb: object, **kwargs: object) -> DummyClient:
+            create_calls.append(dict(kwargs))
+            if "pair_on_connect" in kwargs:
+                raise TypeError(
+                    "create_client() got an unexpected keyword argument 'pair_on_connect'"
+                )
+            if "connect_timeout" in kwargs:
+                raise TypeError(
+                    "create_client() got an unexpected keyword argument 'connect_timeout'"
+                )
+            return DummyClient()
 
-    orchestrator.client_manager = SimpleNamespace(create_client=_create_client)
-    created = orchestrator._client_manager_create_client(
-        "AA:BB:CC:DD:EE:FF",
-        lambda _client: None,
-        pair_on_connect=True,
-        connect_timeout=5.0,
-    )
-    assert isinstance(created, DummyClient)
-    assert create_calls
+        orchestrator.client_manager = SimpleNamespace(create_client=_create_client)
+        created = orchestrator._client_manager_create_client(
+            "AA:BB:CC:DD:EE:FF",
+            lambda _client: None,
+            pair_on_connect=True,
+            connect_timeout=5.0,
+        )
+        assert isinstance(created, DummyClient)
+        assert create_calls
 
-    connect_calls: list[dict[str, object]] = []
+        connect_calls: list[dict[str, object]] = []
 
-    def _connect_client(_client: object, **kwargs: object) -> None:
-        connect_calls.append(dict(kwargs))
-        if "timeout" in kwargs:
-            raise TypeError("connect_client() got an unexpected keyword argument 'timeout'")
+        def _connect_client(_client: object, **kwargs: object) -> None:
+            connect_calls.append(dict(kwargs))
+            if "timeout" in kwargs:
+                raise TypeError(
+                    "connect_client() got an unexpected keyword argument 'timeout'"
+                )
 
-    orchestrator.client_manager = SimpleNamespace(connect_client=_connect_client)
-    orchestrator._client_manager_connect_client(DummyClient(), timeout=1.0)
-    assert connect_calls == [{"timeout": 1.0}, {}]
-
-    iface.close()
+        orchestrator.client_manager = SimpleNamespace(connect_client=_connect_client)
+        orchestrator._client_manager_connect_client(DummyClient(), timeout=1.0)
+        assert connect_calls == [{"timeout": 1.0}, {}]
 
 
 def test_connection_orchestrator_direct_and_retry_exception_paths(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Direct/retry connect helpers should close clients on exceptional paths."""
-    iface, orchestrator = _make_orchestrator(monkeypatch)
-    try:
+    with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
         closed_clients: list[object] = []
         orchestrator._client_manager_safe_close_client = lambda client: closed_clients.append(client)
 
@@ -276,55 +283,51 @@ def test_connection_orchestrator_direct_and_retry_exception_paths(
         orchestrator.interface = SimpleNamespace()
         with pytest.raises(AttributeError):
             orchestrator._compat_find_device("AA:BB:CC:DD:EE:FF")
-    finally:
-        iface.close()
 
 
 def test_connection_orchestrator_finalize_and_establish_error_paths(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Finalize/establish helpers should cover invalid state and cleanup-on-failure branches."""
-    iface, orchestrator = _make_orchestrator(monkeypatch)
-    orchestrator.state_manager = SimpleNamespace(
-        current_state=ConnectionState.DISCONNECTED,
-        transition_to=lambda _state: False,
-    )
-
-    with pytest.raises(iface.BLEError):
-        orchestrator._finalize_connection(
-            DummyClient(),
-            "AA:BB:CC:DD:EE:FF",
-            lambda _client: None,
-            lambda: None,
+    with _make_orchestrator(monkeypatch) as (iface, orchestrator):
+        orchestrator.state_manager = SimpleNamespace(
+            current_state=ConnectionState.DISCONNECTED,
+            transition_to=lambda _state: False,
         )
 
-    orchestrator._validator_validate_connection_request = lambda: None
-    orchestrator._raise_if_interface_closing = lambda: None
-    orchestrator._prepare_connection_target = lambda **_kwargs: ("AA", "aa")
-    orchestrator._resolve_connection_timeouts = lambda **_kwargs: (1.0, 1.0)
-    orchestrator._state_transition_to = lambda _state: True
-    client = DummyClient()
-    orchestrator._attempt_direct_connect = lambda **_kwargs: (None, False)
-    orchestrator._resolve_retry_target = lambda **_kwargs: ("AA", "AA", 1.0)
-    orchestrator._connect_retry_target = lambda **_kwargs: (client, "AA")
-    orchestrator._finalize_connection = lambda *_args, **_kwargs: (_ for _ in ()).throw(
-        RuntimeError("boom")
-    )
-    closed: list[object] = []
-    orchestrator._client_manager_safe_close_client = lambda c: closed.append(c)
-    orchestrator._transition_failure_to_disconnected = lambda _ctx: None
+        with pytest.raises(iface.BLEError):
+            orchestrator._finalize_connection(
+                DummyClient(),
+                "AA:BB:CC:DD:EE:FF",
+                lambda _client: None,
+                lambda: None,
+            )
 
-    with pytest.raises(RuntimeError, match="boom"):
-        orchestrator._establish_connection(
-            address="AA",
-            current_address=None,
-            register_notifications_func=lambda _client: None,
-            on_connected_func=lambda: None,
-            on_disconnect_func=lambda _client: None,
+        orchestrator._validator_validate_connection_request = lambda: None
+        orchestrator._raise_if_interface_closing = lambda: None
+        orchestrator._prepare_connection_target = lambda **_kwargs: ("AA", "aa")
+        orchestrator._resolve_connection_timeouts = lambda **_kwargs: (1.0, 1.0)
+        orchestrator._state_transition_to = lambda _state: True
+        client = DummyClient()
+        orchestrator._attempt_direct_connect = lambda **_kwargs: (None, False)
+        orchestrator._resolve_retry_target = lambda **_kwargs: ("AA", "AA", 1.0)
+        orchestrator._connect_retry_target = lambda **_kwargs: (client, "AA")
+        orchestrator._finalize_connection = lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("boom")
         )
-    assert closed == [client]
+        closed: list[object] = []
+        orchestrator._client_manager_safe_close_client = lambda c: closed.append(c)
+        orchestrator._transition_failure_to_disconnected = lambda _ctx: None
 
-    iface.close()
+        with pytest.raises(RuntimeError, match="boom"):
+            orchestrator._establish_connection(
+                address="AA",
+                current_address=None,
+                register_notifications_func=lambda _client: None,
+                on_connected_func=lambda: None,
+                on_disconnect_func=lambda _client: None,
+            )
+        assert closed == [client]
 
 
 def test_discovery_manager_typeerror_and_invalid_response_paths(
@@ -478,286 +481,281 @@ def test_orchestrator_dispatch_and_event_remaining_branches(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Connection orchestrator dispatch helper should cover remaining guard branches."""
-    iface, orchestrator = _make_orchestrator(monkeypatch)
-
-    assert (
-        orchestrator._dispatch_public_or_underscore(
-            target=SimpleNamespace(_legacy=MagicMock()),
-            public_name="public",
-            underscore_name="_legacy",
-            call_member=False,
-            default_if_missing="fallback",
-        )
-        == "fallback"
-    )
-
-    validator = ConnectionValidator(BLEStateManager(), RLock(), _TestBLEError)
-    with pytest.raises(AttributeError):
-        orchestrator._dispatch_public_or_underscore(
-            target=validator,
-            public_name="missing",
-            underscore_name="_missing",
-            prefer_instance_type=ConnectionValidator,
-            call_member=True,
+    with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
+        assert (
+            orchestrator._dispatch_public_or_underscore(
+                target=SimpleNamespace(_legacy=MagicMock()),
+                public_name="public",
+                underscore_name="_legacy",
+                call_member=False,
+                default_if_missing="fallback",
+            )
+            == "fallback"
         )
 
-    validator_non_callable = ConnectionValidator(BLEStateManager(), RLock(), _TestBLEError)
-    validator_non_callable.validate_connection_request = 123  # type: ignore[method-assign]
-    with pytest.raises(AttributeError):
-        orchestrator._dispatch_public_or_underscore(
-            target=validator_non_callable,
-            public_name="validate_connection_request",
-            underscore_name="_validate_connection_request",
-            prefer_instance_type=ConnectionValidator,
-            call_member=True,
+        validator = ConnectionValidator(BLEStateManager(), RLock(), _TestBLEError)
+        with pytest.raises(AttributeError):
+            orchestrator._dispatch_public_or_underscore(
+                target=validator,
+                public_name="missing",
+                underscore_name="_missing",
+                prefer_instance_type=ConnectionValidator,
+                call_member=True,
+            )
+
+        validator_non_callable = ConnectionValidator(BLEStateManager(), RLock(), _TestBLEError)
+        validator_non_callable.validate_connection_request = 123  # type: ignore[method-assign]
+        with pytest.raises(AttributeError):
+            orchestrator._dispatch_public_or_underscore(
+                target=validator_non_callable,
+                public_name="validate_connection_request",
+                underscore_name="_validate_connection_request",
+                prefer_instance_type=ConnectionValidator,
+                call_member=True,
+            )
+
+        called: list[str] = []
+        validator_callable = ConnectionValidator(BLEStateManager(), RLock(), _TestBLEError)
+        validator_callable.validate_connection_request = lambda: called.append("called")  # type: ignore[method-assign]
+        assert (
+            orchestrator._dispatch_public_or_underscore(
+                target=validator_callable,
+                public_name="validate_connection_request",
+                underscore_name="_validate_connection_request",
+                prefer_instance_type=ConnectionValidator,
+                call_member=True,
+            )
+            is None
+        )
+        assert called == ["called"]
+        assert (
+            orchestrator._dispatch_public_or_underscore(
+                target=validator_callable,
+                public_name="BLEError",
+                underscore_name="_ble_error",
+                prefer_instance_type=ConnectionValidator,
+                call_member=False,
+            )
+            is _TestBLEError
         )
 
-    called: list[str] = []
-    validator_callable = ConnectionValidator(BLEStateManager(), RLock(), _TestBLEError)
-    validator_callable.validate_connection_request = lambda: called.append("called")  # type: ignore[method-assign]
-    assert (
-        orchestrator._dispatch_public_or_underscore(
-            target=validator_callable,
-            public_name="validate_connection_request",
-            underscore_name="_validate_connection_request",
-            prefer_instance_type=ConnectionValidator,
-            call_member=True,
-        )
-        is None
-    )
-    assert called == ["called"]
-    assert (
-        orchestrator._dispatch_public_or_underscore(
-            target=validator_callable,
-            public_name="BLEError",
-            underscore_name="_ble_error",
-            prefer_instance_type=ConnectionValidator,
-            call_member=False,
-        )
-        is _TestBLEError
-    )
+        with pytest.raises(AttributeError):
+            orchestrator._dispatch_public_or_underscore(
+                target=SimpleNamespace(),
+                public_name="missing",
+                underscore_name="_missing",
+                call_member=False,
+            )
 
-    with pytest.raises(AttributeError):
-        orchestrator._dispatch_public_or_underscore(
-            target=SimpleNamespace(),
-            public_name="missing",
-            underscore_name="_missing",
-            call_member=False,
+        orchestrator.thread_coordinator = SimpleNamespace(
+            set_event=lambda _name: (_ for _ in ()).throw(RuntimeError("event failed"))
         )
-
-    orchestrator.thread_coordinator = SimpleNamespace(
-        set_event=lambda _name: (_ for _ in ()).throw(RuntimeError("event failed"))
-    )
-    orchestrator._thread_set_event("evt")
-    iface.close()
+        orchestrator._thread_set_event("evt")
 
 
 def test_orchestrator_create_connect_direct_retry_remaining_branches(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Create/connect/direct/retry helpers should hit remaining TypeError and cleanup branches."""
-    iface, orchestrator = _make_orchestrator(monkeypatch)
-
-    orchestrator.client_manager = SimpleNamespace(
-        create_client=lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            TypeError("plain typeerror")
+    with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
+        orchestrator.client_manager = SimpleNamespace(
+            create_client=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                TypeError("plain typeerror")
+            )
         )
-    )
-    with pytest.raises(TypeError, match="plain typeerror"):
-        orchestrator._client_manager_create_client(
-            "AA:BB:CC:DD:EE:FF",
-            lambda _client: None,
-            pair_on_connect=True,
-            connect_timeout=1.0,
+        with pytest.raises(TypeError, match="plain typeerror"):
+            orchestrator._client_manager_create_client(
+                "AA:BB:CC:DD:EE:FF",
+                lambda _client: None,
+                pair_on_connect=True,
+                connect_timeout=1.0,
+            )
+
+        orchestrator.client_manager = SimpleNamespace(
+            connect_client=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                TypeError("plain typeerror")
+            )
+        )
+        with pytest.raises(TypeError, match="plain typeerror"):
+            orchestrator._client_manager_connect_client(DummyClient(), timeout=1.0)
+
+        direct_client = DummyClient()
+        closed_clients: list[object] = []
+        orchestrator._client_manager_create_client = lambda *_args, **_kwargs: direct_client
+        orchestrator._client_manager_connect_client = (
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("direct fail"))
+        )
+        orchestrator._client_manager_safe_close_client = lambda client: closed_clients.append(
+            client
+        )
+        with pytest.raises(ValueError, match="direct fail"):
+            orchestrator._attempt_direct_connect(
+                target_address="AA:BB:CC:DD:EE:FF",
+                normalized_target="aabbccddeeff",
+                on_disconnect_func=lambda _client: None,
+                pair_on_connect=False,
+                direct_connect_timeout=1.0,
+                register_notifications_func=lambda _client: None,
+                on_connected_func=lambda: None,
+                emit_connected_side_effects=True,
+            )
+        assert direct_client in closed_clients
+
+        retry_client = DummyClient()
+        closed_clients.clear()
+        orchestrator._client_manager_create_client = lambda *_args, **_kwargs: retry_client
+        orchestrator._client_manager_connect_client = (
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(SystemExit())
+        )
+        with pytest.raises(SystemExit):
+            orchestrator._connect_retry_target(
+                connection_target="AA:BB:CC:DD:EE:FF",
+                resolved_address="AA:BB:CC:DD:EE:FF",
+                target_address="AA:BB:CC:DD:EE:FF",
+                skip_discovery_scan=False,
+                on_disconnect_func=lambda _client: None,
+                pair_on_connect=False,
+                retry_connect_timeout=1.0,
+                discovery_connect_timeout=1.0,
+            )
+        assert retry_client in closed_clients
+
+        retry_client = DummyClient()
+        closed_clients.clear()
+        orchestrator._client_manager_create_client = lambda *_args, **_kwargs: retry_client
+        orchestrator._client_manager_connect_client = (
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(BleakError("retry fail"))
+        )
+        with pytest.raises(BleakError, match="retry fail"):
+            orchestrator._connect_retry_target(
+                connection_target="AA:BB:CC:DD:EE:FF",
+                resolved_address="AA:BB:CC:DD:EE:FF",
+                target_address="AA:BB:CC:DD:EE:FF",
+                skip_discovery_scan=False,
+                on_disconnect_func=lambda _client: None,
+                pair_on_connect=False,
+                retry_connect_timeout=1.0,
+                discovery_connect_timeout=1.0,
+            )
+        assert retry_client in closed_clients
+
+        first_retry_client = DummyClient()
+        second_retry_client = DummyClient()
+        create_clients = iter([first_retry_client, second_retry_client])
+        closed_clients.clear()
+        orchestrator._client_manager_create_client = lambda *_args, **_kwargs: next(
+            create_clients
         )
 
-    orchestrator.client_manager = SimpleNamespace(
-        connect_client=lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            TypeError("plain typeerror")
-        )
-    )
-    with pytest.raises(TypeError, match="plain typeerror"):
-        orchestrator._client_manager_connect_client(DummyClient(), timeout=1.0)
+        def _connect_side_effect(*_args: object, **_kwargs: object) -> None:
+            if _connect_side_effect.calls == 0:
+                _connect_side_effect.calls += 1
+                raise BleakDeviceNotFoundError("device not found")
+            raise RuntimeError("discovery connect failed")
 
-    direct_client = DummyClient()
-    closed_clients: list[object] = []
-    orchestrator._client_manager_create_client = lambda *_args, **_kwargs: direct_client
-    orchestrator._client_manager_connect_client = (
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("direct fail"))
-    )
-    orchestrator._client_manager_safe_close_client = lambda client: closed_clients.append(
-        client
-    )
-    with pytest.raises(ValueError, match="direct fail"):
-        orchestrator._attempt_direct_connect(
-            target_address="AA:BB:CC:DD:EE:FF",
-            normalized_target="aabbccddeeff",
-            on_disconnect_func=lambda _client: None,
-            pair_on_connect=False,
-            direct_connect_timeout=1.0,
-            register_notifications_func=lambda _client: None,
-            on_connected_func=lambda: None,
-            emit_connected_side_effects=True,
-        )
-    assert direct_client in closed_clients
-
-    retry_client = DummyClient()
-    closed_clients.clear()
-    orchestrator._client_manager_create_client = lambda *_args, **_kwargs: retry_client
-    orchestrator._client_manager_connect_client = (
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(SystemExit())
-    )
-    with pytest.raises(SystemExit):
-        orchestrator._connect_retry_target(
-            connection_target="AA:BB:CC:DD:EE:FF",
-            resolved_address="AA:BB:CC:DD:EE:FF",
-            target_address="AA:BB:CC:DD:EE:FF",
-            skip_discovery_scan=False,
-            on_disconnect_func=lambda _client: None,
-            pair_on_connect=False,
-            retry_connect_timeout=1.0,
-            discovery_connect_timeout=1.0,
-        )
-    assert retry_client in closed_clients
-
-    retry_client = DummyClient()
-    closed_clients.clear()
-    orchestrator._client_manager_create_client = lambda *_args, **_kwargs: retry_client
-    orchestrator._client_manager_connect_client = (
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(BleakError("retry fail"))
-    )
-    with pytest.raises(BleakError, match="retry fail"):
-        orchestrator._connect_retry_target(
-            connection_target="AA:BB:CC:DD:EE:FF",
-            resolved_address="AA:BB:CC:DD:EE:FF",
-            target_address="AA:BB:CC:DD:EE:FF",
-            skip_discovery_scan=False,
-            on_disconnect_func=lambda _client: None,
-            pair_on_connect=False,
-            retry_connect_timeout=1.0,
-            discovery_connect_timeout=1.0,
-        )
-    assert retry_client in closed_clients
-
-    first_retry_client = DummyClient()
-    second_retry_client = DummyClient()
-    create_clients = iter([first_retry_client, second_retry_client])
-    closed_clients.clear()
-    orchestrator._client_manager_create_client = lambda *_args, **_kwargs: next(
-        create_clients
-    )
-
-    def _connect_side_effect(*_args: object, **_kwargs: object) -> None:
-        if _connect_side_effect.calls == 0:
-            _connect_side_effect.calls += 1
-            raise BleakDeviceNotFoundError("device not found")
-        raise RuntimeError("discovery connect failed")
-
-    _connect_side_effect.calls = 0
-    orchestrator._client_manager_connect_client = _connect_side_effect
-    orchestrator._compat_find_device = lambda _target: SimpleNamespace(address="AA:BB")
-    with pytest.raises(RuntimeError, match="discovery connect failed"):
-        orchestrator._connect_retry_target(
-            connection_target="AA:BB:CC:DD:EE:FF",
-            resolved_address="AA:BB:CC:DD:EE:FF",
-            target_address="AA:BB:CC:DD:EE:FF",
-            skip_discovery_scan=True,
-            on_disconnect_func=lambda _client: None,
-            pair_on_connect=False,
-            retry_connect_timeout=1.0,
-            discovery_connect_timeout=1.0,
-        )
-    assert closed_clients == [first_retry_client, second_retry_client]
-    iface.close()
+        _connect_side_effect.calls = 0
+        orchestrator._client_manager_connect_client = _connect_side_effect
+        orchestrator._compat_find_device = lambda _target: SimpleNamespace(address="AA:BB")
+        with pytest.raises(RuntimeError, match="discovery connect failed"):
+            orchestrator._connect_retry_target(
+                connection_target="AA:BB:CC:DD:EE:FF",
+                resolved_address="AA:BB:CC:DD:EE:FF",
+                target_address="AA:BB:CC:DD:EE:FF",
+                skip_discovery_scan=True,
+                on_disconnect_func=lambda _client: None,
+                pair_on_connect=False,
+                retry_connect_timeout=1.0,
+                discovery_connect_timeout=1.0,
+            )
+        assert closed_clients == [first_retry_client, second_retry_client]
 
 
 def test_orchestrator_finalize_and_establish_remaining_branches(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Finalize/establish paths should cover remaining invalidation and cleanup branches."""
-    iface, orchestrator = _make_orchestrator(monkeypatch)
-    connected_client = SimpleNamespace(isConnected=lambda: True)
+    with _make_orchestrator(monkeypatch) as (iface, orchestrator):
+        connected_client = SimpleNamespace(isConnected=lambda: True)
 
-    state_values = iter([ConnectionState.CONNECTING, ConnectionState.DISCONNECTED])
-    orchestrator._state_current_state = lambda: next(state_values)
-    with pytest.raises(iface.BLEError):
-        orchestrator._finalize_connection(
-            connected_client,
-            "AA:BB:CC:DD:EE:FF",
-            lambda _client: None,
-            lambda: None,
+        state_values = iter([ConnectionState.CONNECTING, ConnectionState.DISCONNECTED])
+        orchestrator._state_current_state = lambda: next(state_values)
+        with pytest.raises(iface.BLEError):
+            orchestrator._finalize_connection(
+                connected_client,
+                "AA:BB:CC:DD:EE:FF",
+                lambda _client: None,
+                lambda: None,
+            )
+
+        orchestrator._state_current_state = lambda: ConnectionState.CONNECTING
+        monkeypatch.setattr(
+            ConnectionValidator,
+            "_client_is_connected",
+            staticmethod(lambda _client: False),
+        )
+        with pytest.raises(iface.BLEError):
+            orchestrator._finalize_connection(
+                connected_client,
+                "AA:BB:CC:DD:EE:FF",
+                lambda _client: None,
+                lambda: None,
+            )
+
+        monkeypatch.setattr(
+            ConnectionValidator,
+            "_client_is_connected",
+            staticmethod(lambda _client: True),
+        )
+        orchestrator._state_transition_to = lambda _state: False
+        with pytest.raises(iface.BLEError):
+            orchestrator._finalize_connection(
+                connected_client,
+                "AA:BB:CC:DD:EE:FF",
+                lambda _client: None,
+                lambda: None,
+            )
+
+        retry_client = DummyClient()
+        closed_clients: list[object] = []
+        orchestrator._validator_validate_connection_request = lambda: None
+        orchestrator._raise_if_interface_closing = lambda: None
+        orchestrator._prepare_connection_target = lambda **_kwargs: ("AA", "aa")
+        orchestrator._resolve_connection_timeouts = lambda **_kwargs: (1.0, 1.0)
+        orchestrator._state_transition_to = lambda _state: True
+        orchestrator._attempt_direct_connect = lambda **_kwargs: (None, False)
+        orchestrator._resolve_retry_target = lambda **_kwargs: ("AA", "AA", 1.0)
+        orchestrator._connect_retry_target = lambda **_kwargs: (retry_client, "AA")
+        orchestrator._client_manager_safe_close_client = lambda client: closed_clients.append(
+            client
+        )
+        orchestrator._transition_failure_to_disconnected = lambda _ctx: None
+        orchestrator._finalize_connection = (
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(BleakDBusError("dbus", "err"))
         )
 
-    orchestrator._state_current_state = lambda: ConnectionState.CONNECTING
-    monkeypatch.setattr(
-        ConnectionValidator,
-        "_client_is_connected",
-        staticmethod(lambda _client: False),
-    )
-    with pytest.raises(iface.BLEError):
-        orchestrator._finalize_connection(
-            connected_client,
-            "AA:BB:CC:DD:EE:FF",
-            lambda _client: None,
-            lambda: None,
-        )
+        with pytest.raises(BleakDBusError):
+            orchestrator._establish_connection(
+                address="AA",
+                current_address=None,
+                register_notifications_func=lambda _client: None,
+                on_connected_func=lambda: None,
+                on_disconnect_func=lambda _client: None,
+            )
+        assert closed_clients == [retry_client]
 
-    monkeypatch.setattr(
-        ConnectionValidator,
-        "_client_is_connected",
-        staticmethod(lambda _client: True),
-    )
-    orchestrator._state_transition_to = lambda _state: False
-    with pytest.raises(iface.BLEError):
-        orchestrator._finalize_connection(
-            connected_client,
-            "AA:BB:CC:DD:EE:FF",
-            lambda _client: None,
-            lambda: None,
+        closed_clients.clear()
+        orchestrator._finalize_connection = (
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(SystemExit())
         )
-
-    retry_client = DummyClient()
-    closed_clients: list[object] = []
-    orchestrator._validator_validate_connection_request = lambda: None
-    orchestrator._raise_if_interface_closing = lambda: None
-    orchestrator._prepare_connection_target = lambda **_kwargs: ("AA", "aa")
-    orchestrator._resolve_connection_timeouts = lambda **_kwargs: (1.0, 1.0)
-    orchestrator._state_transition_to = lambda _state: True
-    orchestrator._attempt_direct_connect = lambda **_kwargs: (None, False)
-    orchestrator._resolve_retry_target = lambda **_kwargs: ("AA", "AA", 1.0)
-    orchestrator._connect_retry_target = lambda **_kwargs: (retry_client, "AA")
-    orchestrator._client_manager_safe_close_client = lambda client: closed_clients.append(
-        client
-    )
-    orchestrator._transition_failure_to_disconnected = lambda _ctx: None
-    orchestrator._finalize_connection = (
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(BleakDBusError("dbus", "err"))
-    )
-
-    with pytest.raises(BleakDBusError):
-        orchestrator._establish_connection(
-            address="AA",
-            current_address=None,
-            register_notifications_func=lambda _client: None,
-            on_connected_func=lambda: None,
-            on_disconnect_func=lambda _client: None,
-        )
-    assert closed_clients == [retry_client]
-
-    closed_clients.clear()
-    orchestrator._finalize_connection = (
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(SystemExit())
-    )
-    with pytest.raises(SystemExit):
-        orchestrator._establish_connection(
-            address="AA",
-            current_address=None,
-            register_notifications_func=lambda _client: None,
-            on_connected_func=lambda: None,
-            on_disconnect_func=lambda _client: None,
-        )
-    assert closed_clients == [retry_client]
-    iface.close()
+        with pytest.raises(SystemExit):
+            orchestrator._establish_connection(
+                address="AA",
+                current_address=None,
+                register_notifications_func=lambda _client: None,
+                on_connected_func=lambda: None,
+                on_disconnect_func=lambda _client: None,
+            )
+        assert closed_clients == [retry_client]
 
 
 def test_discovery_probe_and_factory_kwarg_rejection_branches() -> None:

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -28,6 +28,8 @@ from tests.test_ble_interface_fixtures import DummyClient, _build_interface
 pytestmark = pytest.mark.unit
 
 MOCK_IMPORT_UNAVAILABLE_MSG = "mock import unavailable"
+TEST_BLE_ADDRESS = "AA:BB:CC:DD:EE:FF"
+TEST_CONNECT_TIMEOUT_SECONDS = 5.0
 
 
 class _TestBLEError(Exception):
@@ -153,7 +155,7 @@ def test_client_manager_thread_dispatch_and_wrapper_paths(
 
     manager._create_client = MagicMock(return_value=DummyClient())
     assert isinstance(
-        manager.create_client("AA:BB:CC:DD:EE:FF", lambda _client: None),
+        manager.create_client(TEST_BLE_ADDRESS, lambda _client: None),
         DummyClient,
     )
 
@@ -162,9 +164,7 @@ def test_client_manager_thread_dispatch_and_wrapper_paths(
     manager._connect_client.assert_called_once()
 
 
-def test_client_manager_connect_client_recovers_from_services_property_bleak_error() -> (
-    None
-):
+def test_client_manager_connect_client_recovers_from_services_property_bleak_error() -> None:
     """_connect_client should force service discovery when services property access fails."""
     manager = ClientManager(
         BLEStateManager(),
@@ -278,21 +278,21 @@ def test_connection_orchestrator_dispatch_set_event_and_kwarg_fallbacks(
         ) -> DummyClient:
             create_calls.append(dict(kwargs))
             if "pair_on_connect" in kwargs:
-                raise TypeError(
+                raise TypeError(  # noqa: TRY003 - intentional fixture message shape
                     "create_client() got an unexpected keyword argument 'pair_on_connect'"
                 )
             if "connect_timeout" in kwargs:
-                raise TypeError(
+                raise TypeError(  # noqa: TRY003 - intentional fixture message shape
                     "create_client() got an unexpected keyword argument 'connect_timeout'"
                 )
             return DummyClient()
 
         orchestrator.client_manager = SimpleNamespace(create_client=_create_client)
         created = orchestrator._client_manager_create_client(
-            "AA:BB:CC:DD:EE:FF",
+            TEST_BLE_ADDRESS,
             lambda _client: None,
             pair_on_connect=True,
-            connect_timeout=5.0,
+            connect_timeout=TEST_CONNECT_TIMEOUT_SECONDS,
         )
         assert isinstance(created, DummyClient)
         assert create_calls[-1] == {}
@@ -304,7 +304,7 @@ def test_connection_orchestrator_dispatch_set_event_and_kwarg_fallbacks(
         def _connect_client(_client: object, **kwargs: object) -> None:
             connect_calls.append(dict(kwargs))
             if "timeout" in kwargs:
-                raise TypeError(
+                raise TypeError(  # noqa: TRY003 - intentional fixture message shape
                     "connect_client() got an unexpected keyword argument 'timeout'"
                 )
 
@@ -338,7 +338,7 @@ def test_connection_orchestrator_direct_and_retry_exception_paths(
 
         with pytest.raises(RuntimeError, match="finalize failed"):
             orchestrator._attempt_direct_connect(
-                target_address="AA:BB:CC:DD:EE:FF",
+                target_address=TEST_BLE_ADDRESS,
                 normalized_target="aabbccddeeff",
                 on_disconnect_func=lambda _client: None,
                 pair_on_connect=False,
@@ -360,9 +360,9 @@ def test_connection_orchestrator_direct_and_retry_exception_paths(
 
         with pytest.raises(RuntimeError, match="connect failed"):
             orchestrator._connect_retry_target(
-                connection_target="AA:BB:CC:DD:EE:FF",
-                resolved_address="AA:BB:CC:DD:EE:FF",
-                target_address="AA:BB:CC:DD:EE:FF",
+                connection_target=TEST_BLE_ADDRESS,
+                resolved_address=TEST_BLE_ADDRESS,
+                target_address=TEST_BLE_ADDRESS,
                 skip_discovery_scan=False,
                 on_disconnect_func=lambda _client: None,
                 pair_on_connect=False,
@@ -373,7 +373,7 @@ def test_connection_orchestrator_direct_and_retry_exception_paths(
 
         orchestrator.interface = SimpleNamespace()
         with pytest.raises(AttributeError):
-            orchestrator._compat_find_device("AA:BB:CC:DD:EE:FF")
+            orchestrator._compat_find_device(TEST_BLE_ADDRESS)
 
 
 def test_connection_orchestrator_finalize_and_establish_error_paths(
@@ -389,7 +389,7 @@ def test_connection_orchestrator_finalize_and_establish_error_paths(
         with pytest.raises(iface.BLEError):
             orchestrator._finalize_connection(
                 DummyClient(),
-                "AA:BB:CC:DD:EE:FF",
+                TEST_BLE_ADDRESS,
                 lambda _client: None,
                 lambda: None,
             )
@@ -508,7 +508,7 @@ def test_connection_validator_client_wrapper_and_manager_remaining_branches() ->
     validator = ConnectionValidator(BLEStateManager(), RLock(), _TestBLEError)
     assert (
         validator.check_existing_client(
-            SimpleNamespace(is_connected=True, address="AA:BB:CC:DD:EE:FF"),
+            SimpleNamespace(is_connected=True, address=TEST_BLE_ADDRESS),
             None,
             None,
         )
@@ -668,7 +668,7 @@ def test_orchestrator_create_connect_direct_retry_remaining_branches(
         )
         with pytest.raises(TypeError, match="plain typeerror"):
             orchestrator._client_manager_create_client(
-                "AA:BB:CC:DD:EE:FF",
+                TEST_BLE_ADDRESS,
                 lambda _client: None,
                 pair_on_connect=True,
                 connect_timeout=1.0,
@@ -695,7 +695,7 @@ def test_orchestrator_create_connect_direct_retry_remaining_branches(
         )
         with pytest.raises(ValueError, match="direct fail"):
             orchestrator._attempt_direct_connect(
-                target_address="AA:BB:CC:DD:EE:FF",
+                target_address=TEST_BLE_ADDRESS,
                 normalized_target="aabbccddeeff",
                 on_disconnect_func=lambda _client: None,
                 pair_on_connect=False,
@@ -716,9 +716,9 @@ def test_orchestrator_create_connect_direct_retry_remaining_branches(
         ).throw(SystemExit())
         with pytest.raises(SystemExit):
             orchestrator._connect_retry_target(
-                connection_target="AA:BB:CC:DD:EE:FF",
-                resolved_address="AA:BB:CC:DD:EE:FF",
-                target_address="AA:BB:CC:DD:EE:FF",
+                connection_target=TEST_BLE_ADDRESS,
+                resolved_address=TEST_BLE_ADDRESS,
+                target_address=TEST_BLE_ADDRESS,
                 skip_discovery_scan=False,
                 on_disconnect_func=lambda _client: None,
                 pair_on_connect=False,
@@ -737,9 +737,9 @@ def test_orchestrator_create_connect_direct_retry_remaining_branches(
         ).throw(BleakError("retry fail"))
         with pytest.raises(BleakError, match="retry fail"):
             orchestrator._connect_retry_target(
-                connection_target="AA:BB:CC:DD:EE:FF",
-                resolved_address="AA:BB:CC:DD:EE:FF",
-                target_address="AA:BB:CC:DD:EE:FF",
+                connection_target=TEST_BLE_ADDRESS,
+                resolved_address=TEST_BLE_ADDRESS,
+                target_address=TEST_BLE_ADDRESS,
                 skip_discovery_scan=False,
                 on_disconnect_func=lambda _client: None,
                 pair_on_connect=False,
@@ -770,9 +770,9 @@ def test_orchestrator_create_connect_direct_retry_remaining_branches(
         )
         with pytest.raises(RuntimeError, match="discovery connect failed"):
             orchestrator._connect_retry_target(
-                connection_target="AA:BB:CC:DD:EE:FF",
-                resolved_address="AA:BB:CC:DD:EE:FF",
-                target_address="AA:BB:CC:DD:EE:FF",
+                connection_target=TEST_BLE_ADDRESS,
+                resolved_address=TEST_BLE_ADDRESS,
+                target_address=TEST_BLE_ADDRESS,
                 skip_discovery_scan=True,
                 on_disconnect_func=lambda _client: None,
                 pair_on_connect=False,
@@ -794,7 +794,7 @@ def test_orchestrator_finalize_and_establish_remaining_branches(
         with pytest.raises(iface.BLEError):
             orchestrator._finalize_connection(
                 connected_client,
-                "AA:BB:CC:DD:EE:FF",
+                TEST_BLE_ADDRESS,
                 lambda _client: None,
                 lambda: None,
             )
@@ -808,7 +808,7 @@ def test_orchestrator_finalize_and_establish_remaining_branches(
         with pytest.raises(iface.BLEError):
             orchestrator._finalize_connection(
                 connected_client,
-                "AA:BB:CC:DD:EE:FF",
+                TEST_BLE_ADDRESS,
                 lambda _client: None,
                 lambda: None,
             )
@@ -822,7 +822,7 @@ def test_orchestrator_finalize_and_establish_remaining_branches(
         with pytest.raises(iface.BLEError):
             orchestrator._finalize_connection(
                 connected_client,
-                "AA:BB:CC:DD:EE:FF",
+                TEST_BLE_ADDRESS,
                 lambda _client: None,
                 lambda: None,
             )
@@ -907,7 +907,7 @@ def test_discovery_probe_and_factory_kwarg_rejection_branches() -> None:
 
     def _factory_rejecting_kwarg(**kwargs: object) -> _GoodDiscoveryClient:
         if kwargs:
-            raise TypeError(
+            raise TypeError(  # noqa: TRY003 - intentional fixture message shape
                 "factory() got an unexpected keyword argument 'log_if_no_address'"
             )
         return _GoodDiscoveryClient()
@@ -999,7 +999,7 @@ def test_discovery_missing_discover_and_typeerror_rejection_branches() -> None:
 
         @staticmethod
         def discover(**_kwargs: object) -> dict[str, Any]:
-            raise TypeError(
+            raise TypeError(  # noqa: TRY003 - intentional fixture message shape
                 "discover() got an unexpected keyword argument 'return_adv'"
             )
 
@@ -1141,7 +1141,7 @@ def test_bleclient_remaining_hook_and_connection_branches() -> None:
 
     def _failing_safe_cleanup(cleanup: Any, *args: object, **kwargs: object) -> None:
         if "cleanup_name" in kwargs:
-            raise TypeError(
+            raise TypeError(  # noqa: TRY003 - intentional fixture message shape
                 "safe_cleanup() got an unexpected keyword argument 'cleanup_name'"
             )
         _ = args

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -160,7 +160,9 @@ def test_client_manager_thread_dispatch_and_wrapper_paths(
     manager._connect_client.assert_called_once()
 
 
-def test_client_manager_connect_client_recovers_from_services_property_bleak_error() -> None:
+def test_client_manager_connect_client_recovers_from_services_property_bleak_error() -> (
+    None
+):
     """_connect_client should force service discovery when services property access fails."""
     manager = ClientManager(
         BLEStateManager(),
@@ -759,6 +761,7 @@ def test_orchestrator_create_connect_direct_retry_remaining_branches(
                 connect_attempt_count[0] += 1
                 raise BleakDeviceNotFoundError("device not found")
             raise RuntimeError("discovery connect failed")
+
         orchestrator._client_manager_connect_client = _connect_side_effect
         orchestrator._compat_find_device = lambda _target: SimpleNamespace(
             address="AA:BB"

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -27,6 +27,8 @@ from tests.test_ble_interface_fixtures import DummyClient, _build_interface
 
 pytestmark = pytest.mark.unit
 
+MOCK_IMPORT_UNAVAILABLE_MSG = "mock import unavailable"
+
 
 class _TestBLEError(Exception):
     """Custom BLEError type for focused branch tests."""
@@ -88,7 +90,7 @@ def test_connection_helpers_cover_mock_import_and_inline_safe_cleanup(
         level: int = 0,
     ) -> object:
         if name == "unittest.mock":
-            raise ImportError("mock import unavailable")
+            raise ImportError(MOCK_IMPORT_UNAVAILABLE_MSG)
         return real_import(name, globals_arg, locals_arg, fromlist, level)
 
     monkeypatch.setattr(builtins, "__import__", _import_with_mock_failure)

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -83,7 +83,9 @@ def test_client_manager_thread_dispatch_and_wrapper_paths(
     )
 
     created = SimpleNamespace(name="created")
-    manager.thread_coordinator = SimpleNamespace(create_thread=lambda **_kwargs: created)
+    manager.thread_coordinator = SimpleNamespace(
+        create_thread=lambda **_kwargs: created
+    )
     assert (
         manager._thread_create_thread(
             target=lambda: None,
@@ -96,10 +98,14 @@ def test_client_manager_thread_dispatch_and_wrapper_paths(
 
     manager.thread_coordinator = SimpleNamespace()
     with pytest.raises(AttributeError):
-        manager._thread_create_thread(target=lambda: None, args=(), name="n", daemon=True)
+        manager._thread_create_thread(
+            target=lambda: None, args=(), name="n", daemon=True
+        )
 
     started: list[object] = []
-    manager.thread_coordinator = SimpleNamespace(_start_thread=lambda thread: started.append(thread))
+    manager.thread_coordinator = SimpleNamespace(
+        _start_thread=lambda thread: started.append(thread)
+    )
     manager._thread_start_thread(created)
     assert started == [created]
 
@@ -121,7 +127,9 @@ def test_client_manager_thread_dispatch_and_wrapper_paths(
 def test_client_manager_update_reference_thread_failure_closes_inline() -> None:
     """update_client_reference should close old client inline on thread start failure."""
     lock = RLock()
-    manager = ClientManager(BLEStateManager(), lock, SimpleNamespace(), BLEErrorHandler())
+    manager = ClientManager(
+        BLEStateManager(), lock, SimpleNamespace(), BLEErrorHandler()
+    )
 
     old_client = DummyClient()
     new_client = DummyClient()
@@ -192,7 +200,9 @@ def test_connection_orchestrator_dispatch_set_event_and_kwarg_fallbacks(
 
         create_calls: list[dict[str, object]] = []
 
-        def _create_client(_device: object, _cb: object, **kwargs: object) -> DummyClient:
+        def _create_client(
+            _device: object, _cb: object, **kwargs: object
+        ) -> DummyClient:
             create_calls.append(dict(kwargs))
             if "pair_on_connect" in kwargs:
                 raise TypeError(
@@ -234,18 +244,22 @@ def test_connection_orchestrator_direct_and_retry_exception_paths(
     """Direct/retry connect helpers should close clients on exceptional paths."""
     with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
         closed_clients: list[object] = []
-        orchestrator._client_manager_safe_close_client = lambda client: closed_clients.append(client)
+        orchestrator._client_manager_safe_close_client = (
+            lambda client: closed_clients.append(client)
+        )
 
         class _SimpleClient(DummyClient):
             pass
 
         created_client = _SimpleClient()
-        orchestrator._client_manager_create_client = lambda *_args, **_kwargs: created_client
+        orchestrator._client_manager_create_client = (
+            lambda *_args, **_kwargs: created_client
+        )
         orchestrator._client_manager_connect_client = lambda *_args, **_kwargs: None
         orchestrator._raise_if_interface_closing = lambda: None
-        orchestrator._finalize_connection = lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            RuntimeError("finalize failed")
-        )
+        orchestrator._finalize_connection = lambda *_args, **_kwargs: (
+            _ for _ in ()
+        ).throw(RuntimeError("finalize failed"))
 
         with pytest.raises(RuntimeError, match="finalize failed"):
             orchestrator._attempt_direct_connect(
@@ -262,10 +276,12 @@ def test_connection_orchestrator_direct_and_retry_exception_paths(
 
         closed_clients.clear()
         retry_client = _SimpleClient()
-        orchestrator._client_manager_create_client = lambda *_args, **_kwargs: retry_client
-        orchestrator._client_manager_connect_client = lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            RuntimeError("connect failed")
+        orchestrator._client_manager_create_client = (
+            lambda *_args, **_kwargs: retry_client
         )
+        orchestrator._client_manager_connect_client = lambda *_args, **_kwargs: (
+            _ for _ in ()
+        ).throw(RuntimeError("connect failed"))
 
         with pytest.raises(RuntimeError, match="connect failed"):
             orchestrator._connect_retry_target(
@@ -312,9 +328,9 @@ def test_connection_orchestrator_finalize_and_establish_error_paths(
         orchestrator._attempt_direct_connect = lambda **_kwargs: (None, False)
         orchestrator._resolve_retry_target = lambda **_kwargs: ("AA", "AA", 1.0)
         orchestrator._connect_retry_target = lambda **_kwargs: (client, "AA")
-        orchestrator._finalize_connection = lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            RuntimeError("boom")
-        )
+        orchestrator._finalize_connection = lambda *_args, **_kwargs: (
+            _ for _ in ()
+        ).throw(RuntimeError("boom"))
         closed: list[object] = []
         orchestrator._client_manager_safe_close_client = lambda c: closed.append(c)
         orchestrator._transition_failure_to_disconnected = lambda _ctx: None
@@ -397,7 +413,9 @@ def test_client_error_handler_and_connection_state_branches(
     client.bleak_client = SimpleNamespace(is_connected=MagicMock())
     assert client.isConnected() is False
 
-    client.bleak_client = SimpleNamespace(is_connected=MagicMock(return_value=MagicMock()))
+    client.bleak_client = SimpleNamespace(
+        is_connected=MagicMock(return_value=MagicMock())
+    )
     assert client.isConnected() is False
 
     class _BleakWithBrokenServices:
@@ -422,14 +440,20 @@ def test_connection_validator_client_wrapper_and_manager_remaining_branches() ->
         is True
     )
     assert (
-        ConnectionValidator._client_is_connected(SimpleNamespace(isConnected=MagicMock()))
+        ConnectionValidator._client_is_connected(
+            SimpleNamespace(isConnected=MagicMock())
+        )
         is False
     )
 
-    manager = ClientManager(BLEStateManager(), RLock(), SimpleNamespace(), BLEErrorHandler())
+    manager = ClientManager(
+        BLEStateManager(), RLock(), SimpleNamespace(), BLEErrorHandler()
+    )
     started: list[object] = []
     marker = SimpleNamespace(name="public-start")
-    manager.thread_coordinator = SimpleNamespace(start_thread=lambda thread: started.append(thread))
+    manager.thread_coordinator = SimpleNamespace(
+        start_thread=lambda thread: started.append(thread)
+    )
     manager._thread_start_thread(marker)
     assert started == [marker]
 
@@ -503,7 +527,9 @@ def test_orchestrator_dispatch_and_event_remaining_branches(
                 call_member=True,
             )
 
-        validator_non_callable = ConnectionValidator(BLEStateManager(), RLock(), _TestBLEError)
+        validator_non_callable = ConnectionValidator(
+            BLEStateManager(), RLock(), _TestBLEError
+        )
         validator_non_callable.validate_connection_request = 123  # type: ignore[method-assign]
         with pytest.raises(AttributeError):
             orchestrator._dispatch_public_or_underscore(
@@ -515,7 +541,9 @@ def test_orchestrator_dispatch_and_event_remaining_branches(
             )
 
         called: list[str] = []
-        validator_callable = ConnectionValidator(BLEStateManager(), RLock(), _TestBLEError)
+        validator_callable = ConnectionValidator(
+            BLEStateManager(), RLock(), _TestBLEError
+        )
         validator_callable.validate_connection_request = lambda: called.append("called")  # type: ignore[method-assign]
         assert (
             orchestrator._dispatch_public_or_underscore(
@@ -581,12 +609,14 @@ def test_orchestrator_create_connect_direct_retry_remaining_branches(
 
         direct_client = DummyClient()
         closed_clients: list[object] = []
-        orchestrator._client_manager_create_client = lambda *_args, **_kwargs: direct_client
-        orchestrator._client_manager_connect_client = (
-            lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("direct fail"))
+        orchestrator._client_manager_create_client = (
+            lambda *_args, **_kwargs: direct_client
         )
-        orchestrator._client_manager_safe_close_client = lambda client: closed_clients.append(
-            client
+        orchestrator._client_manager_connect_client = lambda *_args, **_kwargs: (
+            _ for _ in ()
+        ).throw(ValueError("direct fail"))
+        orchestrator._client_manager_safe_close_client = (
+            lambda client: closed_clients.append(client)
         )
         with pytest.raises(ValueError, match="direct fail"):
             orchestrator._attempt_direct_connect(
@@ -603,10 +633,12 @@ def test_orchestrator_create_connect_direct_retry_remaining_branches(
 
         retry_client = DummyClient()
         closed_clients.clear()
-        orchestrator._client_manager_create_client = lambda *_args, **_kwargs: retry_client
-        orchestrator._client_manager_connect_client = (
-            lambda *_args, **_kwargs: (_ for _ in ()).throw(SystemExit())
+        orchestrator._client_manager_create_client = (
+            lambda *_args, **_kwargs: retry_client
         )
+        orchestrator._client_manager_connect_client = lambda *_args, **_kwargs: (
+            _ for _ in ()
+        ).throw(SystemExit())
         with pytest.raises(SystemExit):
             orchestrator._connect_retry_target(
                 connection_target="AA:BB:CC:DD:EE:FF",
@@ -622,10 +654,12 @@ def test_orchestrator_create_connect_direct_retry_remaining_branches(
 
         retry_client = DummyClient()
         closed_clients.clear()
-        orchestrator._client_manager_create_client = lambda *_args, **_kwargs: retry_client
-        orchestrator._client_manager_connect_client = (
-            lambda *_args, **_kwargs: (_ for _ in ()).throw(BleakError("retry fail"))
+        orchestrator._client_manager_create_client = (
+            lambda *_args, **_kwargs: retry_client
         )
+        orchestrator._client_manager_connect_client = lambda *_args, **_kwargs: (
+            _ for _ in ()
+        ).throw(BleakError("retry fail"))
         with pytest.raises(BleakError, match="retry fail"):
             orchestrator._connect_retry_target(
                 connection_target="AA:BB:CC:DD:EE:FF",
@@ -655,7 +689,9 @@ def test_orchestrator_create_connect_direct_retry_remaining_branches(
 
         _connect_side_effect.calls = 0
         orchestrator._client_manager_connect_client = _connect_side_effect
-        orchestrator._compat_find_device = lambda _target: SimpleNamespace(address="AA:BB")
+        orchestrator._compat_find_device = lambda _target: SimpleNamespace(
+            address="AA:BB"
+        )
         with pytest.raises(RuntimeError, match="discovery connect failed"):
             orchestrator._connect_retry_target(
                 connection_target="AA:BB:CC:DD:EE:FF",
@@ -725,13 +761,13 @@ def test_orchestrator_finalize_and_establish_remaining_branches(
         orchestrator._attempt_direct_connect = lambda **_kwargs: (None, False)
         orchestrator._resolve_retry_target = lambda **_kwargs: ("AA", "AA", 1.0)
         orchestrator._connect_retry_target = lambda **_kwargs: (retry_client, "AA")
-        orchestrator._client_manager_safe_close_client = lambda client: closed_clients.append(
-            client
+        orchestrator._client_manager_safe_close_client = (
+            lambda client: closed_clients.append(client)
         )
         orchestrator._transition_failure_to_disconnected = lambda _ctx: None
-        orchestrator._finalize_connection = (
-            lambda *_args, **_kwargs: (_ for _ in ()).throw(BleakDBusError("dbus", "err"))
-        )
+        orchestrator._finalize_connection = lambda *_args, **_kwargs: (
+            _ for _ in ()
+        ).throw(BleakDBusError("dbus", "err"))
 
         with pytest.raises(BleakDBusError):
             orchestrator._establish_connection(
@@ -744,9 +780,9 @@ def test_orchestrator_finalize_and_establish_remaining_branches(
         assert closed_clients == [retry_client]
 
         closed_clients.clear()
-        orchestrator._finalize_connection = (
-            lambda *_args, **_kwargs: (_ for _ in ()).throw(SystemExit())
-        )
+        orchestrator._finalize_connection = lambda *_args, **_kwargs: (
+            _ for _ in ()
+        ).throw(SystemExit())
         with pytest.raises(SystemExit):
             orchestrator._establish_connection(
                 address="AA",
@@ -773,7 +809,9 @@ def test_discovery_probe_and_factory_kwarg_rejection_branches() -> None:
         def close() -> None:
             return None
 
-    manager_probe_error = DiscoveryManager(client_factory=lambda **_kwargs: _GoodDiscoveryClient())
+    manager_probe_error = DiscoveryManager(
+        client_factory=lambda **_kwargs: _GoodDiscoveryClient()
+    )
     manager_probe_error._client = SimpleNamespace(
         bleak_client=object(),
         isConnected=lambda: (_ for _ in ()).throw(RuntimeError("probe failure")),
@@ -781,7 +819,9 @@ def test_discovery_probe_and_factory_kwarg_rejection_branches() -> None:
     )
     assert manager_probe_error._discover_devices(address=None) == []
 
-    manager_bool_member = DiscoveryManager(client_factory=lambda **_kwargs: _GoodDiscoveryClient())
+    manager_bool_member = DiscoveryManager(
+        client_factory=lambda **_kwargs: _GoodDiscoveryClient()
+    )
     manager_bool_member._client = SimpleNamespace(
         bleak_client=object(),
         is_connected=False,
@@ -819,7 +859,9 @@ def test_discovery_missing_discover_and_typeerror_rejection_branches() -> None:
         def close() -> None:
             return None
 
-    manager_missing = DiscoveryManager(client_factory=lambda **_kwargs: _FlakyDiscoverClient())
+    manager_missing = DiscoveryManager(
+        client_factory=lambda **_kwargs: _FlakyDiscoverClient()
+    )
     with pytest.raises(DiscoveryClientError):
         manager_missing._discover_devices(address=None)
 
@@ -869,7 +911,9 @@ def test_discovery_missing_discover_and_typeerror_rejection_branches() -> None:
                 # 3) _is_discovery_client_like check at line 548
                 self._post_set_reads_remaining = 3
 
-    manager_line567 = _Line567Manager(client_factory=lambda **_kwargs: _DiscoveryLikeClient())
+    manager_line567 = _Line567Manager(
+        client_factory=lambda **_kwargs: _DiscoveryLikeClient()
+    )
     with pytest.raises(DiscoveryClientError):
         manager_line567._discover_devices(address=None)
 
@@ -887,7 +931,9 @@ def test_discovery_missing_discover_and_typeerror_rejection_branches() -> None:
         def close() -> None:
             return None
 
-    manager_kwarg = DiscoveryManager(client_factory=lambda **_kwargs: _UnexpectedKwargClient())
+    manager_kwarg = DiscoveryManager(
+        client_factory=lambda **_kwargs: _UnexpectedKwargClient()
+    )
     with pytest.raises(DiscoveryClientError):
         manager_kwarg._discover_devices(address=None)
 
@@ -953,7 +999,9 @@ def test_discovery_awaitable_and_exception_handler_branches() -> None:
         def close() -> None:
             return None
 
-    manager_dbus = DiscoveryManager(client_factory=lambda **_kwargs: _DbusErrorDiscoveryClient())
+    manager_dbus = DiscoveryManager(
+        client_factory=lambda **_kwargs: _DbusErrorDiscoveryClient()
+    )
     with pytest.raises(BleakDBusError):
         manager_dbus._discover_devices(address=None)
 
@@ -986,7 +1034,9 @@ def test_discovery_awaitable_and_exception_handler_branches() -> None:
         def close() -> None:
             return None
 
-    manager_value = DiscoveryManager(client_factory=lambda **_kwargs: _ValueErrorDiscoveryClient())
+    manager_value = DiscoveryManager(
+        client_factory=lambda **_kwargs: _ValueErrorDiscoveryClient()
+    )
     assert manager_value._discover_devices(address=None) == []
 
 
@@ -994,7 +1044,9 @@ def test_bleclient_remaining_hook_and_connection_branches() -> None:
     """BLEClient helper methods should cover remaining hook/connection/property branches."""
     client = object.__new__(BLEClient)
     client.BLEError = BLEClient.BLEError
-    client.error_handler = SimpleNamespace(safe_cleanup=object(), _safe_cleanup=object())
+    client.error_handler = SimpleNamespace(
+        safe_cleanup=object(), _safe_cleanup=object()
+    )
     assert client._resolve_error_handler_hook("safe_cleanup", "_safe_cleanup") is None
 
     client.error_handler = SimpleNamespace(
@@ -1030,7 +1082,9 @@ def test_bleclient_remaining_hook_and_connection_branches() -> None:
     client.bleak_client = SimpleNamespace(is_connected=MagicMock())
     assert client.isConnected() is False
 
-    client.bleak_client = SimpleNamespace(is_connected=MagicMock(return_value=MagicMock()))
+    client.bleak_client = SimpleNamespace(
+        is_connected=MagicMock(return_value=MagicMock())
+    )
     assert client.isConnected() is False
 
     class _BrokenServices:

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import contextlib
+from collections.abc import Iterator
 from threading import Event, RLock
 from types import SimpleNamespace
-from typing import Any, Iterator
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -681,13 +682,13 @@ def test_orchestrator_create_connect_direct_retry_remaining_branches(
             create_clients
         )
 
+        connect_attempt_count = [0]
+
         def _connect_side_effect(*_args: object, **_kwargs: object) -> None:
-            if _connect_side_effect.calls == 0:
-                _connect_side_effect.calls += 1
+            if connect_attempt_count[0] == 0:
+                connect_attempt_count[0] += 1
                 raise BleakDeviceNotFoundError("device not found")
             raise RuntimeError("discovery connect failed")
-
-        _connect_side_effect.calls = 0
         orchestrator._client_manager_connect_client = _connect_side_effect
         orchestrator._compat_find_device = lambda _target: SimpleNamespace(
             address="AA:BB"

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -223,7 +223,9 @@ def test_connection_orchestrator_dispatch_set_event_and_kwarg_fallbacks(
             connect_timeout=5.0,
         )
         assert isinstance(created, DummyClient)
-        assert create_calls
+        assert create_calls[-1] == {}
+        assert any("pair_on_connect" in call for call in create_calls[:-1])
+        assert any("connect_timeout" in call for call in create_calls[:-1])
 
         connect_calls: list[dict[str, object]] = []
 

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -2,16 +2,18 @@
 
 from __future__ import annotations
 
+import builtins
 import contextlib
 from collections.abc import Iterator
 from threading import Event, RLock
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
 from bleak.exc import BleakDBusError, BleakDeviceNotFoundError, BleakError
 
+import meshtastic.interfaces.ble.connection as connection_mod
 from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.connection import (
     ClientManager,
@@ -72,6 +74,39 @@ def test_connection_validator_client_is_connected_member_paths() -> None:
     assert ConnectionValidator._client_is_connected(client_unknown) is False
 
 
+def test_connection_helpers_cover_mock_import_and_inline_safe_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Connection helper utilities should handle import fallback and inline cleanup execution."""
+    real_import = builtins.__import__
+
+    def _import_with_mock_failure(
+        name: str,
+        globals_arg: dict[str, object] | None = None,
+        locals_arg: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        if name == "unittest.mock":
+            raise ImportError("mock import unavailable")
+        return real_import(name, globals_arg, locals_arg, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _import_with_mock_failure)
+    assert connection_mod._is_mock_instance(object()) is False
+
+    cleanup_calls: list[str] = []
+
+    def _cleanup() -> None:
+        cleanup_calls.append("ran")
+
+    assert connection_mod._run_safe_cleanup(
+        _cleanup,
+        cleanup_name="client close",
+        safe_cleanup_hook=lambda *_args, **_kwargs: False,
+    )
+    assert cleanup_calls == ["ran"]
+
+
 def test_client_manager_thread_dispatch_and_wrapper_paths(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -123,6 +158,39 @@ def test_client_manager_thread_dispatch_and_wrapper_paths(
     manager._connect_client = MagicMock(return_value=None)
     manager.connect_client(DummyClient())
     manager._connect_client.assert_called_once()
+
+
+def test_client_manager_connect_client_recovers_from_services_property_bleak_error() -> None:
+    """_connect_client should force service discovery when services property access fails."""
+    manager = ClientManager(
+        BLEStateManager(),
+        RLock(),
+        SimpleNamespace(),
+        BLEErrorHandler(),
+    )
+
+    class _BleakClientWithFailingServices:
+        @property
+        def services(self) -> None:
+            raise BleakError("services not ready")
+
+    class _ConnectedClient:
+        def __init__(self) -> None:
+            self.connect_calls: list[dict[str, object]] = []
+            self.get_services_calls = 0
+            self.bleak_client = _BleakClientWithFailingServices()
+
+        def connect(self, **kwargs: object) -> None:
+            self.connect_calls.append(dict(kwargs))
+
+        def _get_services(self) -> None:
+            self.get_services_calls += 1
+
+    client = _ConnectedClient()
+    manager._connect_client(cast(BLEClient, client))
+
+    assert client.connect_calls
+    assert client.get_services_calls == 1
 
 
 def test_client_manager_update_reference_thread_failure_closes_inline() -> None:

--- a/tests/test_ble_integration_scenarios.py
+++ b/tests/test_ble_integration_scenarios.py
@@ -130,7 +130,9 @@ def test_client_manager_handles_concurrent_updates() -> None:
         thread.ident = 1
         thread.is_alive.return_value = True
 
-    thread_coordinator._create_thread.side_effect = lambda *_args, **_kwargs: _new_thread()
+    thread_coordinator._create_thread.side_effect = (
+        lambda *_args, **_kwargs: _new_thread()
+    )
     thread_coordinator._start_thread.side_effect = _mark_started
     error_handler = MagicMock()
 

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -4547,12 +4547,20 @@ def test_transient_read_retry_uses_zero_based_delay(
 
 @pytest.mark.parametrize(
     "invalid_delay",
-    [True, -1.0, math.nan, math.inf, -math.inf],
+    [
+        True,
+        -1.0,
+        math.nan,
+        math.inf,
+        -math.inf,
+        pytest.param("1.0", id="string"),
+        pytest.param(object(), id="opaque-object"),
+    ],
 )
 def test_retry_policy_get_delay_rejects_invalid_numeric_outputs(
     invalid_delay: object,
 ) -> None:
-    """Retry delay helper should clamp bool/non-finite/negative results to 0.0."""
+    """Retry delay helper should clamp invalid bool/non-finite/negative/non-numeric results to 0.0."""
 
     class InvalidDelayPolicy:
         def get_delay(self, _attempt: int) -> object:
@@ -5009,9 +5017,12 @@ def test_handle_malformed_fromnum_warns_at_threshold_and_resets_counter(
 
         iface._handle_malformed_fromnum("bad notification")
 
-        assert warning_calls
+        assert len(warning_calls) == 1
         with iface._malformed_notification_lock:
             assert iface._malformed_notification_count == 0
+
+        iface._handle_malformed_fromnum("bad notification")
+        assert len(warning_calls) == 1
     finally:
         iface.close()
 
@@ -5042,9 +5053,7 @@ def test_report_notification_handler_error_covers_hook_and_fallback_paths(
     assert "missing-hook" in debug_calls
 
 
-def test_invoke_safe_execute_compat_skips_callable_only_after_positional_failure() -> (
-    None
-):
+def test_invoke_safe_execute_compat_skips_callable_only_after_positional_failure() -> None:
     """Positional safe_execute failures should not trigger a second handler invocation."""
 
     calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
@@ -5078,9 +5087,7 @@ def test_invoke_safe_execute_compat_skips_callable_only_after_positional_failure
     assert len(calls) == 2
 
 
-def test_invoke_safe_execute_compat_tries_callable_only_after_positional_signature_error() -> (
-    None
-):
+def test_invoke_safe_execute_compat_tries_callable_only_after_positional_signature_error() -> None:
     """Positional signature mismatch should continue to callable-only compatibility probe."""
 
     calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
@@ -5115,9 +5122,7 @@ def test_invoke_safe_execute_compat_tries_callable_only_after_positional_signatu
     assert len(calls) == 3
 
 
-def test_invoke_safe_execute_compat_covers_keyword_positional_and_callable_only_paths() -> (
-    None
-):
+def test_invoke_safe_execute_compat_covers_keyword_positional_and_callable_only_paths() -> None:
     """safe_execute compatibility helper should cover success/fallback branches."""
 
     def _run_scenario(
@@ -5146,7 +5151,7 @@ def test_invoke_safe_execute_compat_covers_keyword_positional_and_callable_only_
         assert len(fallback_runs) == expect_fallback_runs
 
     _run_scenario(
-        lambda func, *args, **kwargs: func(),
+        lambda func, *_args, **_kwargs: func(),
         expect_handler_runs=1,
         expect_fallback_runs=0,
     )
@@ -5479,9 +5484,7 @@ def test_discovery_manager_accepts_discover_underscore_only_factory() -> None:
     assert devices == [filtered_device]
 
 
-def test_discovery_manager_prefers_configured_underscore_discover_over_unconfigured_mock_public_discover() -> (
-    None
-):
+def test_discovery_manager_prefers_configured_underscore_discover_over_unconfigured_mock_public_discover() -> None:
     """Verify discovery prefers configured ``_discover`` over unconfigured ``discover``.
 
     Returns
@@ -6448,10 +6451,12 @@ def test_register_notifications_safe_call_inline_fallback_when_safe_execute_unco
     client = _ClientWithCallbacks()
     iface = _build_interface(monkeypatch, client, start_receive_thread=False)
     errors: list[str] = []
+    safe_execute = MagicMock()
+    legacy_safe_execute = MagicMock()
     try:
         iface.error_handler = SimpleNamespace(
-            safe_execute=MagicMock(),
-            _safe_execute=MagicMock(),
+            safe_execute=safe_execute,
+            _safe_execute=legacy_safe_execute,
         )
         monkeypatch.setattr(
             iface,
@@ -6470,6 +6475,8 @@ def test_register_notifications_safe_call_inline_fallback_when_safe_execute_unco
         client.callbacks[LOGRADIO_UUID]("sender", b"log")
 
         assert errors == ["Error in log notification handler"]
+        safe_execute.assert_not_called()
+        legacy_safe_execute.assert_not_called()
     finally:
         iface.close()
 
@@ -6494,9 +6501,12 @@ def test_register_notifications_safe_execute_fallback_still_invokes_handler(
                     Callable[[Any, bytes], None], args[1]
                 )
 
+    safe_execute_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
     def _incompatible_safe_execute(
         _func: Callable[[], None], *args: object, **kwargs: object
     ) -> None:
+        safe_execute_calls.append((args, dict(kwargs)))
         if "error_msg" in kwargs:
             raise TypeError(SAFE_EXECUTE_UNEXPECTED_ERROR_MSG)
         if args:
@@ -6523,6 +6533,7 @@ def test_register_notifications_safe_execute_fallback_still_invokes_handler(
         client.callbacks[LOGRADIO_UUID]("sender", b"log")
 
         assert log_calls == [("sender", b"log")]
+        assert len(safe_execute_calls) == 2
         error_hook.assert_not_called()
     finally:
         iface.close()

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -766,11 +766,15 @@ def test_ble_interface_pair_uses_temporary_client_when_disconnected(
     cleanup_calls: list[Any] = []
 
     if factory_mode == "with_optional_kwargs":
+
         def _temp_client_factory(_address: str, **_kwargs: object) -> SimpleNamespace:
             return temp_client
+
     elif factory_mode == "without_optional_kwargs":
+
         def _temp_client_factory(_address: str) -> SimpleNamespace:
             return temp_client
+
     else:
         pytest.fail(f"Unexpected factory_mode: {factory_mode}")
 
@@ -5153,7 +5157,9 @@ def test_discovery_manager_accepts_discover_underscore_only_factory() -> None:
     assert devices == [filtered_device]
 
 
-def test_discovery_manager_prefers_configured_underscore_discover_over_unconfigured_mock_public_discover() -> None:
+def test_discovery_manager_prefers_configured_underscore_discover_over_unconfigured_mock_public_discover() -> (
+    None
+):
     """Verify discovery prefers configured ``_discover`` over unconfigured ``discover``.
 
     Returns

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -4927,6 +4927,81 @@ def test_find_device_direct_connect_without_discovery_manager() -> None:
     assert direct_device.name == address
 
 
+def test_invoke_safe_execute_compat_skips_callable_only_after_positional_failure() -> None:
+    """Positional safe_execute failures should not trigger a second handler invocation."""
+
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    handler_runs: list[str] = []
+    fallbacks: list[str] = []
+
+    def _handler_thunk() -> None:
+        handler_runs.append("run")
+        raise RuntimeError("handler failed")
+
+    def _fallback() -> None:
+        fallbacks.append("fallback")
+
+    def _legacy_safe_execute(
+        func: Callable[[], None], *args: object, **kwargs: object
+    ) -> None:
+        calls.append((args, dict(kwargs)))
+        if "error_msg" in kwargs:
+            raise TypeError(
+                "safe_execute() got an unexpected keyword argument 'error_msg'"
+            )
+        func()
+
+    BLEInterface._invoke_safe_execute_compat(
+        _legacy_safe_execute,
+        _handler_thunk,
+        error_msg="notification error",
+        fallback=_fallback,
+    )
+
+    assert handler_runs == ["run"]
+    assert fallbacks == ["fallback"]
+    assert len(calls) == 2
+
+
+def test_invoke_safe_execute_compat_tries_callable_only_after_positional_signature_error() -> None:
+    """Positional signature mismatch should continue to callable-only compatibility probe."""
+
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    handler_runs: list[str] = []
+    fallbacks: list[str] = []
+
+    def _handler_thunk() -> None:
+        handler_runs.append("run")
+
+    def _fallback() -> None:
+        fallbacks.append("fallback")
+
+    def _legacy_safe_execute(
+        func: Callable[[], None], *args: object, **kwargs: object
+    ) -> None:
+        calls.append((args, dict(kwargs)))
+        if "error_msg" in kwargs:
+            raise TypeError(
+                "safe_execute() got an unexpected keyword argument 'error_msg'"
+            )
+        if args:
+            raise TypeError(
+                "takes 1 positional argument but 2 positional arguments were given"
+            )
+        func()
+
+    BLEInterface._invoke_safe_execute_compat(
+        _legacy_safe_execute,
+        _handler_thunk,
+        error_msg="notification error",
+        fallback=_fallback,
+    )
+
+    assert handler_runs == ["run"]
+    assert fallbacks == []
+    assert len(calls) == 3
+
+
 def test_wait_for_disconnect_notifications_skips_unconfigured_queuework(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -5043,12 +5043,12 @@ def test_report_notification_handler_error_covers_hook_and_fallback_paths(
     iface._report_notification_handler_error("hook-error")
 
     # Unconfigured child mock should be treated as unavailable and fall back to logger.debug.
-    fallback_hook = MagicMock()
-    iface.error_handler = SimpleNamespace(handle_unhandled_exception=fallback_hook)
+    error_handler = MagicMock()
+    iface.error_handler = error_handler
     iface._report_notification_handler_error("missing-hook")
 
     raising_hook.assert_called_once_with("hook-error")
-    fallback_hook.assert_not_called()
+    error_handler.handle_unhandled_exception.assert_not_called()
     assert "hook-error" in debug_calls
     assert "missing-hook" in debug_calls
 

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -5042,7 +5042,9 @@ def test_report_notification_handler_error_covers_hook_and_fallback_paths(
     assert "missing-hook" in debug_calls
 
 
-def test_invoke_safe_execute_compat_skips_callable_only_after_positional_failure() -> None:
+def test_invoke_safe_execute_compat_skips_callable_only_after_positional_failure() -> (
+    None
+):
     """Positional safe_execute failures should not trigger a second handler invocation."""
 
     calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
@@ -5076,7 +5078,9 @@ def test_invoke_safe_execute_compat_skips_callable_only_after_positional_failure
     assert len(calls) == 2
 
 
-def test_invoke_safe_execute_compat_tries_callable_only_after_positional_signature_error() -> None:
+def test_invoke_safe_execute_compat_tries_callable_only_after_positional_signature_error() -> (
+    None
+):
     """Positional signature mismatch should continue to callable-only compatibility probe."""
 
     calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
@@ -5111,7 +5115,9 @@ def test_invoke_safe_execute_compat_tries_callable_only_after_positional_signatu
     assert len(calls) == 3
 
 
-def test_invoke_safe_execute_compat_covers_keyword_positional_and_callable_only_paths() -> None:
+def test_invoke_safe_execute_compat_covers_keyword_positional_and_callable_only_paths() -> (
+    None
+):
     """safe_execute compatibility helper should cover success/fallback branches."""
 
     def _run_scenario(
@@ -5473,7 +5479,9 @@ def test_discovery_manager_accepts_discover_underscore_only_factory() -> None:
     assert devices == [filtered_device]
 
 
-def test_discovery_manager_prefers_configured_underscore_discover_over_unconfigured_mock_public_discover() -> None:
+def test_discovery_manager_prefers_configured_underscore_discover_over_unconfigured_mock_public_discover() -> (
+    None
+):
     """Verify discovery prefers configured ``_discover`` over unconfigured ``discover``.
 
     Returns

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -4813,13 +4813,14 @@ def test_start_receive_thread_clears_cached_thread_when_start_fails(
             raising=True,
         )
 
+        if invoke_start == "facade":
+            start_receive = iface._start_receive_thread
+        else:
+            def start_receive(*, name: str) -> None:
+                BLELifecycleService._start_receive_thread(iface, name=name)
+
         with pytest.raises(RuntimeError, match=START_FAILED_MSG):
-            if invoke_start == "facade":
-                iface._start_receive_thread(name="BLEReceiveStartFailure")
-            else:
-                BLELifecycleService._start_receive_thread(
-                    iface, name="BLEReceiveStartFailure"
-                )
+            start_receive(name="BLEReceiveStartFailure")
 
         assert iface._receiveThread is None
     finally:
@@ -5157,9 +5158,7 @@ def test_discovery_manager_accepts_discover_underscore_only_factory() -> None:
     assert devices == [filtered_device]
 
 
-def test_discovery_manager_prefers_configured_underscore_discover_over_unconfigured_mock_public_discover() -> (
-    None
-):
+def test_discovery_manager_prefers_configured_underscore_discover_over_unconfigured_mock_public_discover() -> None:
     """Verify discovery prefers configured ``_discover`` over unconfigured ``discover``.
 
     Returns

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -4761,24 +4761,28 @@ def test_start_receive_thread_skips_when_interface_closed(
     iface._start_receive_thread(name="BLEReceiveAfterClose")
 
 
+@pytest.mark.parametrize(
+    "invoke_start",
+    ["service", "facade"],
+)
 def test_start_receive_thread_clears_cached_thread_when_start_fails(
     monkeypatch: pytest.MonkeyPatch,
+    invoke_start: str,
 ) -> None:
-    """Verify start failures clear cached receive-thread references.
-
-    Parameters
-    ----------
-    monkeypatch : pytest.MonkeyPatch
-        Fixture used to patch thread-coordinator start behavior.
-
-    Returns
-    -------
-    None
-    """
+    """Verify start failures clear cached receive-thread references for service/facade paths."""
+    from meshtastic.interfaces.ble.interface import BLEInterface
     from meshtastic.interfaces.ble.lifecycle_service import BLELifecycleService
 
     iface = _build_interface(monkeypatch, DummyClient(), start_receive_thread=False)
     try:
+        if invoke_start == "facade":
+            monkeypatch.setattr(
+                type(iface),
+                "_start_receive_thread",
+                BLEInterface._start_receive_thread,
+                raising=True,
+            )
+
         with iface._state_lock:
             iface._want_receive = True
         thread_like = SimpleNamespace(
@@ -4806,65 +4810,12 @@ def test_start_receive_thread_clears_cached_thread_when_start_fails(
         )
 
         with pytest.raises(RuntimeError, match=START_FAILED_MSG):
-            BLELifecycleService._start_receive_thread(iface, name="BLEReceiveStartFailure")
-
-        assert iface._receiveThread is None
-    finally:
-        iface.close()
-
-
-def test_start_receive_thread_facade_clears_cached_thread_when_start_fails(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Verify facade start failures clear cached receive-thread references.
-
-    Parameters
-    ----------
-    monkeypatch : pytest.MonkeyPatch
-        Fixture used to patch thread-coordinator start behavior.
-
-    Returns
-    -------
-    None
-    """
-    from meshtastic.interfaces.ble.interface import BLEInterface
-
-    iface = _build_interface(monkeypatch, DummyClient(), start_receive_thread=False)
-    try:
-        monkeypatch.setattr(
-            type(iface),
-            "_start_receive_thread",
-            BLEInterface._start_receive_thread,
-            raising=True,
-        )
-        with iface._state_lock:
-            iface._want_receive = True
-        thread_like = SimpleNamespace(
-            name="BLEReceiveStartFailure",
-            ident=None,
-            is_alive=lambda: False,
-        )
-        monkeypatch.setattr(
-            iface.thread_coordinator,
-            "_create_thread",
-            lambda **_kwargs: thread_like,
-            raising=True,
-        )
-
-        def _raise_start_failure(_thread: object) -> None:
-            assert _thread is thread_like
-            assert iface._receiveThread is thread_like
-            raise RuntimeError(START_FAILED_MSG)
-
-        monkeypatch.setattr(
-            iface.thread_coordinator,
-            "_start_thread",
-            _raise_start_failure,
-            raising=True,
-        )
-
-        with pytest.raises(RuntimeError, match=START_FAILED_MSG):
-            iface._start_receive_thread(name="BLEReceiveStartFailure")
+            if invoke_start == "facade":
+                iface._start_receive_thread(name="BLEReceiveStartFailure")
+            else:
+                BLELifecycleService._start_receive_thread(
+                    iface, name="BLEReceiveStartFailure"
+                )
 
         assert iface._receiveThread is None
     finally:

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -2116,6 +2116,41 @@ def test_ble_interface_close_bounds_wait_on_spurious_management_wakeups(
     assert any("Timed out waiting" in record.message for record in caplog.records)
 
 
+def test_ble_interface_close_forwards_management_wait_poll_seconds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """close() should forward management shutdown timing kwargs to lifecycle close."""
+    from meshtastic.interfaces.ble import interface as interface_mod
+    from meshtastic.interfaces.ble.lifecycle_service import BLELifecycleService
+
+    iface = object.__new__(BLEInterface)
+    close_calls: list[dict[str, object]] = []
+
+    def _capture_close(
+        _iface: object,
+        *,
+        management_shutdown_wait_timeout: float,
+        management_wait_poll_seconds: float,
+    ) -> None:
+        close_calls.append(
+            {
+                "management_shutdown_wait_timeout": management_shutdown_wait_timeout,
+                "management_wait_poll_seconds": management_wait_poll_seconds,
+            }
+        )
+
+    monkeypatch.setattr(BLELifecycleService, "_close", staticmethod(_capture_close))
+
+    BLEInterface.close(iface)
+
+    assert close_calls == [
+        {
+            "management_shutdown_wait_timeout": interface_mod._MANAGEMENT_SHUTDOWN_WAIT_TIMEOUT_SECONDS,
+            "management_wait_poll_seconds": interface_mod._MANAGEMENT_CONNECT_WAIT_POLL_SECONDS,
+        }
+    ]
+
+
 def test_ble_interface_implicit_trust_releases_connect_lock_before_subprocess(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -4498,6 +4533,16 @@ def test_transient_read_retry_uses_zero_based_delay(
     iface.close()
 
 
+def test_retry_policy_get_delay_rejects_invalid_numeric_outputs() -> None:
+    """Retry delay helper should clamp bool/non-finite/negative results to 0.0."""
+
+    class BoolDelayPolicy:
+        def get_delay(self, _attempt: int) -> bool:
+            return True
+
+    assert BLEInterface._retry_policy_get_delay(BoolDelayPolicy(), attempt=0) == 0.0
+
+
 def test_receive_recovery_backoff_reaches_configured_cap_for_non_power_of_two(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -4927,6 +4972,56 @@ def test_find_device_direct_connect_without_discovery_manager() -> None:
     assert direct_device.name == address
 
 
+def test_handle_malformed_fromnum_warns_at_threshold_and_resets_counter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed FROMNUM counter should emit warning at threshold then reset."""
+    from meshtastic.interfaces.ble.interface import MALFORMED_NOTIFICATION_THRESHOLD
+
+    iface = _build_interface(monkeypatch, DummyClient(), start_receive_thread=False)
+    warning_calls: list[tuple[object, ...]] = []
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.interface.logger.warning",
+        lambda *args, **_kwargs: warning_calls.append(args),
+    )
+    try:
+        with iface._malformed_notification_lock:
+            iface._malformed_notification_count = MALFORMED_NOTIFICATION_THRESHOLD - 1
+
+        iface._handle_malformed_fromnum("bad notification")
+
+        assert warning_calls
+        with iface._malformed_notification_lock:
+            assert iface._malformed_notification_count == 0
+    finally:
+        iface.close()
+
+
+def test_report_notification_handler_error_covers_hook_and_fallback_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Notification error reporting should handle hook failures and missing hooks."""
+    iface = object.__new__(BLEInterface)
+    debug_calls: list[str] = []
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.interface.logger.debug",
+        lambda message, *_args, **_kwargs: debug_calls.append(cast(str, message)),
+    )
+
+    def _raising_report(_message: str) -> None:
+        raise RuntimeError("hook failed")
+
+    iface.error_handler = SimpleNamespace(handle_unhandled_exception=_raising_report)
+    iface._report_notification_handler_error("hook-error")
+
+    # Unconfigured child mock should be treated as unavailable and fall back to logger.debug.
+    iface.error_handler = SimpleNamespace(handle_unhandled_exception=MagicMock())
+    iface._report_notification_handler_error("missing-hook")
+
+    assert "hook-error" in debug_calls
+    assert "missing-hook" in debug_calls
+
+
 def test_invoke_safe_execute_compat_skips_callable_only_after_positional_failure() -> None:
     """Positional safe_execute failures should not trigger a second handler invocation."""
 
@@ -5000,6 +5095,121 @@ def test_invoke_safe_execute_compat_tries_callable_only_after_positional_signatu
     assert handler_runs == ["run"]
     assert fallbacks == []
     assert len(calls) == 3
+
+
+def test_invoke_safe_execute_compat_covers_keyword_positional_and_callable_only_paths() -> None:
+    """safe_execute compatibility helper should cover success/fallback branches."""
+
+    def _run_scenario(
+        safe_execute: Callable[..., object],
+        *,
+        expect_handler_runs: int,
+        expect_fallback_runs: int,
+    ) -> None:
+        handler_runs: list[str] = []
+        fallback_runs: list[str] = []
+
+        def _handler() -> None:
+            handler_runs.append("run")
+
+        def _fallback() -> None:
+            fallback_runs.append("fallback")
+
+        BLEInterface._invoke_safe_execute_compat(
+            safe_execute,
+            _handler,
+            error_msg="notification error",
+            fallback=_fallback,
+        )
+
+        assert len(handler_runs) == expect_handler_runs
+        assert len(fallback_runs) == expect_fallback_runs
+
+    _run_scenario(
+        lambda func, *args, **kwargs: func(),
+        expect_handler_runs=1,
+        expect_fallback_runs=0,
+    )
+
+    def _keyword_typeerror(
+        _func: Callable[[], None], *args: object, **kwargs: object
+    ) -> None:
+        _ = args
+        _ = kwargs
+        raise TypeError("different type error")
+
+    _run_scenario(
+        _keyword_typeerror,
+        expect_handler_runs=0,
+        expect_fallback_runs=1,
+    )
+
+    def _keyword_exception(
+        _func: Callable[[], None], *args: object, **kwargs: object
+    ) -> None:
+        _ = args
+        _ = kwargs
+        raise RuntimeError("keyword call failed")
+
+    _run_scenario(
+        _keyword_exception,
+        expect_handler_runs=0,
+        expect_fallback_runs=1,
+    )
+
+    def _positional_success(
+        func: Callable[[], None], *args: object, **kwargs: object
+    ) -> None:
+        if "error_msg" in kwargs:
+            raise TypeError(
+                "safe_execute() got an unexpected keyword argument 'error_msg'"
+            )
+        if args:
+            func()
+            return
+        raise AssertionError("callable-only path should not execute")
+
+    _run_scenario(
+        _positional_success,
+        expect_handler_runs=1,
+        expect_fallback_runs=0,
+    )
+
+    def _non_signature_positional_typeerror(
+        _func: Callable[[], None], *args: object, **kwargs: object
+    ) -> None:
+        if "error_msg" in kwargs:
+            raise TypeError(
+                "safe_execute() got an unexpected keyword argument 'error_msg'"
+            )
+        if args:
+            raise TypeError("handler raised type error")
+        raise AssertionError("callable-only path should not execute")
+
+    _run_scenario(
+        _non_signature_positional_typeerror,
+        expect_handler_runs=0,
+        expect_fallback_runs=1,
+    )
+
+    def _callable_only_exception(
+        _func: Callable[[], None], *args: object, **kwargs: object
+    ) -> None:
+        if "error_msg" in kwargs:
+            raise TypeError(
+                "safe_execute() got an unexpected keyword argument 'error_msg'"
+            )
+        if args:
+            raise TypeError(
+                "takes 1 positional argument but 2 positional arguments were given"
+            )
+        raise RuntimeError("callable-only failed")
+
+    _run_scenario(
+        _callable_only_exception,
+        expect_handler_runs=0,
+        expect_fallback_runs=1,
+    )
 
 
 def test_wait_for_disconnect_notifications_skips_unconfigured_queuework(
@@ -5129,6 +5339,15 @@ def test_publish_connection_status_falls_back_inline_when_non_blocking_enqueue_u
     )
 
     assert sent == [("meshtastic.connection.status", iface, False)]
+
+
+def test_get_publishing_thread_prefers_instance_override() -> None:
+    """_get_publishing_thread should return an instance override when configured."""
+    iface = object.__new__(BLEInterface)
+    override_thread = SimpleNamespace(name="override-thread")
+    iface._publishing_thread_override = override_thread
+
+    assert iface._get_publishing_thread() is override_thread
 
 
 def test_discovery_manager_filters_meshtastic_devices(
@@ -6175,6 +6394,55 @@ def test_log_notification_registration(
     ), "FROMNUM notification should register a callable handler"
 
     iface.close()
+
+
+def test_register_notifications_safe_call_inline_fallback_when_safe_execute_unconfigured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Notification wrappers should use inline fallback when safe_execute hooks are unconfigured."""
+
+    class _ClientWithCallbacks(DummyClient):
+        def __init__(self) -> None:
+            super().__init__()
+            self.callbacks: dict[str, Callable[[Any, bytes], None]] = {}
+
+        def has_characteristic(self, uuid: str) -> bool:
+            return uuid in {LOGRADIO_UUID, FROMNUM_UUID}
+
+        def start_notify(self, *args: Any, **kwargs: Any) -> None:
+            _ = kwargs
+            if len(args) >= 2:
+                self.callbacks[str(args[0])] = cast(
+                    Callable[[Any, bytes], None], args[1]
+                )
+
+    client = _ClientWithCallbacks()
+    iface = _build_interface(monkeypatch, client, start_receive_thread=False)
+    errors: list[str] = []
+    try:
+        iface.error_handler = SimpleNamespace(
+            safe_execute=MagicMock(),
+            _safe_execute=MagicMock(),
+        )
+        monkeypatch.setattr(
+            iface,
+            "_log_radio_handler",
+            lambda _sender, _data: (_ for _ in ()).throw(RuntimeError("handler boom")),
+            raising=True,
+        )
+        monkeypatch.setattr(
+            iface,
+            "_report_notification_handler_error",
+            lambda msg: errors.append(msg),
+            raising=True,
+        )
+
+        iface._register_notifications(cast(BLEClient, client))
+        client.callbacks[LOGRADIO_UUID]("sender", b"log")
+
+        assert errors == ["Error in log notification handler"]
+    finally:
+        iface.close()
 
 
 def test_register_notifications_retries_fromnum_notify_acquired_once(

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -66,6 +66,17 @@ pytestmark = pytest.mark.unit
 _MAX_SPURIOUS_CONNECT_WAIT_CALLS_BEFORE_FAIL = 10
 _MAX_SPURIOUS_CLOSE_WAIT_CALLS_BEFORE_FAIL = 50
 START_FAILED_MSG = "start failed"
+SAFE_EXECUTE_UNEXPECTED_ERROR_MSG = (
+    "safe_execute() got an unexpected keyword argument 'error_msg'"
+)
+SAFE_EXECUTE_POSITIONAL_MISMATCH_ERROR_MSG = (
+    "takes 1 positional argument but 2 positional arguments were given"
+)
+SAFE_EXECUTE_DIFFERENT_TYPE_ERROR_MSG = "different type error"
+SAFE_EXECUTE_KEYWORD_CALL_FAILED_MSG = "keyword call failed"
+SAFE_EXECUTE_HANDLER_TYPE_ERROR_MSG = "handler raised type error"
+SAFE_EXECUTE_CALLABLE_ONLY_ERROR_MSG = "callable-only failed"
+SAFE_EXECUTE_LEGACY_POSITIONAL_MISMATCH_ERROR_MSG = "legacy positional mismatch"
 
 
 def _pin_trust_environment(
@@ -5050,9 +5061,7 @@ def test_invoke_safe_execute_compat_skips_callable_only_after_positional_failure
     ) -> None:
         calls.append((args, dict(kwargs)))
         if "error_msg" in kwargs:
-            raise TypeError(
-                "safe_execute() got an unexpected keyword argument 'error_msg'"
-            )
+            raise TypeError(SAFE_EXECUTE_UNEXPECTED_ERROR_MSG)
         func()
 
     BLEInterface._invoke_safe_execute_compat(
@@ -5063,7 +5072,7 @@ def test_invoke_safe_execute_compat_skips_callable_only_after_positional_failure
     )
 
     assert handler_runs == ["run"]
-    assert fallbacks == ["fallback"]
+    assert fallbacks == []
     assert len(calls) == 2
 
 
@@ -5085,13 +5094,9 @@ def test_invoke_safe_execute_compat_tries_callable_only_after_positional_signatu
     ) -> None:
         calls.append((args, dict(kwargs)))
         if "error_msg" in kwargs:
-            raise TypeError(
-                "safe_execute() got an unexpected keyword argument 'error_msg'"
-            )
+            raise TypeError(SAFE_EXECUTE_UNEXPECTED_ERROR_MSG)
         if args:
-            raise TypeError(
-                "takes 1 positional argument but 2 positional arguments were given"
-            )
+            raise TypeError(SAFE_EXECUTE_POSITIONAL_MISMATCH_ERROR_MSG)
         func()
 
     BLEInterface._invoke_safe_execute_compat(
@@ -5106,9 +5111,7 @@ def test_invoke_safe_execute_compat_tries_callable_only_after_positional_signatu
     assert len(calls) == 3
 
 
-def test_invoke_safe_execute_compat_covers_keyword_positional_and_callable_only_paths() -> (
-    None
-):
+def test_invoke_safe_execute_compat_covers_keyword_positional_and_callable_only_paths() -> None:
     """safe_execute compatibility helper should cover success/fallback branches."""
 
     def _run_scenario(
@@ -5147,7 +5150,7 @@ def test_invoke_safe_execute_compat_covers_keyword_positional_and_callable_only_
     ) -> None:
         _ = args
         _ = kwargs
-        raise TypeError("different type error")
+        raise TypeError(SAFE_EXECUTE_DIFFERENT_TYPE_ERROR_MSG)
 
     _run_scenario(
         _keyword_typeerror,
@@ -5160,7 +5163,7 @@ def test_invoke_safe_execute_compat_covers_keyword_positional_and_callable_only_
     ) -> None:
         _ = args
         _ = kwargs
-        raise RuntimeError("keyword call failed")
+        raise RuntimeError(SAFE_EXECUTE_KEYWORD_CALL_FAILED_MSG)
 
     _run_scenario(
         _keyword_exception,
@@ -5172,9 +5175,7 @@ def test_invoke_safe_execute_compat_covers_keyword_positional_and_callable_only_
         func: Callable[[], None], *args: object, **kwargs: object
     ) -> None:
         if "error_msg" in kwargs:
-            raise TypeError(
-                "safe_execute() got an unexpected keyword argument 'error_msg'"
-            )
+            raise TypeError(SAFE_EXECUTE_UNEXPECTED_ERROR_MSG)
         if args:
             func()
             return
@@ -5190,11 +5191,9 @@ def test_invoke_safe_execute_compat_covers_keyword_positional_and_callable_only_
         _func: Callable[[], None], *args: object, **kwargs: object
     ) -> None:
         if "error_msg" in kwargs:
-            raise TypeError(
-                "safe_execute() got an unexpected keyword argument 'error_msg'"
-            )
+            raise TypeError(SAFE_EXECUTE_UNEXPECTED_ERROR_MSG)
         if args:
-            raise TypeError("handler raised type error")
+            raise TypeError(SAFE_EXECUTE_HANDLER_TYPE_ERROR_MSG)
         raise AssertionError("callable-only path should not execute")
 
     _run_scenario(
@@ -5207,14 +5206,10 @@ def test_invoke_safe_execute_compat_covers_keyword_positional_and_callable_only_
         _func: Callable[[], None], *args: object, **kwargs: object
     ) -> None:
         if "error_msg" in kwargs:
-            raise TypeError(
-                "safe_execute() got an unexpected keyword argument 'error_msg'"
-            )
+            raise TypeError(SAFE_EXECUTE_UNEXPECTED_ERROR_MSG)
         if args:
-            raise TypeError(
-                "takes 1 positional argument but 2 positional arguments were given"
-            )
-        raise RuntimeError("callable-only failed")
+            raise TypeError(SAFE_EXECUTE_POSITIONAL_MISMATCH_ERROR_MSG)
+        raise RuntimeError(SAFE_EXECUTE_CALLABLE_ONLY_ERROR_MSG)
 
     _run_scenario(
         _callable_only_exception,
@@ -5478,9 +5473,7 @@ def test_discovery_manager_accepts_discover_underscore_only_factory() -> None:
     assert devices == [filtered_device]
 
 
-def test_discovery_manager_prefers_configured_underscore_discover_over_unconfigured_mock_public_discover() -> (
-    None
-):
+def test_discovery_manager_prefers_configured_underscore_discover_over_unconfigured_mock_public_discover() -> None:
     """Verify discovery prefers configured ``_discover`` over unconfigured ``discover``.
 
     Returns
@@ -6437,7 +6430,7 @@ def test_register_notifications_safe_call_inline_fallback_when_safe_execute_unco
         def has_characteristic(self, uuid: str) -> bool:
             return uuid in {LOGRADIO_UUID, FROMNUM_UUID}
 
-        def start_notify(self, *args: Any, **kwargs: Any) -> None:
+        def start_notify(self, *args: object, **kwargs: object) -> None:
             _ = kwargs
             if len(args) >= 2:
                 self.callbacks[str(args[0])] = cast(
@@ -6486,7 +6479,7 @@ def test_register_notifications_safe_execute_fallback_still_invokes_handler(
         def has_characteristic(self, uuid: str) -> bool:
             return uuid in {LOGRADIO_UUID, FROMNUM_UUID}
 
-        def start_notify(self, *args: Any, **kwargs: Any) -> None:
+        def start_notify(self, *args: object, **kwargs: object) -> None:
             _ = kwargs
             if len(args) >= 2:
                 self.callbacks[str(args[0])] = cast(
@@ -6497,11 +6490,9 @@ def test_register_notifications_safe_execute_fallback_still_invokes_handler(
         _func: Callable[[], None], *args: object, **kwargs: object
     ) -> None:
         if "error_msg" in kwargs:
-            raise TypeError(
-                "safe_execute() got an unexpected keyword argument 'error_msg'"
-            )
+            raise TypeError(SAFE_EXECUTE_UNEXPECTED_ERROR_MSG)
         if args:
-            raise TypeError("legacy positional mismatch")
+            raise TypeError(SAFE_EXECUTE_LEGACY_POSITIONAL_MISMATCH_ERROR_MSG)
         raise AssertionError("callable-only probe should be skipped in this path")
 
     client = _ClientWithCallbacks()
@@ -6544,7 +6535,7 @@ def test_register_notifications_retries_fromnum_notify_acquired_once(
         def has_characteristic(self, uuid: str) -> bool:
             return uuid == FROMNUM_UUID
 
-        def start_notify(self, *args: Any, **kwargs: Any) -> None:
+        def start_notify(self, *args: object, **kwargs: object) -> None:
             _ = kwargs
             if args and args[0] == FROMNUM_UUID:
                 self.fromnum_start_attempts += 1
@@ -6578,7 +6569,7 @@ def test_register_notifications_re_raises_non_notify_acquired_dbus_error(
         def has_characteristic(self, uuid: str) -> bool:
             return uuid == FROMNUM_UUID
 
-        def start_notify(self, *args: Any, **kwargs: Any) -> None:
+        def start_notify(self, *args: object, **kwargs: object) -> None:
             _ = kwargs
             if args and args[0] == FROMNUM_UUID:
                 raise BleakDBusError(
@@ -6612,7 +6603,7 @@ def test_register_notifications_falls_back_to_polling_after_repeated_notify_acqu
         def has_characteristic(self, uuid: str) -> bool:
             return uuid == FROMNUM_UUID
 
-        def start_notify(self, *args: Any, **kwargs: Any) -> None:
+        def start_notify(self, *args: object, **kwargs: object) -> None:
             _ = kwargs
             if args and args[0] == FROMNUM_UUID:
                 self.fromnum_start_attempts += 1

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -4861,6 +4861,7 @@ def test_start_receive_thread_clears_cached_thread_when_start_fails(
         if invoke_start == "facade":
             start_receive = iface._start_receive_thread
         else:
+
             def start_receive(*, name: str) -> None:
                 BLELifecycleService._start_receive_thread(iface, name=name)
 
@@ -5022,7 +5023,9 @@ def test_report_notification_handler_error_covers_hook_and_fallback_paths(
     assert "missing-hook" in debug_calls
 
 
-def test_invoke_safe_execute_compat_skips_callable_only_after_positional_failure() -> None:
+def test_invoke_safe_execute_compat_skips_callable_only_after_positional_failure() -> (
+    None
+):
     """Positional safe_execute failures should not trigger a second handler invocation."""
 
     calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
@@ -5058,7 +5061,9 @@ def test_invoke_safe_execute_compat_skips_callable_only_after_positional_failure
     assert len(calls) == 2
 
 
-def test_invoke_safe_execute_compat_tries_callable_only_after_positional_signature_error() -> None:
+def test_invoke_safe_execute_compat_tries_callable_only_after_positional_signature_error() -> (
+    None
+):
     """Positional signature mismatch should continue to callable-only compatibility probe."""
 
     calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
@@ -5097,7 +5102,9 @@ def test_invoke_safe_execute_compat_tries_callable_only_after_positional_signatu
     assert len(calls) == 3
 
 
-def test_invoke_safe_execute_compat_covers_keyword_positional_and_callable_only_paths() -> None:
+def test_invoke_safe_execute_compat_covers_keyword_positional_and_callable_only_paths() -> (
+    None
+):
     """safe_execute compatibility helper should cover success/fallback branches."""
 
     def _run_scenario(
@@ -5452,7 +5459,9 @@ def test_discovery_manager_accepts_discover_underscore_only_factory() -> None:
     assert devices == [filtered_device]
 
 
-def test_discovery_manager_prefers_configured_underscore_discover_over_unconfigured_mock_public_discover() -> None:
+def test_discovery_manager_prefers_configured_underscore_discover_over_unconfigured_mock_public_discover() -> (
+    None
+):
     """Verify discovery prefers configured ``_discover`` over unconfigured ``discover``.
 
     Returns

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -3,6 +3,7 @@
 import asyncio
 import contextlib
 import logging
+import math
 import re
 import subprocess
 import threading
@@ -4533,14 +4534,20 @@ def test_transient_read_retry_uses_zero_based_delay(
     iface.close()
 
 
-def test_retry_policy_get_delay_rejects_invalid_numeric_outputs() -> None:
+@pytest.mark.parametrize(
+    "invalid_delay",
+    [True, -1.0, math.nan, math.inf, -math.inf],
+)
+def test_retry_policy_get_delay_rejects_invalid_numeric_outputs(
+    invalid_delay: object,
+) -> None:
     """Retry delay helper should clamp bool/non-finite/negative results to 0.0."""
 
-    class BoolDelayPolicy:
-        def get_delay(self, _attempt: int) -> bool:
-            return True
+    class InvalidDelayPolicy:
+        def get_delay(self, _attempt: int) -> object:
+            return invalid_delay
 
-    assert BLEInterface._retry_policy_get_delay(BoolDelayPolicy(), attempt=0) == 0.0
+    assert BLEInterface._retry_policy_get_delay(InvalidDelayPolicy(), attempt=0) == 0.0
 
 
 def test_receive_recovery_backoff_reaches_configured_cap_for_non_power_of_two(
@@ -5009,23 +5016,22 @@ def test_report_notification_handler_error_covers_hook_and_fallback_paths(
         lambda message, *_args, **_kwargs: debug_calls.append(cast(str, message)),
     )
 
-    def _raising_report(_message: str) -> None:
-        raise RuntimeError("hook failed")
-
-    iface.error_handler = SimpleNamespace(handle_unhandled_exception=_raising_report)
+    raising_hook = MagicMock(side_effect=RuntimeError("hook failed"))
+    iface.error_handler = SimpleNamespace(handle_unhandled_exception=raising_hook)
     iface._report_notification_handler_error("hook-error")
 
     # Unconfigured child mock should be treated as unavailable and fall back to logger.debug.
-    iface.error_handler = SimpleNamespace(handle_unhandled_exception=MagicMock())
+    fallback_hook = MagicMock()
+    iface.error_handler = SimpleNamespace(handle_unhandled_exception=fallback_hook)
     iface._report_notification_handler_error("missing-hook")
 
+    raising_hook.assert_called_once_with("hook-error")
+    fallback_hook.assert_not_called()
     assert "hook-error" in debug_calls
     assert "missing-hook" in debug_calls
 
 
-def test_invoke_safe_execute_compat_skips_callable_only_after_positional_failure() -> (
-    None
-):
+def test_invoke_safe_execute_compat_skips_callable_only_after_positional_failure() -> None:
     """Positional safe_execute failures should not trigger a second handler invocation."""
 
     calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
@@ -5061,9 +5067,7 @@ def test_invoke_safe_execute_compat_skips_callable_only_after_positional_failure
     assert len(calls) == 2
 
 
-def test_invoke_safe_execute_compat_tries_callable_only_after_positional_signature_error() -> (
-    None
-):
+def test_invoke_safe_execute_compat_tries_callable_only_after_positional_signature_error() -> None:
     """Positional signature mismatch should continue to callable-only compatibility probe."""
 
     calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
@@ -5355,6 +5359,21 @@ def test_get_publishing_thread_prefers_instance_override() -> None:
     iface._publishing_thread_override = override_thread
 
     assert iface._get_publishing_thread() is override_thread
+
+
+def test_get_publishing_thread_falls_back_to_module_publishing_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_get_publishing_thread should return module-level publishingThread when override is unset."""
+    iface = object.__new__(BLEInterface)
+    iface._publishing_thread_override = None
+    module_thread = SimpleNamespace(name="module-thread")
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.interface.publishingThread",
+        module_thread,
+    )
+
+    assert iface._get_publishing_thread() is module_thread
 
 
 def test_discovery_manager_filters_meshtastic_devices(
@@ -6450,6 +6469,62 @@ def test_register_notifications_safe_call_inline_fallback_when_safe_execute_unco
         client.callbacks[LOGRADIO_UUID]("sender", b"log")
 
         assert errors == ["Error in log notification handler"]
+    finally:
+        iface.close()
+
+
+def test_register_notifications_safe_execute_fallback_still_invokes_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Incompatible safe_execute signatures should fallback to direct handler invocation."""
+
+    class _ClientWithCallbacks(DummyClient):
+        def __init__(self) -> None:
+            super().__init__()
+            self.callbacks: dict[str, Callable[[Any, bytes], None]] = {}
+
+        def has_characteristic(self, uuid: str) -> bool:
+            return uuid in {LOGRADIO_UUID, FROMNUM_UUID}
+
+        def start_notify(self, *args: Any, **kwargs: Any) -> None:
+            _ = kwargs
+            if len(args) >= 2:
+                self.callbacks[str(args[0])] = cast(
+                    Callable[[Any, bytes], None], args[1]
+                )
+
+    def _incompatible_safe_execute(
+        _func: Callable[[], None], *args: object, **kwargs: object
+    ) -> None:
+        if "error_msg" in kwargs:
+            raise TypeError(
+                "safe_execute() got an unexpected keyword argument 'error_msg'"
+            )
+        if args:
+            raise TypeError("legacy positional mismatch")
+        raise AssertionError("callable-only probe should be skipped in this path")
+
+    client = _ClientWithCallbacks()
+    iface = _build_interface(monkeypatch, client, start_receive_thread=False)
+    log_calls: list[tuple[object, bytes]] = []
+    error_hook = MagicMock()
+    try:
+        iface.error_handler = SimpleNamespace(
+            safe_execute=_incompatible_safe_execute,
+            handle_unhandled_exception=error_hook,
+        )
+        monkeypatch.setattr(
+            iface,
+            "_log_radio_handler",
+            lambda sender, data: log_calls.append((sender, data)),
+            raising=True,
+        )
+
+        iface._register_notifications(cast(BLEClient, client))
+        client.callbacks[LOGRADIO_UUID]("sender", b"log")
+
+        assert log_calls == [("sender", b"log")]
+        error_hook.assert_not_called()
     finally:
         iface.close()
 

--- a/tests/test_ble_lifecycle_receive_targets.py
+++ b/tests/test_ble_lifecycle_receive_targets.py
@@ -918,6 +918,51 @@ def test_receive_service_branch_targets(monkeypatch: pytest.MonkeyPatch) -> None
     iface.close()
 
 
+@pytest.mark.parametrize("raw_ever_connected", [MagicMock(), "invalid-state"])
+def test_wait_for_read_trigger_normalizes_non_bool_ever_connected(
+    monkeypatch: pytest.MonkeyPatch,
+    raw_ever_connected: object,
+) -> None:
+    """_wait_for_read_trigger should treat non-bool _ever_connected values as False."""
+    iface = _make_iface(monkeypatch)
+    try:
+        with iface._state_lock:
+            iface._ever_connected = raw_ever_connected
+            iface._fromnum_notify_enabled = False
+            iface._closed = False
+
+        reconnected_checks: list[str] = []
+        monkeypatch.setattr(
+            BLEReceiveRecoveryService,
+            "_coordinator_wait_for_event",
+            staticmethod(lambda *_args, **_kwargs: False),
+        )
+        monkeypatch.setattr(
+            BLEReceiveRecoveryService,
+            "_coordinator_check_and_clear_event",
+            staticmethod(
+                lambda *_args, **_kwargs: (
+                    reconnected_checks.append("checked") or True
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            BLEReceiveRecoveryService,
+            "_should_poll_without_notify",
+            staticmethod(lambda _iface: True),
+        )
+
+        proceed, poll_without_notify = BLEReceiveRecoveryService._wait_for_read_trigger(
+            iface,
+            coordinator=SimpleNamespace(),
+            wait_timeout=0.1,
+        )
+        assert (proceed, poll_without_notify) == (True, True)
+        assert reconnected_checks == []
+    finally:
+        iface.close()
+
+
 def test_lifecycle_remaining_error_handler_branch_targets(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_ble_lifecycle_receive_targets.py
+++ b/tests/test_ble_lifecycle_receive_targets.py
@@ -941,9 +941,7 @@ def test_wait_for_read_trigger_normalizes_non_bool_ever_connected(
             BLEReceiveRecoveryService,
             "_coordinator_check_and_clear_event",
             staticmethod(
-                lambda *_args, **_kwargs: (
-                    reconnected_checks.append("checked") or True
-                )
+                lambda *_args, **_kwargs: (reconnected_checks.append("checked") or True)
             ),
         )
         monkeypatch.setattr(

--- a/tests/test_ble_lifecycle_receive_targets.py
+++ b/tests/test_ble_lifecycle_receive_targets.py
@@ -67,14 +67,22 @@ def test_lifecycle_error_handler_cleanup_and_execute_branches(
         "cleanup-op",
     )
 
-    def _keyword_incompatible_safe_execute(func: Any, *args: object, **kwargs: object) -> object:
+    def _keyword_incompatible_safe_execute(
+        func: Any, *args: object, **kwargs: object
+    ) -> object:
         if "error_msg" in kwargs:
-            raise TypeError("safe_execute() got an unexpected keyword argument 'error_msg'")
+            raise TypeError(
+                "safe_execute() got an unexpected keyword argument 'error_msg'"
+            )
         if args:
-            raise TypeError("takes 1 positional argument but 2 positional arguments were given")
+            raise TypeError(
+                "takes 1 positional argument but 2 positional arguments were given"
+            )
         return func()
 
-    iface.error_handler = SimpleNamespace(safe_execute=_keyword_incompatible_safe_execute)
+    iface.error_handler = SimpleNamespace(
+        safe_execute=_keyword_incompatible_safe_execute
+    )
     assert (
         BLELifecycleService._error_handler_safe_execute(
             iface,
@@ -264,12 +272,16 @@ def test_lifecycle_disconnect_planning_and_side_effect_paths(
         iface.client = DummyClient()
         iface._disconnect_notified = True
         iface._state_manager._transition_to(ConnectionState.CONNECTING)
-    assert BLELifecycleService._resolve_disconnect_target(iface, "src", None, None).early_return
+    assert BLELifecycleService._resolve_disconnect_target(
+        iface, "src", None, None
+    ).early_return
 
     with iface._state_lock:
         iface._state_manager._reset_to_disconnected()
         iface._disconnect_notified = True
-    assert BLELifecycleService._resolve_disconnect_target(iface, "src", None, None).early_return
+    assert BLELifecycleService._resolve_disconnect_target(
+        iface, "src", None, None
+    ).early_return
 
     previous = DummyClient()
     previous.address = "AA:BB:CC:DD:EE:FF"
@@ -288,7 +300,9 @@ def test_lifecycle_disconnect_planning_and_side_effect_paths(
         "_state_manager_reset_to_disconnected",
         staticmethod(lambda *_args, **_kwargs: False),
     )
-    detailed_plan = BLELifecycleService._resolve_disconnect_target(iface, "src", None, None)
+    detailed_plan = BLELifecycleService._resolve_disconnect_target(
+        iface, "src", None, None
+    )
     assert detailed_plan.early_return is None
 
     iface.client = DummyClient()
@@ -317,7 +331,9 @@ def test_lifecycle_disconnect_planning_and_side_effect_paths(
         was_publish_pending=False,
         was_replacement_pending=False,
     )
-    assert BLELifecycleService._execute_disconnect_side_effects(iface, plan=stale_plan, source="stale")
+    assert BLELifecycleService._execute_disconnect_side_effects(
+        iface, plan=stale_plan, source="stale"
+    )
     assert disconnected_keys == ["stale-key"]
     assert closed_previous == ["closed-previous"]
 
@@ -421,7 +437,9 @@ def test_lifecycle_invalidation_and_publish_verification_paths(
             "meshtastic.interfaces.ble.lifecycle_service._is_currently_connected_elsewhere",
             lambda key, owner: bool(key == "key2"),
         )
-        assert BLELifecycleService._has_lost_gate_ownership(iface, "key1", "key2") is True
+        assert (
+            BLELifecycleService._has_lost_gate_ownership(iface, "key1", "key2") is True
+        )
 
         iface.client = DummyClient()
         iface._connection_alias_key = "alias"
@@ -549,7 +567,9 @@ def test_lifecycle_shutdown_and_finalize_close_paths(
             is False
         )
 
-        never_started = SimpleNamespace(name="never", ident=None, is_alive=lambda: False)
+        never_started = SimpleNamespace(
+            name="never", ident=None, is_alive=lambda: False
+        )
         iface._receiveThread = never_started
         BLELifecycleService._shutdown_receive_thread(iface)
         assert iface._receiveThread is None
@@ -656,8 +676,12 @@ def test_receive_service_branch_targets(monkeypatch: pytest.MonkeyPatch) -> None
         _check_and_clear_event=lambda _event: True,
         _clear_event=lambda _event: None,
     )
-    assert BLEReceiveRecoveryService._coordinator_wait_for_event(coordinator, "evt", timeout=0.1)
-    assert BLEReceiveRecoveryService._coordinator_check_and_clear_event(coordinator, "evt")
+    assert BLEReceiveRecoveryService._coordinator_wait_for_event(
+        coordinator, "evt", timeout=0.1
+    )
+    assert BLEReceiveRecoveryService._coordinator_check_and_clear_event(
+        coordinator, "evt"
+    )
     BLEReceiveRecoveryService._coordinator_clear_event(coordinator, "evt")
 
     iface._fromnum_notify_enabled = False
@@ -702,8 +726,8 @@ def test_receive_service_branch_targets(monkeypatch: pytest.MonkeyPatch) -> None
         is_connecting=MagicMock(),
         _is_connecting=True,
     )
-    client, is_connecting, publish_pending, is_closing = BLEReceiveRecoveryService._snapshot_client_state(
-        iface
+    client, is_connecting, publish_pending, is_closing = (
+        BLEReceiveRecoveryService._snapshot_client_state(iface)
     )
     assert client is iface.client
     assert is_connecting is True
@@ -751,7 +775,11 @@ def test_receive_service_branch_targets(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setattr(
         BLEReceiveRecoveryService,
         "_read_and_handle_payload",
-        staticmethod(lambda *_args, **_kwargs: (_ for _ in ()).throw(BleakDBusError("err", "dbus"))),
+        staticmethod(
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                BleakDBusError("err", "dbus")
+            )
+        ),
     )
     iface._handle_read_loop_disconnect = lambda *_args, **_kwargs: True
     assert BLEReceiveRecoveryService._handle_payload_read(
@@ -763,7 +791,9 @@ def test_receive_service_branch_targets(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setattr(
         BLEReceiveRecoveryService,
         "_read_and_handle_payload",
-        staticmethod(lambda *_args, **_kwargs: (_ for _ in ()).throw(BleakError("transient"))),
+        staticmethod(
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(BleakError("transient"))
+        ),
     )
     iface._handle_transient_read_error = lambda _err: (_ for _ in ()).throw(
         iface.BLEError("fatal")
@@ -798,16 +828,21 @@ def test_receive_service_branch_targets(monkeypatch: pytest.MonkeyPatch) -> None
         staticmethod(lambda *_args, **_kwargs: False),
     )
     iface._should_run_receive_loop = MagicMock(side_effect=[True, True, False])
-    assert BLEReceiveRecoveryService._run_receive_cycle(
-        iface,
-        coordinator=SimpleNamespace(),
-        wait_timeout=0.1,
-    ) is False
+    assert (
+        BLEReceiveRecoveryService._run_receive_cycle(
+            iface,
+            coordinator=SimpleNamespace(),
+            wait_timeout=0.1,
+        )
+        is False
+    )
 
     monkeypatch.setattr(
         BLEReceiveRecoveryService,
         "_run_receive_cycle",
-        staticmethod(lambda *_args, **_kwargs: (_ for _ in ()).throw(_FatalReceiveError("fatal"))),
+        staticmethod(
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(_FatalReceiveError("fatal"))
+        ),
     )
     iface._recover_receive_thread = MagicMock()
     BLEReceiveRecoveryService._receive_from_radio_impl(iface)
@@ -840,10 +875,14 @@ def test_receive_service_branch_targets(monkeypatch: pytest.MonkeyPatch) -> None
     iface._retry_policy_should_retry = lambda _policy, count: count < 1
     iface._retry_policy_get_delay = lambda _policy, _attempt: 0.01
     iface._read_retry_count = 0
-    BLEReceiveRecoveryService._handle_transient_read_error(iface, BleakError("transient"))
+    BLEReceiveRecoveryService._handle_transient_read_error(
+        iface, BleakError("transient")
+    )
     iface._retry_policy_should_retry = lambda _policy, _count: False
     with pytest.raises(iface.BLEError):
-        BLEReceiveRecoveryService._handle_transient_read_error(iface, BleakError("fatal"))
+        BLEReceiveRecoveryService._handle_transient_read_error(
+            iface, BleakError("fatal")
+        )
 
     iface._last_empty_read_warning = 0.0
     iface._suppressed_empty_read_warnings = 2
@@ -873,9 +912,13 @@ def test_lifecycle_remaining_branch_targets(
     BLELifecycleService._error_handler_safe_cleanup(iface, lambda: None, "cleanup")
 
     # lifecycle _error_handler_safe_execute positional compatibility fallbacks
-    def _safe_execute_non_positional(func: Any, *args: object, **kwargs: object) -> object:
+    def _safe_execute_non_positional(
+        func: Any, *args: object, **kwargs: object
+    ) -> object:
         if "error_msg" in kwargs:
-            raise TypeError("safe_execute() got an unexpected keyword argument 'error_msg'")
+            raise TypeError(
+                "safe_execute() got an unexpected keyword argument 'error_msg'"
+            )
         if args:
             raise TypeError("totally different positional failure")
         return func()
@@ -890,14 +933,22 @@ def test_lifecycle_remaining_branch_targets(
         == "fallback-none"
     )
 
-    def _safe_execute_positional_then_fail(func: Any, *args: object, **kwargs: object) -> object:
+    def _safe_execute_positional_then_fail(
+        func: Any, *args: object, **kwargs: object
+    ) -> object:
         if "error_msg" in kwargs:
-            raise TypeError("safe_execute() got an unexpected keyword argument 'error_msg'")
+            raise TypeError(
+                "safe_execute() got an unexpected keyword argument 'error_msg'"
+            )
         if args:
-            raise TypeError("takes 1 positional argument but 2 positional arguments were given")
+            raise TypeError(
+                "takes 1 positional argument but 2 positional arguments were given"
+            )
         raise RuntimeError("hook failed")
 
-    iface.error_handler = SimpleNamespace(safe_execute=_safe_execute_positional_then_fail)
+    iface.error_handler = SimpleNamespace(
+        safe_execute=_safe_execute_positional_then_fail
+    )
     assert (
         BLELifecycleService._error_handler_safe_execute(
             iface,
@@ -941,7 +992,12 @@ def test_lifecycle_remaining_branch_targets(
         iface.client = DummyClient()
         iface._closed = True
         iface._state_manager._reset_to_disconnected()
-    assert BLELifecycleService._resolve_disconnect_target(iface, "src", None, None).early_return is False
+    assert (
+        BLELifecycleService._resolve_disconnect_target(
+            iface, "src", None, None
+        ).early_return
+        is False
+    )
 
     with iface._state_lock:
         iface.client = None
@@ -951,7 +1007,9 @@ def test_lifecycle_remaining_branch_targets(
         iface._disconnect_notified = False
         iface._state_manager._reset_to_disconnected()
     bleak_client = SimpleNamespace(address="AA:BB:CC:DD:EE:FF")
-    plan = BLELifecycleService._resolve_disconnect_target(iface, "src", None, bleak_client)
+    plan = BLELifecycleService._resolve_disconnect_target(
+        iface, "src", None, bleak_client
+    )
     assert plan.address == "AA:BB:CC:DD:EE:FF"
 
     # lifecycle close_previous_client_async branches
@@ -961,7 +1019,11 @@ def test_lifecycle_remaining_branch_targets(
     monkeypatch.setattr(
         BLELifecycleService,
         "_thread_create_thread",
-        staticmethod(lambda *_args, **_kwargs: SimpleNamespace(ident=None, is_alive=lambda: False)),
+        staticmethod(
+            lambda *_args, **_kwargs: SimpleNamespace(
+                ident=None, is_alive=lambda: False
+            )
+        ),
     )
     monkeypatch.setattr(
         BLELifecycleService,
@@ -979,7 +1041,9 @@ def test_lifecycle_remaining_branch_targets(
     monkeypatch.setattr(
         BLELifecycleService,
         "_thread_start_thread",
-        staticmethod(lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("fail"))),
+        staticmethod(
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("fail"))
+        ),
     )
     BLELifecycleService._close_previous_client_async(iface, previous_client)
 
@@ -1023,14 +1087,25 @@ def test_lifecycle_remaining_branch_targets(
         is_closing=True,
     )
     assert BLELifecycleService._state_manager_is_connected(iface) is True
-    assert BLELifecycleService._state_manager_current_state(iface) == ConnectionState.CONNECTED
+    assert (
+        BLELifecycleService._state_manager_current_state(iface)
+        == ConnectionState.CONNECTED
+    )
     assert BLELifecycleService._state_manager_is_closing(iface) is True
 
     iface._state_manager = SimpleNamespace(current_state=ConnectionState.CONNECTED)
-    assert BLELifecycleService._state_manager_current_state(iface) == ConnectionState.CONNECTED
+    assert (
+        BLELifecycleService._state_manager_current_state(iface)
+        == ConnectionState.CONNECTED
+    )
 
-    iface._state_manager = SimpleNamespace(_current_state=lambda: ConnectionState.CONNECTED)
-    assert BLELifecycleService._state_manager_current_state(iface) == ConnectionState.CONNECTED
+    iface._state_manager = SimpleNamespace(
+        _current_state=lambda: ConnectionState.CONNECTED
+    )
+    assert (
+        BLELifecycleService._state_manager_current_state(iface)
+        == ConnectionState.CONNECTED
+    )
 
     client_member = SimpleNamespace(_is_connected=True)
     assert BLELifecycleService._client_is_connected(client_member) is True
@@ -1099,7 +1174,9 @@ def test_lifecycle_remaining_branch_targets(
             )
         ),
     )
-    iface._raise_for_invalidated_connect_result = MagicMock(side_effect=iface.BLEError("invalid"))
+    iface._raise_for_invalidated_connect_result = MagicMock(
+        side_effect=iface.BLEError("invalid")
+    )
     with pytest.raises(iface.BLEError, match="invalid"):
         BLELifecycleService._verify_and_publish_connected(
             iface,
@@ -1181,7 +1258,9 @@ def test_receive_service_remaining_branch_targets(
         )
         is True
     )
-    BLEReceiveRecoveryService._coordinator_wait_for_event(SimpleNamespace(), "evt", timeout=0.5)
+    BLEReceiveRecoveryService._coordinator_wait_for_event(
+        SimpleNamespace(), "evt", timeout=0.5
+    )
     assert wait_calls
 
     assert (
@@ -1254,7 +1333,11 @@ def test_receive_service_remaining_branch_targets(
     monkeypatch.setattr(
         BLEReceiveRecoveryService,
         "_read_and_handle_payload",
-        staticmethod(lambda *_args, **_kwargs: (_ for _ in ()).throw(BleakDBusError("err", "dbus"))),
+        staticmethod(
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                BleakDBusError("err", "dbus")
+            )
+        ),
     )
     iface._handle_read_loop_disconnect = lambda *_args, **_kwargs: False
     assert BLEReceiveRecoveryService._handle_payload_read(
@@ -1278,7 +1361,9 @@ def test_receive_service_remaining_branch_targets(
     monkeypatch.setattr(
         BLEReceiveRecoveryService,
         "_read_and_handle_payload",
-        staticmethod(lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("unexpected"))),
+        staticmethod(
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("unexpected"))
+        ),
     )
     iface._handle_read_loop_disconnect = lambda *_args, **_kwargs: False
     assert BLEReceiveRecoveryService._handle_payload_read(
@@ -1293,11 +1378,14 @@ def test_receive_service_remaining_branch_targets(
         staticmethod(lambda *_args, **_kwargs: (False, False)),
     )
     iface._should_run_receive_loop = MagicMock(side_effect=[True, False])
-    assert BLEReceiveRecoveryService._run_receive_cycle(
-        iface,
-        coordinator=SimpleNamespace(),
-        wait_timeout=0.1,
-    ) is True
+    assert (
+        BLEReceiveRecoveryService._run_receive_cycle(
+            iface,
+            coordinator=SimpleNamespace(),
+            wait_timeout=0.1,
+        )
+        is True
+    )
 
     monkeypatch.setattr(
         BLEReceiveRecoveryService,
@@ -1310,11 +1398,14 @@ def test_receive_service_remaining_branch_targets(
         staticmethod(lambda _iface: (None, False, False, False)),
     )
     iface._should_run_receive_loop = MagicMock(side_effect=[True, True, False])
-    assert BLEReceiveRecoveryService._run_receive_cycle(
-        iface,
-        coordinator=SimpleNamespace(),
-        wait_timeout=0.1,
-    ) is True
+    assert (
+        BLEReceiveRecoveryService._run_receive_cycle(
+            iface,
+            coordinator=SimpleNamespace(),
+            wait_timeout=0.1,
+        )
+        is True
+    )
 
     monkeypatch.setattr(
         BLEReceiveRecoveryService,
@@ -1327,7 +1418,9 @@ def test_receive_service_remaining_branch_targets(
     monkeypatch.setattr(
         BLEReceiveRecoveryService,
         "_run_receive_cycle",
-        staticmethod(lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("fatal"))),
+        staticmethod(
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("fatal"))
+        ),
     )
     iface._recover_receive_thread = MagicMock()
     BLEReceiveRecoveryService._receive_from_radio_impl(iface)
@@ -1346,7 +1439,9 @@ def test_receive_service_remaining_branch_targets(
     iface._handle_disconnect = lambda *_args, **_kwargs: True
     iface._shutdown_event = SimpleNamespace(wait=lambda timeout=None: False)
     iface._should_run_receive_loop = lambda: True
-    iface._start_receive_thread = lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("restart failed"))
+    iface._start_receive_thread = lambda **_kwargs: (_ for _ in ()).throw(
+        RuntimeError("restart failed")
+    )
     with pytest.raises(RuntimeError, match="restart failed"):
         BLEReceiveRecoveryService._recover_receive_thread(iface, "reason")
 
@@ -1355,7 +1450,9 @@ def test_receive_service_remaining_branch_targets(
     iface._retry_policy_get_delay = lambda _policy, _attempt: 0.01
     iface._empty_read_policy = object()
     iface._log_empty_read_warning = MagicMock()
-    assert BLEReceiveRecoveryService._read_from_radio_with_retries(iface, client) is None
+    assert (
+        BLEReceiveRecoveryService._read_from_radio_with_retries(iface, client) is None
+    )
     iface._log_empty_read_warning.assert_called_once()
 
     iface._state_manager = importlib.import_module(
@@ -1383,7 +1480,9 @@ def test_lifecycle_remaining_error_handler_execute_paths(
             raise TypeError("non positional-compatible failure")
         return func()
 
-    iface.error_handler = SimpleNamespace(safe_execute=_hook_non_positional_with_func_run)
+    iface.error_handler = SimpleNamespace(
+        safe_execute=_hook_non_positional_with_func_run
+    )
     assert (
         BLELifecycleService._error_handler_safe_execute(
             iface,
@@ -1393,7 +1492,9 @@ def test_lifecycle_remaining_error_handler_execute_paths(
         is None
     )
 
-    def _hook_positional_then_runtime(func: Any, *args: object, **kwargs: object) -> object:
+    def _hook_positional_then_runtime(
+        func: Any, *args: object, **kwargs: object
+    ) -> object:
         if "error_msg" in kwargs:
             raise TypeError(
                 "safe_execute() got an unexpected keyword argument 'error_msg'"
@@ -1415,7 +1516,9 @@ def test_lifecycle_remaining_error_handler_execute_paths(
         is None
     )
 
-    def _hook_runtime_on_positional(func: Any, *args: object, **kwargs: object) -> object:
+    def _hook_runtime_on_positional(
+        func: Any, *args: object, **kwargs: object
+    ) -> object:
         if "error_msg" in kwargs:
             raise TypeError(
                 "safe_execute() got an unexpected keyword argument 'error_msg'"
@@ -1677,7 +1780,9 @@ def test_receive_remaining_branches(
     monkeypatch.setattr(
         BLEReceiveRecoveryService,
         "_run_receive_cycle",
-        staticmethod(lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("fatal"))),
+        staticmethod(
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("fatal"))
+        ),
     )
     iface._recover_receive_thread = lambda reason: recovered.append(reason)
     BLEReceiveRecoveryService._receive_from_radio_impl(iface)

--- a/tests/test_ble_lifecycle_receive_targets.py
+++ b/tests/test_ble_lifecycle_receive_targets.py
@@ -356,222 +356,266 @@ def test_lifecycle_disconnect_planning_and_side_effect_paths(
     iface.close()
 
 
-def test_lifecycle_state_helpers_and_finalize_paths(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Lifecycle state-helper and shutdown/finalize helpers should cover fallback branches."""
+def test_lifecycle_state_manager_helper_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """State-manager compatibility helpers should cover callable/member/missing paths."""
     iface = _make_iface(monkeypatch)
-
-    iface._state_manager = SimpleNamespace(
-        is_connected=MagicMock(),
-        _is_connected=True,
-        current_state=MagicMock(),
-        _current_state=ConnectionState.CONNECTED,
-        transition_to=lambda _state: True,
-        _transition_to=lambda _state: True,
-        reset_to_disconnected=lambda: True,
-        _reset_to_disconnected=lambda: True,
-        is_closing=MagicMock(),
-        _is_closing=True,
-    )
-    assert BLELifecycleService._state_manager_is_connected(iface) is True
-    assert BLELifecycleService._state_manager_current_state(iface) == ConnectionState.CONNECTED
-    assert BLELifecycleService._state_manager_transition_to(iface, ConnectionState.CONNECTED)
-    assert BLELifecycleService._state_manager_reset_to_disconnected(iface)
-    assert BLELifecycleService._state_manager_is_closing(iface) is True
-
-    iface._state_manager = SimpleNamespace()
-    with pytest.raises(AttributeError):
-        BLELifecycleService._state_manager_is_connected(iface)
-    with pytest.raises(AttributeError):
-        BLELifecycleService._state_manager_current_state(iface)
-    with pytest.raises(AttributeError):
-        BLELifecycleService._state_manager_transition_to(iface, ConnectionState.CONNECTED)
-    with pytest.raises(AttributeError):
-        BLELifecycleService._state_manager_reset_to_disconnected(iface)
-
-    bad_client = SimpleNamespace(
-        isConnected=lambda: "not-bool",
-        is_connected=MagicMock(),
-        _is_connected=MagicMock(),
-    )
-    with pytest.raises(AttributeError):
-        BLELifecycleService._client_is_connected(bad_client)
-
-    monkeypatch.setattr(
-        "meshtastic.interfaces.ble.lifecycle_service._is_currently_connected_elsewhere",
-        lambda key, owner: bool(key == "key2"),
-    )
-    assert BLELifecycleService._has_lost_gate_ownership(iface, "key1", "key2") is True
-
-    iface.client = DummyClient()
-    iface._connection_alias_key = "alias"
-    iface._sorted_address_keys = lambda *_keys: ["k1", "k2"]
-    iface._mark_address_keys_disconnected = MagicMock()
-    iface._discard_invalidated_connected_client = MagicMock()
-    with pytest.raises(iface.BLEError, match=ERROR_INTERFACE_CLOSING):
-        BLELifecycleService._raise_for_invalidated_connect_result(
-            iface,
-            DummyClient(),
-            "device-key",
-            "alias-key",
-            is_closing=True,
-            lost_gate_ownership=False,
-            restore_address=None,
-            restore_last_connection_request=None,
+    try:
+        iface._state_manager = SimpleNamespace(
+            is_connected=MagicMock(),
+            _is_connected=True,
+            current_state=MagicMock(),
+            _current_state=ConnectionState.CONNECTED,
+            transition_to=lambda _state: True,
+            _transition_to=lambda _state: True,
+            reset_to_disconnected=lambda: True,
+            _reset_to_disconnected=lambda: True,
+            is_closing=MagicMock(),
+            _is_closing=True,
         )
-
-    iface._ever_connected = MagicMock()
-    assert BLELifecycleService._ever_connected_flag(iface) is False
-
-    snapshots = [
-        _OwnershipSnapshot(True, False, False, False),
-        _OwnershipSnapshot(True, False, False, False),
-        _OwnershipSnapshot(False, False, False, False),
-    ]
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_verify_ownership_snapshot",
-        staticmethod(lambda *_args, **_kwargs: snapshots.pop(0)),
-    )
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_get_connected_client_status_locked",
-        staticmethod(lambda *_args, **_kwargs: (True, False)),
-    )
-    iface._raise_for_invalidated_connect_result = MagicMock(
-        side_effect=iface.BLEError("invalidated")
-    )
-    with pytest.raises(iface.BLEError, match="invalidated"):
-        BLELifecycleService._verify_and_publish_connected(
-            iface,
-            DummyClient(),
-            "key",
-            "alias",
-            restore_address=None,
-            restore_last_connection_request=None,
+        assert BLELifecycleService._state_manager_is_connected(iface) is True
+        assert (
+            BLELifecycleService._state_manager_current_state(iface)
+            == ConnectionState.CONNECTED
         )
-
-    iface.thread_coordinator = SimpleNamespace(cleanup=lambda: (_ for _ in ()).throw(RuntimeError("cleanup")))
-    BLELifecycleService._cleanup_thread_coordinator(iface)
-    iface.thread_coordinator = SimpleNamespace(_cleanup=lambda: (_ for _ in ()).throw(RuntimeError("legacy-cleanup")))
-    BLELifecycleService._cleanup_thread_coordinator(iface)
-    iface.thread_coordinator = SimpleNamespace()
-    BLELifecycleService._cleanup_thread_coordinator(iface)
-
-    iface._connection_alias_key = "alias"
-    iface._mark_address_keys_connected = MagicMock()
-    iface._mark_address_keys_disconnected = MagicMock()
-    statuses = [(True, False), (True, False), (False, False)]
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_get_connected_client_status",
-        staticmethod(lambda *_args, **_kwargs: statuses[0]),
-    )
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_get_connected_client_status_locked",
-        staticmethod(lambda *_args, **_kwargs: statuses.pop(0)),
-    )
-    BLELifecycleService._finalize_connection_gates(
-        iface,
-        DummyClient(),
-        "dev",
-        "alias",
-    )
-
-    with iface._management_lock:
-        iface._management_inflight = 0
-    with iface._state_lock:
-        iface._closed = False
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_state_manager_current_state",
-        staticmethod(lambda _iface: ConnectionState.CONNECTED),
-    )
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_state_manager_transition_to",
-        staticmethod(lambda *_args, **_kwargs: False),
-    )
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_state_manager_reset_to_disconnected",
-        staticmethod(lambda *_args, **_kwargs: False),
-    )
-    assert (
-        BLELifecycleService._await_management_shutdown(
-            iface,
-            management_shutdown_wait_timeout=0.01,
-            management_wait_poll_seconds=0.01,
+        assert BLELifecycleService._state_manager_transition_to(
+            iface, ConnectionState.CONNECTED
         )
-        is False
-    )
+        assert BLELifecycleService._state_manager_reset_to_disconnected(iface)
+        assert BLELifecycleService._state_manager_is_closing(iface) is True
 
-    never_started = SimpleNamespace(name="never", ident=None, is_alive=lambda: False)
-    iface._receiveThread = never_started
-    BLELifecycleService._shutdown_receive_thread(iface)
-    assert iface._receiveThread is None
+        iface._state_manager = SimpleNamespace()
+        with pytest.raises(AttributeError):
+            BLELifecycleService._state_manager_is_connected(iface)
+        with pytest.raises(AttributeError):
+            BLELifecycleService._state_manager_current_state(iface)
+        with pytest.raises(AttributeError):
+            BLELifecycleService._state_manager_transition_to(
+                iface, ConnectionState.CONNECTED
+            )
+        with pytest.raises(AttributeError):
+            BLELifecycleService._state_manager_reset_to_disconnected(iface)
 
-    class _AliveThread:
-        ident = 1
+        bad_client = SimpleNamespace(
+            isConnected=lambda: "not-bool",
+            is_connected=MagicMock(),
+            _is_connected=MagicMock(),
+        )
+        with pytest.raises(AttributeError):
+            BLELifecycleService._client_is_connected(bad_client)
+    finally:
+        iface._state_manager = importlib.import_module(
+            "meshtastic.interfaces.ble.state"
+        ).BLEStateManager()
+        iface.close()
 
-        @staticmethod
-        def is_alive() -> bool:
-            return True
 
-        @staticmethod
-        def join(timeout: float | None = None) -> None:
-            _ = timeout
+def test_lifecycle_invalidation_and_publish_verification_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalidation helpers should cover ownership-loss and verify/publish races."""
+    iface = _make_iface(monkeypatch)
+    try:
+        monkeypatch.setattr(
+            "meshtastic.interfaces.ble.lifecycle_service._is_currently_connected_elsewhere",
+            lambda key, owner: bool(key == "key2"),
+        )
+        assert BLELifecycleService._has_lost_gate_ownership(iface, "key1", "key2") is True
 
-    iface._receiveThread = _AliveThread()
-    BLELifecycleService._shutdown_receive_thread(iface)
-
-    with iface._state_lock:
-        iface._client_publish_pending = False
-        iface._client_replacement_pending = True
-        iface._disconnect_notified = False
-    assert BLELifecycleService._consume_disconnect_notification_state(iface) is True
-
-    notification_manager = SimpleNamespace(unsubscribe_all=lambda *_args, **_kwargs: None)
-    iface._notification_manager = notification_manager
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_detach_client_for_shutdown",
-        staticmethod(lambda _iface: (DummyClient(), False)),
-    )
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_error_handler_safe_cleanup",
-        staticmethod(lambda _iface, func, _name: func()),
-    )
-    iface._management_target_gate = lambda _address: contextlib.nullcontext()
-    iface._disconnect_and_close_client = lambda _client: None
-    iface._wait_for_disconnect_notifications = lambda: None
-    iface._disconnected = lambda: None
-    BLELifecycleService._shutdown_client(iface, management_wait_timed_out=False)
-
-    with iface._state_lock:
+        iface.client = DummyClient()
         iface._connection_alias_key = "alias"
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_state_manager_transition_to",
-        staticmethod(lambda *_args, **_kwargs: False),
-    )
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_state_manager_reset_to_disconnected",
-        staticmethod(lambda *_args, **_kwargs: False),
-    )
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_state_manager_current_state",
-        staticmethod(lambda _iface: ConnectionState.CONNECTING),
-    )
-    BLELifecycleService._finalize_close_state(iface)
+        iface._sorted_address_keys = lambda *_keys: ["k1", "k2"]
+        iface._mark_address_keys_disconnected = MagicMock()
+        iface._discard_invalidated_connected_client = MagicMock()
+        with pytest.raises(iface.BLEError, match=ERROR_INTERFACE_CLOSING):
+            BLELifecycleService._raise_for_invalidated_connect_result(
+                iface,
+                DummyClient(),
+                "device-key",
+                "alias-key",
+                is_closing=True,
+                lost_gate_ownership=False,
+                restore_address=None,
+                restore_last_connection_request=None,
+            )
 
-    iface._state_manager = importlib.import_module(
-        "meshtastic.interfaces.ble.state"
-    ).BLEStateManager()
-    iface.close()
+        iface._ever_connected = MagicMock()
+        assert BLELifecycleService._ever_connected_flag(iface) is False
+
+        snapshots = [
+            _OwnershipSnapshot(True, False, False, False),
+            _OwnershipSnapshot(True, False, False, False),
+            _OwnershipSnapshot(False, False, False, False),
+        ]
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_verify_ownership_snapshot",
+            staticmethod(lambda *_args, **_kwargs: snapshots.pop(0)),
+        )
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_get_connected_client_status_locked",
+            staticmethod(lambda *_args, **_kwargs: (True, False)),
+        )
+        iface._raise_for_invalidated_connect_result = MagicMock(
+            side_effect=iface.BLEError("invalidated")
+        )
+        with pytest.raises(iface.BLEError, match="invalidated"):
+            BLELifecycleService._verify_and_publish_connected(
+                iface,
+                DummyClient(),
+                "key",
+                "alias",
+                restore_address=None,
+                restore_last_connection_request=None,
+            )
+    finally:
+        iface.close()
+
+
+def test_lifecycle_finalize_and_cleanup_thread_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Thread-coordinator cleanup and finalize-connection gates should cover fallback branches."""
+    iface = _make_iface(monkeypatch)
+    try:
+        iface.thread_coordinator = SimpleNamespace(
+            cleanup=lambda: (_ for _ in ()).throw(RuntimeError("cleanup"))
+        )
+        BLELifecycleService._cleanup_thread_coordinator(iface)
+        iface.thread_coordinator = SimpleNamespace(
+            _cleanup=lambda: (_ for _ in ()).throw(RuntimeError("legacy-cleanup"))
+        )
+        BLELifecycleService._cleanup_thread_coordinator(iface)
+        iface.thread_coordinator = SimpleNamespace()
+        BLELifecycleService._cleanup_thread_coordinator(iface)
+
+        iface._connection_alias_key = "alias"
+        iface._mark_address_keys_connected = MagicMock()
+        iface._mark_address_keys_disconnected = MagicMock()
+        statuses = [(True, False), (True, False), (False, False)]
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_get_connected_client_status",
+            staticmethod(lambda *_args, **_kwargs: statuses[0]),
+        )
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_get_connected_client_status_locked",
+            staticmethod(lambda *_args, **_kwargs: statuses.pop(0)),
+        )
+        BLELifecycleService._finalize_connection_gates(
+            iface,
+            DummyClient(),
+            "dev",
+            "alias",
+        )
+    finally:
+        iface.close()
+
+
+def test_lifecycle_shutdown_and_finalize_close_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shutdown-management, receive-thread, and final-close helpers should cover fallback paths."""
+    iface = _make_iface(monkeypatch)
+    try:
+        with iface._management_lock:
+            iface._management_inflight = 0
+        with iface._state_lock:
+            iface._closed = False
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_state_manager_current_state",
+            staticmethod(lambda _iface: ConnectionState.CONNECTED),
+        )
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_state_manager_transition_to",
+            staticmethod(lambda *_args, **_kwargs: False),
+        )
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_state_manager_reset_to_disconnected",
+            staticmethod(lambda *_args, **_kwargs: False),
+        )
+        assert (
+            BLELifecycleService._await_management_shutdown(
+                iface,
+                management_shutdown_wait_timeout=0.01,
+                management_wait_poll_seconds=0.01,
+            )
+            is False
+        )
+
+        never_started = SimpleNamespace(name="never", ident=None, is_alive=lambda: False)
+        iface._receiveThread = never_started
+        BLELifecycleService._shutdown_receive_thread(iface)
+        assert iface._receiveThread is None
+
+        class _AliveThread:
+            ident = 1
+
+            @staticmethod
+            def is_alive() -> bool:
+                return True
+
+            @staticmethod
+            def join(timeout: float | None = None) -> None:
+                _ = timeout
+
+        iface._receiveThread = _AliveThread()
+        BLELifecycleService._shutdown_receive_thread(iface)
+
+        with iface._state_lock:
+            iface._client_publish_pending = False
+            iface._client_replacement_pending = True
+            iface._disconnect_notified = False
+        assert BLELifecycleService._consume_disconnect_notification_state(iface) is True
+
+        iface._notification_manager = SimpleNamespace(
+            unsubscribe_all=lambda *_args, **_kwargs: None
+        )
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_detach_client_for_shutdown",
+            staticmethod(lambda _iface: (DummyClient(), False)),
+        )
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_error_handler_safe_cleanup",
+            staticmethod(lambda _iface, func, _name: func()),
+        )
+        iface._management_target_gate = lambda _address: contextlib.nullcontext()
+        iface._disconnect_and_close_client = lambda _client: None
+        iface._wait_for_disconnect_notifications = lambda: None
+        iface._disconnected = lambda: None
+        BLELifecycleService._shutdown_client(iface, management_wait_timed_out=False)
+
+        with iface._state_lock:
+            iface._connection_alias_key = "alias"
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_state_manager_transition_to",
+            staticmethod(lambda *_args, **_kwargs: False),
+        )
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_state_manager_reset_to_disconnected",
+            staticmethod(lambda *_args, **_kwargs: False),
+        )
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_state_manager_current_state",
+            staticmethod(lambda _iface: ConnectionState.CONNECTING),
+        )
+        BLELifecycleService._finalize_close_state(iface)
+    finally:
+        iface._state_manager = importlib.import_module(
+            "meshtastic.interfaces.ble.state"
+        ).BLEStateManager()
+        iface.close()
 
 
 def test_receive_service_branch_targets(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -814,10 +858,10 @@ def test_receive_service_branch_targets(monkeypatch: pytest.MonkeyPatch) -> None
     iface.close()
 
 
-def test_lifecycle_and_receive_remaining_branch_targets(
+def test_lifecycle_remaining_branch_targets(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Cover remaining lifecycle/receive branch targets with focused micro-scenarios."""
+    """Cover remaining lifecycle branch targets with focused micro-scenarios."""
     iface = _make_iface(monkeypatch)
 
     # lifecycle _error_handler_safe_cleanup non-keyword TypeError path (line 165)
@@ -1111,6 +1155,17 @@ def test_lifecycle_and_receive_remaining_branch_targets(
     iface._wait_for_disconnect_notifications = lambda: None
     iface._disconnected = lambda: None
     BLELifecycleService._shutdown_client(iface, management_wait_timed_out=False)
+    iface._state_manager = importlib.import_module(
+        "meshtastic.interfaces.ble.state"
+    ).BLEStateManager()
+    iface.close()
+
+
+def test_receive_service_remaining_branch_targets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cover remaining receive-service branch targets with focused micro-scenarios."""
+    iface = _make_iface(monkeypatch)
 
     # receive helper remaining branch scenarios
     wait_calls: list[float] = []
@@ -1310,10 +1365,10 @@ def test_lifecycle_and_receive_remaining_branch_targets(
     iface.close()
 
 
-def test_lifecycle_remaining_error_handler_and_invalidation_paths(
+def test_lifecycle_remaining_error_handler_execute_paths(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Cover remaining lifecycle error-handler and invalidation branches."""
+    """Cover remaining lifecycle error-handler execute-hook branches."""
     iface = _make_iface(monkeypatch)
 
     def _hook_non_positional_with_func_run(
@@ -1416,6 +1471,14 @@ def test_lifecycle_remaining_error_handler_and_invalidation_paths(
         )
         is None
     )
+    iface.close()
+
+
+def test_lifecycle_remaining_invalidation_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cover remaining lifecycle invalidation and finalize-gate branches."""
+    iface = _make_iface(monkeypatch)
 
     tracked_client = DummyClient()
     with iface._state_lock:

--- a/tests/test_ble_lifecycle_receive_targets.py
+++ b/tests/test_ble_lifecycle_receive_targets.py
@@ -1597,114 +1597,115 @@ def test_lifecycle_remaining_error_handler_execute_paths(
 ) -> None:
     """Cover remaining lifecycle error-handler execute-hook branches."""
     iface = _make_iface(monkeypatch)
+    try:
+        def _hook_non_positional_with_func_run(
+            func: Any, *args: object, **kwargs: object
+        ) -> object:
+            if "error_msg" in kwargs:
+                raise TypeError(
+                    "safe_execute() got an unexpected keyword argument 'error_msg'"
+                )
+            if args:
+                func()
+                raise TypeError("non positional-compatible failure")
+            return func()
 
-    def _hook_non_positional_with_func_run(
-        func: Any, *args: object, **kwargs: object
-    ) -> object:
-        if "error_msg" in kwargs:
-            raise TypeError(
-                "safe_execute() got an unexpected keyword argument 'error_msg'"
+        iface.error_handler = SimpleNamespace(
+            safe_execute=_hook_non_positional_with_func_run
+        )
+        assert (
+            BLELifecycleService._error_handler_safe_execute(
+                iface,
+                lambda: "unused",
+                error_msg="line-234",
             )
-        if args:
+            is None
+        )
+
+        def _hook_positional_then_runtime(
+            func: Any, *args: object, **kwargs: object
+        ) -> object:
+            if "error_msg" in kwargs:
+                raise TypeError(
+                    "safe_execute() got an unexpected keyword argument 'error_msg'"
+                )
+            if args:
+                raise TypeError(
+                    "takes 1 positional argument but 2 positional arguments were given"
+                )
             func()
-            raise TypeError("non positional-compatible failure")
-        return func()
+            raise RuntimeError("post-run failure")
 
-    iface.error_handler = SimpleNamespace(
-        safe_execute=_hook_non_positional_with_func_run
-    )
-    assert (
-        BLELifecycleService._error_handler_safe_execute(
-            iface,
-            lambda: "unused",
-            error_msg="line-234",
+        iface.error_handler = SimpleNamespace(safe_execute=_hook_positional_then_runtime)
+        assert (
+            BLELifecycleService._error_handler_safe_execute(
+                iface,
+                lambda: "unused",
+                error_msg="line-241",
+            )
+            is None
         )
-        is None
-    )
 
-    def _hook_positional_then_runtime(
-        func: Any, *args: object, **kwargs: object
-    ) -> object:
-        if "error_msg" in kwargs:
-            raise TypeError(
-                "safe_execute() got an unexpected keyword argument 'error_msg'"
-            )
-        if args:
-            raise TypeError(
-                "takes 1 positional argument but 2 positional arguments were given"
-            )
-        func()
-        raise RuntimeError("post-run failure")
+        def _hook_runtime_on_positional(
+            func: Any, *args: object, **kwargs: object
+        ) -> object:
+            if "error_msg" in kwargs:
+                raise TypeError(
+                    "safe_execute() got an unexpected keyword argument 'error_msg'"
+                )
+            if args:
+                raise RuntimeError("positional runtime failure")
+            return func()
 
-    iface.error_handler = SimpleNamespace(safe_execute=_hook_positional_then_runtime)
-    assert (
-        BLELifecycleService._error_handler_safe_execute(
-            iface,
-            lambda: "unused",
-            error_msg="line-241",
+        iface.error_handler = SimpleNamespace(safe_execute=_hook_runtime_on_positional)
+        assert (
+            BLELifecycleService._error_handler_safe_execute(
+                iface,
+                lambda: "unused",
+                error_msg="line-243",
+            )
+            == "unused"
         )
-        is None
-    )
 
-    def _hook_runtime_on_positional(
-        func: Any, *args: object, **kwargs: object
-    ) -> object:
-        if "error_msg" in kwargs:
-            raise TypeError(
-                "safe_execute() got an unexpected keyword argument 'error_msg'"
-            )
-        if args:
-            raise RuntimeError("positional runtime failure")
-        return func()
+        def _hook_runtime_on_positional_with_func(
+            func: Any, *args: object, **kwargs: object
+        ) -> object:
+            if "error_msg" in kwargs:
+                raise TypeError(
+                    "safe_execute() got an unexpected keyword argument 'error_msg'"
+                )
+            if args:
+                func()
+                raise RuntimeError("positional runtime failure with func")
+            return func()
 
-    iface.error_handler = SimpleNamespace(safe_execute=_hook_runtime_on_positional)
-    assert (
-        BLELifecycleService._error_handler_safe_execute(
-            iface,
-            lambda: "unused",
-            error_msg="line-243",
+        iface.error_handler = SimpleNamespace(
+            safe_execute=_hook_runtime_on_positional_with_func
         )
-        == "unused"
-    )
-
-    def _hook_runtime_on_positional_with_func(
-        func: Any, *args: object, **kwargs: object
-    ) -> object:
-        if "error_msg" in kwargs:
-            raise TypeError(
-                "safe_execute() got an unexpected keyword argument 'error_msg'"
+        assert (
+            BLELifecycleService._error_handler_safe_execute(
+                iface,
+                lambda: "unused",
+                error_msg="line-245",
             )
-        if args:
+            is None
+        )
+
+        def _hook_runtime_on_keyword(func: Any, **_kwargs: object) -> object:
             func()
-            raise RuntimeError("positional runtime failure with func")
-        return func()
+            raise RuntimeError("keyword runtime failure")
 
-    iface.error_handler = SimpleNamespace(
-        safe_execute=_hook_runtime_on_positional_with_func
-    )
-    assert (
-        BLELifecycleService._error_handler_safe_execute(
-            iface,
-            lambda: "unused",
-            error_msg="line-245",
+        iface.error_handler = SimpleNamespace(safe_execute=_hook_runtime_on_keyword)
+        assert (
+            BLELifecycleService._error_handler_safe_execute(
+                iface,
+                lambda: "unused",
+                error_msg="line-248",
+            )
+            is None
         )
-        is None
-    )
-
-    def _hook_runtime_on_keyword(func: Any, **_kwargs: object) -> object:
-        func()
-        raise RuntimeError("keyword runtime failure")
-
-    iface.error_handler = SimpleNamespace(safe_execute=_hook_runtime_on_keyword)
-    assert (
-        BLELifecycleService._error_handler_safe_execute(
-            iface,
-            lambda: "unused",
-            error_msg="line-248",
-        )
-        is None
-    )
-    iface.close()
+    finally:
+        iface.close()
 
 
 def test_lifecycle_remaining_invalidation_paths(
@@ -1712,119 +1713,120 @@ def test_lifecycle_remaining_invalidation_paths(
 ) -> None:
     """Cover remaining lifecycle invalidation and finalize-gate branches."""
     iface = _make_iface(monkeypatch)
-
-    tracked_client = DummyClient()
-    with iface._state_lock:
-        iface.client = tracked_client
-        iface._client_publish_pending = False
-        iface._client_replacement_pending = False
-        iface._last_connection_request = "AA:BB"
-    with monkeypatch.context() as m:
-        m.setattr(
-            BLELifecycleService,
-            "_state_manager_is_closing",
-            staticmethod(lambda _iface: True),
-        )
-        BLELifecycleService._discard_invalidated_connected_client(
-            iface,
-            tracked_client,
-            restore_address="AA:BB",
-            restore_last_connection_request="AA:BB",
-        )
-    assert iface._last_connection_request is None
-
-    with iface._state_lock:
-        iface.client = None
-        iface._client_publish_pending = True
-        iface._client_replacement_pending = False
-        iface._last_connection_request = "pending"
-    with monkeypatch.context() as m:
-        m.setattr(
-            BLELifecycleService,
-            "_state_manager_is_closing",
-            staticmethod(lambda _iface: True),
-        )
-        BLELifecycleService._discard_invalidated_connected_client(
-            iface,
-            DummyClient(),
-            restore_address="CC:DD",
-            restore_last_connection_request="CC:DD",
-        )
-    assert iface._last_connection_request is None
-
-    disconnected_keys: list[str] = []
-    iface._sorted_address_keys = lambda *_keys: ["stale-key"]
-    iface._mark_address_keys_disconnected = lambda *keys: disconnected_keys.extend(
-        [k for k in keys if k is not None]
-    )
-    iface._discard_invalidated_connected_client = lambda *_args, **_kwargs: None
-    with pytest.raises(iface.BLEError):
-        BLELifecycleService._raise_for_invalidated_connect_result(
-            iface,
-            DummyClient(),
-            "device-key",
-            "alias-key",
-            is_closing=False,
-            lost_gate_ownership=True,
-            restore_address=None,
-            restore_last_connection_request=None,
-        )
-    assert disconnected_keys == ["stale-key"]
-
-    iface._raise_for_invalidated_connect_result = MagicMock(
-        side_effect=iface.BLEError("invalidated")
-    )
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_verify_ownership_snapshot",
-        staticmethod(
-            lambda *_args, **_kwargs: _OwnershipSnapshot(
-                still_owned=True,
-                is_closing=False,
-                lost_gate_ownership=False,
-                prior_ever_connected=False,
+    try:
+        tracked_client = DummyClient()
+        with iface._state_lock:
+            iface.client = tracked_client
+            iface._client_publish_pending = False
+            iface._client_replacement_pending = False
+            iface._last_connection_request = "AA:BB"
+        with monkeypatch.context() as m:
+            m.setattr(
+                BLELifecycleService,
+                "_state_manager_is_closing",
+                staticmethod(lambda _iface: True),
             )
-        ),
-    )
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_get_connected_client_status_locked",
-        staticmethod(lambda *_args, **_kwargs: (False, False)),
-    )
-    with pytest.raises(iface.BLEError, match="invalidated"):
-        BLELifecycleService._verify_and_publish_connected(
+            BLELifecycleService._discard_invalidated_connected_client(
+                iface,
+                tracked_client,
+                restore_address="AA:BB",
+                restore_last_connection_request="AA:BB",
+            )
+        assert iface._last_connection_request is None
+
+        with iface._state_lock:
+            iface.client = None
+            iface._client_publish_pending = True
+            iface._client_replacement_pending = False
+            iface._last_connection_request = "pending"
+        with monkeypatch.context() as m:
+            m.setattr(
+                BLELifecycleService,
+                "_state_manager_is_closing",
+                staticmethod(lambda _iface: True),
+            )
+            BLELifecycleService._discard_invalidated_connected_client(
+                iface,
+                DummyClient(),
+                restore_address="CC:DD",
+                restore_last_connection_request="CC:DD",
+            )
+        assert iface._last_connection_request is None
+
+        disconnected_keys: list[str] = []
+        iface._sorted_address_keys = lambda *_keys: ["stale-key"]
+        iface._mark_address_keys_disconnected = lambda *keys: disconnected_keys.extend(
+            [k for k in keys if k is not None]
+        )
+        iface._discard_invalidated_connected_client = lambda *_args, **_kwargs: None
+        with pytest.raises(iface.BLEError):
+            BLELifecycleService._raise_for_invalidated_connect_result(
+                iface,
+                DummyClient(),
+                "device-key",
+                "alias-key",
+                is_closing=False,
+                lost_gate_ownership=True,
+                restore_address=None,
+                restore_last_connection_request=None,
+            )
+        assert disconnected_keys == ["stale-key"]
+
+        iface._raise_for_invalidated_connect_result = MagicMock(
+            side_effect=iface.BLEError("invalidated")
+        )
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_verify_ownership_snapshot",
+            staticmethod(
+                lambda *_args, **_kwargs: _OwnershipSnapshot(
+                    still_owned=True,
+                    is_closing=False,
+                    lost_gate_ownership=False,
+                    prior_ever_connected=False,
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_get_connected_client_status_locked",
+            staticmethod(lambda *_args, **_kwargs: (False, False)),
+        )
+        with pytest.raises(iface.BLEError, match="invalidated"):
+            BLELifecycleService._verify_and_publish_connected(
+                iface,
+                DummyClient(),
+                "device-key",
+                "alias-key",
+                restore_address=None,
+                restore_last_connection_request=None,
+            )
+
+        cleanup_keys: list[str] = []
+        status_values = [(True, False), (False, True)]
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_get_connected_client_status",
+            staticmethod(lambda *_args, **_kwargs: (True, False)),
+        )
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_get_connected_client_status_locked",
+            staticmethod(lambda *_args, **_kwargs: status_values.pop(0)),
+        )
+        iface._mark_address_keys_connected = lambda *_keys: None
+        iface._mark_address_keys_disconnected = lambda *keys: cleanup_keys.extend(
+            [k for k in keys if k is not None]
+        )
+        BLELifecycleService._finalize_connection_gates(
             iface,
             DummyClient(),
-            "device-key",
-            "alias-key",
-            restore_address=None,
-            restore_last_connection_request=None,
+            "closing-device",
+            "closing-alias",
         )
-
-    cleanup_keys: list[str] = []
-    status_values = [(True, False), (False, True)]
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_get_connected_client_status",
-        staticmethod(lambda *_args, **_kwargs: (True, False)),
-    )
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_get_connected_client_status_locked",
-        staticmethod(lambda *_args, **_kwargs: status_values.pop(0)),
-    )
-    iface._mark_address_keys_connected = lambda *_keys: None
-    iface._mark_address_keys_disconnected = lambda *keys: cleanup_keys.extend(
-        [k for k in keys if k is not None]
-    )
-    BLELifecycleService._finalize_connection_gates(
-        iface,
-        DummyClient(),
-        "closing-device",
-        "closing-alias",
-    )
-    assert cleanup_keys == ["closing-device", "closing-alias"]
-    iface.close()
+        assert cleanup_keys == ["closing-device", "closing-alias"]
+    finally:
+        iface.close()
 
 
 def test_receive_remaining_branches(
@@ -1832,112 +1834,115 @@ def test_receive_remaining_branches(
 ) -> None:
     """Cover remaining receive-service branch paths."""
     iface = _make_iface(monkeypatch)
-
-    assert (
-        BLEReceiveRecoveryService._coordinator_check_and_clear_event(
-            SimpleNamespace(), "evt"
+    try:
+        assert (
+            BLEReceiveRecoveryService._coordinator_check_and_clear_event(
+                SimpleNamespace(), "evt"
+            )
+            is False
         )
-        is False
-    )
 
-    iface._state_manager = SimpleNamespace()
-    _, is_connecting, _, _ = BLEReceiveRecoveryService._snapshot_client_state(iface)
-    assert is_connecting is False
-    iface._state_manager = importlib.import_module(
-        "meshtastic.interfaces.ble.state"
-    ).BLEStateManager()
+        iface._state_manager = SimpleNamespace()
+        _, is_connecting, _, _ = BLEReceiveRecoveryService._snapshot_client_state(iface)
+        assert is_connecting is False
+        iface._state_manager = importlib.import_module(
+            "meshtastic.interfaces.ble.state"
+        ).BLEStateManager()
 
-    monkeypatch.setattr(
-        BLEReceiveRecoveryService,
-        "_read_and_handle_payload",
-        staticmethod(
-            lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("unexpected"))
-        ),
-    )
-    iface._handle_read_loop_disconnect = lambda *_args, **_kwargs: True
-    assert BLEReceiveRecoveryService._handle_payload_read(
-        iface,
-        DummyClient(),
-        poll_without_notify=False,
-    ) == (True, False)
-    iface._handle_read_loop_disconnect = lambda *_args, **_kwargs: False
-    assert BLEReceiveRecoveryService._handle_payload_read(
-        iface,
-        DummyClient(),
-        poll_without_notify=False,
-    ) == (True, True)
-
-    monkeypatch.setattr(
-        BLEReceiveRecoveryService,
-        "_wait_for_read_trigger",
-        staticmethod(lambda *_args, **_kwargs: (True, False)),
-    )
-    monkeypatch.setattr(
-        BLEReceiveRecoveryService,
-        "_snapshot_client_state",
-        staticmethod(lambda _iface: (None, False, False, False)),
-    )
-    monkeypatch.setattr(
-        BLEReceiveRecoveryService,
-        "_process_client_state",
-        staticmethod(lambda *_args, **_kwargs: False),
-    )
-    iface._should_run_receive_loop = MagicMock(side_effect=[True, True, False])
-    assert BLEReceiveRecoveryService._run_receive_cycle(
-        iface,
-        coordinator=SimpleNamespace(),
-        wait_timeout=0.1,
-    )
-
-    monkeypatch.setattr(
-        BLEReceiveRecoveryService,
-        "_snapshot_client_state",
-        staticmethod(lambda _iface: (DummyClient(), False, False, False)),
-    )
-    monkeypatch.setattr(
-        BLEReceiveRecoveryService,
-        "_handle_payload_read",
-        staticmethod(lambda *_args, **_kwargs: (True, False)),
-    )
-    iface._should_run_receive_loop = MagicMock(side_effect=[True, True, False])
-    assert BLEReceiveRecoveryService._run_receive_cycle(
-        iface,
-        coordinator=SimpleNamespace(),
-        wait_timeout=0.1,
-    )
-
-    recovered: list[str] = []
-    monkeypatch.setattr(
-        BLEReceiveRecoveryService,
-        "_run_receive_cycle",
-        staticmethod(
-            lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("fatal"))
-        ),
-    )
-    iface._recover_receive_thread = lambda reason: recovered.append(reason)
-    BLEReceiveRecoveryService._receive_from_radio_impl(iface)
-    assert recovered == ["receive_thread_fatal"]
-
-    with monkeypatch.context() as m:
-        monotonic_values = iter([100.0, 100.1])
-        m.setattr(
-            "meshtastic.interfaces.ble.receive_service.time.monotonic",
-            lambda: next(monotonic_values),
+        monkeypatch.setattr(
+            BLEReceiveRecoveryService,
+            "_read_and_handle_payload",
+            staticmethod(
+                lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                    ValueError("unexpected")
+                )
+            ),
         )
-        with iface._state_lock:
-            iface.client = DummyClient()
-            iface._closed = False
-            iface._receive_recovery_attempts = 3
-            iface._last_recovery_time = 99.0
-        iface._handle_disconnect = lambda *_args, **_kwargs: True
-        iface._shutdown_event = SimpleNamespace(
-            wait=lambda timeout=None: False,
-            set=lambda: None,
+        iface._handle_read_loop_disconnect = lambda *_args, **_kwargs: True
+        assert BLEReceiveRecoveryService._handle_payload_read(
+            iface,
+            DummyClient(),
+            poll_without_notify=False,
+        ) == (True, False)
+        iface._handle_read_loop_disconnect = lambda *_args, **_kwargs: False
+        assert BLEReceiveRecoveryService._handle_payload_read(
+            iface,
+            DummyClient(),
+            poll_without_notify=False,
+        ) == (True, True)
+
+        monkeypatch.setattr(
+            BLEReceiveRecoveryService,
+            "_wait_for_read_trigger",
+            staticmethod(lambda *_args, **_kwargs: (True, False)),
         )
-        iface._should_run_receive_loop = lambda: True
-        started: list[dict[str, object]] = []
-        iface._start_receive_thread = lambda **kwargs: started.append(kwargs)
-        BLEReceiveRecoveryService._recover_receive_thread(iface, "recover")
-    assert started == [{"name": "BLEReceiveRecovery", "reset_recovery": False}]
-    iface._shutdown_event = threading.Event()
-    iface.close()
+        monkeypatch.setattr(
+            BLEReceiveRecoveryService,
+            "_snapshot_client_state",
+            staticmethod(lambda _iface: (None, False, False, False)),
+        )
+        monkeypatch.setattr(
+            BLEReceiveRecoveryService,
+            "_process_client_state",
+            staticmethod(lambda *_args, **_kwargs: False),
+        )
+        iface._should_run_receive_loop = MagicMock(side_effect=[True, True, False])
+        assert BLEReceiveRecoveryService._run_receive_cycle(
+            iface,
+            coordinator=SimpleNamespace(),
+            wait_timeout=0.1,
+        )
+
+        monkeypatch.setattr(
+            BLEReceiveRecoveryService,
+            "_snapshot_client_state",
+            staticmethod(lambda _iface: (DummyClient(), False, False, False)),
+        )
+        monkeypatch.setattr(
+            BLEReceiveRecoveryService,
+            "_handle_payload_read",
+            staticmethod(lambda *_args, **_kwargs: (True, False)),
+        )
+        iface._should_run_receive_loop = MagicMock(side_effect=[True, True, False])
+        assert BLEReceiveRecoveryService._run_receive_cycle(
+            iface,
+            coordinator=SimpleNamespace(),
+            wait_timeout=0.1,
+        )
+
+        recovered: list[str] = []
+        monkeypatch.setattr(
+            BLEReceiveRecoveryService,
+            "_run_receive_cycle",
+            staticmethod(
+                lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("fatal"))
+            ),
+        )
+        iface._recover_receive_thread = lambda reason: recovered.append(reason)
+        BLEReceiveRecoveryService._receive_from_radio_impl(iface)
+        assert recovered == ["receive_thread_fatal"]
+
+        with monkeypatch.context() as m:
+            monotonic_values = iter([100.0, 100.1])
+            m.setattr(
+                "meshtastic.interfaces.ble.receive_service.time.monotonic",
+                lambda: next(monotonic_values),
+            )
+            with iface._state_lock:
+                iface.client = DummyClient()
+                iface._closed = False
+                iface._receive_recovery_attempts = 3
+                iface._last_recovery_time = 99.0
+            iface._handle_disconnect = lambda *_args, **_kwargs: True
+            iface._shutdown_event = SimpleNamespace(
+                wait=lambda timeout=None: False,
+                set=lambda: None,
+            )
+            iface._should_run_receive_loop = lambda: True
+            started: list[dict[str, object]] = []
+            iface._start_receive_thread = lambda **kwargs: started.append(kwargs)
+            BLEReceiveRecoveryService._recover_receive_thread(iface, "recover")
+        assert started == [{"name": "BLEReceiveRecovery", "reset_recovery": False}]
+        iface._shutdown_event = threading.Event()
+    finally:
+        iface.close()

--- a/tests/test_ble_lifecycle_receive_targets.py
+++ b/tests/test_ble_lifecycle_receive_targets.py
@@ -468,9 +468,24 @@ def test_lifecycle_invalidation_and_publish_verification_paths(
         assert BLELifecycleService._ever_connected_flag(iface) is False
 
         snapshots = [
-            _OwnershipSnapshot(True, False, False, False),
-            _OwnershipSnapshot(True, False, False, False),
-            _OwnershipSnapshot(False, False, False, False),
+            _OwnershipSnapshot(
+                still_owned=True,
+                is_closing=False,
+                lost_gate_ownership=False,
+                prior_ever_connected=False,
+            ),
+            _OwnershipSnapshot(
+                still_owned=True,
+                is_closing=False,
+                lost_gate_ownership=False,
+                prior_ever_connected=False,
+            ),
+            _OwnershipSnapshot(
+                still_owned=False,
+                is_closing=False,
+                lost_gate_ownership=False,
+                prior_ever_connected=False,
+            ),
         ]
         monkeypatch.setattr(
             BLELifecycleService,

--- a/tests/test_ble_lifecycle_receive_targets.py
+++ b/tests/test_ble_lifecycle_receive_targets.py
@@ -378,17 +378,20 @@ def test_lifecycle_state_manager_helper_paths(
     """State-manager compatibility helpers should cover callable/member/missing paths."""
     iface = _make_iface(monkeypatch)
     try:
+        current_state_public = MagicMock(return_value=ConnectionState.CONNECTED)
+        transition_to_public = MagicMock(return_value=True)
+        reset_to_disconnected_public = MagicMock(return_value=True)
         iface._state_manager = SimpleNamespace(
-            is_connected=MagicMock(),
-            _is_connected=True,
-            current_state=MagicMock(),
-            _current_state=ConnectionState.CONNECTED,
-            transition_to=lambda _state: True,
-            _transition_to=lambda _state: True,
-            reset_to_disconnected=lambda: True,
-            _reset_to_disconnected=lambda: True,
-            is_closing=MagicMock(),
-            _is_closing=True,
+            is_connected=True,
+            _is_connected=False,
+            current_state=current_state_public,
+            _current_state=ConnectionState.DISCONNECTED,
+            transition_to=transition_to_public,
+            _transition_to=lambda _state: False,
+            reset_to_disconnected=reset_to_disconnected_public,
+            _reset_to_disconnected=lambda: False,
+            is_closing=True,
+            _is_closing=False,
         )
         assert BLELifecycleService._state_manager_is_connected(iface) is True
         assert (
@@ -400,6 +403,9 @@ def test_lifecycle_state_manager_helper_paths(
         )
         assert BLELifecycleService._state_manager_reset_to_disconnected(iface)
         assert BLELifecycleService._state_manager_is_closing(iface) is True
+        current_state_public.assert_called_once_with()
+        transition_to_public.assert_called_once_with(ConnectionState.CONNECTED)
+        reset_to_disconnected_public.assert_called_once_with()
 
         iface._state_manager = SimpleNamespace()
         with pytest.raises(AttributeError):
@@ -897,569 +903,635 @@ def test_receive_service_branch_targets(monkeypatch: pytest.MonkeyPatch) -> None
     iface.close()
 
 
-def test_lifecycle_remaining_branch_targets(
+def test_lifecycle_remaining_error_handler_branch_targets(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Cover remaining lifecycle branch targets with focused micro-scenarios."""
+    """Lifecycle error-handler compatibility fallbacks should stay best effort."""
     iface = _make_iface(monkeypatch)
-
-    # lifecycle _error_handler_safe_cleanup non-keyword TypeError path (line 165)
-    iface.error_handler = SimpleNamespace(
-        safe_cleanup=lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            TypeError("non-keyword type error")
+    try:
+        iface.error_handler = SimpleNamespace(
+            safe_cleanup=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                TypeError("non-keyword type error")
+            )
         )
-    )
-    BLELifecycleService._error_handler_safe_cleanup(iface, lambda: None, "cleanup")
+        BLELifecycleService._error_handler_safe_cleanup(iface, lambda: None, "cleanup")
 
-    # lifecycle _error_handler_safe_execute positional compatibility fallbacks
-    def _safe_execute_non_positional(
-        func: Any, *args: object, **kwargs: object
-    ) -> object:
-        if "error_msg" in kwargs:
-            raise TypeError(
-                "safe_execute() got an unexpected keyword argument 'error_msg'"
+        def _safe_execute_non_positional(
+            func: Any, *args: object, **kwargs: object
+        ) -> object:
+            if "error_msg" in kwargs:
+                raise TypeError(
+                    "safe_execute() got an unexpected keyword argument 'error_msg'"
+                )
+            if args:
+                raise TypeError("totally different positional failure")
+            return func()
+
+        iface.error_handler = SimpleNamespace(safe_execute=_safe_execute_non_positional)
+        assert (
+            BLELifecycleService._error_handler_safe_execute(
+                iface,
+                lambda: "fallback-none",
+                error_msg="msg",
             )
-        if args:
-            raise TypeError("totally different positional failure")
-        return func()
-
-    iface.error_handler = SimpleNamespace(safe_execute=_safe_execute_non_positional)
-    assert (
-        BLELifecycleService._error_handler_safe_execute(
-            iface,
-            lambda: "fallback-none",
-            error_msg="msg",
+            == "fallback-none"
         )
-        == "fallback-none"
-    )
 
-    def _safe_execute_positional_then_fail(
-        func: Any, *args: object, **kwargs: object
-    ) -> object:
-        if "error_msg" in kwargs:
-            raise TypeError(
-                "safe_execute() got an unexpected keyword argument 'error_msg'"
-            )
-        if args:
-            raise TypeError(
-                "takes 1 positional argument but 2 positional arguments were given"
-            )
-        raise RuntimeError("hook failed")
+        def _safe_execute_positional_then_fail(
+            func: Any, *args: object, **kwargs: object
+        ) -> object:
+            if "error_msg" in kwargs:
+                raise TypeError(
+                    "safe_execute() got an unexpected keyword argument 'error_msg'"
+                )
+            if args:
+                raise TypeError(
+                    "takes 1 positional argument but 2 positional arguments were given"
+                )
+            raise RuntimeError("hook failed")
 
-    iface.error_handler = SimpleNamespace(
-        safe_execute=_safe_execute_positional_then_fail
-    )
-    assert (
-        BLELifecycleService._error_handler_safe_execute(
-            iface,
-            lambda: "unused",
-            error_msg="msg",
+        iface.error_handler = SimpleNamespace(
+            safe_execute=_safe_execute_positional_then_fail
         )
-        == "unused"
-    )
-
-    # lifecycle public thread helper branches
-    start_calls: list[object] = []
-    join_calls: list[float | None] = []
-    set_calls: list[str] = []
-    clear_calls: list[str] = []
-    wake_calls: list[str] = []
-    iface.thread_coordinator = SimpleNamespace(
-        start_thread=lambda thread: start_calls.append(thread),
-        join_thread=lambda _thread, timeout=None: join_calls.append(timeout),
-        set_event=lambda name: set_calls.append(name),
-        clear_events=lambda *names: clear_calls.extend(names),
-        wake_waiting_threads=lambda *names: wake_calls.extend(names),
-    )
-    thread_marker = SimpleNamespace(name="thread-marker")
-    BLELifecycleService._thread_start_thread(iface, thread_marker)
-    BLELifecycleService._thread_join_thread(iface, thread_marker, timeout=0.25)
-    BLELifecycleService._thread_set_event(iface, "set-me")
-    BLELifecycleService._thread_clear_events(iface, "clear-me")
-    BLELifecycleService._thread_wake_waiting_threads(iface, "wake-me")
-    assert start_calls == [thread_marker]
-    assert join_calls == [0.25]
-    assert set_calls == ["set-me"]
-    assert clear_calls == ["clear-me"]
-    assert wake_calls == ["wake-me"]
-
-    # lifecycle _thread_join_thread missing join path (line 432)
-    iface.thread_coordinator = SimpleNamespace()
-    BLELifecycleService._thread_join_thread(iface, SimpleNamespace(), timeout=0.1)
-
-    # lifecycle disconnect target closing early return (796-797) and bleak address fallback (868)
-    with iface._state_lock:
-        iface.client = DummyClient()
-        iface._closed = True
-        iface._state_manager._reset_to_disconnected()
-    assert (
-        BLELifecycleService._resolve_disconnect_target(
-            iface, "src", None, None
-        ).early_return
-        is False
-    )
-
-    with iface._state_lock:
-        iface.client = None
-        iface._closed = False
-        iface._client_publish_pending = True
-        iface._client_replacement_pending = False
-        iface._disconnect_notified = False
-        iface._state_manager._reset_to_disconnected()
-    bleak_client = SimpleNamespace(address="AA:BB:CC:DD:EE:FF")
-    plan = BLELifecycleService._resolve_disconnect_target(
-        iface, "src", None, bleak_client
-    )
-    assert plan.address == "AA:BB:CC:DD:EE:FF"
-
-    # lifecycle close_previous_client_async branches
-    BLELifecycleService._close_previous_client_async(iface, None)
-    previous_client = DummyClient()
-    previous_client.address = "AA:BB:CC:DD:EE:FF"
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_thread_create_thread",
-        staticmethod(
-            lambda *_args, **_kwargs: SimpleNamespace(
-                ident=None, is_alive=lambda: False
+        assert (
+            BLELifecycleService._error_handler_safe_execute(
+                iface,
+                lambda: "unused",
+                error_msg="msg",
             )
-        ),
-    )
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_thread_start_thread",
-        staticmethod(lambda *_args, **_kwargs: None),
-    )
-    BLELifecycleService._close_previous_client_async(iface, previous_client)
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_thread_start_thread",
-        staticmethod(lambda *_args, **_kwargs: (_ for _ in ()).throw(SystemExit())),
-    )
-    with pytest.raises(SystemExit):
+            == "unused"
+        )
+    finally:
+        iface.close()
+
+
+def test_lifecycle_remaining_thread_and_disconnect_target_branches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lifecycle thread dispatch and disconnect-target helpers should cover edge branches."""
+    iface = _make_iface(monkeypatch)
+    try:
+        start_calls: list[object] = []
+        join_calls: list[float | None] = []
+        set_calls: list[str] = []
+        clear_calls: list[str] = []
+        wake_calls: list[str] = []
+        iface.thread_coordinator = SimpleNamespace(
+            start_thread=lambda thread: start_calls.append(thread),
+            join_thread=lambda _thread, timeout=None: join_calls.append(timeout),
+            set_event=lambda name: set_calls.append(name),
+            clear_events=lambda *names: clear_calls.extend(names),
+            wake_waiting_threads=lambda *names: wake_calls.extend(names),
+        )
+        thread_marker = SimpleNamespace(name="thread-marker")
+        BLELifecycleService._thread_start_thread(iface, thread_marker)
+        BLELifecycleService._thread_join_thread(iface, thread_marker, timeout=0.25)
+        BLELifecycleService._thread_set_event(iface, "set-me")
+        BLELifecycleService._thread_clear_events(iface, "clear-me")
+        BLELifecycleService._thread_wake_waiting_threads(iface, "wake-me")
+        assert start_calls == [thread_marker]
+        assert join_calls == [0.25]
+        assert set_calls == ["set-me"]
+        assert clear_calls == ["clear-me"]
+        assert wake_calls == ["wake-me"]
+
+        iface.thread_coordinator = SimpleNamespace()
+        BLELifecycleService._thread_join_thread(iface, SimpleNamespace(), timeout=0.1)
+
+        with iface._state_lock:
+            iface.client = DummyClient()
+            iface._closed = True
+            iface._state_manager._reset_to_disconnected()
+        assert (
+            BLELifecycleService._resolve_disconnect_target(
+                iface, "src", None, None
+            ).early_return
+            is False
+        )
+
+        with iface._state_lock:
+            iface.client = None
+            iface._closed = False
+            iface._client_publish_pending = True
+            iface._client_replacement_pending = False
+            iface._disconnect_notified = False
+            iface._state_manager._reset_to_disconnected()
+        bleak_client = SimpleNamespace(address="AA:BB:CC:DD:EE:FF")
+        plan = BLELifecycleService._resolve_disconnect_target(
+            iface, "src", None, bleak_client
+        )
+        assert plan.address == "AA:BB:CC:DD:EE:FF"
+    finally:
+        iface.close()
+
+
+def test_lifecycle_remaining_close_previous_client_async_branches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Previous-client async close should cover start success/failure branches."""
+    iface = _make_iface(monkeypatch)
+    try:
+        BLELifecycleService._close_previous_client_async(iface, None)
+        previous_client = DummyClient()
+        previous_client.address = "AA:BB:CC:DD:EE:FF"
+
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_thread_create_thread",
+            staticmethod(
+                lambda *_args, **_kwargs: SimpleNamespace(
+                    ident=None, is_alive=lambda: False
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_thread_start_thread",
+            staticmethod(lambda *_args, **_kwargs: None),
+        )
         BLELifecycleService._close_previous_client_async(iface, previous_client)
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_thread_start_thread",
-        staticmethod(
-            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("fail"))
-        ),
-    )
-    BLELifecycleService._close_previous_client_async(iface, previous_client)
 
-    # lifecycle _discard_invalidated_connected_client fallback reset paths
-    iface.client = DummyClient()
-    iface._client_publish_pending = False
-    iface._connection_alias_key = "alias"
-    with monkeypatch.context() as m:
-        m.setattr(
+        monkeypatch.setattr(
             BLELifecycleService,
-            "_state_manager_is_closing",
-            staticmethod(lambda _iface: False),
+            "_thread_start_thread",
+            staticmethod(lambda *_args, **_kwargs: (_ for _ in ()).throw(SystemExit())),
         )
-        m.setattr(
+        with pytest.raises(SystemExit):
+            BLELifecycleService._close_previous_client_async(iface, previous_client)
+
+        monkeypatch.setattr(
             BLELifecycleService,
-            "_state_manager_reset_to_disconnected",
-            staticmethod(lambda *_args, **_kwargs: False),
+            "_thread_start_thread",
+            staticmethod(
+                lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("fail"))
+            ),
         )
-        m.setattr(
-            BLELifecycleService,
-            "_state_manager_transition_to",
-            staticmethod(lambda *_args, **_kwargs: False),
+        BLELifecycleService._close_previous_client_async(iface, previous_client)
+    finally:
+        iface.close()
+
+
+def test_lifecycle_remaining_invalidation_and_state_helper_branches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalidation and state helper branches should remain deterministic."""
+    iface = _make_iface(monkeypatch)
+    try:
+        iface.client = DummyClient()
+        iface._client_publish_pending = False
+        iface._connection_alias_key = "alias"
+        with monkeypatch.context() as m:
+            m.setattr(
+                BLELifecycleService,
+                "_state_manager_is_closing",
+                staticmethod(lambda _iface: False),
+            )
+            m.setattr(
+                BLELifecycleService,
+                "_state_manager_reset_to_disconnected",
+                staticmethod(lambda *_args, **_kwargs: False),
+            )
+            m.setattr(
+                BLELifecycleService,
+                "_state_manager_transition_to",
+                staticmethod(lambda *_args, **_kwargs: False),
+            )
+            m.setattr(
+                BLELifecycleService,
+                "_state_manager_current_state",
+                staticmethod(lambda _iface: ConnectionState.CONNECTING),
+            )
+            BLELifecycleService._discard_invalidated_connected_client(
+                iface,
+                iface.client,
+                restore_address="AA",
+                restore_last_connection_request="AA",
+            )
+
+        iface._state_manager = SimpleNamespace(
+            is_connected=True,
+            current_state=lambda: ConnectionState.CONNECTED,
+            _current_state=lambda: ConnectionState.DISCONNECTED,
+            is_closing=True,
         )
-        m.setattr(
-            BLELifecycleService,
-            "_state_manager_current_state",
-            staticmethod(lambda _iface: ConnectionState.CONNECTING),
+        assert BLELifecycleService._state_manager_is_connected(iface) is True
+        assert (
+            BLELifecycleService._state_manager_current_state(iface)
+            == ConnectionState.CONNECTED
         )
-        BLELifecycleService._discard_invalidated_connected_client(
-            iface,
-            iface.client,
-            restore_address="AA",
-            restore_last_connection_request="AA",
-        )
+        assert BLELifecycleService._state_manager_is_closing(iface) is True
 
-    # lifecycle state helper branches
-    iface._state_manager = SimpleNamespace(
-        is_connected=True,
-        current_state=lambda: ConnectionState.CONNECTED,
-        _current_state=lambda: ConnectionState.DISCONNECTED,
-        is_closing=True,
-    )
-    assert BLELifecycleService._state_manager_is_connected(iface) is True
-    assert (
-        BLELifecycleService._state_manager_current_state(iface)
-        == ConnectionState.CONNECTED
-    )
-    assert BLELifecycleService._state_manager_is_closing(iface) is True
-
-    iface._state_manager = SimpleNamespace(current_state=ConnectionState.CONNECTED)
-    assert (
-        BLELifecycleService._state_manager_current_state(iface)
-        == ConnectionState.CONNECTED
-    )
-
-    iface._state_manager = SimpleNamespace(
-        _current_state=lambda: ConnectionState.CONNECTED
-    )
-    assert (
-        BLELifecycleService._state_manager_current_state(iface)
-        == ConnectionState.CONNECTED
-    )
-
-    client_member = SimpleNamespace(_is_connected=True)
-    assert BLELifecycleService._client_is_connected(client_member) is True
-
-    iface._sorted_address_keys = lambda *_keys: ["key-a", "key-b"]
-    iface._mark_address_keys_disconnected = MagicMock()
-    iface._discard_invalidated_connected_client = MagicMock()
-    with pytest.raises(iface.BLEError):
-        BLELifecycleService._raise_for_invalidated_connect_result(
-            iface,
-            DummyClient(),
-            "dev",
-            "alias",
-            is_closing=False,
-            lost_gate_ownership=False,
-            restore_address=None,
-            restore_last_connection_request=None,
+        iface._state_manager = SimpleNamespace(current_state=ConnectionState.CONNECTED)
+        assert (
+            BLELifecycleService._state_manager_current_state(iface)
+            == ConnectionState.CONNECTED
         )
 
-    # lifecycle verify/publish race branches and invalidation fallback
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_verify_ownership_snapshot",
-        staticmethod(
-            lambda *_args, **_kwargs: _OwnershipSnapshot(
-                still_owned=True,
+        iface._state_manager = SimpleNamespace(
+            _current_state=lambda: ConnectionState.CONNECTED
+        )
+        assert (
+            BLELifecycleService._state_manager_current_state(iface)
+            == ConnectionState.CONNECTED
+        )
+
+        client_member = SimpleNamespace(_is_connected=True)
+        assert BLELifecycleService._client_is_connected(client_member) is True
+
+        iface._sorted_address_keys = lambda *_keys: ["key-a", "key-b"]
+        iface._mark_address_keys_disconnected = MagicMock()
+        iface._discard_invalidated_connected_client = MagicMock()
+        with pytest.raises(iface.BLEError):
+            BLELifecycleService._raise_for_invalidated_connect_result(
+                iface,
+                DummyClient(),
+                "dev",
+                "alias",
                 is_closing=False,
                 lost_gate_ownership=False,
-                prior_ever_connected=False,
+                restore_address=None,
+                restore_last_connection_request=None,
             )
-        ),
-    )
-    status_values = [(True, False), (True, False), (False, False)]
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_get_connected_client_status_locked",
-        staticmethod(lambda *_args, **_kwargs: status_values.pop(0)),
-    )
-    iface._client_publish_pending = True
-    iface._client_replacement_pending = True
-    iface._disconnect_notified = True
-    iface.client = DummyClient()
-    iface._connected = lambda: None
-    disconnected_calls: list[str] = []
-    iface._disconnected = lambda: disconnected_calls.append("disconnected")
-    iface._emit_verified_connection_side_effects = lambda _client: None
-    BLELifecycleService._verify_and_publish_connected(
-        iface,
-        iface.client,
-        "dev",
-        "alias",
-        restore_address=None,
-        restore_last_connection_request=None,
-    )
-    assert disconnected_calls == ["disconnected"]
+    finally:
+        iface._state_manager = importlib.import_module(
+            "meshtastic.interfaces.ble.state"
+        ).BLEStateManager()
+        iface.close()
 
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_verify_ownership_snapshot",
-        staticmethod(
-            lambda *_args, **_kwargs: _OwnershipSnapshot(
-                still_owned=False,
-                is_closing=False,
-                lost_gate_ownership=False,
-                prior_ever_connected=False,
-            )
-        ),
-    )
-    iface._raise_for_invalidated_connect_result = MagicMock(
-        side_effect=iface.BLEError("invalid")
-    )
-    with pytest.raises(iface.BLEError, match="invalid"):
+
+def test_lifecycle_remaining_verify_finalize_and_shutdown_branches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify/publish, gate-finalize, and shutdown helpers should cover remaining branches."""
+    iface = _make_iface(monkeypatch)
+    try:
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_verify_ownership_snapshot",
+            staticmethod(
+                lambda *_args, **_kwargs: _OwnershipSnapshot(
+                    still_owned=True,
+                    is_closing=False,
+                    lost_gate_ownership=False,
+                    prior_ever_connected=False,
+                )
+            ),
+        )
+        status_values = [(True, False), (True, False), (False, False)]
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_get_connected_client_status_locked",
+            staticmethod(lambda *_args, **_kwargs: status_values.pop(0)),
+        )
+        iface._client_publish_pending = True
+        iface._client_replacement_pending = True
+        iface._disconnect_notified = True
+        iface.client = DummyClient()
+        iface._connected = lambda: None
+        disconnected_calls: list[str] = []
+        iface._disconnected = lambda: disconnected_calls.append("disconnected")
+        iface._emit_verified_connection_side_effects = lambda _client: None
         BLELifecycleService._verify_and_publish_connected(
             iface,
-            DummyClient(),
+            iface.client,
             "dev",
             "alias",
             restore_address=None,
             restore_last_connection_request=None,
         )
+        assert disconnected_calls == ["disconnected"]
 
-    # lifecycle finalize gate cleanup branch
-    gate_statuses = [(True, False), (False, False)]
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_get_connected_client_status",
-        staticmethod(lambda *_args, **_kwargs: gate_statuses[0]),
-    )
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_get_connected_client_status_locked",
-        staticmethod(lambda *_args, **_kwargs: gate_statuses.pop(0)),
-    )
-    iface._mark_address_keys_connected = lambda *_keys: None
-    disconnected_gate_keys: list[str] = []
-    iface._mark_address_keys_disconnected = lambda *keys: disconnected_gate_keys.extend(
-        [k for k in keys if k is not None]
-    )
-    BLELifecycleService._finalize_connection_gates(
-        iface,
-        DummyClient(),
-        "dev",
-        "alias",
-    )
-    assert disconnected_gate_keys == ["dev", "alias"]
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_verify_ownership_snapshot",
+            staticmethod(
+                lambda *_args, **_kwargs: _OwnershipSnapshot(
+                    still_owned=False,
+                    is_closing=False,
+                    lost_gate_ownership=False,
+                    prior_ever_connected=False,
+                )
+            ),
+        )
+        iface._raise_for_invalidated_connect_result = MagicMock(
+            side_effect=iface.BLEError("invalid")
+        )
+        with pytest.raises(iface.BLEError, match="invalid"):
+            BLELifecycleService._verify_and_publish_connected(
+                iface,
+                DummyClient(),
+                "dev",
+                "alias",
+                restore_address=None,
+                restore_last_connection_request=None,
+            )
 
-    # lifecycle shutdown receive thread self-join branch and missing unsubscribe debug path
-    iface._receiveThread = threading.current_thread()
-    BLELifecycleService._shutdown_receive_thread(iface)
+        gate_statuses = [(True, False), (False, False)]
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_get_connected_client_status",
+            staticmethod(lambda *_args, **_kwargs: gate_statuses[0]),
+        )
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_get_connected_client_status_locked",
+            staticmethod(lambda *_args, **_kwargs: gate_statuses.pop(0)),
+        )
+        iface._mark_address_keys_connected = lambda *_keys: None
+        disconnected_gate_keys: list[str] = []
+        iface._mark_address_keys_disconnected = (
+            lambda *keys: disconnected_gate_keys.extend(
+                [k for k in keys if k is not None]
+            )
+        )
+        BLELifecycleService._finalize_connection_gates(
+            iface,
+            DummyClient(),
+            "dev",
+            "alias",
+        )
+        assert disconnected_gate_keys == ["dev", "alias"]
 
-    iface._notification_manager = SimpleNamespace()
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_detach_client_for_shutdown",
-        staticmethod(lambda _iface: (DummyClient(), False)),
-    )
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_error_handler_safe_cleanup",
-        staticmethod(lambda _iface, func, _name: func()),
-    )
-    iface._management_target_gate = lambda _address: contextlib.nullcontext()
-    iface._disconnect_and_close_client = lambda _client: None
-    iface._wait_for_disconnect_notifications = lambda: None
-    iface._disconnected = lambda: None
-    BLELifecycleService._shutdown_client(iface, management_wait_timed_out=False)
-    iface._state_manager = importlib.import_module(
-        "meshtastic.interfaces.ble.state"
-    ).BLEStateManager()
-    iface.close()
+        iface._receiveThread = threading.current_thread()
+        BLELifecycleService._shutdown_receive_thread(iface)
+
+        iface._notification_manager = SimpleNamespace()
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_detach_client_for_shutdown",
+            staticmethod(lambda _iface: (DummyClient(), False)),
+        )
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_error_handler_safe_cleanup",
+            staticmethod(lambda _iface, func, _name: func()),
+        )
+        iface._management_target_gate = lambda _address: contextlib.nullcontext()
+        iface._disconnect_and_close_client = lambda _client: None
+        iface._wait_for_disconnect_notifications = lambda: None
+        iface._disconnected = lambda: None
+        BLELifecycleService._shutdown_client(iface, management_wait_timed_out=False)
+    finally:
+        iface._state_manager = importlib.import_module(
+            "meshtastic.interfaces.ble.state"
+        ).BLEStateManager()
+        iface.close()
 
 
-def test_receive_service_remaining_branch_targets(
+def test_receive_service_remaining_coordinator_and_snapshot_branches(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Cover remaining receive-service branch targets with focused micro-scenarios."""
+    """Receive coordinator/snapshot helpers should cover remaining compatibility branches."""
     iface = _make_iface(monkeypatch)
-
-    # receive helper remaining branch scenarios
-    wait_calls: list[float] = []
-    monkeypatch.setattr(
-        "meshtastic.interfaces.ble.receive_service._sleep",
-        lambda delay: wait_calls.append(delay),
-    )
-    assert (
-        BLEReceiveRecoveryService._coordinator_wait_for_event(
-            SimpleNamespace(wait_for_event=lambda _event, timeout=None: True),
-            "evt",
-            timeout=0.5,
+    try:
+        wait_calls: list[float] = []
+        monkeypatch.setattr(
+            "meshtastic.interfaces.ble.receive_service._sleep",
+            lambda delay: wait_calls.append(delay),
         )
-        is True
-    )
-    BLEReceiveRecoveryService._coordinator_wait_for_event(
-        SimpleNamespace(), "evt", timeout=0.5
-    )
-    assert wait_calls
-
-    assert (
-        BLEReceiveRecoveryService._coordinator_check_and_clear_event(
-            SimpleNamespace(check_and_clear_event=lambda _event: True),
-            "evt",
-        )
-        is True
-    )
-    assert (
-        BLEReceiveRecoveryService._coordinator_check_and_clear_event(
-            SimpleNamespace(_check_and_clear_event=lambda _event: True),
-            "evt",
-        )
-        is True
-    )
-    BLEReceiveRecoveryService._coordinator_clear_event(
-        SimpleNamespace(clear_events=lambda *_events: None),
-        "evt",
-    )
-    BLEReceiveRecoveryService._coordinator_clear_event(
-        SimpleNamespace(clear_event=lambda _event: None),
-        "evt",
-    )
-
-    iface._state_manager = SimpleNamespace(is_connecting=lambda: True)
-    assert BLEReceiveRecoveryService._snapshot_client_state(iface)[1] is True
-    iface._state_manager = SimpleNamespace(_is_connecting=lambda: True)
-    assert BLEReceiveRecoveryService._snapshot_client_state(iface)[1] is True
-    iface._state_manager = SimpleNamespace(_is_connecting=False)
-    assert BLEReceiveRecoveryService._snapshot_client_state(iface)[1] is False
-    iface._state_manager = importlib.import_module(
-        "meshtastic.interfaces.ble.state"
-    ).BLEStateManager()
-
-    assert BLEReceiveRecoveryService._process_client_state(
-        iface,
-        coordinator=SimpleNamespace(),
-        wait_timeout=0.1,
-        client=None,
-        is_connecting=False,
-        publish_pending=False,
-        is_closing=False,
-    )
-
-    with iface._state_lock:
-        iface._receive_recovery_attempts = 1
-        iface._last_recovery_time = 0.0
-    BLEReceiveRecoveryService._reset_recovery_after_stability(iface)
-
-    iface._read_from_radio_with_retries = lambda *_args, **_kwargs: b"payload"
-    iface._handle_from_radio = lambda _payload: None
-    assert BLEReceiveRecoveryService._read_and_handle_payload(
-        iface,
-        DummyClient(),
-        poll_without_notify=False,
-    )
-
-    monkeypatch.setattr(
-        BLEReceiveRecoveryService,
-        "_read_and_handle_payload",
-        staticmethod(lambda *_args, **_kwargs: False),
-    )
-    assert BLEReceiveRecoveryService._handle_payload_read(
-        iface,
-        DummyClient(),
-        poll_without_notify=False,
-    ) == (True, False)
-
-    monkeypatch.setattr(
-        BLEReceiveRecoveryService,
-        "_read_and_handle_payload",
-        staticmethod(
-            lambda *_args, **_kwargs: (_ for _ in ()).throw(
-                BleakDBusError("err", "dbus")
+        assert (
+            BLEReceiveRecoveryService._coordinator_wait_for_event(
+                SimpleNamespace(wait_for_event=lambda _event, timeout=None: True),
+                "evt",
+                timeout=0.5,
             )
-        ),
-    )
-    iface._handle_read_loop_disconnect = lambda *_args, **_kwargs: False
-    assert BLEReceiveRecoveryService._handle_payload_read(
-        iface,
-        DummyClient(),
-        poll_without_notify=False,
-    ) == (True, True)
+            is True
+        )
+        BLEReceiveRecoveryService._coordinator_wait_for_event(
+            SimpleNamespace(), "evt", timeout=0.5
+        )
+        assert wait_calls
 
-    monkeypatch.setattr(
-        BLEReceiveRecoveryService,
-        "_read_and_handle_payload",
-        staticmethod(lambda *_args, **_kwargs: (_ for _ in ()).throw(SystemExit())),
-    )
-    with pytest.raises(SystemExit):
-        BLEReceiveRecoveryService._handle_payload_read(
+        assert (
+            BLEReceiveRecoveryService._coordinator_check_and_clear_event(
+                SimpleNamespace(check_and_clear_event=lambda _event: True),
+                "evt",
+            )
+            is True
+        )
+        assert (
+            BLEReceiveRecoveryService._coordinator_check_and_clear_event(
+                SimpleNamespace(_check_and_clear_event=lambda _event: True),
+                "evt",
+            )
+            is True
+        )
+        BLEReceiveRecoveryService._coordinator_clear_event(
+            SimpleNamespace(clear_events=lambda *_events: None),
+            "evt",
+        )
+        BLEReceiveRecoveryService._coordinator_clear_event(
+            SimpleNamespace(clear_event=lambda _event: None),
+            "evt",
+        )
+
+        iface._state_manager = SimpleNamespace(is_connecting=lambda: True)
+        assert BLEReceiveRecoveryService._snapshot_client_state(iface)[1] is True
+        iface._state_manager = SimpleNamespace(_is_connecting=lambda: True)
+        assert BLEReceiveRecoveryService._snapshot_client_state(iface)[1] is True
+        iface._state_manager = SimpleNamespace(_is_connecting=False)
+        assert BLEReceiveRecoveryService._snapshot_client_state(iface)[1] is False
+        iface._state_manager = importlib.import_module(
+            "meshtastic.interfaces.ble.state"
+        ).BLEStateManager()
+
+        assert BLEReceiveRecoveryService._process_client_state(
+            iface,
+            coordinator=SimpleNamespace(),
+            wait_timeout=0.1,
+            client=None,
+            is_connecting=False,
+            publish_pending=False,
+            is_closing=False,
+        )
+
+        with iface._state_lock:
+            iface._receive_recovery_attempts = 1
+            iface._last_recovery_time = 0.0
+        BLEReceiveRecoveryService._reset_recovery_after_stability(iface)
+    finally:
+        iface._state_manager = importlib.import_module(
+            "meshtastic.interfaces.ble.state"
+        ).BLEStateManager()
+        iface.close()
+
+
+def test_receive_service_remaining_payload_read_branches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Receive payload-read helpers should cover normal and exceptional branches."""
+    iface = _make_iface(monkeypatch)
+    try:
+        iface._read_from_radio_with_retries = lambda *_args, **_kwargs: b"payload"
+        iface._handle_from_radio = lambda _payload: None
+        assert BLEReceiveRecoveryService._read_and_handle_payload(
             iface,
             DummyClient(),
             poll_without_notify=False,
         )
 
-    monkeypatch.setattr(
-        BLEReceiveRecoveryService,
-        "_read_and_handle_payload",
-        staticmethod(
-            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("unexpected"))
-        ),
-    )
-    iface._handle_read_loop_disconnect = lambda *_args, **_kwargs: False
-    assert BLEReceiveRecoveryService._handle_payload_read(
-        iface,
-        DummyClient(),
-        poll_without_notify=False,
-    ) == (True, True)
-
-    monkeypatch.setattr(
-        BLEReceiveRecoveryService,
-        "_wait_for_read_trigger",
-        staticmethod(lambda *_args, **_kwargs: (False, False)),
-    )
-    iface._should_run_receive_loop = MagicMock(side_effect=[True, False])
-    assert (
-        BLEReceiveRecoveryService._run_receive_cycle(
-            iface,
-            coordinator=SimpleNamespace(),
-            wait_timeout=0.1,
+        monkeypatch.setattr(
+            BLEReceiveRecoveryService,
+            "_read_and_handle_payload",
+            staticmethod(lambda *_args, **_kwargs: False),
         )
-        is True
-    )
-
-    monkeypatch.setattr(
-        BLEReceiveRecoveryService,
-        "_wait_for_read_trigger",
-        staticmethod(lambda *_args, **_kwargs: (True, False)),
-    )
-    monkeypatch.setattr(
-        BLEReceiveRecoveryService,
-        "_snapshot_client_state",
-        staticmethod(lambda _iface: (None, False, False, False)),
-    )
-    iface._should_run_receive_loop = MagicMock(side_effect=[True, True, False])
-    assert (
-        BLEReceiveRecoveryService._run_receive_cycle(
+        assert BLEReceiveRecoveryService._handle_payload_read(
             iface,
-            coordinator=SimpleNamespace(),
-            wait_timeout=0.1,
-        )
-        is True
-    )
+            DummyClient(),
+            poll_without_notify=False,
+        ) == (True, False)
 
-    monkeypatch.setattr(
-        BLEReceiveRecoveryService,
-        "_run_receive_cycle",
-        staticmethod(lambda *_args, **_kwargs: (_ for _ in ()).throw(SystemExit())),
-    )
-    with pytest.raises(SystemExit):
+        monkeypatch.setattr(
+            BLEReceiveRecoveryService,
+            "_read_and_handle_payload",
+            staticmethod(
+                lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                    BleakDBusError("err", "dbus")
+                )
+            ),
+        )
+        iface._handle_read_loop_disconnect = lambda *_args, **_kwargs: False
+        assert BLEReceiveRecoveryService._handle_payload_read(
+            iface,
+            DummyClient(),
+            poll_without_notify=False,
+        ) == (True, True)
+
+        monkeypatch.setattr(
+            BLEReceiveRecoveryService,
+            "_read_and_handle_payload",
+            staticmethod(lambda *_args, **_kwargs: (_ for _ in ()).throw(SystemExit())),
+        )
+        with pytest.raises(SystemExit):
+            BLEReceiveRecoveryService._handle_payload_read(
+                iface,
+                DummyClient(),
+                poll_without_notify=False,
+            )
+
+        monkeypatch.setattr(
+            BLEReceiveRecoveryService,
+            "_read_and_handle_payload",
+            staticmethod(
+                lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                    RuntimeError("unexpected")
+                )
+            ),
+        )
+        iface._handle_read_loop_disconnect = lambda *_args, **_kwargs: False
+        assert BLEReceiveRecoveryService._handle_payload_read(
+            iface,
+            DummyClient(),
+            poll_without_notify=False,
+        ) == (True, True)
+    finally:
+        iface.close()
+
+
+def test_receive_service_remaining_cycle_and_impl_branches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Receive-cycle and receive-loop implementation should cover remaining branches."""
+    iface = _make_iface(monkeypatch)
+    try:
+        monkeypatch.setattr(
+            BLEReceiveRecoveryService,
+            "_wait_for_read_trigger",
+            staticmethod(lambda *_args, **_kwargs: (False, False)),
+        )
+        iface._should_run_receive_loop = MagicMock(side_effect=[True, False])
+        assert (
+            BLEReceiveRecoveryService._run_receive_cycle(
+                iface,
+                coordinator=SimpleNamespace(),
+                wait_timeout=0.1,
+            )
+            is True
+        )
+
+        monkeypatch.setattr(
+            BLEReceiveRecoveryService,
+            "_wait_for_read_trigger",
+            staticmethod(lambda *_args, **_kwargs: (True, False)),
+        )
+        monkeypatch.setattr(
+            BLEReceiveRecoveryService,
+            "_snapshot_client_state",
+            staticmethod(lambda _iface: (None, False, False, False)),
+        )
+        iface._should_run_receive_loop = MagicMock(side_effect=[True, True, False])
+        assert (
+            BLEReceiveRecoveryService._run_receive_cycle(
+                iface,
+                coordinator=SimpleNamespace(),
+                wait_timeout=0.1,
+            )
+            is True
+        )
+
+        monkeypatch.setattr(
+            BLEReceiveRecoveryService,
+            "_run_receive_cycle",
+            staticmethod(lambda *_args, **_kwargs: (_ for _ in ()).throw(SystemExit())),
+        )
+        with pytest.raises(SystemExit):
+            BLEReceiveRecoveryService._receive_from_radio_impl(iface)
+
+        monkeypatch.setattr(
+            BLEReceiveRecoveryService,
+            "_run_receive_cycle",
+            staticmethod(
+                lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("fatal"))
+            ),
+        )
+        iface._recover_receive_thread = MagicMock()
         BLEReceiveRecoveryService._receive_from_radio_impl(iface)
+    finally:
+        iface.close()
 
-    monkeypatch.setattr(
-        BLEReceiveRecoveryService,
-        "_run_receive_cycle",
-        staticmethod(
-            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("fatal"))
-        ),
-    )
-    iface._recover_receive_thread = MagicMock()
-    BLEReceiveRecoveryService._receive_from_radio_impl(iface)
 
-    iface._state_manager = importlib.import_module(
-        "meshtastic.interfaces.ble.state"
-    ).BLEStateManager()
-    with iface._state_lock:
-        iface._closed = True
-    BLEReceiveRecoveryService._recover_receive_thread(iface, "reason")
-
-    with iface._state_lock:
-        iface._receive_recovery_attempts = 10
-        iface._last_recovery_time = 0.0
-        iface._closed = False
-    iface._handle_disconnect = lambda *_args, **_kwargs: True
-    iface._shutdown_event = SimpleNamespace(wait=lambda timeout=None: False)
-    iface._should_run_receive_loop = lambda: True
-    iface._start_receive_thread = lambda **_kwargs: (_ for _ in ()).throw(
-        RuntimeError("restart failed")
-    )
-    with pytest.raises(RuntimeError, match="restart failed"):
+def test_receive_service_remaining_recovery_and_empty_read_branches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Receive recovery and empty-read warning paths should hit remaining branches."""
+    iface = _make_iface(monkeypatch)
+    try:
+        iface._state_manager = importlib.import_module(
+            "meshtastic.interfaces.ble.state"
+        ).BLEStateManager()
+        with iface._state_lock:
+            iface._closed = True
         BLEReceiveRecoveryService._recover_receive_thread(iface, "reason")
 
-    client = DummyClient()
-    client.read_gatt_char = lambda *_args, **_kwargs: b""
-    iface._retry_policy_get_delay = lambda _policy, _attempt: 0.01
-    iface._empty_read_policy = object()
-    iface._log_empty_read_warning = MagicMock()
-    assert (
-        BLEReceiveRecoveryService._read_from_radio_with_retries(iface, client) is None
-    )
-    iface._log_empty_read_warning.assert_called_once()
+        with iface._state_lock:
+            iface._receive_recovery_attempts = 10
+            iface._last_recovery_time = 0.0
+            iface._closed = False
+        iface._handle_disconnect = lambda *_args, **_kwargs: True
+        iface._shutdown_event = SimpleNamespace(wait=lambda timeout=None: False)
+        iface._should_run_receive_loop = lambda: True
+        iface._start_receive_thread = lambda **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("restart failed")
+        )
+        with pytest.raises(RuntimeError, match="restart failed"):
+            BLEReceiveRecoveryService._recover_receive_thread(iface, "reason")
 
-    iface._state_manager = importlib.import_module(
-        "meshtastic.interfaces.ble.state"
-    ).BLEStateManager()
-    iface._shutdown_event = threading.Event()
-    iface.close()
+        client = DummyClient()
+        client.read_gatt_char = lambda *_args, **_kwargs: b""
+        iface._retry_policy_get_delay = lambda _policy, _attempt: 0.01
+        iface._empty_read_policy = object()
+        iface._log_empty_read_warning = MagicMock()
+        assert (
+            BLEReceiveRecoveryService._read_from_radio_with_retries(iface, client)
+            is None
+        )
+        iface._log_empty_read_warning.assert_called_once()
+    finally:
+        iface._state_manager = importlib.import_module(
+            "meshtastic.interfaces.ble.state"
+        ).BLEStateManager()
+        iface._shutdown_event = threading.Event()
+        iface.close()
 
 
 def test_lifecycle_remaining_error_handler_execute_paths(

--- a/tests/test_ble_lifecycle_receive_targets.py
+++ b/tests/test_ble_lifecycle_receive_targets.py
@@ -33,90 +33,96 @@ def _make_iface(monkeypatch: pytest.MonkeyPatch) -> Any:
     return _build_interface(monkeypatch, DummyClient(), start_receive_thread=False)
 
 
+def _reset_state_manager(iface: Any) -> None:
+    iface._state_manager = importlib.import_module(
+        "meshtastic.interfaces.ble.state"
+    ).BLEStateManager()
+
+
 def test_lifecycle_error_handler_cleanup_and_execute_branches(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Lifecycle error-handler adapters should cover compatibility fallback branches."""
     iface = _make_iface(monkeypatch)
+    try:
+        legacy_cleanup_calls: list[str] = []
 
-    legacy_cleanup_calls: list[str] = []
+        def _legacy_cleanup(func: Any, _operation_name: str) -> None:
+            func()
+            legacy_cleanup_calls.append("ran")
+            raise RuntimeError("hook post-processing failure")
 
-    def _legacy_cleanup(func: Any, _operation_name: str) -> None:
-        func()
-        legacy_cleanup_calls.append("ran")
-        raise RuntimeError("hook post-processing failure")
+        iface.error_handler = SimpleNamespace(
+            safe_cleanup=MagicMock(),
+            _safe_cleanup=_legacy_cleanup,
+        )
 
-    iface.error_handler = SimpleNamespace(
-        safe_cleanup=MagicMock(),
-        _safe_cleanup=_legacy_cleanup,
-    )
+        cleanup_calls: list[str] = []
+        BLELifecycleService._error_handler_safe_cleanup(
+            iface,
+            lambda: cleanup_calls.append("cleanup"),
+            "cleanup-op",
+        )
+        assert cleanup_calls == ["cleanup"]
+        assert legacy_cleanup_calls == ["ran"]
 
-    cleanup_calls: list[str] = []
-    BLELifecycleService._error_handler_safe_cleanup(
-        iface,
-        lambda: cleanup_calls.append("cleanup"),
-        "cleanup-op",
-    )
-    assert cleanup_calls == ["cleanup"]
-    assert legacy_cleanup_calls == ["ran"]
+        iface.error_handler = SimpleNamespace()
+        BLELifecycleService._error_handler_safe_cleanup(
+            iface,
+            lambda: (_ for _ in ()).throw(RuntimeError("cleanup failed")),
+            "cleanup-op",
+        )
 
-    iface.error_handler = SimpleNamespace()
-    BLELifecycleService._error_handler_safe_cleanup(
-        iface,
-        lambda: (_ for _ in ()).throw(RuntimeError("cleanup failed")),
-        "cleanup-op",
-    )
+        def _keyword_incompatible_safe_execute(
+            func: Any, *args: object, **kwargs: object
+        ) -> object:
+            if "error_msg" in kwargs:
+                raise TypeError(  # noqa: TRY003 - intentional fixture message shape
+                    "safe_execute() got an unexpected keyword argument 'error_msg'"
+                )
+            if args:
+                raise TypeError(  # noqa: TRY003 - intentional fixture message shape
+                    "takes 1 positional argument but 2 positional arguments were given"
+                )
+            return func()
 
-    def _keyword_incompatible_safe_execute(
-        func: Any, *args: object, **kwargs: object
-    ) -> object:
-        if "error_msg" in kwargs:
-            raise TypeError(
-                "safe_execute() got an unexpected keyword argument 'error_msg'"
+        iface.error_handler = SimpleNamespace(
+            safe_execute=_keyword_incompatible_safe_execute
+        )
+        assert (
+            BLELifecycleService._error_handler_safe_execute(
+                iface,
+                lambda: "ok",
+                error_msg="execute-error",
             )
-        if args:
-            raise TypeError(
-                "takes 1 positional argument but 2 positional arguments were given"
+            == "ok"
+        )
+
+        def _typeerror_after_running(func: Any, **_kwargs: object) -> object:
+            func()
+            raise TypeError("non-keyword type error")
+
+        iface.error_handler = SimpleNamespace(safe_execute=_typeerror_after_running)
+        assert (
+            BLELifecycleService._error_handler_safe_execute(
+                iface,
+                lambda: "ran",
+                error_msg="execute-error",
             )
-        return func()
-
-    iface.error_handler = SimpleNamespace(
-        safe_execute=_keyword_incompatible_safe_execute
-    )
-    assert (
-        BLELifecycleService._error_handler_safe_execute(
-            iface,
-            lambda: "ok",
-            error_msg="execute-error",
+            is None
         )
-        == "ok"
-    )
 
-    def _typeerror_after_running(func: Any, **_kwargs: object) -> object:
-        func()
-        raise TypeError("non-keyword type error")
-
-    iface.error_handler = SimpleNamespace(safe_execute=_typeerror_after_running)
-    assert (
-        BLELifecycleService._error_handler_safe_execute(
-            iface,
-            lambda: "ran",
-            error_msg="execute-error",
+        iface.error_handler = SimpleNamespace()
+        assert (
+            BLELifecycleService._error_handler_safe_execute(
+                iface,
+                lambda: (_ for _ in ()).throw(RuntimeError("fallback failed")),
+                error_msg="fallback",
+            )
+            is None
         )
-        is None
-    )
-
-    iface.error_handler = SimpleNamespace()
-    assert (
-        BLELifecycleService._error_handler_safe_execute(
-            iface,
-            lambda: (_ for _ in ()).throw(RuntimeError("fallback failed")),
-            error_msg="fallback",
-        )
-        is None
-    )
-
-    iface.close()
+    finally:
+        iface.close()
 
 
 def test_lifecycle_thread_dispatch_helpers_cover_legacy_and_missing(
@@ -427,9 +433,7 @@ def test_lifecycle_state_manager_helper_paths(
         with pytest.raises(AttributeError):
             BLELifecycleService._client_is_connected(bad_client)
     finally:
-        iface._state_manager = importlib.import_module(
-            "meshtastic.interfaces.ble.state"
-        ).BLEStateManager()
+        _reset_state_manager(iface)
         iface.close()
 
 
@@ -653,9 +657,7 @@ def test_lifecycle_shutdown_and_finalize_close_paths(
         )
         BLELifecycleService._finalize_close_state(iface)
     finally:
-        iface._state_manager = importlib.import_module(
-            "meshtastic.interfaces.ble.state"
-        ).BLEStateManager()
+        _reset_state_manager(iface)
         iface.close()
 
 
@@ -754,9 +756,7 @@ def test_receive_service_branch_targets(monkeypatch: pytest.MonkeyPatch) -> None
     assert is_connecting is True
     assert isinstance(publish_pending, bool)
     assert isinstance(is_closing, bool)
-    iface._state_manager = importlib.import_module(
-        "meshtastic.interfaces.ble.state"
-    ).BLEStateManager()
+    _reset_state_manager(iface)
 
     iface.auto_reconnect = True
     with iface._state_lock:
@@ -911,9 +911,7 @@ def test_receive_service_branch_targets(monkeypatch: pytest.MonkeyPatch) -> None
     iface._last_empty_read_warning = 10**9
     BLEReceiveRecoveryService._log_empty_read_warning(iface)
 
-    iface._state_manager = importlib.import_module(
-        "meshtastic.interfaces.ble.state"
-    ).BLEStateManager()
+    _reset_state_manager(iface)
     iface._shutdown_event = threading.Event()
     iface.close()
 
@@ -978,7 +976,7 @@ def test_lifecycle_remaining_error_handler_branch_targets(
             func: Any, *args: object, **kwargs: object
         ) -> object:
             if "error_msg" in kwargs:
-                raise TypeError(
+                raise TypeError(  # noqa: TRY003 - intentional fixture message shape
                     "safe_execute() got an unexpected keyword argument 'error_msg'"
                 )
             if args:
@@ -999,11 +997,11 @@ def test_lifecycle_remaining_error_handler_branch_targets(
             func: Any, *args: object, **kwargs: object
         ) -> object:
             if "error_msg" in kwargs:
-                raise TypeError(
+                raise TypeError(  # noqa: TRY003 - intentional fixture message shape
                     "safe_execute() got an unexpected keyword argument 'error_msg'"
                 )
             if args:
-                raise TypeError(
+                raise TypeError(  # noqa: TRY003 - intentional fixture message shape
                     "takes 1 positional argument but 2 positional arguments were given"
                 )
             raise RuntimeError("hook failed")
@@ -1211,9 +1209,7 @@ def test_lifecycle_remaining_invalidation_and_state_helper_branches(
                 restore_last_connection_request=None,
             )
     finally:
-        iface._state_manager = importlib.import_module(
-            "meshtastic.interfaces.ble.state"
-        ).BLEStateManager()
+        _reset_state_manager(iface)
         iface.close()
 
 
@@ -1330,9 +1326,7 @@ def test_lifecycle_remaining_verify_finalize_and_shutdown_branches(
         iface._disconnected = lambda: None
         BLELifecycleService._shutdown_client(iface, management_wait_timed_out=False)
     finally:
-        iface._state_manager = importlib.import_module(
-            "meshtastic.interfaces.ble.state"
-        ).BLEStateManager()
+        _reset_state_manager(iface)
         iface.close()
 
 
@@ -1389,9 +1383,7 @@ def test_receive_service_remaining_coordinator_and_snapshot_branches(
         assert BLEReceiveRecoveryService._snapshot_client_state(iface)[1] is True
         iface._state_manager = SimpleNamespace(_is_connecting=False)
         assert BLEReceiveRecoveryService._snapshot_client_state(iface)[1] is False
-        iface._state_manager = importlib.import_module(
-            "meshtastic.interfaces.ble.state"
-        ).BLEStateManager()
+        _reset_state_manager(iface)
 
         assert BLEReceiveRecoveryService._process_client_state(
             iface,
@@ -1408,9 +1400,7 @@ def test_receive_service_remaining_coordinator_and_snapshot_branches(
             iface._last_recovery_time = 0.0
         BLEReceiveRecoveryService._reset_recovery_after_stability(iface)
     finally:
-        iface._state_manager = importlib.import_module(
-            "meshtastic.interfaces.ble.state"
-        ).BLEStateManager()
+        _reset_state_manager(iface)
         iface.close()
 
 
@@ -1554,9 +1544,7 @@ def test_receive_service_remaining_recovery_and_empty_read_branches(
     """Receive recovery and empty-read warning paths should hit remaining branches."""
     iface = _make_iface(monkeypatch)
     try:
-        iface._state_manager = importlib.import_module(
-            "meshtastic.interfaces.ble.state"
-        ).BLEStateManager()
+        _reset_state_manager(iface)
         with iface._state_lock:
             iface._closed = True
         BLEReceiveRecoveryService._recover_receive_thread(iface, "reason")
@@ -1585,9 +1573,7 @@ def test_receive_service_remaining_recovery_and_empty_read_branches(
         )
         iface._log_empty_read_warning.assert_called_once()
     finally:
-        iface._state_manager = importlib.import_module(
-            "meshtastic.interfaces.ble.state"
-        ).BLEStateManager()
+        _reset_state_manager(iface)
         iface._shutdown_event = threading.Event()
         iface.close()
 
@@ -1603,7 +1589,7 @@ def test_lifecycle_remaining_error_handler_execute_paths(
             func: Any, *args: object, **kwargs: object
         ) -> object:
             if "error_msg" in kwargs:
-                raise TypeError(
+                raise TypeError(  # noqa: TRY003 - intentional fixture message shape
                     "safe_execute() got an unexpected keyword argument 'error_msg'"
                 )
             if args:
@@ -1627,11 +1613,11 @@ def test_lifecycle_remaining_error_handler_execute_paths(
             func: Any, *args: object, **kwargs: object
         ) -> object:
             if "error_msg" in kwargs:
-                raise TypeError(
+                raise TypeError(  # noqa: TRY003 - intentional fixture message shape
                     "safe_execute() got an unexpected keyword argument 'error_msg'"
                 )
             if args:
-                raise TypeError(
+                raise TypeError(  # noqa: TRY003 - intentional fixture message shape
                     "takes 1 positional argument but 2 positional arguments were given"
                 )
             func()
@@ -1653,7 +1639,7 @@ def test_lifecycle_remaining_error_handler_execute_paths(
             func: Any, *args: object, **kwargs: object
         ) -> object:
             if "error_msg" in kwargs:
-                raise TypeError(
+                raise TypeError(  # noqa: TRY003 - intentional fixture message shape
                     "safe_execute() got an unexpected keyword argument 'error_msg'"
                 )
             if args:
@@ -1674,7 +1660,7 @@ def test_lifecycle_remaining_error_handler_execute_paths(
             func: Any, *args: object, **kwargs: object
         ) -> object:
             if "error_msg" in kwargs:
-                raise TypeError(
+                raise TypeError(  # noqa: TRY003 - intentional fixture message shape
                     "safe_execute() got an unexpected keyword argument 'error_msg'"
                 )
             if args:
@@ -1848,9 +1834,7 @@ def test_receive_remaining_branches(
         iface._state_manager = SimpleNamespace()
         _, is_connecting, _, _ = BLEReceiveRecoveryService._snapshot_client_state(iface)
         assert is_connecting is False
-        iface._state_manager = importlib.import_module(
-            "meshtastic.interfaces.ble.state"
-        ).BLEStateManager()
+        _reset_state_manager(iface)
 
         monkeypatch.setattr(
             BLEReceiveRecoveryService,

--- a/tests/test_ble_lifecycle_receive_targets.py
+++ b/tests/test_ble_lifecycle_receive_targets.py
@@ -1598,6 +1598,7 @@ def test_lifecycle_remaining_error_handler_execute_paths(
     """Cover remaining lifecycle error-handler execute-hook branches."""
     iface = _make_iface(monkeypatch)
     try:
+
         def _hook_non_positional_with_func_run(
             func: Any, *args: object, **kwargs: object
         ) -> object:
@@ -1636,7 +1637,9 @@ def test_lifecycle_remaining_error_handler_execute_paths(
             func()
             raise RuntimeError("post-run failure")
 
-        iface.error_handler = SimpleNamespace(safe_execute=_hook_positional_then_runtime)
+        iface.error_handler = SimpleNamespace(
+            safe_execute=_hook_positional_then_runtime
+        )
         assert (
             BLELifecycleService._error_handler_safe_execute(
                 iface,

--- a/tests/test_ble_lifecycle_receive_targets.py
+++ b/tests/test_ble_lifecycle_receive_targets.py
@@ -6,7 +6,7 @@ import contextlib
 import importlib
 import threading
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Protocol
 from unittest.mock import MagicMock
 
 import pytest
@@ -29,11 +29,15 @@ class _FatalReceiveError(RuntimeError):
     """Used by receive-loop tests."""
 
 
+class _IfaceWithStateManager(Protocol):
+    _state_manager: object
+
+
 def _make_iface(monkeypatch: pytest.MonkeyPatch) -> Any:
     return _build_interface(monkeypatch, DummyClient(), start_receive_thread=False)
 
 
-def _reset_state_manager(iface: Any) -> None:
+def _reset_state_manager(iface: _IfaceWithStateManager) -> None:
     iface._state_manager = importlib.import_module(
         "meshtastic.interfaces.ble.state"
     ).BLEStateManager()

--- a/tests/test_ble_utils_service_targets.py
+++ b/tests/test_ble_utils_service_targets.py
@@ -491,6 +491,51 @@ def test_management_helpers_cover_factory_and_target_edge_paths(
         fresh_iface.close()
 
 
+def test_resolve_management_target_existing_client_explicit_address_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_resolve_management_target should validate explicit existing-client paths and resolver fallback."""
+    iface = _build_interface(monkeypatch, DummyClient(), start_receive_thread=False)
+    try:
+        start_context = SimpleNamespace(
+            target_address=None,
+            use_existing_client_without_resolved_address=True,
+            expected_implicit_binding=None,
+        )
+        iface._validate_management_preconditions = lambda: None
+        iface._get_management_client_if_available = lambda _address: None
+
+        with pytest.raises(iface.BLEError, match="changed"):
+            BLEManagementCommandsService._resolve_management_target(
+                iface, "target-id", start_context
+            )
+
+        refreshed_client = DummyClient()
+        refreshed_client.address = None
+        refreshed_client.bleak_client = SimpleNamespace(address=None)
+        resolved_addresses: list[str | None] = []
+
+        iface._get_management_client_if_available = lambda _address: refreshed_client
+        iface._extract_client_address = lambda _client: None
+
+        def _resolve_target_address(address: str | None) -> str:
+            resolved_addresses.append(address)
+            return "AA:BB:CC:DD:EE:FF"
+
+        iface._resolve_target_address_for_management = _resolve_target_address
+
+        target, active_client = BLEManagementCommandsService._resolve_management_target(
+            iface,
+            "target-id",
+            start_context,
+        )
+        assert target == "AA:BB:CC:DD:EE:FF"
+        assert active_client is refreshed_client
+        assert resolved_addresses == ["target-id"]
+    finally:
+        iface.close()
+
+
 def test_management_execute_with_client_preserves_command_outcome_on_close_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_ble_utils_service_targets.py
+++ b/tests/test_ble_utils_service_targets.py
@@ -438,7 +438,7 @@ def test_management_helpers_cover_factory_and_target_edge_paths(
         if kwargs:
             raise TypeError(
                 "factory() got an unexpected keyword argument 'log_if_no_address'"
-            )
+            )  # noqa: TRY003 - intentional test fixture message shape
         client = DummyClient()
         client.address = address
         return client

--- a/tests/test_ble_utils_service_targets.py
+++ b/tests/test_ble_utils_service_targets.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import importlib
 import contextlib
+import importlib
 from queue import Empty, Full
 from threading import Event, RLock
 from types import SimpleNamespace
@@ -97,7 +97,9 @@ def test_safe_execute_adapter_covers_kwarg_stripping_and_fallback_paths() -> Non
                 )
         return func()
 
-    iface = SimpleNamespace(error_handler=SimpleNamespace(safe_execute=_compat_safe_execute))
+    iface = SimpleNamespace(
+        error_handler=SimpleNamespace(safe_execute=_compat_safe_execute)
+    )
     assert (
         ble_utils._safe_execute_through_adapter(
             iface,
@@ -169,6 +171,7 @@ def test_thread_start_probe_handles_invalid_ident_and_is_alive_errors() -> None:
 
 def test_compatibility_event_service_enqueue_paths() -> None:
     """Callback enqueue helper should cover non-blocking and fallback queue paths."""
+
     def callback() -> None:
         return None
 
@@ -186,7 +189,9 @@ def test_compatibility_event_service_enqueue_paths() -> None:
         is False
     )
 
-    no_put_nowait = SimpleNamespace(queueWork=None, queue=SimpleNamespace(), thread=None)
+    no_put_nowait = SimpleNamespace(
+        queueWork=None, queue=SimpleNamespace(), thread=None
+    )
     assert (
         BLECompatibilityEventService._enqueue_publish_callback(
             no_put_nowait,
@@ -380,10 +385,14 @@ def test_reconnection_error_types_and_hook_resolution() -> None:
         state_manager=BLEStateManager(),
         state_lock=RLock(),
         thread_coordinator=SimpleNamespace(
-            create_thread=lambda **_kwargs: SimpleNamespace(ident=None, is_alive=lambda: False),
+            create_thread=lambda **_kwargs: SimpleNamespace(
+                ident=None, is_alive=lambda: False
+            ),
             start_thread=lambda _thread: None,
         ),
-        interface=SimpleNamespace(_is_connection_closing=False, _can_initiate_connection=True),
+        interface=SimpleNamespace(
+            _is_connection_closing=False, _can_initiate_connection=True
+        ),
     )
     hook = scheduler._resolve_thread_coordinator_hook("create_thread", "_create_thread")
     assert callable(hook)
@@ -399,15 +408,22 @@ def test_reconnection_schedule_thread_not_started_and_policy_missing_method() ->
         state_manager=BLEStateManager(),
         state_lock=RLock(),
         thread_coordinator=SimpleNamespace(
-            create_thread=lambda **_kwargs: SimpleNamespace(ident=None, is_alive=lambda: False),
+            create_thread=lambda **_kwargs: SimpleNamespace(
+                ident=None, is_alive=lambda: False
+            ),
             start_thread=lambda _thread: None,
         ),
-        interface=SimpleNamespace(_is_connection_closing=False, _can_initiate_connection=True),
+        interface=SimpleNamespace(
+            _is_connection_closing=False, _can_initiate_connection=True
+        ),
     )
 
     assert scheduler._schedule_reconnect(True, Event()) is False
 
-    worker = ReconnectWorker(interface=SimpleNamespace(auto_reconnect=True), reconnect_policy=SimpleNamespace())
+    worker = ReconnectWorker(
+        interface=SimpleNamespace(auto_reconnect=True),
+        reconnect_policy=SimpleNamespace(),
+    )
     with pytest.raises(ReconnectPolicyMissingMethodError):
         worker._call_policy("next_attempt")
 
@@ -416,9 +432,12 @@ def test_management_helpers_cover_factory_and_target_edge_paths(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Management helper branches should handle factory fallback and target drift."""
+
     def _reject_kwarg(address: str, **kwargs: object) -> DummyClient:
         if kwargs:
-            raise TypeError("factory() got an unexpected keyword argument 'log_if_no_address'")
+            raise TypeError(
+                "factory() got an unexpected keyword argument 'log_if_no_address'"
+            )
         client = DummyClient()
         client.address = address
         return client
@@ -447,7 +466,9 @@ def test_management_helpers_cover_factory_and_target_edge_paths(
     finally:
         iface.close()
 
-    fresh_iface = _build_interface(monkeypatch, DummyClient(), start_receive_thread=False)
+    fresh_iface = _build_interface(
+        monkeypatch, DummyClient(), start_receive_thread=False
+    )
     try:
         start_context = SimpleNamespace(
             target_address=None,
@@ -495,7 +516,9 @@ def test_management_execute_management_command_existing_client_and_trust_edges(
 ) -> None:
     """Management command and trust helpers should cover missing-target and subprocess branches."""
     iface = _build_interface(monkeypatch, DummyClient(), start_receive_thread=False)
-    bluetooth_iface = _build_interface(monkeypatch, DummyClient(), start_receive_thread=False)
+    bluetooth_iface = _build_interface(
+        monkeypatch, DummyClient(), start_receive_thread=False
+    )
     try:
         start_context = SimpleNamespace(
             expected_implicit_binding=None,
@@ -516,7 +539,9 @@ def test_management_execute_management_command_existing_client_and_trust_edges(
         monkeypatch.setattr(
             BLEManagementCommandsService,
             "_acquire_client_for_target",
-            staticmethod(lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError())),
+            staticmethod(
+                lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError())
+            ),
         )
 
         assert (
@@ -531,7 +556,9 @@ def test_management_execute_management_command_existing_client_and_trust_edges(
         )
 
         bluetooth_iface._format_bluetoothctl_address = lambda address: address
-        bluetooth_iface._management_target_gate = lambda _address: contextlib.nullcontext()
+        bluetooth_iface._management_target_gate = (
+            lambda _address: contextlib.nullcontext()
+        )
 
         class _SubprocessModule:
             TimeoutExpired = RuntimeError
@@ -573,7 +600,9 @@ def test_management_execute_management_command_existing_client_and_trust_edges(
                 None,
                 timeout=1.0,
                 sys_module=SimpleNamespace(platform="linux"),
-                shutil_module=SimpleNamespace(which=lambda _name: "/usr/bin/bluetoothctl"),
+                shutil_module=SimpleNamespace(
+                    which=lambda _name: "/usr/bin/bluetoothctl"
+                ),
                 subprocess_module=_SubprocessModule,
                 trust_hex_blob_re=importlib.import_module(
                     "meshtastic.interfaces.ble.management_service"
@@ -614,7 +643,9 @@ def test_utils_remaining_optional_kwarg_and_safe_execute_branches() -> None:
         )
 
     iface_no_hooks = SimpleNamespace(
-        error_handler=SimpleNamespace(safe_execute=MagicMock(), _safe_execute=MagicMock())
+        error_handler=SimpleNamespace(
+            safe_execute=MagicMock(), _safe_execute=MagicMock()
+        )
     )
     assert ble_utils._resolve_safe_execute(iface_no_hooks) is None
 
@@ -681,7 +712,9 @@ def test_compatibility_resolve_safe_execute_wrapper() -> None:
 
 def test_compatibility_enqueue_returns_false_when_no_enqueue_path() -> None:
     """enqueue_publish_callback should return False when no queue path exists."""
-    publishing_thread = SimpleNamespace(queueWork=None, queue=SimpleNamespace(), thread=None)
+    publishing_thread = SimpleNamespace(
+        queueWork=None, queue=SimpleNamespace(), thread=None
+    )
     assert (
         BLECompatibilityEventService._enqueue_publish_callback(
             publishing_thread,
@@ -718,6 +751,7 @@ def test_compatibility_service_remaining_enqueue_wait_and_drain_branches(
 
     iface = _build_interface(monkeypatch, DummyClient(), start_receive_thread=False)
     try:
+
         class _NeverSetEvent:
             def set(self) -> None:
                 return None
@@ -767,9 +801,13 @@ def test_compatibility_service_remaining_enqueue_wait_and_drain_branches(
             flush_event,
             publishing_thread=SimpleNamespace(
                 thread=SimpleNamespace(
-                    _drain_publish_queue=lambda _event: called_thread_drain.append("thread")
+                    _drain_publish_queue=lambda _event: called_thread_drain.append(
+                        "thread"
+                    )
                 ),
-                queue=SimpleNamespace(get_nowait=lambda: (_ for _ in ()).throw(Empty())),
+                queue=SimpleNamespace(
+                    get_nowait=lambda: (_ for _ in ()).throw(Empty())
+                ),
             ),
         )
         assert called_thread_drain == ["thread"]
@@ -780,7 +818,9 @@ def test_compatibility_service_remaining_enqueue_wait_and_drain_branches(
             publishing_thread=SimpleNamespace(
                 thread=None,
                 queue=SimpleNamespace(
-                    get_nowait=lambda: (_ for _ in ()).throw(RuntimeError("queue read failed"))
+                    get_nowait=lambda: (_ for _ in ()).throw(
+                        RuntimeError("queue read failed")
+                    )
                 ),
             ),
         )
@@ -796,16 +836,23 @@ def test_reconnect_scheduler_start_exception_and_management_trust_truncation(
         state_manager=BLEStateManager(),
         state_lock=RLock(),
         thread_coordinator=SimpleNamespace(
-            create_thread=lambda **_kwargs: SimpleNamespace(ident=1, is_alive=lambda: True),
-            start_thread=lambda _thread: (_ for _ in ()).throw(RuntimeError("start failed")),
+            create_thread=lambda **_kwargs: SimpleNamespace(
+                ident=1, is_alive=lambda: True
+            ),
+            start_thread=lambda _thread: (_ for _ in ()).throw(
+                RuntimeError("start failed")
+            ),
         ),
-        interface=SimpleNamespace(_is_connection_closing=False, _can_initiate_connection=True),
+        interface=SimpleNamespace(
+            _is_connection_closing=False, _can_initiate_connection=True
+        ),
     )
     with pytest.raises(RuntimeError, match="start failed"):
         scheduler._schedule_reconnect(True, Event())
 
     iface = _build_interface(monkeypatch, DummyClient(), start_receive_thread=False)
     try:
+
         class _FailingSubprocess:
             TimeoutExpired = RuntimeError
 

--- a/tests/test_ble_utils_service_targets.py
+++ b/tests/test_ble_utils_service_targets.py
@@ -436,9 +436,9 @@ def test_management_helpers_cover_factory_and_target_edge_paths(
 
     def _reject_kwarg(address: str, **kwargs: object) -> DummyClient:
         if kwargs:
-            raise TypeError(
+            raise TypeError(  # noqa: TRY003 - intentional test fixture message shape
                 "factory() got an unexpected keyword argument 'log_if_no_address'"
-            )  # noqa: TRY003 - intentional test fixture message shape
+            )
         client = DummyClient()
         client.address = address
         return client
@@ -530,7 +530,7 @@ def test_resolve_management_target_existing_client_explicit_address_paths(
             start_context,
         )
         assert target == "AA:BB:CC:DD:EE:FF"
-        assert active_client is refreshed_client
+        assert active_client is None
         assert resolved_addresses == ["target-id"]
     finally:
         iface.close()

--- a/tests/test_ble_utils_service_targets.py
+++ b/tests/test_ble_utils_service_targets.py
@@ -418,7 +418,8 @@ def test_reconnection_schedule_thread_not_started_and_policy_missing_method() ->
         ),
     )
 
-    assert scheduler._schedule_reconnect(True, Event()) is False
+    should_reconnect = True
+    assert scheduler._schedule_reconnect(should_reconnect, Event()) is False
 
     worker = ReconnectWorker(
         interface=SimpleNamespace(auto_reconnect=True),
@@ -847,8 +848,9 @@ def test_reconnect_scheduler_start_exception_and_management_trust_truncation(
             _is_connection_closing=False, _can_initiate_connection=True
         ),
     )
+    should_reconnect = True
     with pytest.raises(RuntimeError, match="start failed"):
-        scheduler._schedule_reconnect(True, Event())
+        scheduler._schedule_reconnect(should_reconnect, Event())
 
     iface = _build_interface(monkeypatch, DummyClient(), start_receive_thread=False)
     try:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR centralizes BLE cleanup and mock-detection logic, tightens management locking and target resolution, improves notification error handling and retry validation, and expands tests and compatibility documentation. Most changes are internal refactors to make edge-case behavior and tests more robust while preserving runtime compatibility via shims and adapter aliases.

## Key Changes

### Features
- New helpers:
  - `_is_mock_instance()` — unified detection of unittest Mock/NonCallableMock instances.
  - `_run_safe_cleanup()` — consolidated best-effort cleanup runner that delegates to an optional safe-cleanup hook and tracks execution.
- Pluggable publishing thread:
  - `BLEInterface._publishing_thread_override` and `_get_publishing_thread()` to allow per-instance override of the publishing thread.
- Unified notification/handler compat support:
  - `_invoke_safe_execute_compat()` to accept multiple `safe_execute` hook signatures.
  - `_report_notification_handler_error()` to route handler errors via configured hooks with best-effort fallback logging.
- Timeout factory change:
  - `_with_timeout` usage updated to accept a (timeout_label, timeout_seconds) factory for richer timeout errors.

### Fixes
- Retry policy validation:
  - `_retry_policy_get_delay` now validates returned delays as finite real numbers (rejects booleans, NaN, ±Inf) and falls back to 0.0, logging invalid results.
- Management and locking:
  - Broadened lock scopes in management flows (`_start_management_phase`, `_resolve_management_target`) to include `_state_lock`, reducing races and ensuring consistent target resolution.
  - Improved logic for preferring/refetching refreshed clients and validating implicit-binding changes.
- Cleanup and race conditions:
  - Centralized cleanup reduces duplicate/missed cleanup tracking and fixes boolean-to-float conversion edge cases and test-time class/method access issues.
- Notification & receive handling:
  - Better routing and reporting of notification-handler errors; safer invocation across legacy and modern `safe_execute` signatures.
  - Minor read/receive adjustments (use of lifecycle helper for ever-connected checks, small logging tweak).

### Refactors
- Replaced inline cleanup and mock-detection logic with the new helpers across connection and lifecycle paths.
- Reworked `_dispatch_public_or_underscore()` to use per-function kwdefaults as sentinels and `_is_mock_instance()` for mock detection.
- Replaced direct module-level `publishingThread` references with instance-resolution via `_get_publishing_thread()`.
- Minor import reorganizations and formatting/documentation improvements across BLE modules (lifecycle, management, receive, interface, connection, discovery, errors).
- Many docstring expansions and clearer notes about suppressed exceptions during shutdown sequences.

### Documentation & Tests
- COMPATIBILITY.md:
  - Expanded and reformatted compatibility tables into a canonical module→symbol mapping (many snake_case entries presented as camelCase canonical names) and added alias mappings (e.g., publish_connection_status_legacy → publish_connection_status).
  - Documents internal adapter aliases and underscore-prefixed mappings for many BLE-related symbols.
- Tests:
  - Large additions and updates to tests to cover new helpers, safe-cleanup behavior, safe_execute compatibility, retry validation, publishing-thread override, management target resolution, and receive/lifecycle scenarios.
  - Test scaffolding changes, including converting `_make_orchestrator()` into a context manager and adding targeted unit tests for mock import fallback and cleanup behavior.

## Breaking changes / Migration notes

- No intended behavioral breaking changes; runtime compatibility is preserved via documented shims and adapter aliases. However:
  - COMPATIBILITY.md lists canonical names (many snake_case → camelCase and some public → underscore-prefixed internal mappings). Callers or integrations that inspect or import specific symbols by name should verify they reference the canonical names or rely on the compatibility aliases documented in COMPATIBILITY.md.
  - Tests or tooling that depended on previously public symbol names by exact name may need to update to the canonical names or use the compatibility aliases described in the updated documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->