### PR TITLE
Add automated protobuf submodule update workflow

### DIFF
--- a/.github/workflows/renovate-protobuf-submodule-regen.yml
+++ b/.github/workflows/renovate-protobuf-submodule-regen.yml
@@ -5,7 +5,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - protobufs
-      - .gitmodules
 
 permissions:
   contents: write
@@ -43,7 +42,7 @@ jobs:
       - name: Install Poetry
         run: |
           python -m pip install --upgrade pip
-          python -m pip install poetry
+          python -m pip install "poetry==2.3.2"
 
       - name: Sync submodules
         run: |

--- a/.github/workflows/renovate-protobuf-submodule-regen.yml
+++ b/.github/workflows/renovate-protobuf-submodule-regen.yml
@@ -1,0 +1,79 @@
+name: Regenerate protobufs for Renovate submodule updates
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - protobufs
+      - .gitmodules
+
+permissions:
+  contents: write
+  pull-requests: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  NANOPB_VERSION: 0.4.9.1
+  NANOPB_SHA256: 951a9ab2385424a4cdf245d0c84f4c88c6ccbc65a0dade4b246d50c068f24128
+
+jobs:
+  regenerate-protobufs:
+    if: >
+      github.actor == 'renovate[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'renovate/')
+    runs-on: ubuntu-latest
+    concurrency:
+      group: protobuf-regen-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout Renovate branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          submodules: true
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install poetry
+
+      - name: Sync submodules
+        run: |
+          git submodule sync --recursive
+          git submodule update --init --recursive
+
+      - name: Download nanopb
+        run: |
+          curl -fsSL -o nanopb-${NANOPB_VERSION}-linux-x86.tar.gz https://jpa.kapsi.fi/nanopb/download/nanopb-${NANOPB_VERSION}-linux-x86.tar.gz
+          echo "${NANOPB_SHA256}  nanopb-${NANOPB_VERSION}-linux-x86.tar.gz" | sha256sum -c -
+          tar xzf nanopb-${NANOPB_VERSION}-linux-x86.tar.gz
+          mv nanopb-${NANOPB_VERSION}-linux-x86 nanopb-${NANOPB_VERSION}
+
+      - name: Install Python dependencies
+        run: poetry install --with dev
+
+      - name: Re-generate protocol buffers
+        run: ./bin/regen-protobufs.sh
+
+      - name: Commit generated protobuf changes
+        env:
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          git config --global user.name 'github-actions'
+          git config --global user.email 'bot@noreply.github.com'
+          git add protobufs
+          git add meshtastic/protobuf
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git commit -m "build(protobufs): regenerate protobuf outputs"
+            git push origin "HEAD:${PR_HEAD_REF}"
+          else
+            echo "No changes to commit"
+          fi

--- a/.github/workflows/renovate-protobuf-submodule-regen.yml
+++ b/.github/workflows/renovate-protobuf-submodule-regen.yml
@@ -71,7 +71,7 @@ jobs:
           git config --global user.email 'bot@noreply.github.com'
           git add protobufs
           git add meshtastic/protobuf
-          if [[ -n "$(git status --porcelain)" ]]; then
+          if ! git diff --cached --quiet; then
             git commit -m "build(protobufs): regenerate protobuf outputs"
             git push origin "HEAD:${PR_HEAD_REF}"
           else

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "protobufs"]
 	path = protobufs
 	url = http://github.com/meshtastic/protobufs
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "protobufs"]
 	path = protobufs
-	url = http://github.com/meshtastic/protobufs
+	url = https://github.com/meshtastic/protobufs
 	branch = master

--- a/renovate.json
+++ b/renovate.json
@@ -40,6 +40,8 @@
     {
       "description": "Automerge protobuf submodule updates after regen workflow passes",
       "matchManagers": ["git-submodules"],
+      "matchDepNames": ["protobufs"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest", "pinDigest"],
       "automerge": true
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -38,7 +38,7 @@
       "automerge": false
     },
     {
-      "description": "Automerge protobuf submodule updates after regen workflow passes",
+      "description": "Automerge protobuf submodule updates",
       "matchManagers": ["git-submodules"],
       "matchDepNames": ["protobufs"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest", "pinDigest"],

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:best-practices"],
   "forkProcessing": "enabled",
   "mode": "full",
-  "enabledManagers": ["poetry", "github-actions"],
+  "enabledManagers": ["poetry", "github-actions", "git-submodules"],
   "timezone": "America/Chicago",
   "schedule": ["after 9am and before 11pm on Sunday"],
   "updateNotScheduled": true,
@@ -36,6 +36,11 @@
       "description": "Keep bleak updates manual for planned migration work",
       "matchPackageNames": ["bleak"],
       "automerge": false
+    },
+    {
+      "description": "Automerge protobuf submodule updates after regen workflow passes",
+      "matchManagers": ["git-submodules"],
+      "automerge": true
     }
   ],
   "lockFileMaintenance": {
@@ -43,6 +48,6 @@
     "schedule": ["after 9am and before 11pm on Sunday"]
   },
   "git-submodules": {
-    "enabled": false
+    "enabled": true
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Overview

This PR enables automated tracking and safe auto-merging of the protobufs git submodule and adds a GitHub Actions workflow that regenerates and commits generated protobuf outputs when Renovate opens or updates submodule PRs. The intent is to keep generated protobuf artifacts in sync with submodule updates while avoiding noisy or unnecessary commits.

Key Changes

Features
- Enabled Renovate git-submodules manager (renovate.json: added "git-submodules" to enabledManagers and set git-submodules.enabled: true).
- Added a package rule to automerge protobufs submodule updates (renovate.json: matchManagers: ["git-submodules"], matchDepNames: ["protobufs"], matchUpdateTypes: ["minor","patch","pin","digest","pinDigest"], automerge: true).
- Added a new GitHub Actions workflow (.github/workflows/renovate-protobuf-submodule-regen.yml) that:
  - Triggers on PR events affecting protobufs or .gitmodules.
  - Runs only for Renovate-authored PRs from branches starting with "renovate/" and originating from the same repository.
  - Checks out the PR branch with submodules, sets up Python 3.12 and Poetry, syncs submodules, downloads a pinned nanopb tarball (with SHA-256 verification), runs the regeneration script (./bin/regen-protobufs.sh), and pushes commits back to the PR branch if there are changes.

Fixes / CI improvements
- Workflow commits only when there are staged diffs to avoid no-op commits.
- Workflow uses explicit permissions (contents: write, pull-requests: read) and concurrency to avoid concurrent regen runs for the same PR.

Refactors / config tweaks
- Updated .gitmodules to use HTTPS for the protobufs submodule URL and explicitly track branch = master.
- Renovate configuration cleanup: added git-submodules to packageRules and adjusted automerge behavior for protobufs submodule updates.

Breaking changes / Migration notes

- No breaking API changes. No special migration required.
- Operational notes: the regen workflow assumes Renovate will open submodule PRs from branches prefixed with "renovate/" and that the bot has permission to push to those branches in the same repository. The nanopb tarball is pinned by version and SHA; updating that requires changing the workflow env values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->