### PR TITLE
Upgrade Bleak to 3.0.1 with backwards-compatible adapter handling

### DIFF
--- a/BLE.md
+++ b/BLE.md
@@ -10,7 +10,7 @@ recommended patterns for code that embeds `meshtastic-python`.
 | Component                                    | Responsibility                                                                                                                                     |
 | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `BLEInterface`                               | User-facing entry point; extends `MeshInterface` with BLE lifecycle management                                                                     |
-| `BLEClient`                                  | Synchronous wrapper around Bleak; delegates async calls to the singleton runner                                                                    |
+| `BLEClient`                                  | Synchronous wrapper around Bleak; delegates async calls to the singleton runner and normalizes deprecated `adapter=` args to Bleak 3 `bluez` args  |
 | `BLECoroutineRunner`                         | Process-wide singleton with one background thread and one asyncio event loop                                                                       |
 | `BLEStateManager`                            | Centralized state machine (states: `DISCONNECTED`, `CONNECTING`, `CONNECTED`, `DISCONNECTING`, `RECONNECTING`, `ERROR`)                            |
 | `BLEErrorHandler`                            | Unified exception-handling helpers used across the BLE subsystem                                                                                   |
@@ -109,6 +109,30 @@ recommended patterns for code that embeds `meshtastic-python`.
   during connect (`pair_on_connect=True` or `connect(pair=True)`), and also
   exposes an explicit Linux trust helper (`trust(address=None)`) that calls
   `bluetoothctl trust <addr>`.
+
+---
+
+## Bleak 3 compatibility notes
+
+- The project now targets `bleak` `^3.0.1`.
+- Bleak 3 deprecates `adapter=...` in favor of
+  `bluez={"adapter": ...}` for Linux/BlueZ arguments.
+- `BLEClient` keeps compatibility for older callers by translating legacy
+  `adapter=` kwargs to `bluez={"adapter": ...}` when creating clients and
+  when running scanner discovery.
+- Preferred new call style for Linux adapter selection is:
+
+```python
+client = BLEClient(address="AA:BB:CC:DD:EE:FF", bluez={"adapter": "hci0"})
+devices = client.discover(timeout=10.0, return_adv=True, bluez={"adapter": "hci0"})
+```
+
+- Bleak 3 introduces `BleakGATTProtocolError` for GATT protocol-level
+  read/write failures. In the Meshtastic receive loop, this is handled with the
+  same disconnect/recovery path used for `BleakDBusError` so recovery behavior
+  remains consistent.
+- The compatibility shim `meshtastic.ble_interface` now also re-exports
+  `BleakGATTProtocolError` with the other retained Bleak symbols.
 
 ---
 
@@ -483,6 +507,7 @@ with BLEInterface(address="DD:DD:13:27:74:29") as iface:
 | Layered reconnect loops                       | Use either the library's `auto_reconnect=True` **or** your own loop, never both.                                                                           |
 | Aggressive retry cadence                      | Include exponential backoff; long `scan + connect` calls during rapid retries exhaust BlueZ.                                                               |
 | Forgetting to resubscribe notifications       | Use the same instance so `NotificationManager` can call `_resubscribe_all()` automatically after reconnects (non-`FROMNUM_UUID`; dispatcher owns FROMNUM). |
+| Passing only deprecated `adapter=` kwargs     | Prefer `bluez={"adapter": "hci0"}` for Bleak 3; `BLEClient` still translates legacy `adapter=` for compatibility.                                          |
 | Not closing the interface                     | Always call `close()` or use the context-manager pattern; unclosed BLE handles on Linux prevent future connections (BlueZ quirk).                          |
 
 ---

--- a/meshtastic/ble_interface.py
+++ b/meshtastic/ble_interface.py
@@ -21,6 +21,7 @@ try:
     from bleak.exc import (  # noqa: F401  # pylint: disable=unused-import
         BleakDBusError,
         BleakError,
+        BleakGATTProtocolError,
     )
 except ModuleNotFoundError as exc:  # pragma: no cover - dependency guard
     if exc.name != "bleak":
@@ -68,6 +69,7 @@ _COMPAT_BLEAK_EXPORTS = (
     "BLEDevice",
     "BleakError",
     "BleakDBusError",
+    "BleakGATTProtocolError",
 )
 
 # Stable public API delegates to canonical facade exports plus retained Bleak

--- a/meshtastic/interfaces/ble/client.py
+++ b/meshtastic/interfaces/ble/client.py
@@ -214,9 +214,39 @@ class BLEClient:
             if log_if_no_address:
                 logger.debug("No address provided - only discover method will work.")
             return
+        transport_kwargs = self._normalize_bluez_adapter_kwargs(kwargs)
         # kwargs intentionally forward to BleakRootClient's external, untyped constructor.
-        self.bleak_client = BleakRootClient(address, **kwargs)
+        self.bleak_client = BleakRootClient(address, **transport_kwargs)
         self._sync_address_from_bleak()
+
+    @staticmethod
+    def _normalize_bluez_adapter_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Normalize deprecated ``adapter`` kwarg into Bleak 3 ``bluez`` args.
+
+        Bleak 3 deprecates ``adapter=...`` in favor of
+        ``bluez={"adapter": ...}``. We translate when possible to avoid
+        deprecation warnings while preserving caller-provided explicit ``bluez``
+        mappings.
+        """
+        normalized_kwargs = dict(kwargs)
+        adapter = normalized_kwargs.pop("adapter", None)
+        if adapter is None:
+            return normalized_kwargs
+
+        bluez_kwargs = normalized_kwargs.get("bluez")
+        if bluez_kwargs is None:
+            normalized_kwargs["bluez"] = {"adapter": adapter}
+            return normalized_kwargs
+        if isinstance(bluez_kwargs, dict):
+            merged_bluez_kwargs = dict(bluez_kwargs)
+            merged_bluez_kwargs.setdefault("adapter", adapter)
+            normalized_kwargs["bluez"] = merged_bluez_kwargs
+            return normalized_kwargs
+
+        # Preserve historical kwarg behavior when ``bluez`` is provided with an
+        # unexpected type that we cannot safely merge.
+        normalized_kwargs["adapter"] = adapter
+        return normalized_kwargs
 
     def _sync_address_from_bleak(self) -> None:
         """Refresh cached address from the underlying Bleak client when available."""
@@ -418,7 +448,8 @@ class BLEClient:
     def _discover(self, **kwargs: Any) -> Any:
         """Discover nearby BLE devices.
 
-        Keyword arguments are forwarded to BleakScanner.discover (for example: `timeout`, `adapter`) to configure discovery.
+        Keyword arguments are forwarded to BleakScanner.discover (for example:
+        `timeout`, `bluez={"adapter": "hci0"}`) to configure discovery.
 
         Parameters
         ----------
@@ -430,7 +461,8 @@ class BLEClient:
         Any
             A list of discovered `BLEDevice` objects.
         """
-        return self._async_await(BleakScanner.discover(**kwargs))
+        discover_kwargs = self._normalize_bluez_adapter_kwargs(kwargs)
+        return self._async_await(BleakScanner.discover(**discover_kwargs))
 
     def discover(self, **kwargs: Any) -> Any:
         """Discover nearby BLE devices.

--- a/meshtastic/interfaces/ble/receive_service.py
+++ b/meshtastic/interfaces/ble/receive_service.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from functools import wraps
 from typing import TYPE_CHECKING, cast
 
-from bleak.exc import BleakDBusError, BleakError
+from bleak.exc import BleakDBusError, BleakError, BleakGATTProtocolError
 
 from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.constants import (
@@ -869,7 +869,7 @@ class BLEReceiveRecoveryController:
             ):
                 return True, False
             return False, False
-        except BleakDBusError as exc:
+        except (BleakDBusError, BleakGATTProtocolError) as exc:
             if self.handle_read_loop_disconnect(repr(exc), client):
                 return True, False
             return True, True
@@ -953,6 +953,7 @@ class BLEReceiveRecoveryController:
             raise
         except (
             BleakDBusError,
+            BleakGATTProtocolError,
             BLEClient.BLEError,
             BleakError,
             DecodeError,

--- a/poetry.lock
+++ b/poetry.lock
@@ -1327,14 +1327,14 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "hypothesis"
-version = "6.151.9"
+version = "6.151.12"
 description = "The property-based testing library for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "hypothesis-6.151.9-py3-none-any.whl", hash = "sha256:7b7220585c67759b1b1ef839b1e6e9e3d82ed468cfc1ece43c67184848d7edd9"},
-    {file = "hypothesis-6.151.9.tar.gz", hash = "sha256:2f284428dda6c3c48c580de0e18470ff9c7f5ef628a647ee8002f38c3f9097ca"},
+    {file = "hypothesis-6.151.12-py3-none-any.whl", hash = "sha256:37d4f3a768365c30571b11dfd7a6857a12173d933010b2c4ab65619f1b5952c5"},
+    {file = "hypothesis-6.151.12.tar.gz", hash = "sha256:be485f503979af4c3dfa19e3fc2b967d0458e7f8c4e28128d7e215e0a55102e0"},
 ]
 
 [package.dependencies]
@@ -5164,4 +5164,4 @@ tunnel = ["pytap2"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10,<3.15"
-content-hash = "9db270cb1513fe1b26bc22e0182c88779a9a4170033c7379c9ce78af880f3e36"
+content-hash = "6388f9e10b6b7739ac6fd2f36ad7a62baf8a6bec7e4dc4b79d4057d65b33c24d"

--- a/poetry.lock
+++ b/poetry.lock
@@ -284,14 +284,14 @@ css = ["tinycss2 (>=1.1.0,<1.5)"]
 
 [[package]]
 name = "bleak"
-version = "2.1.1"
+version = "3.0.1"
 description = "Bluetooth Low Energy platform Agnostic Klient"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "bleak-2.1.1-py3-none-any.whl", hash = "sha256:61ac1925073b580c896a92a8c404088c5e5ec9dc3c5bd6fc17554a15779d83de"},
-    {file = "bleak-2.1.1.tar.gz", hash = "sha256:4600cc5852f2392ce886547e127623f188e689489c5946d422172adf80635cf9"},
+    {file = "bleak-3.0.1-py3-none-any.whl", hash = "sha256:49f93f24ce96610529842da2d9856e7f46597e25966c0f1cfc737f0191566de6"},
+    {file = "bleak-3.0.1.tar.gz", hash = "sha256:c8ff077519f8c30a972fd0d22f47a54b981184b2f2a0886d02e55acadbc1045d"},
 ]
 
 [package.dependencies]
@@ -5164,4 +5164,4 @@ tunnel = ["pytap2"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10,<3.15"
-content-hash = "8061a62583d24743ebda482fcc43d888aef40a247a7736fc11604fe8793f963b"
+content-hash = "9db270cb1513fe1b26bc22e0182c88779a9a4170033c7379c9ce78af880f3e36"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ pandas-stubs = { version = "^2.3.3.260113", optional = true }
 wcwidth = { version = "^0.6.0", optional = true }
 
 [tool.poetry.group.dev.dependencies]
-hypothesis = "6.151.9"
+hypothesis = "6.151.12"
 pytest = "9.0.2"
 pytest-cov = "7.0.0"
 pytest-timeout = "2.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ requests = "^2.33.0"
 pyyaml = "^6.0.1"
 # Keep pypubsub >=4.0.7 for PEP 561 `py.typed` metadata in strict type checking.
 pypubsub = "^4.0.7"
-bleak = "^2.1.1"
+bleak = "^3.0.1"
 packaging = "^26.0"
 argcomplete = { version = "^3.5.2", optional = true }
 pyqrcode = { version = "^1.2.1", optional = true }

--- a/renovate.json
+++ b/renovate.json
@@ -34,7 +34,7 @@
   ],
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["after 9am and before 1pm on Sunday"]
+    "schedule": ["after 9am and before 11pm on Sunday"]
   },
   "git-submodules": {
     "enabled": false

--- a/tests/test_ble_client_edge_cases.py
+++ b/tests/test_ble_client_edge_cases.py
@@ -210,6 +210,27 @@ def test_bleclient_init_with_address_syncs_from_bleak(
 
 
 @pytest.mark.unit
+def test_bleclient_init_translates_adapter_kwarg_to_bluez(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BLEClient should map deprecated adapter kwarg to bluez adapter args."""
+
+    captured_kwargs: list[dict[str, Any]] = []
+
+    class _BleakStub:
+        def __init__(self, _address: object, **kwargs: object) -> None:
+            captured_kwargs.append(dict(kwargs))
+            self.address = "AA:BB:CC:DD:EE:FF"
+
+    monkeypatch.setattr("meshtastic.interfaces.ble.client.BleakRootClient", _BleakStub)
+
+    client = BLEClient("11:22:33:44:55:66", adapter="hci0")
+    assert client.bleak_client is not None
+    assert captured_kwargs == [{"bluez": {"adapter": "hci0"}}]
+    client.close()
+
+
+@pytest.mark.unit
 def test_bleclient_sync_address_noops_without_bleak_client(
     ble_client: BLEClient,
 ) -> None:

--- a/tests/test_ble_client_edge_cases.py
+++ b/tests/test_ble_client_edge_cases.py
@@ -231,6 +231,52 @@ def test_bleclient_init_translates_adapter_kwarg_to_bluez(
 
 
 @pytest.mark.unit
+def test_bleclient_discover_translates_adapter_kwarg_to_bluez(
+    monkeypatch: pytest.MonkeyPatch,
+    ble_client: BLEClient,
+) -> None:
+    """BLEClient discover() should map deprecated adapter kwarg to bluez args."""
+    captured_kwargs: list[dict[str, Any]] = []
+
+    async def _discover_stub(**kwargs: Any) -> list[Any]:
+        captured_kwargs.append(dict(kwargs))
+        return []
+
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.client.BleakScanner.discover",
+        _discover_stub,
+    )
+    monkeypatch.setattr(ble_client, "_async_await", _make_run_awaitable())
+
+    assert ble_client.discover(adapter="hci0") == []
+    assert captured_kwargs == [{"bluez": {"adapter": "hci0"}}]
+
+
+@pytest.mark.unit
+def test_bleclient_init_prefers_explicit_bluez_adapter_over_adapter_kwarg(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BLEClient should preserve explicit bluez adapter when adapter kwarg is also set."""
+    captured_kwargs: list[dict[str, Any]] = []
+
+    class _BleakStub:
+        def __init__(self, _address: object, **kwargs: object) -> None:
+            captured_kwargs.append(dict(kwargs))
+            self.address = "AA:BB:CC:DD:EE:FF"
+
+    monkeypatch.setattr("meshtastic.interfaces.ble.client.BleakRootClient", _BleakStub)
+
+    client = BLEClient(
+        "11:22:33:44:55:66",
+        adapter="hci0",
+        bluez={"adapter": "hci1"},
+    )
+    assert client.bleak_client is not None
+    assert captured_kwargs == [{"bluez": {"adapter": "hci1"}}]
+    client.close()
+
+
+@pytest.mark.unit
 def test_bleclient_sync_address_noops_without_bleak_client(
     ble_client: BLEClient,
 ) -> None:

--- a/tests/test_ble_interface_fixtures.py
+++ b/tests/test_ble_interface_fixtures.py
@@ -400,10 +400,14 @@ def mock_bleak_exc(
     class _StubBleakDeviceNotFoundError(_StubBleakError):
         """Stub BleakDeviceNotFoundError type for tests."""
 
+    class _StubBleakGATTProtocolError(_StubBleakError):
+        """Stub BleakGATTProtocolError type for tests."""
+
     bleak_exc_module_any = cast(Any, bleak_exc_module)
     bleak_exc_module_any.BleakError = _StubBleakError
     bleak_exc_module_any.BleakDBusError = _StubBleakDBusError
     bleak_exc_module_any.BleakDeviceNotFoundError = _StubBleakDeviceNotFoundError
+    bleak_exc_module_any.BleakGATTProtocolError = _StubBleakGATTProtocolError
 
     # Attach to parent module
     cast(Any, mock_bleak).exc = bleak_exc_module

--- a/tests/test_ble_lifecycle_receive_targets.py
+++ b/tests/test_ble_lifecycle_receive_targets.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import contextlib
 import importlib
+import itertools
 import threading
-import time
 from types import SimpleNamespace
 from typing import Any, Protocol
 from unittest.mock import MagicMock
@@ -2784,11 +2784,12 @@ def test_receive_remaining_branches(
         assert recovered == ["receive_thread_fatal"]
 
         with monkeypatch.context() as m:
-            monotonic_values = iter([100.0, 100.1])
-            real_monotonic = time.monotonic
+            monotonic_values = itertools.chain(
+                [100.0, 100.1], itertools.repeat(100.1)
+            )
             m.setattr(
                 "meshtastic.interfaces.ble.receive_service.time.monotonic",
-                lambda: next(monotonic_values, real_monotonic()),
+                lambda: next(monotonic_values),
             )
             with iface._state_lock:
                 iface.client = DummyClient()

--- a/tests/test_ble_lifecycle_receive_targets.py
+++ b/tests/test_ble_lifecycle_receive_targets.py
@@ -44,7 +44,14 @@ def _make_iface(monkeypatch: pytest.MonkeyPatch) -> Any:
 
 
 def _make_gatt_protocol_error() -> BaseException:
-    """Create a BleakGATTProtocolError across constructor signature variants."""
+    """Create a BleakGATTProtocolError across constructor signature variants.
+
+    Returns
+    -------
+    BaseException
+        BleakGATTProtocolError instance compatible with multiple constructor
+        signatures, or a ``BleakError("gatt")`` fallback.
+    """
     for args in (("gatt",), (1,), ("gatt", 1), ()):
         try:
             return BleakGATTProtocolError(*args)  # type: ignore[misc]

--- a/tests/test_ble_lifecycle_receive_targets.py
+++ b/tests/test_ble_lifecycle_receive_targets.py
@@ -5,12 +5,18 @@ from __future__ import annotations
 import contextlib
 import importlib
 import threading
+import time
 from types import SimpleNamespace
 from typing import Any, Protocol
 from unittest.mock import MagicMock
 
 import pytest
 from bleak.exc import BleakDBusError, BleakError
+
+try:
+    from bleak.exc import BleakGATTProtocolError
+except ImportError:  # pragma: no cover - compatibility with older local envs
+    BleakGATTProtocolError = BleakError  # type: ignore[assignment]
 
 from meshtastic.interfaces.ble.constants import ERROR_INTERFACE_CLOSING
 from meshtastic.interfaces.ble.lifecycle_primitives import (
@@ -35,6 +41,16 @@ class _IfaceWithStateManager(Protocol):
 
 def _make_iface(monkeypatch: pytest.MonkeyPatch) -> Any:
     return _build_interface(monkeypatch, DummyClient(), start_receive_thread=False)
+
+
+def _make_gatt_protocol_error() -> BaseException:
+    """Create a BleakGATTProtocolError across constructor signature variants."""
+    for args in (("gatt",), (1,), ("gatt", 1), ()):
+        try:
+            return BleakGATTProtocolError(*args)  # type: ignore[misc]
+        except TypeError:
+            continue
+    return BleakError("gatt")
 
 
 def _reset_state_manager(iface: _IfaceWithStateManager) -> None:
@@ -1556,6 +1572,20 @@ def test_receive_service_branch_targets_payload_paths(
         monkeypatch.setattr(
             controller,
             "_read_and_handle_payload",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                _make_gatt_protocol_error()
+            ),
+        )
+        iface._handle_read_loop_disconnect = lambda *_args, **_kwargs: True
+        assert BLEReceiveRecoveryService._handle_payload_read(
+            iface,
+            DummyClient(),
+            poll_without_notify=False,
+        ) == (True, False)
+
+        monkeypatch.setattr(
+            controller,
+            "_read_and_handle_payload",
             lambda *_args, **_kwargs: (_ for _ in ()).throw(BleakError("transient")),
         )
         iface._handle_transient_read_error = lambda _err: (_ for _ in ()).throw(
@@ -2755,9 +2785,10 @@ def test_receive_remaining_branches(
 
         with monkeypatch.context() as m:
             monotonic_values = iter([100.0, 100.1])
+            real_monotonic = time.monotonic
             m.setattr(
                 "meshtastic.interfaces.ble.receive_service.time.monotonic",
-                lambda: next(monotonic_values),
+                lambda: next(monotonic_values, real_monotonic()),
             )
             with iface._state_lock:
                 iface.client = DummyClient()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR updates Meshtastic's BLE support for Bleak 3 (bumped to ^3.0.1) while preserving backwards-compatible handling of the legacy adapter kwarg. It adds a helper to translate adapter="..." into Bleak 3’s BlueZ-style bluez={"adapter": ...}, forwards the normalized kwargs in client creation and discovery, expands error handling to include BleakGATTProtocolError, updates docs, and adds tests covering the new behaviors.

## Key Changes

Features & Compatibility
- Bumped `bleak` dependency in pyproject.toml from `^2.1.1` → `^3.0.1`.
- Added `BLEClient._normalize_bluez_adapter_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]` to translate legacy `adapter=...` into `bluez={"adapter": ...}` when appropriate.
- Applied adapter-kwarg normalization in BLEClient initialization and in discovery (scanner) call sites.
- Updated documentation (BLE.md) to show preferred `bluez={"adapter": "hci0"}` usage and to document the translation behavior.

Error handling
- Imported `BleakGATTProtocolError` from `bleak.exc` and re-exported it via `meshtastic.ble_interface`.
- Treat `BleakGATTProtocolError` the same as `BleakDBusError` in the receive/read-loop disconnect handling.
- Include `BleakGATTProtocolError` in the set of fatal exceptions that trigger receive-thread recovery.

Tests & Fixtures
- Added unit test verifying that `BLEClient(..., adapter="hci0")` translates into `bluez={"adapter": "hci0"}` when constructing the underlying Bleak client.
- Extended receive-service lifecycle tests to exercise `BleakGATTProtocolError` handling and added helpers to synthesize the error across bleak versions.
- Updated fixtures to stub/export a `BleakGATTProtocolError` for environments without it.

Refactors / Documentation
- Adjusted docstrings/examples to reference `bluez={"adapter": "hci0"}` instead of the deprecated `adapter` parameter.
- BLE.md updated with compatibility notes, examples, and a “common pitfalls” hint advising callers to prefer `bluez={"adapter": ...}`.

## Breaking changes / Migration notes
- No breaking runtime changes: legacy `adapter="hciX"` kwargs are automatically translated for compatibility.
- Recommended migration: callers should move to Bleak 3 style and pass adapter selection as bluez={"adapter": "hciX"} for clarity and future-proofing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->