### PR TITLE
mtjk: prepare first fork release (package rename, OIDC publish, compatibility preserved)

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to publish (for example v2.7.8.post1)"
+        description: Tag to publish (for example v2.7.8.post1)
         required: false
         type: string
   release:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,7 +1,12 @@
 name: Publish to PyPI
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (for example v2.7.8.post1)"
+        required: false
+        type: string
   release:
     types: [published]
 
@@ -12,25 +17,33 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
-  build-and-publish:
+  build:
     runs-on: ubuntu-latest
-    environment: pypi-release
+    outputs:
+      tag: ${{ steps.release_tag.outputs.tag }}
+      version: ${{ steps.release_tag.outputs.version }}
     permissions:
-      id-token: write
       contents: read
-      packages: read
     steps:
       - name: Resolve release tag
         id: release_tag
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            if [[ "${GITHUB_REF}" != refs/tags/* ]]; then
-              echo "::error::workflow_dispatch must be triggered from a tag, not '${GITHUB_REF}'."
+          TAG_INPUT="${{ github.event.inputs.tag || '' }}"
+
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            TAG="${{ github.event.release.tag_name }}"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            if [[ -n "${TAG_INPUT}" ]]; then
+              TAG="${TAG_INPUT}"
+            elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+              TAG="${GITHUB_REF_NAME}"
+            else
+              echo "::error::workflow_dispatch must be triggered from a tag ref or include the 'tag' input."
               exit 1
             fi
-            TAG="${GITHUB_REF_NAME}"
           else
-            TAG="${{ github.event.release.tag_name }}"
+            echo "::error::Unsupported event '${{ github.event_name }}'."
+            exit 1
           fi
           if [[ -z "${TAG}" ]]; then
             echo "::error::Unable to resolve release tag."
@@ -94,5 +107,29 @@ jobs:
       - name: Check distributions
         run: python -m twine check dist/*
 
+      - name: Upload built distributions
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: pypi-dist-${{ steps.release_tag.outputs.tag }}
+          path: dist/*
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi-release
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Download built distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: pypi-dist-${{ needs.build.outputs.tag }}
+          path: dist
+
       - name: Publish to PyPI (Trusted Publisher)
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        with:
+          packages-dir: dist

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -49,6 +49,10 @@ jobs:
             echo "::error::Unable to resolve release tag."
             exit 1
           fi
+          if [[ ! "${TAG}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z]+)*$ ]]; then
+            echo "::error::Resolved tag '${TAG}' does not look like a release tag/version."
+            exit 1
+          fi
           VERSION="${TAG#v}"
           if [[ -z "${VERSION}" ]]; then
             echo "::error::Resolved empty version from tag '${TAG}'."
@@ -124,7 +128,7 @@ jobs:
       contents: read
     steps:
       - name: Download built distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: pypi-dist-${{ needs.build.outputs.tag }}
           path: dist

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -20,13 +20,68 @@ jobs:
       contents: read
       packages: read
     steps:
-      - name: Checkout
+      - name: Resolve release tag
+        id: release_tag
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            if [[ "${GITHUB_REF}" != refs/tags/* ]]; then
+              echo "::error::workflow_dispatch must be triggered from a tag, not '${GITHUB_REF}'."
+              exit 1
+            fi
+            TAG="${GITHUB_REF_NAME}"
+          else
+            TAG="${{ github.event.release.tag_name }}"
+          fi
+          if [[ -z "${TAG}" ]]; then
+            echo "::error::Unable to resolve release tag."
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          if [[ -z "${VERSION}" ]]; then
+            echo "::error::Resolved empty version from tag '${TAG}'."
+            exit 1
+          fi
+          echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+
+      - name: Checkout tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.release_tag.outputs.tag }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
+
+      - name: Read package metadata
+        id: package_metadata
+        run: |
+          python - <<'PY' >> "${GITHUB_OUTPUT}"
+          from pathlib import Path
+          import tomllib
+
+          pyproject = tomllib.loads(Path("pyproject.toml").read_text())
+          poetry_data = pyproject["tool"]["poetry"]
+          print(f"name={poetry_data['name']}")
+          print(f"version={poetry_data['version']}")
+          PY
+
+      - name: Validate package name and tag/version match
+        run: |
+          PACKAGE_NAME="${{ steps.package_metadata.outputs.name }}"
+          PACKAGE_VERSION="${{ steps.package_metadata.outputs.version }}"
+          TAG_VERSION="${{ steps.release_tag.outputs.version }}"
+
+          if [[ "${PACKAGE_NAME}" != "mtjk" ]]; then
+            echo "::error::Expected tool.poetry.name to be 'mtjk', got '${PACKAGE_NAME}'."
+            exit 1
+          fi
+
+          if [[ "${PACKAGE_VERSION}" != "${TAG_VERSION}" ]]; then
+            echo "::error::Version mismatch: tag '${{ steps.release_tag.outputs.tag }}' -> '${TAG_VERSION}', pyproject -> '${PACKAGE_VERSION}'."
+            exit 1
+          fi
 
       - name: Install build dependencies
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,10 @@
-# Contributing to Meshtastic Python
+# Contributing to mtjk (Meshtastic Python Fork)
 
 ## Development resources
 
+- Fork repository: <https://github.com/jeremiah-k/meshtastic-python>
+- Fork issue tracker: <https://github.com/jeremiah-k/meshtastic-python/issues>
+- Upstream technical docs (still useful reference):
 - [API Documentation](https://python.meshtastic.org/)
 - [Meshtastic Python Development](https://meshtastic.org/docs/development/python/)
 - [Building Meshtastic Python](https://meshtastic.org/docs/development/python/building/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,10 +5,10 @@
 - Fork repository: <https://github.com/jeremiah-k/meshtastic-python>
 - Fork issue tracker: <https://github.com/jeremiah-k/meshtastic-python/issues>
 - Upstream technical docs (still useful reference):
-- [API Documentation](https://python.meshtastic.org/)
-- [Meshtastic Python Development](https://meshtastic.org/docs/development/python/)
-- [Building Meshtastic Python](https://meshtastic.org/docs/development/python/building/)
-- [Using the Meshtastic Python Library](https://meshtastic.org/docs/development/python/library/)
+  - [API Documentation](https://python.meshtastic.org/)
+  - [Meshtastic Python Development](https://meshtastic.org/docs/development/python/)
+  - [Building Meshtastic Python](https://meshtastic.org/docs/development/python/building/)
+  - [Using the Meshtastic Python Library](https://meshtastic.org/docs/development/python/library/)
 
 ## Python and typing baseline
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <p style="font-size:15px;" align="center">A Python library and client for use with Meshtastic devices. </p>
 
 [![codecov](https://codecov.io/gh/meshtastic/python/branch/master/graph/badge.svg?token=TIWPJL73KV)](https://codecov.io/gh/meshtastic/python)
-![PyPI - Downloads](https://img.shields.io/pypi/dm/meshtastic)
+![PyPI - Downloads](https://img.shields.io/pypi/dm/mtjk)
 [![CI](https://img.shields.io/github/actions/workflow/status/meshtastic/python/ci.yml?branch=master&label=actions&logo=github&color=yellow)](https://github.com/meshtastic/python/actions/workflows/ci.yml)
 [![CLA assistant](https://cla-assistant.io/readme/badge/meshtastic/python)](https://cla-assistant.io/meshtastic/python)
 [![Fiscal Contributors](https://opencollective.com/meshtastic/tiers/badge.svg?label=Fiscal%20Contributors&color=deeppink)](https://opencollective.com/meshtastic/)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ It is intended to be a drop-in, backward-compatible replacement for upstream:
 - CLI command remains `meshtastic`
 - existing API compatibility is intentionally preserved
 
-This is a temporary fork used to ship and validate changes while we upstream improvements.
+`mtjk` is a maintained fork, published separately while changes are validated and selectively upstreamed.
+Work on this fork began in September 2025; early BLE-focused details are in [BLE.md](BLE.md).
 
 ## Install the CLI (recommended: pipx)
 
@@ -42,6 +43,9 @@ meshtastic --version
 To install the latest unreleased version from this repository (clean install):
 
 ```bash
+# If you previously installed upstream via pipx, remove it first:
+pipx uninstall meshtastic || true
+
 pipx uninstall mtjk || true
 pipx install "git+https://github.com/jeremiah-k/meshtastic-python.git@develop"
 ```

--- a/README.md
+++ b/README.md
@@ -17,9 +17,8 @@ Work on this fork began in September 2025; early BLE-focused details are in [BLE
 - CI and release workflows were modernized, including Trusted Publisher-based PyPI release flow
 
 For technical details, see:
+- [REFACTOR_PROGRAM.md](REFACTOR_PROGRAM.md): rationale and early change log for the major refactor work in this fork.
 - [COMPATIBILITY.md](COMPATIBILITY.md): canonical inventory of compatibility shims, deprecations, and migration mapping.
-- [BLE.md](BLE.md): BLE architecture notes, lifecycle behavior, and BLE-specific implementation guidance.
-- [REFACTOR_PROGRAM.md](REFACTOR_PROGRAM.md): rationale and change log for the major refactor work in this fork.
 - [CONTRIBUTING.md](CONTRIBUTING.md): local setup, CI-equivalent checks, and contributor workflow conventions.
 
 ## Install the CLI (recommended: pipx)

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ Please do not file fork-specific issues with upstream maintainers.
 
 ## Release Notes (Maintainers)
 
+- Versions match upstream releases with a `.postN` suffix (e.g., `2.7.8.post1` is the first fork release based on upstream `2.7.8`).
+- Create a GitHub release with tag `vX.Y.Z[.postN]` (or push the tag manually). This triggers the PyPI publish workflow via Trusted Publisher.
 - Trusted Publisher workflow expects the git tag version to match `pyproject.toml` exactly.
 - Supported tag formats are `vX.Y.Z...` or `X.Y.Z...` (both map to the same package version check).
 - PyPI Trusted Publisher must match this repo/workflow/environment tuple:

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # mtjk (Meshtastic Python Fork)
 
-`mtjk` is a work-in-progress fork of the Meshtastic Python project.
+`mtjk` is a fork of the Meshtastic Python project, published as `mtjk`.
 
 It is intended to be a drop-in, backward-compatible replacement for upstream:
 - package import namespace remains `meshtastic`
 - CLI command remains `meshtastic`
 - existing API compatibility is intentionally preserved
 
-This fork is temporary. The goal is to upstream what proves valuable after hardening and validation.
+This is a temporary fork used to ship and validate changes while we upstream improvements.
 
 ## Install the CLI (recommended: pipx)
 
@@ -144,3 +144,10 @@ Report issues for this fork here:
 - <https://github.com/jeremiah-k/meshtastic-python/issues>
 
 Please do not file fork-specific issues with upstream maintainers.
+
+## Release Notes (Maintainers)
+
+- Trusted Publisher workflow expects the git tag version to match `pyproject.toml` exactly.
+- Supported tag formats are `vX.Y.Z...` or `X.Y.Z...` (both map to the same package version check).
+- PyPI Trusted Publisher must match this repo/workflow/environment tuple:
+  `jeremiah-k/meshtastic-python` + `.github/workflows/pypi-publish.yml` + `pypi-release`.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ It is intended to be a drop-in, backward-compatible replacement for upstream:
 `mtjk` is a maintained fork, published separately while changes are validated and selectively upstreamed.
 Work on this fork began in September 2025; early BLE-focused details are in [BLE.md](BLE.md).
 
+## What Changed in This Fork
+
+- major BLE and interface internals were refactored for maintainability while keeping compatibility shims in place
+- concurrency and lifecycle paths were tightened to reduce race-condition and shutdown edge cases
+- CI and release workflows were modernized, including Trusted Publisher-based PyPI release flow
+
+For technical details, see:
+- [COMPATIBILITY.md](COMPATIBILITY.md): canonical inventory of compatibility shims, deprecations, and migration mapping.
+- [BLE.md](BLE.md): BLE architecture notes, lifecycle behavior, and BLE-specific implementation guidance.
+- [REFACTOR_PROGRAM.md](REFACTOR_PROGRAM.md): rationale and change log for the major refactor work in this fork.
+- [CONTRIBUTING.md](CONTRIBUTING.md): local setup, CI-equivalent checks, and contributor workflow conventions.
+
 ## Install the CLI (recommended: pipx)
 
 `pipx` is recommended for CLI tools so each app gets an isolated environment.
@@ -129,18 +141,6 @@ interface = meshtastic.serial_interface.SerialInterface()
 interface.sendText("hello mesh")
 interface.close()
 ```
-
-## What Changed in This Fork
-
-- major BLE and interface internals were refactored for maintainability while keeping compatibility shims in place
-- concurrency and lifecycle paths were tightened to reduce race-condition and shutdown edge cases
-- CI and release workflows were modernized, including Trusted Publisher-based PyPI release flow
-
-For technical details, see:
-- [COMPATIBILITY.md](COMPATIBILITY.md): canonical inventory of compatibility shims, deprecations, and migration mapping.
-- [BLE.md](BLE.md): BLE architecture notes, lifecycle behavior, and BLE-specific implementation guidance.
-- [REFACTOR_PROGRAM.md](REFACTOR_PROGRAM.md): rationale and change log for the major refactor work in this fork.
-- [CONTRIBUTING.md](CONTRIBUTING.md): local setup, CI-equivalent checks, and contributor workflow conventions.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,9 @@ If you previously installed upstream `meshtastic`, remove it before installing t
 ```bash
 # If installed with pipx:
 pipx uninstall meshtastic || true
-pipx uninstall mtjk || true
 
 # If installed with pip in a Python environment:
-python3 -m pip uninstall -y meshtastic mtjk
+python3 -m pip uninstall -y meshtastic
 ```
 
 ### 2) Install this fork
@@ -38,6 +37,14 @@ pipx install mtjk
 meshtastic --version
 ```
 
+### Install latest from Git (`develop`)
+
+To install the latest unreleased version from this repository:
+
+```bash
+pipx install --force "git+https://github.com/jeremiah-k/meshtastic-python.git@develop"
+```
+
 ## Upgrade / Uninstall
 
 ```bash
@@ -46,6 +53,68 @@ pipx uninstall mtjk
 ```
 
 ## Developer Usage (existing Meshtastic API)
+
+Dependency name is `mtjk`, but import namespace remains `meshtastic`.
+
+Important:
+- If your dependency spec says `meshtastic`, you will install upstream.
+- Use `mtjk` in dependency specs to install this fork.
+- This fork does not provide `import mtjk`.
+
+### requirements.txt
+
+```text
+mtjk
+```
+
+Unreleased from Git:
+
+```text
+mtjk @ git+https://github.com/jeremiah-k/meshtastic-python.git@develop
+```
+
+If you need optional CLI extras in a dependency spec:
+
+```text
+mtjk[cli]
+mtjk[cli] @ git+https://github.com/jeremiah-k/meshtastic-python.git@develop
+```
+
+### pyproject.toml (PEP 621)
+
+```toml
+[project]
+dependencies = [
+  "mtjk",
+]
+```
+
+Unreleased from Git:
+
+```toml
+[project]
+dependencies = [
+  "mtjk @ git+https://github.com/jeremiah-k/meshtastic-python.git@develop",
+]
+```
+
+### setup.cfg
+
+```ini
+[options]
+install_requires =
+    mtjk
+```
+
+Unreleased from Git:
+
+```ini
+[options]
+install_requires =
+    mtjk @ git+https://github.com/jeremiah-k/meshtastic-python.git@develop
+```
+
+### Python import (unchanged)
 
 ```python
 import meshtastic

--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ meshtastic --version
 
 ### Install latest from Git (`develop`)
 
-To install the latest unreleased version from this repository:
+To install the latest unreleased version from this repository (clean install):
 
 ```bash
-pipx install --force "git+https://github.com/jeremiah-k/meshtastic-python.git@develop"
+pipx uninstall mtjk || true
+pipx install "git+https://github.com/jeremiah-k/meshtastic-python.git@develop"
 ```
 
 ## Upgrade / Uninstall
@@ -132,9 +133,10 @@ interface.close()
 - CI and release workflows were modernized, including Trusted Publisher-based PyPI release flow
 
 For technical details, see:
-- `COMPATIBILITY.md`
-- `REFACTOR_PROGRAM.md`
-- `CONTRIBUTING.md`
+- [COMPATIBILITY.md](COMPATIBILITY.md): canonical inventory of compatibility shims, deprecations, and migration mapping.
+- [BLE.md](BLE.md): BLE architecture notes, lifecycle behavior, and BLE-specific implementation guidance.
+- [REFACTOR_PROGRAM.md](REFACTOR_PROGRAM.md): rationale and change log for the major refactor work in this fork.
+- [CONTRIBUTING.md](CONTRIBUTING.md): local setup, CI-equivalent checks, and contributor workflow conventions.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -1,73 +1,75 @@
-# Meshtastic Python
+# mtjk (Meshtastic Python Fork)
 
-<div align="center" markdown="1">
+`mtjk` is a work-in-progress fork of the Meshtastic Python project.
 
-<img src=".github/meshtastic_logo.png" alt="Meshtastic Logo" width="80"/>
+It is intended to be a drop-in, backward-compatible replacement for upstream:
+- package import namespace remains `meshtastic`
+- CLI command remains `meshtastic`
+- existing API compatibility is intentionally preserved
 
-  <h1 align="center"> Meshtastic Python
-</h1>
-  <p style="font-size:15px;" align="center">A Python library and client for use with Meshtastic devices. </p>
+This fork is temporary. The goal is to upstream what proves valuable after hardening and validation.
 
-[![codecov](https://codecov.io/gh/meshtastic/python/branch/master/graph/badge.svg?token=TIWPJL73KV)](https://codecov.io/gh/meshtastic/python)
-![PyPI - Downloads](https://img.shields.io/pypi/dm/mtjk)
-[![CI](https://img.shields.io/github/actions/workflow/status/meshtastic/python/ci.yml?branch=master&label=actions&logo=github&color=yellow)](https://github.com/meshtastic/python/actions/workflows/ci.yml)
-[![CLA assistant](https://cla-assistant.io/readme/badge/meshtastic/python)](https://cla-assistant.io/meshtastic/python)
-[![Fiscal Contributors](https://opencollective.com/meshtastic/tiers/badge.svg?label=Fiscal%20Contributors&color=deeppink)](https://opencollective.com/meshtastic/)
-![GPL-3.0](https://img.shields.io/badge/License-GPL%20v3-blue.svg)
+## Install the CLI (recommended: pipx)
 
-</div>
+`pipx` is recommended for CLI tools so each app gets an isolated environment.
 
-<div align="center">
-	<a href="https://meshtastic.org/docs/software/python/cli/installation">Getting Started Guide</a>
-	-
-	<a href="https://python.meshtastic.org">API Documentation</a>
-</div>
+### 1) Remove prior installs first (recommended)
 
-## Overview
+If you previously installed upstream `meshtastic`, remove it before installing this fork.
 
-This small library (and example application) provides an easy API for sending and receiving messages over mesh radios.
-It also provides access to any of the operations/data available in the device user interface or the Android application.
-Events are delivered using a publish-subscribe model, and you can subscribe to only the message types you are interested in.
+```bash
+# If installed with pipx:
+pipx uninstall meshtastic || true
+pipx uninstall mtjk || true
 
-## Local Development Setup
+# If installed with pip in a Python environment:
+python3 -m pip uninstall -y meshtastic mtjk
+```
 
-For full setup, local checks, and CI-equivalent commands, see
-[CONTRIBUTING.md](CONTRIBUTING.md).
+### 2) Install this fork
 
-## Call for Contributors
+```bash
+pipx install mtjk
+```
 
-This library and CLI has gone without a consistent maintainer for a while, and there's many improvements that could be made. We're all volunteers here and help is extremely appreciated, whether in implementing your own needs or helping maintain the library and CLI in general.
+### 3) Verify
 
-If you're interested in contributing but don't have specific things you'd like to work on, look at the roadmap below!
+```bash
+meshtastic --version
+```
 
-## Roadmap
+## Upgrade / Uninstall
 
-This should always be considered a list in progress and flux -- inclusion doesn't guarantee implementation, and exclusion doesn't mean something's not wanted. GitHub issues are a great place to discuss ideas.
+```bash
+pipx upgrade mtjk
+pipx uninstall mtjk
+```
 
-- ✅ Types
-  - Codebase is `mypy --strict` compatible.
-  - CI still runs `mypy meshtastic/` (non-strict); strict is available via `make ci-strict`.
-- 🟡 Async-friendliness
-  - BLE lifecycle/reconnect internals were substantially refactored and race-hardened.
-  - Additional async-friendly API improvements are still open.
-- 🟡 API consistency and compatibility
-  - Broad camelCase normalization with explicit compatibility shims is in place across key modules.
-  - Historical BLE compatibility surface from 2.7.7 is preserved.
-- ✅ Example readability
-  - Examples were updated and simplified to emphasize library usage patterns
-- ⏳ CLI completeness and consistency
-  - Support full firmware feature coverage in the CLI.
-  - Provide stable, script-friendly output formats.
-- ⏳ CLI input validation and documentation
-  - Clarify compatible/incompatible argument combinations.
-  - Document pubsub events and common workflows.
-- ⏳ Helpers for third-party code
-  - Provide reusable helpers so external tools can share CLI-style connection options.
-- ⏳ Data storage and processing
-  - Standardize packet recording for post-analysis/debugging.
-  - Evaluate persistence beyond nodedb (for example sqlite-backed tooling).
-  - Expand maps/charts/visualization support.
+## Developer Usage (existing Meshtastic API)
 
-## Stats
+```python
+import meshtastic
+import meshtastic.serial_interface
 
-![Alt](https://repobeats.axiom.co/api/embed/c71ee8fc4a79690402e5d2807a41eec5e96d9039.svg "Repobeats analytics image")
+interface = meshtastic.serial_interface.SerialInterface()
+interface.sendText("hello mesh")
+interface.close()
+```
+
+## What Changed in This Fork
+
+- major BLE and interface internals were refactored for maintainability while keeping compatibility shims in place
+- concurrency and lifecycle paths were tightened to reduce race-condition and shutdown edge cases
+- CI and release workflows were modernized, including Trusted Publisher-based PyPI release flow
+
+For technical details, see:
+- `COMPATIBILITY.md`
+- `REFACTOR_PROGRAM.md`
+- `CONTRIBUTING.md`
+
+## Support
+
+Report issues for this fork here:
+- <https://github.com/jeremiah-k/meshtastic-python/issues>
+
+Please do not file fork-specific issues with upstream maintainers.

--- a/meshtastic/__init__.py
+++ b/meshtastic/__init__.py
@@ -2,7 +2,7 @@
 
 Primary interfaces: SerialInterface, TCPInterface, BLEInterface
 
-Install with pip: "[pip3 install meshtastic](https://pypi.org/project/meshtastic/)"
+Install with pip: "[pip3 install mtjk](https://pypi.org/project/mtjk/)"
 
 Source code on [github](https://github.com/meshtastic/python)
 

--- a/meshtastic/__init__.py
+++ b/meshtastic/__init__.py
@@ -4,7 +4,7 @@ Primary interfaces: SerialInterface, TCPInterface, BLEInterface
 
 Install with pip: "[pip3 install mtjk](https://pypi.org/project/mtjk/)"
 
-Source code on [github](https://github.com/meshtastic/python)
+Source code on [github](https://github.com/jeremiah-k/meshtastic-python)
 
 notable properties of interface classes:
 

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -166,7 +166,7 @@ def supportInfo() -> None:
     `meshtastic --info` when filing an issue.
     """
     print("")
-    print("If having issues with meshtastic cli or python library")
+    print("If having issues with meshtastic CLI / python library (mtjk fork)")
     print("or wish to make feature requests, visit:")
     print("https://github.com/jeremiah-k/meshtastic-python/issues")
     print("When adding an issue, be sure to include the following info:")
@@ -180,10 +180,10 @@ def supportInfo() -> None:
     pypi_version = meshtastic.util.check_if_newer_version()
     if pypi_version:
         print(
-            f" meshtastic: v{the_version} (*** newer version v{pypi_version} available ***)"
+            f" meshtastic (mtjk fork): v{the_version} (*** newer version v{pypi_version} available ***)"
         )
     else:
-        print(f" meshtastic: v{the_version}")
+        print(f" meshtastic (mtjk fork): v{the_version}")
     print(f" Executable: {sys.argv[0]}")
     print(
         f" Python: {platform.python_version()} {platform.python_implementation()} {platform.python_compiler()}"

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -168,7 +168,7 @@ def supportInfo() -> None:
     print("")
     print("If having issues with meshtastic cli or python library")
     print("or wish to make feature requests, visit:")
-    print("https://github.com/meshtastic/python/issues")
+    print("https://github.com/jeremiah-k/meshtastic-python/issues")
     print("When adding an issue, be sure to include the following info:")
     print(f" System: {platform.system()}")
     print(f"   Platform: {platform.platform()}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,12 @@
 name = "mtjk"
 version = "2.7.8.post1"
 description = "Python API & client shell for talking to Meshtastic devices"
-authors = ["Meshtastic Developers <contact@meshtastic.org>"]
+authors = ["Meshtastic Developers (upstream project authors)"]
+maintainers = ["Jeremiah K. <17190268+jeremiah-k@users.noreply.github.com>"]
 license = "GPL-3.0-only"
 readme = "README.md"
+homepage = "https://github.com/jeremiah-k/meshtastic-python"
+repository = "https://github.com/jeremiah-k/meshtastic-python"
 packages = [{ include = "meshtastic" }]
 include = [{ path = "meshtastic/py.typed", format = ["sdist", "wheel"] }]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Includes PEP 561 py.typed marker for type checker support
 [tool.poetry]
-name = "meshtastic"
-version = "2.7.8"
+name = "mtjk"
+version = "2.7.8.post1"
 description = "Python API & client shell for talking to Meshtastic devices"
 authors = ["Meshtastic Developers <contact@meshtastic.org>"]
 license = "GPL-3.0-only"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR establishes the fork as a separately published distribution (`mtjk`) while preserving full backward compatibility with upstream usage (`meshtastic` import + CLI).

It also finalizes the release surface for the first fork release, including package metadata, documentation, and a Trusted Publisher–based PyPI workflow.

---

## Key Changes

### Packaging / Distribution
- Renamed distribution from `meshtastic` → `mtjk`
- Version set to `2.7.8.post1` (derived from upstream 2.7.8)
- Runtime version lookup updated to support both `mtjk` and `meshtastic`
- Added maintainer + fork metadata (homepage, repository)

### Release Pipeline
- Replaced token-based PyPI publishing with OIDC Trusted Publisher
- Split build and publish into separate jobs
- Enforced:
  - tag format validation
  - tag ↔ version match
  - package name (`mtjk`) consistency
- Pinned all workflow actions for reproducibility

### Documentation / UX
- Reworked README to clearly define:
  - install package: `mtjk`
  - import namespace: `meshtastic`
  - CLI command: `meshtastic`
- Added pipx migration guidance (uninstall upstream before switching)
- Added maintainer release notes (tag/version expectations)
- Updated support/help output to identify fork

### Repo / Contributor Surface
- CONTRIBUTING.md now prioritizes fork repo + issue tracker
- Upstream docs retained as technical reference

---

## Compatibility

This is a **drop-in replacement at runtime**:

- `pip install mtjk`
- `import meshtastic`
- `meshtastic` CLI

No code changes required for existing consumers.

---

## Breaking Change

- Distribution name has changed:
  - `meshtastic` → `mtjk`

Install/upgrade flows must be updated accordingly.

---

## Notes

- This PR is intentionally limited to packaging, release infrastructure, and user-facing surfaces.
- No behavioral or protocol changes are introduced here.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->