### PR TITLE
Move packet snapshot after correlation and callbacks

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -75,16 +75,16 @@ lint:
           batch: true
           stdin: false
   enabled:
-    - actionlint@1.7.11
-    - black@26.3.0
-    - checkov@3.2.508
+    - actionlint@1.7.12
+    - black@26.3.1
+    - checkov@3.2.513
     - git-diff-check
-    - gitleaks@8.30.0
+    - gitleaks@8.30.1
     - isort@8.0.1
     - markdownlint@0.48.0
-    - osv-scanner@2.3.3
+    - osv-scanner@2.3.5
     - prettier@3.8.1
-    - ruff@0.15.5
+    - ruff@0.15.8
     - shellcheck@0.11.0
     - shfmt@3.6.0
     - taplo@0.10.0

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -898,9 +898,7 @@ def onConnected(interface: MeshInterface) -> None:
             print(f"Triggering OTA update on {interface.hostname}...")
             interface.getNode(
                 ota_dest, requestChannels=False, **getNode_kwargs
-            ).startOTA(
-                mode=admin_pb2.OTAMode.OTA_WIFI, ota_file_hash=ota.hash_bytes()
-            )
+            ).startOTA(mode=admin_pb2.OTAMode.OTA_WIFI, ota_file_hash=ota.hash_bytes())
 
             print("Waiting for device to reboot into OTA mode...")
             time.sleep(OTA_REBOOT_WAIT_SECONDS)

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -2383,9 +2383,9 @@ class MeshInterface:  # pylint: disable=R0902
         self._enrich_packet_identity(packet_context.packet_dict)
         self._classify_packet_runtime(packet_context, meshPacket)
         self._apply_packet_runtime_mutations(packet_context, meshPacket)
-        published_packet = copy.deepcopy(packet_context.packet_dict)
         self._invoke_packet_on_receive(packet_context)
         self._correlate_packet_response_handler(packet_context)
+        published_packet = copy.deepcopy(packet_context.packet_dict)
 
         publication_intents = [
             self._publication_intent(

--- a/meshtastic/tests/test_api_baseline_comparison.py
+++ b/meshtastic/tests/test_api_baseline_comparison.py
@@ -78,8 +78,8 @@ def _is_breaking_signature_change_for_baseline(
         project_root = Path(__file__).resolve().parents[2]
         sys.path.insert(0, str(project_root / "bin"))
         try:
-            from compare_api_surfaces import (
-                _is_breaking_signature_change,  # type: ignore[import-not-found]; pylint: disable=import-error,import-outside-toplevel
+            from compare_api_surfaces import (  # type: ignore[import-not-found]  # pylint: disable=import-error,import-outside-toplevel
+                _is_breaking_signature_change,
             )
         finally:
             sys.path.pop(0)

--- a/meshtastic/tests/test_api_baseline_comparison.py
+++ b/meshtastic/tests/test_api_baseline_comparison.py
@@ -78,8 +78,8 @@ def _is_breaking_signature_change_for_baseline(
         project_root = Path(__file__).resolve().parents[2]
         sys.path.insert(0, str(project_root / "bin"))
         try:
-            from compare_api_surfaces import (  # type: ignore[import-not-found]
-                _is_breaking_signature_change,  # pylint: disable=import-error,import-outside-toplevel
+            from compare_api_surfaces import (
+                _is_breaking_signature_change,  # type: ignore[import-not-found]; pylint: disable=import-error,import-outside-toplevel
             )
         finally:
             sys.path.pop(0)

--- a/meshtastic/tests/test_ble_lifecycle.py
+++ b/meshtastic/tests/test_ble_lifecycle.py
@@ -988,7 +988,9 @@ class TestLifecycleErrorAccess:
     ) -> None:
         """Test _try_safe_execute_variants with error_msg as keyword."""
 
-        def safe_exec(func: Callable[[], Any], *, error_msg: str) -> Any:  # noqa: ARG001
+        def safe_exec(
+            func: Callable[[], Any], *, error_msg: str
+        ) -> Any:  # noqa: ARG001
             return func()
 
         def tracked() -> str:

--- a/meshtastic/tests/test_main_specific_lines.py
+++ b/meshtastic/tests/test_main_specific_lines.py
@@ -443,9 +443,7 @@ def test_set_canned_message_module_unavailable(
             pass  # Expected, but not required for the test
         _out, _err = capsys.readouterr()
         # Check if skip message was printed
-        assert (
-            "canned message" in _out.lower() or "excluded" in _out.lower()
-        )  # noqa
+        assert "canned message" in _out.lower() or "excluded" in _out.lower()  # noqa
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -400,6 +400,33 @@ def test_handlePacketFromRadio_with_a_portnum(caplog: pytest.LogCaptureFixture) 
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+def test_handlePacketFromRadio_text_packet_includes_decoded_text() -> None:
+    """Published TEXT_MESSAGE_APP packets should include decoded.text after onReceive mutation."""
+    with MeshInterface(noProto=True) as iface:
+        sender = 0x13277429
+        iface.nodesByNum = {
+            sender: {"user": {"id": "!13277429"}},
+        }
+        mesh_packet = mesh_pb2.MeshPacket()
+        setattr(mesh_packet, "from", sender)
+        mesh_packet.to = 0xFFFFFFFF
+        mesh_packet.decoded.portnum = portnums_pb2.PortNum.TEXT_MESSAGE_APP
+        mesh_packet.decoded.payload = b"Range test"
+
+        intents = iface._handle_packet_from_radio(
+            mesh_packet,
+            emit_publication=False,
+        )
+
+    assert len(intents) == 1
+    published_decoded = intents[0].payload["packet"]["decoded"]
+    assert published_decoded["portnum"] == "TEXT_MESSAGE_APP"
+    assert published_decoded["payload"] == b"Range test"
+    assert published_decoded["text"] == "Range test"
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
 def test_handlePacketFromRadio_no_portnum(caplog: pytest.LogCaptureFixture) -> None:
     """Verify that _handle_packet_from_radio logs a warning about unknown portnum when a MeshPacket has no portnum."""
     with MeshInterface(noProto=True) as iface:

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -1103,9 +1103,7 @@ def test_start_ota_remote_node_raises_error() -> None:
     with pytest.raises(
         MeshInterface.MeshInterfaceError, match="startOTA only possible on local node"
     ):
-        remote_node.startOTA(
-            mode=admin_pb2.OTAMode.OTA_WIFI, ota_file_hash=test_hash
-        )
+        remote_node.startOTA(mode=admin_pb2.OTAMode.OTA_WIFI, ota_file_hash=test_hash)
 
 
 @pytest.mark.unit


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR adjusts the timing of the `published_packet` deep-copy in packet handling to ensure that mutations applied during the `onReceive` callback (such as decoded text field population) are included in the published payload sent to listeners.

## Changes
**Fixes:**
- Moved the `published_packet` deep-copy operation in `_handle_packet_from_radio()` to occur after `_correlate_packet_response_handler()` rather than before it, ensuring the packet snapshot used for publication captures any state changes made during correlation and receive callbacks

**Tests:**
- Added `test_handlePacketFromRadio_text_packet_includes_decoded_text` to verify that TEXT_MESSAGE_APP packets include the decoded text field after onReceive processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->