### PR TITLE
Add renovate.json configuration for Poetry dependency management

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,7 @@ This is a **temporary fork** of
 [meshtastic/python](https://github.com/meshtastic/python). It exists to ship
 fixes and improvements while they are validated and upstreamed selectively.
 
-**This repository does not accept pull requests.** Community development efforts should be directed to the upstream project:
-
-- Upstream repo: <https://github.com/meshtastic/python>
-- Upstream contributing guide: <https://github.com/meshtastic/python/blob/master/.github/CONTRIBUTING.md>
-
-If you find a fix or improvement here that you would like to carry upstream, please do so.
+**This repository does not accept pull requests.** Community development efforts should be directed to the [upstream project](https://github.com/meshtastic/python). If you find a fix or improvement here that you would like to carry upstream, please do so.
 
 ## Notable Changes
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,18 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "enabledManagers": ["poetry"],
+  "enabledManagers": ["poetry", "github-actions"],
   "timezone": "America/Chicago",
   "schedule": ["after 9:30am and before 10:29am on Sunday"],
   "updateNotScheduled": false,
   "dependencyDashboard": true,
   "dependencyDashboardTitle": "Dependency Updates (mtjk)",
   "separateMajorMinor": true,
-  "prConcurrentLimit": 2,
-  "prHourlyLimit": 2,
+  "prConcurrentLimit": 0,
+  "prHourlyLimit": 0,
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["after 11:00am and before 11:59am on Sunday"]
+    "schedule": ["after 9:30am and before 10:29am on Sunday"]
   },
   "git-submodules": {
     "enabled": false

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["poetry"],
+  "timezone": "America/Chicago",
+  "schedule": ["after 11:00am and before 11:59am on Sunday"],
+  "updateNotScheduled": false,
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": "Dependency Updates (mtjk)",
+  "separateMajorMinor": true,
+  "prConcurrentLimit": 2,
+  "prHourlyLimit": 2,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["after 11:00am and before 11:59am on Sunday"]
+  },
+  "git-submodules": {
+    "enabled": false
+  }
+}

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:recommended"],
   "enabledManagers": ["poetry"],
   "timezone": "America/Chicago",
-  "schedule": ["after 11:00am and before 11:59am on Sunday"],
+  "schedule": ["after 9:30am and before 10:29am on Sunday"],
   "updateNotScheduled": false,
   "dependencyDashboard": true,
   "dependencyDashboardTitle": "Dependency Updates (mtjk)",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This pull request adds a `renovate.json` configuration file to enable automated dependency management using Renovate, with Poetry support and a recommended baseline configuration applied.

## Key Changes

**Configuration:**
- Added `renovate.json` with Renovate Poetry dependency manager enabled
- Applied `config:recommended` preset as baseline configuration
- Configured separate scheduling windows for standard dependency updates and lockfile maintenance (both on Sunday)
- Disabled submodule handling
- Prevented unscheduled automatic updates (`updateNotScheduled: false`)

**Features:**
- Enabled dependency dashboard generation with custom title
- Configured concurrency and rate limits for PR creation (`prConcurrentLimit`, `prHourlyLimit`)
- Enabled separate major/minor version handling for greater control over update types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->