### PR TITLE
Improve BLE disconnect operations and queue status tracking

### DIFF
--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -682,11 +682,40 @@ class ClientManager:
             and not getattr(client, "_closed", False)
             and getattr(client, "bleak_client", None)
         ):
-            _run_safe_cleanup(
-                lambda: client.disconnect(await_timeout=DISCONNECT_TIMEOUT_SECONDS),
-                "client disconnect",
-                safe_cleanup_hook,
-            )
+            is_connected = False
+            for probe_name in ("is_connected", "isConnected", "_is_connected"):
+                is_connected_probe = getattr(client, probe_name, None)
+                if callable(is_connected_probe) and not _is_unconfigured_mock_callable(
+                    is_connected_probe
+                ):
+                    try:
+                        is_connected = bool(is_connected_probe())
+                    except (
+                        Exception
+                    ):  # noqa: BLE001 - shutdown must remain best effort
+                        logger.debug(
+                            "Failed to read BLE client connected state via %s during shutdown.",
+                            probe_name,
+                            exc_info=True,
+                        )
+                    if is_connected:
+                        break
+                elif isinstance(is_connected_probe, bool) and not _is_unconfigured_mock_member(
+                    is_connected_probe
+                ):
+                    is_connected = is_connected_probe
+                    if is_connected:
+                        break
+            if is_connected:
+                _run_safe_cleanup(
+                    lambda: client.disconnect(await_timeout=DISCONNECT_TIMEOUT_SECONDS),
+                    "client disconnect",
+                    safe_cleanup_hook,
+                )
+            else:
+                logger.debug(
+                    "Skipping BLE client disconnect during shutdown: client is not connected."
+                )
         elif skip_disconnect:
             logger.debug(
                 "Skipping BLE client disconnect during interpreter finalization."

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -3162,6 +3162,8 @@ class BLEInterface(MeshInterface):
             _sleep(BLEConfig.SEND_PROPAGATION_DELAY)
             self._set_thread_event(READ_TRIGGER_EVENT)
 
+    # COMPAT_STABLE_SHIM: historical public BLEInterface API alias.
+    # Keep callable without deprecation warning.
     def disconnect(self) -> None:
         """Compatibility alias for callers that expect an explicit disconnect API."""
         self.close()

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -951,9 +951,7 @@ class BLEInterface(MeshInterface):
             except (BleakError, RuntimeError) as e:
                 logger.warning("Device scan failed: %s", e, exc_info=True)
                 return []
-            except (
-                Exception
-            ) as e:  # noqa: BLE001 # pragma: no cover - defensive last resort
+            except Exception as e:  # noqa: BLE001 # pragma: no cover - defensive last resort
                 logger.warning(
                     "Unexpected error during device scan: %s", e, exc_info=True
                 )
@@ -2415,17 +2413,13 @@ class BLEInterface(MeshInterface):
                 or _is_unconfigured_mock_member(notification_dispatcher)
             ):
                 return
-            with contextlib.suppress(
-                Exception
-            ):  # noqa: BLE001 - rollback cleanup is best effort
+            with contextlib.suppress(Exception):  # noqa: BLE001 - rollback cleanup is best effort
                 notification_dispatcher._registered_notification_session_epoch = (
                     notification_session_snapshot[
                         "_registered_notification_session_epoch"
                     ]
                 )
-            with contextlib.suppress(
-                Exception
-            ):  # noqa: BLE001 - rollback cleanup is best effort
+            with contextlib.suppress(Exception):  # noqa: BLE001 - rollback cleanup is best effort
                 started_notify_snapshot = _copy_started_notify_snapshot(
                     notification_session_snapshot["_started_notify_characteristics"]
                 )
@@ -2433,39 +2427,27 @@ class BLEInterface(MeshInterface):
                     notification_dispatcher._started_notify_characteristics = (
                         started_notify_snapshot
                     )
-            with contextlib.suppress(
-                Exception
-            ):  # noqa: BLE001 - rollback cleanup is best effort
+            with contextlib.suppress(Exception):  # noqa: BLE001 - rollback cleanup is best effort
                 notification_dispatcher.fromnum_notify_enabled = (
                     notification_session_snapshot["fromnum_notify_enabled"]
                 )
-            with contextlib.suppress(
-                Exception
-            ):  # noqa: BLE001 - rollback cleanup is best effort
+            with contextlib.suppress(Exception):  # noqa: BLE001 - rollback cleanup is best effort
                 notification_dispatcher.malformed_notification_count = (
                     notification_session_snapshot["malformed_notification_count"]
                 )
-            with contextlib.suppress(
-                Exception
-            ):  # noqa: BLE001 - rollback cleanup is best effort
+            with contextlib.suppress(Exception):  # noqa: BLE001 - rollback cleanup is best effort
                 notification_dispatcher._current_legacy_log_handler = (
                     notification_session_snapshot["_current_legacy_log_handler"]
                 )
-            with contextlib.suppress(
-                Exception
-            ):  # noqa: BLE001 - rollback cleanup is best effort
+            with contextlib.suppress(Exception):  # noqa: BLE001 - rollback cleanup is best effort
                 notification_dispatcher._current_log_handler = (
                     notification_session_snapshot["_current_log_handler"]
                 )
-            with contextlib.suppress(
-                Exception
-            ):  # noqa: BLE001 - rollback cleanup is best effort
+            with contextlib.suppress(Exception):  # noqa: BLE001 - rollback cleanup is best effort
                 notification_dispatcher._current_from_num_handler = (
                     notification_session_snapshot["_current_from_num_handler"]
                 )
-            with contextlib.suppress(
-                Exception
-            ):  # noqa: BLE001 - rollback cleanup is best effort
+            with contextlib.suppress(Exception):  # noqa: BLE001 - rollback cleanup is best effort
                 notification_manager = notification_dispatcher._notification_manager
                 manager_lock = getattr(notification_manager, "_lock", None)
                 active_subscriptions_snapshot = notification_session_snapshot[
@@ -3179,6 +3161,10 @@ class BLEInterface(MeshInterface):
             # Brief delay to allow write to propagate before triggering read
             _sleep(BLEConfig.SEND_PROPAGATION_DELAY)
             self._set_thread_event(READ_TRIGGER_EVENT)
+
+    def disconnect(self) -> None:
+        """Compatibility alias for callers that expect an explicit disconnect API."""
+        self.close()
 
     def close(self) -> None:
         """Shut down the BLE interface and release associated resources."""

--- a/meshtastic/interfaces/ble/receive_service.py
+++ b/meshtastic/interfaces/ble/receive_service.py
@@ -1128,6 +1128,7 @@ class BLEReceiveRecoveryController:
             return
         now = time.monotonic()
         cooldown = BLEConfig.EMPTY_READ_WARNING_COOLDOWN
+        notify_enabled = bool(getattr(iface, "_fromnum_notify_enabled", False))
         if now - iface._last_empty_read_warning >= cooldown:
             suppressed = iface._suppressed_empty_read_warnings
             message = f"Exceeded max retries for empty BLE read from {FROMRADIO_UUID}"
@@ -1136,7 +1137,13 @@ class BLEReceiveRecoveryController:
                     f"{message} (suppressed {suppressed} repeats in the last "
                     f"{cooldown:.0f}s)"
                 )
-            logger.warning(message)
+            if notify_enabled:
+                logger.warning(message)
+            else:
+                logger.debug(
+                    "%s (polling mode without FROMNUM notifications)",
+                    message,
+                )
             iface._last_empty_read_warning = now
             iface._suppressed_empty_read_warnings = 0
             return

--- a/meshtastic/interfaces/ble/receive_service.py
+++ b/meshtastic/interfaces/ble/receive_service.py
@@ -236,9 +236,7 @@ class BLEReceiveRecoveryController:
                     result = raw_is_closing()
                     if isinstance(result, bool):
                         state_is_closing = result
-                except (
-                    Exception
-                ):  # noqa: BLE001 - closing probe must remain best effort
+                except Exception:  # noqa: BLE001 - closing probe must remain best effort
                     state_is_closing = None
             elif not _is_unconfigured_mock_member(raw_is_closing) and isinstance(
                 raw_is_closing, bool
@@ -716,9 +714,7 @@ class BLEReceiveRecoveryController:
             ):
                 try:
                     connecting_result = state_is_connecting()
-                except (
-                    Exception
-                ):  # noqa: BLE001 - snapshot probe must remain best effort
+                except Exception:  # noqa: BLE001 - snapshot probe must remain best effort
                     logger.debug(
                         "Error probing state manager is_connecting()",
                         exc_info=True,
@@ -743,9 +739,7 @@ class BLEReceiveRecoveryController:
                 ) and not _is_unconfigured_mock_callable(legacy_is_connecting):
                     try:
                         connecting_result = legacy_is_connecting()
-                    except (
-                        Exception
-                    ):  # noqa: BLE001 - snapshot probe must remain best effort
+                    except Exception:  # noqa: BLE001 - snapshot probe must remain best effort
                         logger.debug(
                             "Error probing state manager _is_connecting()",
                             exc_info=True,
@@ -1128,7 +1122,12 @@ class BLEReceiveRecoveryController:
             return
         now = time.monotonic()
         cooldown = BLEConfig.EMPTY_READ_WARNING_COOLDOWN
-        notify_enabled = bool(getattr(iface, "_fromnum_notify_enabled", False))
+        raw_notify_enabled: object = getattr(iface, "_fromnum_notify_enabled", False)
+        notify_enabled = (
+            False
+            if _is_unconfigured_mock_member(raw_notify_enabled)
+            else bool(raw_notify_enabled)
+        )
         if now - iface._last_empty_read_warning >= cooldown:
             suppressed = iface._suppressed_empty_read_warnings
             message = f"Exceeded max retries for empty BLE read from {FROMRADIO_UUID}"

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -108,9 +108,7 @@ NODE_NOT_FOUND_DB_UNAVAILABLE_ERROR_TEMPLATE = (
     "NodeId {destination_id} not found and node DB is unavailable"
 )
 HEX_NODE_ID_TAIL_CHARS = frozenset("0123456789abcdefABCDEF")
-NO_RESPONSE_FIRMWARE_ERROR: str = (
-    "No response from node. At least firmware 2.1.22 is required on the destination node."
-)
+NO_RESPONSE_FIRMWARE_ERROR: str = "No response from node. At least firmware 2.1.22 is required on the destination node."
 
 JSONValue: TypeAlias = (
     None | bool | int | float | str | list["JSONValue"] | dict[str, "JSONValue"]
@@ -431,6 +429,10 @@ class _QueueSendRuntime:
         """Apply queue status updates and queue reply correlation."""
         self.record_queue_status(queue_status)
         if queue_status.res:
+            packet_id = queue_status.mesh_packet_id
+            if packet_id != 0:
+                with self._lock:
+                    self._awaiting_queue_status_ids.discard(packet_id)
             return
         self.correlate_queue_status_reply(queue_status)
 
@@ -550,9 +552,9 @@ class MeshInterface:  # pylint: disable=R0902
         # _handle_packet_from_radio (receive thread). Use this lock to serialize
         # responseHandlers access across those call sites.
         self._response_handlers_lock = threading.RLock()
-        self.responseHandlers: dict[int, ResponseHandler] = (
-            {}
-        )  # A map from request ID to the handler
+        self.responseHandlers: dict[
+            int, ResponseHandler
+        ] = {}  # A map from request ID to the handler
         self._response_wait_errors: dict[tuple[str, int], str] = {}
         self._response_wait_acks: set[tuple[str, int]] = set()
         self._active_wait_request_ids: dict[str, set[int]] = {}
@@ -1693,8 +1695,7 @@ class MeshInterface:  # pylint: disable=R0902
                 next_packet_id & PACKET_ID_COUNTER_MASK
             )  # Keep only low 10-bit counter (clear upper 22 bits)
             random_part = (
-                random.randint(0, PACKET_ID_RANDOM_MAX)
-                << PACKET_ID_RANDOM_SHIFT_BITS  # noqa: S311
+                random.randint(0, PACKET_ID_RANDOM_MAX) << PACKET_ID_RANDOM_SHIFT_BITS  # noqa: S311
             ) & PACKET_ID_MASK  # generate number with 10 zeros at end
             self.currentPacketId = next_packet_id | random_part  # combine
             return self.currentPacketId
@@ -1812,9 +1813,7 @@ class MeshInterface:  # pylint: disable=R0902
             self.myInfo = None
             self.nodes = {}  # nodes keyed by ID
             self.nodesByNum = {}  # nodes keyed by nodenum
-            self._localChannels = (
-                []
-            )  # empty until we start getting channels pushed from the device (during config)
+            self._localChannels = []  # empty until we start getting channels pushed from the device (during config)
             config_id = self.configId
             if config_id is None or not self.noNodes:
                 # Keep config_complete_id zero reserved as an unset sentinel.
@@ -2546,9 +2545,9 @@ class MeshInterface:  # pylint: disable=R0902
                 DECODE_ERROR_KEY: decode_error
             }
             if handler.name == "routing":
-                packet_context.packet_dict["decoded"][handler.name][
-                    "errorReason"
-                ] = decode_error
+                packet_context.packet_dict["decoded"][handler.name]["errorReason"] = (
+                    decode_error
+                )
             if handler.name == "admin":
                 # Admin callbacks frequently expect decoded.admin.raw.
                 # Avoid dispatching malformed payloads through that path.

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -252,6 +252,7 @@ class _QueueSendRuntime:
         self._get_queue_status = get_queue_status
         self._set_queue_status = set_queue_status
         self._queue_wait_delay_seconds = queue_wait_delay_seconds
+        self._awaiting_queue_status_ids: set[int] = set()
 
     def has_free_space(self) -> bool:
         """Return whether queue status indicates free TX slots."""
@@ -356,6 +357,8 @@ class _QueueSendRuntime:
                 # Packet send succeeded and there is no explicit queue-status ack
                 # marker yet. Keep it out of immediate resend rotation to avoid
                 # duplicate floods while queue-status correlation catches up.
+                with self._lock:
+                    self._awaiting_queue_status_ids.add(packet_id)
                 logger.debug(
                     "packet %08x sent and awaiting queue-status correlation",
                     packet_id,
@@ -394,22 +397,32 @@ class _QueueSendRuntime:
 
     def correlate_queue_status_reply(self, queue_status: mesh_pb2.QueueStatus) -> None:
         """Correlate queue status mesh_packet_id replies to pending entries."""
+        packet_id = queue_status.mesh_packet_id
         debug_enabled = logger.isEnabledFor(logging.DEBUG)
         with self._lock:
             queue = self._get_queue()
             queue_snapshot = tuple(queue.keys()) if debug_enabled else ()
-            just_queued = queue.pop(queue_status.mesh_packet_id, None)
+            just_queued = queue.pop(packet_id, None)
+            was_awaiting = packet_id in self._awaiting_queue_status_ids
+            if packet_id != 0:
+                self._awaiting_queue_status_ids.discard(packet_id)
         if debug_enabled:
             logger.debug(
                 "queue: %s",
                 " ".join(f"{key:08x}" for key in queue_snapshot),
             )
-        if just_queued is None and queue_status.mesh_packet_id != 0:
+        if just_queued is None and packet_id != 0:
+            if was_awaiting:
+                logger.debug(
+                    "Correlated queue-status reply for packet awaiting correlation %08x",
+                    packet_id,
+                )
+                return
             with self._lock:
-                self._get_queue()[queue_status.mesh_packet_id] = False
+                self._get_queue()[packet_id] = False
             logger.debug(
                 "Reply for unexpected packet ID %08x",
-                queue_status.mesh_packet_id,
+                packet_id,
             )
 
     def handle_queue_status_from_radio(

--- a/meshtastic/tests/test_ble_compat_services_coverage.py
+++ b/meshtastic/tests/test_ble_compat_services_coverage.py
@@ -10,6 +10,7 @@ Covers management_compat_service.py and receive_compat_service.py with focus on:
 
 from __future__ import annotations
 
+import logging
 import re
 from collections.abc import Callable
 from typing import Any
@@ -885,6 +886,51 @@ class TestBLEReceiveRecoveryServiceOperations:
         # Should not raise
         BLEReceiveRecoveryService._log_empty_read_warning(iface)
         controller.log_empty_read_warning.assert_called_once()
+
+
+class TestBLEReceiveRecoveryControllerEmptyReadWarnings:
+    """Test empty-read warning behavior for polling and notify-driven modes."""
+
+    class _Iface:
+        def __init__(self, *, fromnum_notify_enabled: bool) -> None:
+            self._fromnum_notify_enabled = fromnum_notify_enabled
+            self._last_empty_read_warning = 0.0
+            self._suppressed_empty_read_warnings = 0
+
+    def test_log_empty_read_warning_uses_debug_in_polling_mode(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Polling mode without FROMNUM notifications should avoid warning-level noise."""
+        iface = self._Iface(fromnum_notify_enabled=False)
+        controller = BLEReceiveRecoveryController(iface)
+
+        with patch(
+            "meshtastic.interfaces.ble.receive_service.time.monotonic",
+            return_value=100.0,
+        ):
+            with caplog.at_level(logging.DEBUG):
+                controller.log_empty_read_warning()
+
+        assert "Exceeded max retries for empty BLE read" in caplog.text
+        assert "polling mode without FROMNUM notifications" in caplog.text
+        assert not any(record.levelno >= logging.WARNING for record in caplog.records)
+
+    def test_log_empty_read_warning_uses_warning_with_fromnum_notify(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When FROMNUM notifications are enabled, empty-read exhaustion remains warning-level."""
+        iface = self._Iface(fromnum_notify_enabled=True)
+        controller = BLEReceiveRecoveryController(iface)
+
+        with patch(
+            "meshtastic.interfaces.ble.receive_service.time.monotonic",
+            return_value=100.0,
+        ):
+            with caplog.at_level(logging.WARNING):
+                controller.log_empty_read_warning()
+
+        assert "Exceeded max retries for empty BLE read" in caplog.text
+        assert any(record.levelno == logging.WARNING for record in caplog.records)
 
 
 class TestBLEReceiveRecoveryServiceCoordinatorOperations:

--- a/meshtastic/tests/test_ble_compat_services_coverage.py
+++ b/meshtastic/tests/test_ble_compat_services_coverage.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock, Mock, NonCallableMock, patch
 
 import pytest
@@ -902,7 +902,7 @@ class TestBLEReceiveRecoveryControllerEmptyReadWarnings:
     ) -> None:
         """Polling mode without FROMNUM notifications should avoid warning-level noise."""
         iface = self._Iface(fromnum_notify_enabled=False)
-        controller = BLEReceiveRecoveryController(iface)
+        controller = BLEReceiveRecoveryController(cast(Any, iface))
 
         with patch(
             "meshtastic.interfaces.ble.receive_service.time.monotonic",
@@ -920,7 +920,7 @@ class TestBLEReceiveRecoveryControllerEmptyReadWarnings:
     ) -> None:
         """When FROMNUM notifications are enabled, empty-read exhaustion remains warning-level."""
         iface = self._Iface(fromnum_notify_enabled=True)
-        controller = BLEReceiveRecoveryController(iface)
+        controller = BLEReceiveRecoveryController(cast(Any, iface))
 
         with patch(
             "meshtastic.interfaces.ble.receive_service.time.monotonic",

--- a/meshtastic/tests/test_ble_connection_runtime.py
+++ b/meshtastic/tests/test_ble_connection_runtime.py
@@ -1,0 +1,77 @@
+"""Targeted runtime tests for BLE connection shutdown behavior."""
+
+from __future__ import annotations
+
+from threading import Event, RLock
+from unittest.mock import MagicMock
+
+import pytest
+
+from meshtastic.interfaces.ble.connection import ClientManager
+
+pytestmark = pytest.mark.unit
+
+
+class _ErrorHandler:
+    """Minimal error handler compatible with ClientManager cleanup hooks."""
+
+    def safe_cleanup(self, func, cleanup_name=None):  # type: ignore[no-untyped-def]
+        func()
+        return True
+
+
+class _DummyClient:
+    """Minimal BLE client double for shutdown behavior tests."""
+
+    def __init__(self, *, connected: bool) -> None:
+        self._closed = False
+        self._connected = connected
+        self.bleak_client = object()
+        self.disconnect_calls = 0
+        self.close_calls = 0
+        self.last_disconnect_timeout: float | None = None
+
+    def is_connected(self) -> bool:
+        return self._connected
+
+    def disconnect(self, *, await_timeout: float) -> None:
+        self.disconnect_calls += 1
+        self.last_disconnect_timeout = await_timeout
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+def _make_client_manager() -> ClientManager:
+    return ClientManager(
+        state_manager=MagicMock(),
+        state_lock=RLock(),
+        thread_coordinator=MagicMock(),
+        error_handler=_ErrorHandler(),
+    )
+
+
+def test_safe_close_client_skips_disconnect_for_disconnected_client() -> None:
+    """Disconnected clients should not trigger an unnecessary disconnect timeout path."""
+    manager = _make_client_manager()
+    client = _DummyClient(connected=False)
+    done = Event()
+
+    manager._safe_close_client(client, event=done)
+
+    assert done.is_set()
+    assert client.disconnect_calls == 0
+    assert client.close_calls == 1
+
+
+def test_safe_close_client_disconnects_connected_client_before_close() -> None:
+    """Connected clients should still run bounded disconnect before close."""
+    manager = _make_client_manager()
+    client = _DummyClient(connected=True)
+    done = Event()
+
+    manager._safe_close_client(client, event=done)
+
+    assert done.is_set()
+    assert client.disconnect_calls == 1
+    assert client.close_calls == 1

--- a/meshtastic/tests/test_ble_connection_runtime.py
+++ b/meshtastic/tests/test_ble_connection_runtime.py
@@ -10,6 +10,7 @@ import pytest
 
 from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.connection import ClientManager
+from meshtastic.interfaces.ble.constants import DISCONNECT_TIMEOUT_SECONDS
 from meshtastic.interfaces.ble.errors import BLEErrorHandler
 
 pytestmark = pytest.mark.unit
@@ -77,4 +78,5 @@ def test_safe_close_client_disconnects_connected_client_before_close() -> None:
 
     assert done.is_set()
     assert client.disconnect_calls == 1
+    assert client.last_disconnect_timeout == DISCONNECT_TIMEOUT_SECONDS
     assert client.close_calls == 1

--- a/meshtastic/tests/test_ble_connection_runtime.py
+++ b/meshtastic/tests/test_ble_connection_runtime.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 from threading import Event, RLock
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
 
+from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.connection import ClientManager
+from meshtastic.interfaces.ble.errors import BLEErrorHandler
 
 pytestmark = pytest.mark.unit
 
@@ -47,7 +50,7 @@ def _make_client_manager() -> ClientManager:
         state_manager=MagicMock(),
         state_lock=RLock(),
         thread_coordinator=MagicMock(),
-        error_handler=_ErrorHandler(),
+        error_handler=cast(BLEErrorHandler, _ErrorHandler()),
     )
 
 
@@ -57,7 +60,7 @@ def test_safe_close_client_skips_disconnect_for_disconnected_client() -> None:
     client = _DummyClient(connected=False)
     done = Event()
 
-    manager._safe_close_client(client, event=done)
+    manager._safe_close_client(cast(BLEClient, client), event=done)
 
     assert done.is_set()
     assert client.disconnect_calls == 0
@@ -70,7 +73,7 @@ def test_safe_close_client_disconnects_connected_client_before_close() -> None:
     client = _DummyClient(connected=True)
     done = Event()
 
-    manager._safe_close_client(client, event=done)
+    manager._safe_close_client(cast(BLEClient, client), event=done)
 
     assert done.is_set()
     assert client.disconnect_calls == 1

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -3746,6 +3746,32 @@ def test_handle_config_complete_and_queue_status_branches() -> None:
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+def test_handle_queue_status_awaiting_correlation_not_marked_unexpected(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Queue status for recently sent packets should not be logged as unexpected replies."""
+    with MeshInterface(noProto=True) as iface:
+        packet_id = 0x01020304
+        packet = mesh_pb2.ToRadio()
+        packet.packet.id = packet_id
+        resent_queue = OrderedDict([(packet_id, packet)])
+        iface._queue_send_runtime.reconcile_resent_queue(
+            resent_queue=resent_queue,
+            sent_packet_ids={packet_id},
+        )
+
+        with caplog.at_level(logging.DEBUG):
+            iface._handle_queue_status_from_radio(
+                mesh_pb2.QueueStatus(free=3, maxlen=4, res=0, mesh_packet_id=packet_id)
+            )
+
+    assert packet_id not in iface.queue
+    assert "Reply for unexpected packet ID" not in caplog.text
+    assert "Correlated queue-status reply for packet awaiting correlation" in caplog.text
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
 def test_handle_from_radio_branch_matrix(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -3754,7 +3754,9 @@ def test_handle_queue_status_awaiting_correlation_not_marked_unexpected(
         packet_id = 0x01020304
         packet = mesh_pb2.ToRadio()
         packet.packet.id = packet_id
-        resent_queue = OrderedDict([(packet_id, packet)])
+        resent_queue: OrderedDict[int, mesh_pb2.ToRadio | bool] = OrderedDict(
+            [(packet_id, packet)]
+        )
         iface._queue_send_runtime.reconcile_resent_queue(
             resent_queue=resent_queue,
             sent_packet_ids={packet_id},
@@ -3767,7 +3769,9 @@ def test_handle_queue_status_awaiting_correlation_not_marked_unexpected(
 
     assert packet_id not in iface.queue
     assert "Reply for unexpected packet ID" not in caplog.text
-    assert "Correlated queue-status reply for packet awaiting correlation" in caplog.text
+    assert (
+        "Correlated queue-status reply for packet awaiting correlation" in caplog.text
+    )
 
 
 @pytest.mark.unit

--- a/tests/test_ble_connection_edge_cases.py
+++ b/tests/test_ble_connection_edge_cases.py
@@ -40,9 +40,9 @@ def _refresh_connection_symbols() -> None:
     globals()["ClientManager"] = connection_module.ClientManager
     globals()["ConnectionOrchestrator"] = connection_module.ConnectionOrchestrator
     globals()["ConnectionValidator"] = connection_module.ConnectionValidator
-    globals()[
-        "_is_device_not_found_error"
-    ] = connection_module._is_device_not_found_error
+    globals()["_is_device_not_found_error"] = (
+        connection_module._is_device_not_found_error
+    )
 
 
 class MockBLEError(Exception):
@@ -458,6 +458,7 @@ def test_client_manager_safe_close_client_prefers_public_safe_cleanup() -> None:
     mock_client = MagicMock()
     mock_client._closed = False
     mock_client.bleak_client = object()
+    mock_client.is_connected.return_value = True
 
     manager._safe_close_client(mock_client)
 

--- a/tests/test_ble_interface_disconnect_alias.py
+++ b/tests/test_ble_interface_disconnect_alias.py
@@ -1,0 +1,22 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from meshtastic.interfaces.ble.interface import BLEInterface
+
+
+def test_disconnect_delegates_to_close() -> None:
+    iface = object.__new__(BLEInterface)
+    iface.close = MagicMock()
+
+    BLEInterface.disconnect(iface)
+
+    iface.close.assert_called_once_with()
+
+
+def test_disconnect_propagates_close_errors() -> None:
+    iface = object.__new__(BLEInterface)
+    iface.close = MagicMock(side_effect=RuntimeError("close failed"))
+
+    with pytest.raises(RuntimeError, match="close failed"):
+        BLEInterface.disconnect(iface)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR stabilizes BLE shutdown and lifecycle behavior, tightens mesh queue-status correlation to avoid spurious warnings, and simplifies some exception/cleanup patterns. It also adds a BLE disconnect compatibility alias and expands test coverage (BLE disconnect/cleanup, queue-status handling, empty-read warning modes, and related typing/mocks fixes).

## Changes

### Features
- BLE connection probing in shutdown: ClientManager._safe_close_client now probes multiple candidate connection-state attributes/methods (is_connected, isConnected, _is_connected — handling both callables and booleans) and skips calling client.disconnect(...) when the client is already disconnected.
- Compatibility alias: BLEInterface.disconnect() added as a public alias that delegates to close().
- Queue-status correlation tracking: _QueueSendRuntime gains an _awaiting_queue_status_ids set to track sent packet IDs awaiting explicit queue-status correlation; replies for awaiting IDs are correlated (and logged at debug) instead of generating “unexpected packet ID” warnings.
- Adaptive empty-read logging: log_empty_read_warning() emits WARNING when FROMNUM notifications are enabled, and emits DEBUG (with “polling mode without FROMNUM notifications” suffix) when FROMNUM notifications are disabled/absent.

### Fixes / Refactors
- Simplified exception handling: condensed multi-line except (Exception) constructs and multiple contextlib.suppress(Exception) blocks to single-line forms without changing semantics.
- Consolidated cleanup/suppress usage in BLE receive/connection shutdown code to improve readability and reduce duplicated patterns.
- Minor code formatting and type-hint normalization across BLE and mesh interface files.

### Tests & Typing
- Added tests for ClientManager._safe_close_client behavior (skipping disconnect for disconnected clients; disconnecting with DISCONNECT_TIMEOUT_SECONDS when connected).
- Tests verifying BLEInterface.disconnect delegates to close() and propagates errors.
- Tests ensuring queue-status replies for awaiting packet IDs do not trigger “unexpected packet ID” logs and are correctly correlated.
- Tests for empty-read warning behavior in both polling (FROMNUM disabled) and FROMNUM-enabled modes, asserting log level differences.
- Minor test fixture/type mock fixes (e.g., setting mock_client.is_connected.return_value = True where needed, exposing _is_device_not_found_error for test use).

## Breaking changes / Migration notes
- No API-breaking changes: BLEInterface.disconnect is an added alias and existing public behavior is preserved. Test and internal refactors do not change public contracts. If your code relied on prior log severity for empty BLE reads, note that severity may be DEBUG in polling/mock modes when FROMNUM notifications are disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->