### PR TITLE
Remove discovery fallback for explicit BLE addresses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,13 +76,18 @@ jobs:
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: jeremiah-k/meshtastic-python
+          slug: jeremiah-k/mtjk
+          files: ./coverage.xml
+          fail_ci_if_error: false
+          verbose: true
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && matrix.python-version == '3.13' }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: jeremiah-k/meshtastic-python
+          slug: jeremiah-k/mtjk
+          report_type: test_results
+          fail_ci_if_error: false
   pylint:
     name: Pylint (py3.13)
     runs-on: ubuntu-latest

--- a/BLE.md
+++ b/BLE.md
@@ -91,17 +91,21 @@ recommended patterns for code that embeds `meshtastic-python`.
   after `BLEConfig.CONNECTION_GATE_UNOWNED_STALE_SECONDS` (default 300 s).
   A suppressed attempt logs `Connection suppressed: recently connected elsewhere`.
 
-- **Direct-first explicit address semantics.** A direct connect is always tried first
-  (see `DIRECT_CONNECT_TIMEOUT_SECONDS` in
-  [`meshtastic/interfaces/ble/connection.py`](meshtastic/interfaces/ble/connection.py),
+- **Direct-first explicit address semantics.** When an address or identifier is
+  available, a direct connect is tried first (see
+  `BLEConfig.DIRECT_CONNECT_TIMEOUT_SECONDS` in
+  [`meshtastic/interfaces/ble/constants.py`](meshtastic/interfaces/ble/constants.py),
   default 12 s).
   - For caller-explicit BLE addresses (`AA:BB:CC:DD:EE:FF` passed via
     `connect(address=...)`), retries stay direct-only and do **not** fall back
     to discovery scans.
   - Derived reconnect targets (for example carrying a prior `current_address`
     when no explicit address is supplied) may still use discovery fallback.
-  - Discovery fallback is only used when connecting by identifier/name (or when
-    no address is provided) where device resolution is expected to come from
+  - Discovery-only mode (`connect(address=None)` with no derived
+    `current_address`/identifier) starts with scan-based resolution and does not
+    enter the direct-connect path.
+  - Discovery fallback is only used when connecting by identifier/name (or in
+    discovery-only mode) where device resolution is expected to come from
     scanning.
   - Discovery-resolved connects use `BLEConfig.CONNECTION_TIMEOUT` (default 60 s).
 

--- a/BLE.md
+++ b/BLE.md
@@ -91,11 +91,16 @@ recommended patterns for code that embeds `meshtastic-python`.
   after `BLEConfig.CONNECTION_GATE_UNOWNED_STALE_SECONDS` (default 300 s).
   A suppressed attempt logs `Connection suppressed: recently connected elsewhere`.
 
-- **Short direct connect, then scan fallback.** A direct connect is tried first
+- **Direct-first explicit address semantics.** A direct connect is always tried first
   (see `DIRECT_CONNECT_TIMEOUT_SECONDS` in
   [`meshtastic/interfaces/ble/connection.py`](meshtastic/interfaces/ble/connection.py),
-  default 12 s). On failure, a 10 s scan runs and then a full connect uses
-  `BLEConfig.CONNECTION_TIMEOUT` (default 60 s).
+  default 12 s).
+  - For explicit BLE addresses (`AA:BB:CC:DD:EE:FF`), retries stay direct-only
+    and do **not** fall back to discovery scans.
+  - Discovery fallback is only used when connecting by identifier/name (or when
+    no address is provided) where device resolution is expected to come from
+    scanning.
+  - Discovery-resolved connects use `BLEConfig.CONNECTION_TIMEOUT` (default 60 s).
 
 - **Serialized disconnect handling.** A per-interface `_disconnect_lock`
   deduplicates concurrent disconnect callbacks and marks the address as free
@@ -440,9 +445,11 @@ seconds will continue to be suppressed.
 
 ### Keep retries bounded
 
-- The scan + connect cycle can block up to `BLEConfig.CONNECTION_TIMEOUT` (60 s).
-  After a failed cycle, wait at least 30–60 s before retrying to avoid
-  exhausting Linux/BlueZ resources.
+- Explicit-address direct retries are bounded by
+  `DIRECT_CONNECT_TIMEOUT_SECONDS` (default 12 s per attempt).
+- Identifier/no-address discovery + connect cycles can block up to
+  `BLEConfig.CONNECTION_TIMEOUT` (60 s). After a failed cycle, wait at least
+  30–60 s before retrying to avoid exhausting Linux/BlueZ resources.
 - A scan returning zero devices on Linux is expected when the peripheral is
   already connected elsewhere. Rely on the address gate; repeated scans make
   things worse.
@@ -505,7 +512,7 @@ with BLEInterface(address="DD:DD:13:27:74:29") as iface:
 | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Multiple `BLEInterface` instances per address | Reuse one instance; multiple instances collide on the address gate.                                                                                        |
 | Layered reconnect loops                       | Use either the library's `auto_reconnect=True` **or** your own loop, never both.                                                                           |
-| Aggressive retry cadence                      | Include exponential backoff; long `scan + connect` calls during rapid retries exhaust BlueZ.                                                               |
+| Aggressive retry cadence                      | Include exponential backoff; repeated direct retries or `scan + connect` cycles during rapid retries exhaust BlueZ.                                       |
 | Forgetting to resubscribe notifications       | Use the same instance so `NotificationManager` can call `_resubscribe_all()` automatically after reconnects (non-`FROMNUM_UUID`; dispatcher owns FROMNUM). |
 | Passing only deprecated `adapter=` kwargs     | Prefer `bluez={"adapter": "hci0"}` for Bleak 3; `BLEClient` still translates legacy `adapter=` for compatibility.                                          |
 | Not closing the interface                     | Always call `close()` or use the context-manager pattern; unclosed BLE handles on Linux prevent future connections (BlueZ quirk).                          |
@@ -517,8 +524,8 @@ with BLEInterface(address="DD:DD:13:27:74:29") as iface:
 Restart if you observe:
 
 - repeated `Cannot connect while interface is closing` for several minutes, or
-- repeated scan + connect cycles timing out on Linux/BlueZ despite the device
-  being powered and advertising.
+- repeated direct retries (or discovery cycles when using identifier mode)
+  timing out on Linux/BlueZ despite the device being powered and advertising.
 
 A clean restart clears leaked BLE/DBus handles and resets the process-wide
 address gate.

--- a/BLE.md
+++ b/BLE.md
@@ -95,8 +95,11 @@ recommended patterns for code that embeds `meshtastic-python`.
   (see `DIRECT_CONNECT_TIMEOUT_SECONDS` in
   [`meshtastic/interfaces/ble/connection.py`](meshtastic/interfaces/ble/connection.py),
   default 12 s).
-  - For explicit BLE addresses (`AA:BB:CC:DD:EE:FF`), retries stay direct-only
-    and do **not** fall back to discovery scans.
+  - For caller-explicit BLE addresses (`AA:BB:CC:DD:EE:FF` passed via
+    `connect(address=...)`), retries stay direct-only and do **not** fall back
+    to discovery scans.
+  - Derived reconnect targets (for example carrying a prior `current_address`
+    when no explicit address is supplied) may still use discovery fallback.
   - Discovery fallback is only used when connecting by identifier/name (or when
     no address is provided) where device resolution is expected to come from
     scanning.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,8 @@
 
 ## Development resources
 
-- `mtjk` repository: <https://github.com/jeremiah-k/meshtastic-python>
-- `mtjk` issue tracker: <https://github.com/jeremiah-k/meshtastic-python/issues>
+- `mtjk` repository: <https://github.com/jeremiah-k/mtjk>
+- `mtjk` issue tracker: <https://github.com/jeremiah-k/mtjk/issues>
 - Upstream technical docs (still useful reference):
   - [API Documentation](https://python.meshtastic.org/)
   - [Meshtastic Python Development](https://meshtastic.org/docs/development/python/)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To install the latest unreleased version from this repository (clean install):
 pipx uninstall meshtastic || true
 
 pipx uninstall mtjk || true
-pipx install "git+https://github.com/jeremiah-k/meshtastic-python.git@develop"
+pipx install "git+https://github.com/jeremiah-k/mtjk.git@develop"
 ```
 
 ## Upgrade / Uninstall
@@ -99,14 +99,14 @@ mtjk
 Unreleased from Git:
 
 ```text
-mtjk @ git+https://github.com/jeremiah-k/meshtastic-python.git@develop
+mtjk @ git+https://github.com/jeremiah-k/mtjk.git@develop
 ```
 
 If you need optional CLI extras in a dependency spec:
 
 ```text
 mtjk[cli]
-mtjk[cli] @ git+https://github.com/jeremiah-k/meshtastic-python.git@develop
+mtjk[cli] @ git+https://github.com/jeremiah-k/mtjk.git@develop
 ```
 
 ### pyproject.toml (PEP 621)
@@ -123,7 +123,7 @@ Unreleased from Git:
 ```toml
 [project]
 dependencies = [
-  "mtjk @ git+https://github.com/jeremiah-k/meshtastic-python.git@develop",
+  "mtjk @ git+https://github.com/jeremiah-k/mtjk.git@develop",
 ]
 ```
 
@@ -140,7 +140,7 @@ Unreleased from Git:
 ```ini
 [options]
 install_requires =
-    mtjk @ git+https://github.com/jeremiah-k/meshtastic-python.git@develop
+    mtjk @ git+https://github.com/jeremiah-k/mtjk.git@develop
 ```
 
 ### Python import (unchanged)
@@ -158,7 +158,7 @@ interface.close()
 
 Report `mtjk`-specific issues here:
 
-- <https://github.com/jeremiah-k/meshtastic-python/issues>
+- <https://github.com/jeremiah-k/mtjk/issues>
 
 Please do not file `mtjk`-specific issues with upstream maintainers.
 
@@ -169,4 +169,4 @@ Please do not file `mtjk`-specific issues with upstream maintainers.
 - Trusted Publisher workflow expects the git tag version to match `pyproject.toml` exactly.
 - Supported tag formats are `vX.Y.Z...` or `X.Y.Z...` (both map to the same package version check).
 - PyPI Trusted Publisher must match this repo/workflow/environment tuple:
-  `jeremiah-k/meshtastic-python` + `.github/workflows/pypi-publish.yml` + `pypi-release`.
+  `jeremiah-k/mtjk` + `.github/workflows/pypi-publish.yml` + `pypi-release`.

--- a/meshtastic/__init__.py
+++ b/meshtastic/__init__.py
@@ -4,7 +4,7 @@ Primary interfaces: SerialInterface, TCPInterface, BLEInterface
 
 Install with pip: "[pip3 install mtjk](https://pypi.org/project/mtjk/)"
 
-Source code on [github](https://github.com/jeremiah-k/meshtastic-python)
+Source code on [github](https://github.com/jeremiah-k/mtjk)
 
 notable properties of interface classes:
 

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -168,7 +168,7 @@ def supportInfo() -> None:
     print("")
     print("If having issues with meshtastic CLI / python library (mtjk fork)")
     print("or wish to make feature requests, visit:")
-    print("https://github.com/jeremiah-k/meshtastic-python/issues")
+    print("https://github.com/jeremiah-k/mtjk/issues")
     print("When adding an issue, be sure to include the following info:")
     print(f" System: {platform.system()}")
     print(f"   Platform: {platform.platform()}")

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -1322,12 +1322,15 @@ class ConnectionOrchestrator:
                 direct_err,
                 exc_info=True,
             )
-            skip_discovery_scan = _looks_like_ble_address(
-                target_address
-            ) and _is_device_not_found_error(direct_err)
-            if skip_discovery_scan:
+            skip_discovery_scan = _looks_like_ble_address(target_address)
+            if skip_discovery_scan and _is_device_not_found_error(direct_err):
                 logger.debug(
                     "Direct connect reported device-not-found for %s; skipping discovery scan and retrying explicit address connect.",
+                    normalized_target,
+                )
+            elif skip_discovery_scan:
+                logger.debug(
+                    "Direct connect to explicit address %s failed; retrying without discovery scan.",
                     normalized_target,
                 )
             self._client_manager_safe_close_client(client)

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -1326,6 +1326,9 @@ class ConnectionOrchestrator:
                 direct_err,
                 exc_info=True,
             )
+            # Preserve strict direct-only retries only for caller-explicit BLE
+            # addresses. Derived targets (for example current_address carried
+            # into reconnect flows) are still allowed to use discovery fallback.
             skip_discovery_scan = explicit_address and _looks_like_ble_address(
                 target_address
             )
@@ -1337,6 +1340,11 @@ class ConnectionOrchestrator:
             elif skip_discovery_scan:
                 logger.debug(
                     "Direct connect to explicit address %s failed; retrying without discovery scan.",
+                    normalized_target,
+                )
+            elif target_address and _looks_like_ble_address(target_address):
+                logger.debug(
+                    "Direct connect to derived address %s failed; allowing discovery fallback.",
                     normalized_target,
                 )
             self._client_manager_safe_close_client(client)
@@ -1721,12 +1729,13 @@ class ConnectionOrchestrator:
         with self.state_lock:
             if not self._state_transition_to(ConnectionState.CONNECTING):
                 raise self.interface.BLEError(BLECLIENT_ERROR_ALREADY_CONNECTED)
+        is_explicit_target = address is not None
         client: BLEClient | None = None
         skip_discovery_scan = False
         try:
             client, skip_discovery_scan = self._attempt_direct_connect(
                 target_address=target_address,
-                explicit_address=address is not None,
+                explicit_address=is_explicit_target,
                 normalized_target=normalized_target,
                 on_disconnect_func=on_disconnect_func,
                 pair_on_connect=pair_on_connect,

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -1154,7 +1154,7 @@ class ConnectionOrchestrator:
         *,
         address: str | None,
         current_address: str | None,
-    ) -> tuple[str | None, str | None]:
+    ) -> tuple[str | None, str | None, bool]:
         """Resolve and validate the connection target address for this attempt.
 
         Parameters
@@ -1166,9 +1166,11 @@ class ConnectionOrchestrator:
 
         Returns
         -------
-        tuple[str | None, str | None]
-            Tuple of ``(target_address, normalized_target)`` where
-            ``normalized_target`` is produced by :func:`sanitize_address`.
+        tuple[str | None, str | None, bool]
+            Tuple of ``(target_address, normalized_target, explicit_address)``
+            where ``normalized_target`` is produced by
+            :func:`sanitize_address` and ``explicit_address`` tracks whether the
+            target came from the caller-provided ``address`` argument.
 
         Raises
         ------
@@ -1191,7 +1193,7 @@ class ConnectionOrchestrator:
             logger.info("Attempting to connect to %s", target_address)
         else:
             logger.info("Attempting discovery-mode connection (no address specified)")
-        return target_address, normalized_target
+        return target_address, normalized_target, explicit_address
 
     def _resolve_connection_timeouts(
         self,
@@ -1715,9 +1717,11 @@ class ConnectionOrchestrator:
         self._validator_validate_connection_request()
         self._raise_if_interface_closing()
 
-        target_address, normalized_target = self._prepare_connection_target(
-            address=address,
-            current_address=current_address,
+        target_address, normalized_target, explicit_address = (
+            self._prepare_connection_target(
+                address=address,
+                current_address=current_address,
+            )
         )
         direct_connect_timeout, discovery_connect_timeout = (
             self._resolve_connection_timeouts(
@@ -1729,13 +1733,12 @@ class ConnectionOrchestrator:
         with self.state_lock:
             if not self._state_transition_to(ConnectionState.CONNECTING):
                 raise self.interface.BLEError(BLECLIENT_ERROR_ALREADY_CONNECTED)
-        is_explicit_target = address is not None
         client: BLEClient | None = None
         skip_discovery_scan = False
         try:
             client, skip_discovery_scan = self._attempt_direct_connect(
                 target_address=target_address,
-                explicit_address=is_explicit_target,
+                explicit_address=explicit_address,
                 normalized_target=normalized_target,
                 on_disconnect_func=on_disconnect_func,
                 pair_on_connect=pair_on_connect,

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -1242,6 +1242,7 @@ class ConnectionOrchestrator:
         self,
         *,
         target_address: str | None,
+        explicit_address: bool,
         normalized_target: str | None,
         on_disconnect_func: Callable[["BleakRootClient"], None],
         pair_on_connect: bool,
@@ -1256,6 +1257,9 @@ class ConnectionOrchestrator:
         ----------
         target_address : str | None
             Explicit address to connect, or ``None`` for discovery mode.
+        explicit_address : bool
+            Whether ``target_address`` originated from an explicitly supplied
+            ``address`` argument rather than derived current-address state.
         normalized_target : str | None
             Sanitized logging form of ``target_address``.
         on_disconnect_func : Callable[[BleakRootClient], None]
@@ -1322,7 +1326,9 @@ class ConnectionOrchestrator:
                 direct_err,
                 exc_info=True,
             )
-            skip_discovery_scan = _looks_like_ble_address(target_address)
+            skip_discovery_scan = explicit_address and _looks_like_ble_address(
+                target_address
+            )
             if skip_discovery_scan and _is_device_not_found_error(direct_err):
                 logger.debug(
                     "Direct connect reported device-not-found for %s; skipping discovery scan and retrying explicit address connect.",
@@ -1720,6 +1726,7 @@ class ConnectionOrchestrator:
         try:
             client, skip_discovery_scan = self._attempt_direct_connect(
                 target_address=target_address,
+                explicit_address=address is not None,
                 normalized_target=normalized_target,
                 on_disconnect_func=on_disconnect_func,
                 pair_on_connect=pair_on_connect,

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -1317,7 +1317,7 @@ class ConnectionOrchestrator:
             TimeoutError,
         ) as direct_err:
             logger.debug(
-                "Direct connect to %s failed; falling back to discovery: %s",
+                "Direct connect to %s failed; preparing retry path: %s",
                 normalized_target,
                 direct_err,
                 exc_info=True,
@@ -1400,9 +1400,8 @@ class ConnectionOrchestrator:
         on_disconnect_func: Callable[["BleakRootClient"], None],
         pair_on_connect: bool,
         retry_connect_timeout: float,
-        discovery_connect_timeout: float,
     ) -> tuple[BLEClient, str]:
-        """Connect retry target with optional discovery fallback after direct retry.
+        """Connect a resolved retry target and return the connected client.
 
         Parameters
         ----------
@@ -1420,8 +1419,6 @@ class ConnectionOrchestrator:
             Whether pairing should be requested during connect.
         retry_connect_timeout : float
             Timeout for the initial retry connect.
-        discovery_connect_timeout : float
-            Timeout for discovery-fallback connect.
 
         Returns
         -------
@@ -1463,39 +1460,17 @@ class ConnectionOrchestrator:
             OSError,
             TimeoutError,
         ) as retry_err:
-            should_attempt_discovery_after_retry = (
+            if (
                 skip_discovery_scan
                 and target_address is not None
                 and _is_device_not_found_error(retry_err)
-            )
-            if not should_attempt_discovery_after_retry:
-                self._client_manager_safe_close_client(client)
-                raise
-            logger.debug(
-                "Direct retry also reported device-not-found for %s; attempting discovery scan fallback.",
-                sanitize_address(target_address),
-            )
-            self._client_manager_safe_close_client(client)
-
-            self._raise_if_interface_closing()
-            device = self._compat_find_device(target_address)
-            self._raise_if_interface_closing()
-            resolved_address = device.address
-            client = self._client_manager_create_client(
-                device,
-                on_disconnect_func,
-                pair_on_connect=pair_on_connect,
-                connect_timeout=discovery_connect_timeout,
-            )
-            try:
-                self._raise_if_interface_closing()
-                self._client_manager_connect_client(
-                    client,
-                    timeout=discovery_connect_timeout,
+            ):
+                logger.debug(
+                    "Direct retry also reported device-not-found for %s; explicit-address mode does not use discovery fallback.",
+                    sanitize_address(target_address),
                 )
-            except BaseException:
-                self._client_manager_safe_close_client(client)
-                raise
+            self._client_manager_safe_close_client(client)
+            raise
         except Exception:
             self._client_manager_safe_close_client(client)
             raise
@@ -1772,7 +1747,6 @@ class ConnectionOrchestrator:
                 on_disconnect_func=on_disconnect_func,
                 pair_on_connect=pair_on_connect,
                 retry_connect_timeout=retry_connect_timeout,
-                discovery_connect_timeout=discovery_connect_timeout,
             )
 
             self._raise_if_interface_closing()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ authors = ["Meshtastic Developers (upstream project authors)"]
 maintainers = ["Jeremiah K. <jeremiahk@gmx.com>"]
 license = "GPL-3.0-only"
 readme = "README.md"
-homepage = "https://github.com/jeremiah-k/meshtastic-python"
-repository = "https://github.com/jeremiah-k/meshtastic-python"
+homepage = "https://github.com/jeremiah-k/mtjk"
+repository = "https://github.com/jeremiah-k/mtjk"
 packages = [{ include = "meshtastic" }]
 include = [{ path = "meshtastic/py.typed", format = ["sdist", "wheel"] }]
 

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -432,7 +432,7 @@ def test_connection_orchestrator_finalize_and_establish_error_paths(
 
         orchestrator._validator_validate_connection_request = lambda: None
         orchestrator._raise_if_interface_closing = lambda: None
-        orchestrator._prepare_connection_target = lambda **_kwargs: ("AA", "aa")
+        orchestrator._prepare_connection_target = lambda **_kwargs: ("AA", "aa", True)
         orchestrator._resolve_connection_timeouts = lambda **_kwargs: (1.0, 1.0)
         orchestrator._state_transition_to = lambda _state: True
         client = DummyClient()
@@ -858,7 +858,7 @@ def test_orchestrator_finalize_and_establish_remaining_branches(
         closed_clients: list[object] = []
         orchestrator._validator_validate_connection_request = lambda: None
         orchestrator._raise_if_interface_closing = lambda: None
-        orchestrator._prepare_connection_target = lambda **_kwargs: ("AA", "aa")
+        orchestrator._prepare_connection_target = lambda **_kwargs: ("AA", "aa", True)
         orchestrator._resolve_connection_timeouts = lambda **_kwargs: (1.0, 1.0)
         orchestrator._state_transition_to = lambda _state: True
         orchestrator._attempt_direct_connect = lambda **_kwargs: (None, False)

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -369,7 +369,6 @@ def test_connection_orchestrator_direct_and_retry_exception_paths(
                 on_disconnect_func=lambda _client: None,
                 pair_on_connect=False,
                 retry_connect_timeout=1.0,
-                discovery_connect_timeout=1.0,
             )
         assert retry_client in closed_clients
 
@@ -725,7 +724,6 @@ def test_orchestrator_create_connect_direct_retry_remaining_branches(
                 on_disconnect_func=lambda _client: None,
                 pair_on_connect=False,
                 retry_connect_timeout=1.0,
-                discovery_connect_timeout=1.0,
             )
         assert retry_client in closed_clients
 
@@ -746,31 +744,23 @@ def test_orchestrator_create_connect_direct_retry_remaining_branches(
                 on_disconnect_func=lambda _client: None,
                 pair_on_connect=False,
                 retry_connect_timeout=1.0,
-                discovery_connect_timeout=1.0,
             )
         assert retry_client in closed_clients
 
         first_retry_client = DummyClient()
-        second_retry_client = DummyClient()
-        create_clients = iter([first_retry_client, second_retry_client])
         closed_clients.clear()
-        orchestrator._client_manager_create_client = lambda *_args, **_kwargs: next(
-            create_clients
+        orchestrator._client_manager_create_client = (
+            lambda *_args, **_kwargs: first_retry_client
         )
-
-        connect_attempt_count = [0]
 
         def _connect_side_effect(*_args: object, **_kwargs: object) -> None:
-            if connect_attempt_count[0] == 0:
-                connect_attempt_count[0] += 1
-                raise BleakDeviceNotFoundError("device not found")
-            raise RuntimeError("discovery connect failed")
+            raise BleakDeviceNotFoundError("device not found")
 
         orchestrator._client_manager_connect_client = _connect_side_effect
-        orchestrator._compat_find_device = lambda _target: SimpleNamespace(
-            address="AA:BB"
+        orchestrator._compat_find_device = lambda _target: (_ for _ in ()).throw(
+            AssertionError("explicit-address retry should not scan")
         )
-        with pytest.raises(RuntimeError, match="discovery connect failed"):
+        with pytest.raises(BleakDeviceNotFoundError):
             orchestrator._connect_retry_target(
                 connection_target=TEST_BLE_ADDRESS,
                 resolved_address=TEST_BLE_ADDRESS,
@@ -779,9 +769,8 @@ def test_orchestrator_create_connect_direct_retry_remaining_branches(
                 on_disconnect_func=lambda _client: None,
                 pair_on_connect=False,
                 retry_connect_timeout=1.0,
-                discovery_connect_timeout=1.0,
             )
-        assert closed_clients == [first_retry_client, second_retry_client]
+        assert closed_clients == [first_retry_client]
 
 
 def test_orchestrator_finalize_and_establish_remaining_branches(

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -378,6 +378,40 @@ def test_connection_orchestrator_direct_and_retry_exception_paths(
             orchestrator._compat_find_device(TEST_BLE_ADDRESS)
 
 
+def test_attempt_direct_connect_allows_discovery_for_derived_address(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Derived address targets should not force skip_discovery_scan direct-only mode."""
+    with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
+        direct_client = DummyClient()
+        closed_clients: list[object] = []
+        orchestrator._client_manager_create_client = (
+            lambda *_args, **_kwargs: direct_client
+        )
+        orchestrator._client_manager_connect_client = lambda *_args, **_kwargs: (
+            _ for _ in ()
+        ).throw(TimeoutError("direct fail"))
+        orchestrator._client_manager_safe_close_client = (
+            lambda client: closed_clients.append(client)
+        )
+
+        client, skip_discovery_scan = orchestrator._attempt_direct_connect(
+            target_address=TEST_BLE_ADDRESS,
+            explicit_address=False,
+            normalized_target="aabbccddeeff",
+            on_disconnect_func=lambda _client: None,
+            pair_on_connect=False,
+            direct_connect_timeout=1.0,
+            register_notifications_func=lambda _client: None,
+            on_connected_func=lambda: None,
+            emit_connected_side_effects=True,
+        )
+
+        assert client is None
+        assert skip_discovery_scan is False
+        assert closed_clients == [direct_client]
+
+
 def test_connection_orchestrator_finalize_and_establish_error_paths(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -341,6 +341,7 @@ def test_connection_orchestrator_direct_and_retry_exception_paths(
         with pytest.raises(RuntimeError, match="finalize failed"):
             orchestrator._attempt_direct_connect(
                 target_address=TEST_BLE_ADDRESS,
+                explicit_address=True,
                 normalized_target="aabbccddeeff",
                 on_disconnect_func=lambda _client: None,
                 pair_on_connect=False,
@@ -697,6 +698,7 @@ def test_orchestrator_create_connect_direct_retry_remaining_branches(
         with pytest.raises(ValueError, match="direct fail"):
             orchestrator._attempt_direct_connect(
                 target_address=TEST_BLE_ADDRESS,
+                explicit_address=True,
                 normalized_target="aabbccddeeff",
                 on_disconnect_func=lambda _client: None,
                 pair_on_connect=False,

--- a/tests/test_ble_connection_edge_cases.py
+++ b/tests/test_ble_connection_edge_cases.py
@@ -1198,32 +1198,29 @@ def test_connection_orchestrator_preserves_pair_on_connect_across_direct_retry()
 
 
 @pytest.mark.unit
-def test_connection_orchestrator_preserves_pair_on_connect_across_scan_fallback() -> (
+def test_connection_orchestrator_preserves_pair_on_connect_across_identifier_fallback() -> (
     None
 ):
-    """Discovery fallback client creation should also preserve pair_on_connect."""
+    """Identifier-based discovery fallback should preserve pair_on_connect."""
     state_manager = BLEStateManager()
     state_lock = RLock()
     validator = ConnectionValidator(state_manager, state_lock, MockBLEError)
     client_manager = _make_orchestrator_client_manager()
     direct_client = MagicMock()
-    retry_client = MagicMock()
     discovered_client = MagicMock()
     client_manager.create_client.side_effect = [
         direct_client,
-        retry_client,
         discovered_client,
     ]
     client_manager.connect_client.side_effect = [
-        BleakDeviceNotFoundError("AA:BB:CC:DD:EE:FF", "not found"),
-        BleakDeviceNotFoundError("AA:BB:CC:DD:EE:FF", "not found"),
+        BleakDeviceNotFoundError("mesh-node", "not found"),
         None,
     ]
 
     interface = MagicMock()
     interface.BLEError = MockBLEError
     interface._closed = False
-    discovered_device = BLEDevice("AA:BB:CC:DD:EE:FF", "Mesh", details=None)
+    discovered_device = BLEDevice("AA:BB:CC:DD:EE:FF", "mesh-node", details=None)
     interface.findDevice.return_value = discovered_device
 
     orchestrator = ConnectionOrchestrator(
@@ -1238,7 +1235,7 @@ def test_connection_orchestrator_preserves_pair_on_connect_across_scan_fallback(
     orchestrator._finalize_connection = MagicMock()  # type: ignore[method-assign]
 
     result = orchestrator._establish_connection(
-        address="AA:BB:CC:DD:EE:FF",
+        address="mesh-node",
         current_address=None,
         register_notifications_func=lambda _client: None,
         on_connected_func=lambda: None,
@@ -1247,24 +1244,22 @@ def test_connection_orchestrator_preserves_pair_on_connect_across_scan_fallback(
     )
 
     assert result is discovered_client
-    assert client_manager.create_client.call_count == 3
+    assert client_manager.create_client.call_count == 2
     assert [
         call.kwargs["pair_on_connect"]
         for call in client_manager.create_client.call_args_list
-    ] == [True, True, True]
+    ] == [True, True]
     assert [
         call.kwargs["connect_timeout"]
         for call in client_manager.create_client.call_args_list
     ] == [
         BLEConfig.CONNECTION_TIMEOUT,
         BLEConfig.CONNECTION_TIMEOUT,
-        BLEConfig.CONNECTION_TIMEOUT,
     ]
-    assert client_manager.create_client.call_args_list[2].args[0] is discovered_device
+    assert client_manager.create_client.call_args_list[1].args[0] is discovered_device
     assert [
         call.kwargs["timeout"] for call in client_manager.connect_client.call_args_list
     ] == [
-        BLEConfig.CONNECTION_TIMEOUT,
         BLEConfig.CONNECTION_TIMEOUT,
         BLEConfig.CONNECTION_TIMEOUT,
     ]
@@ -1458,22 +1453,19 @@ def test_connection_orchestrator_uses_discovery_for_non_address_identifier_after
 def test_connection_orchestrator_falls_back_to_find_device_when_findDevice_missing() -> (
     None
 ):
-    """Explicit-address retry should use find_device() when findDevice() is absent."""
+    """Identifier fallback should use find_device() when findDevice() is absent."""
     state_manager = BLEStateManager()
     state_lock = RLock()
     validator = ConnectionValidator(state_manager, state_lock, MockBLEError)
     client_manager = _make_orchestrator_client_manager()
     direct_client = MagicMock()
-    retry_client = MagicMock()
     discovered_client = MagicMock()
     client_manager.create_client.side_effect = [
         direct_client,
-        retry_client,
         discovered_client,
     ]
     client_manager.connect_client.side_effect = [
-        BleakDeviceNotFoundError("AA:BB:CC:DD:EE:FF", "not found"),
-        BleakDeviceNotFoundError("AA:BB:CC:DD:EE:FF", "not found"),
+        BleakDeviceNotFoundError("mesh-node", "not found"),
         None,
     ]
 
@@ -1496,7 +1488,7 @@ def test_connection_orchestrator_falls_back_to_find_device_when_findDevice_missi
     orchestrator._finalize_connection = MagicMock()  # type: ignore[method-assign]
 
     result = orchestrator._establish_connection(
-        address="AA:BB:CC:DD:EE:FF",
+        address="mesh-node",
         current_address=None,
         register_notifications_func=lambda _client: None,
         on_connected_func=lambda: None,
@@ -1504,27 +1496,24 @@ def test_connection_orchestrator_falls_back_to_find_device_when_findDevice_missi
     )
 
     assert result is discovered_client
-    interface.find_device.assert_called_once_with("AA:BB:CC:DD:EE:FF")
+    interface.find_device.assert_called_once_with("mesh-node")
 
 
 @pytest.mark.unit
 def test_connection_orchestrator_falls_back_to_underscore_find_device() -> None:
-    """Explicit-address retry should use _find_device() when other names are absent."""
+    """Identifier fallback should use _find_device() when other names are absent."""
     state_manager = BLEStateManager()
     state_lock = RLock()
     validator = ConnectionValidator(state_manager, state_lock, MockBLEError)
     client_manager = _make_orchestrator_client_manager()
     direct_client = MagicMock()
-    retry_client = MagicMock()
     discovered_client = MagicMock()
     client_manager.create_client.side_effect = [
         direct_client,
-        retry_client,
         discovered_client,
     ]
     client_manager.connect_client.side_effect = [
-        BleakDeviceNotFoundError("11:22:33:44:55:66", "not found"),
-        BleakDeviceNotFoundError("11:22:33:44:55:66", "not found"),
+        BleakDeviceNotFoundError("mesh-node", "not found"),
         None,
     ]
 
@@ -1547,7 +1536,7 @@ def test_connection_orchestrator_falls_back_to_underscore_find_device() -> None:
     orchestrator._finalize_connection = MagicMock()  # type: ignore[method-assign]
 
     result = orchestrator._establish_connection(
-        address="11:22:33:44:55:66",
+        address="mesh-node",
         current_address=None,
         register_notifications_func=lambda _client: None,
         on_connected_func=lambda: None,
@@ -1555,37 +1544,32 @@ def test_connection_orchestrator_falls_back_to_underscore_find_device() -> None:
     )
 
     assert result is discovered_client
-    interface._find_device.assert_called_once_with("11:22:33:44:55:66")
+    interface._find_device.assert_called_once_with("mesh-node")
 
 
 @pytest.mark.unit
-def test_connection_orchestrator_falls_back_to_scan_when_direct_retry_still_device_not_found() -> (
+def test_connection_orchestrator_raises_after_explicit_address_direct_retry_not_found() -> (
     None
 ):
-    """Explicit-address retries that keep failing with device-not-found should use discovery fallback."""
+    """Explicit-address direct retries that still fail should not trigger discovery scans."""
     state_manager = BLEStateManager()
     state_lock = RLock()
     validator = ConnectionValidator(state_manager, state_lock, MockBLEError)
     client_manager = _make_orchestrator_client_manager()
     direct_client = MagicMock()
     retry_client = MagicMock()
-    discovered_client = MagicMock()
     client_manager.create_client.side_effect = [
         direct_client,
         retry_client,
-        discovered_client,
     ]
     client_manager.connect_client.side_effect = [
         BleakDeviceNotFoundError("AA:BB:CC:DD:EE:FF", "not found"),
         BleakDeviceNotFoundError("AA:BB:CC:DD:EE:FF", "not found"),
-        None,
     ]
 
     interface = MagicMock()
     interface.BLEError = MockBLEError
     interface._closed = False
-    discovered_device = BLEDevice("AA:BB:CC:DD:EE:FF", "Mesh", details=None)
-    interface.findDevice.return_value = discovered_device
 
     orchestrator = ConnectionOrchestrator(
         interface=interface,
@@ -1598,19 +1582,18 @@ def test_connection_orchestrator_falls_back_to_scan_when_direct_retry_still_devi
     )
     orchestrator._finalize_connection = MagicMock()  # type: ignore[method-assign]
 
-    result = orchestrator._establish_connection(
-        address="AA:BB:CC:DD:EE:FF",
-        current_address=None,
-        register_notifications_func=lambda _client: None,
-        on_connected_func=lambda: None,
-        on_disconnect_func=lambda _client: None,
-    )
+    with pytest.raises(BleakDeviceNotFoundError):
+        orchestrator._establish_connection(
+            address="AA:BB:CC:DD:EE:FF",
+            current_address=None,
+            register_notifications_func=lambda _client: None,
+            on_connected_func=lambda: None,
+            on_disconnect_func=lambda _client: None,
+        )
 
-    assert result is discovered_client
-    interface.findDevice.assert_called_once_with("AA:BB:CC:DD:EE:FF")
-    assert client_manager.connect_client.call_count == 3
+    interface.findDevice.assert_not_called()
+    assert client_manager.connect_client.call_count == 2
     direct_timeout = min(DIRECT_CONNECT_TIMEOUT_SECONDS, BLEConfig.CONNECTION_TIMEOUT)
-    discovery_timeout = BLEConfig.CONNECTION_TIMEOUT
     assert (
         client_manager.connect_client.call_args_list[0].kwargs["timeout"]
         == direct_timeout
@@ -1619,23 +1602,12 @@ def test_connection_orchestrator_falls_back_to_scan_when_direct_retry_still_devi
         client_manager.connect_client.call_args_list[1].kwargs["timeout"]
         == direct_timeout
     )
-    assert (
-        client_manager.connect_client.call_args_list[2].kwargs["timeout"]
-        == discovery_timeout
-    )
     assert [
         call.kwargs["connect_timeout"]
         for call in client_manager.create_client.call_args_list
-    ] == [direct_timeout, direct_timeout, discovery_timeout]
-    assert client_manager.create_client.call_args_list[2].args[0] is discovered_device
+    ] == [direct_timeout, direct_timeout]
     assert client_manager.safe_close_client.call_count == 2
-    orchestrator._finalize_connection.assert_called_once_with(
-        discovered_client,
-        "AA:BB:CC:DD:EE:FF",
-        ANY,
-        ANY,
-        emit_connected_side_effects=True,
-    )
+    orchestrator._finalize_connection.assert_not_called()
 
 
 @pytest.mark.unit

--- a/tests/test_ble_connection_edge_cases.py
+++ b/tests/test_ble_connection_edge_cases.py
@@ -1729,6 +1729,8 @@ def test_connection_orchestrator_raises_after_explicit_address_direct_retry_not_
         )
 
     interface.findDevice.assert_not_called()
+    interface.find_device.assert_not_called()
+    interface._find_device.assert_not_called()
     assert client_manager.connect_client.call_count == 2
     direct_timeout = min(DIRECT_CONNECT_TIMEOUT_SECONDS, BLEConfig.CONNECTION_TIMEOUT)
     assert (

--- a/tests/test_ble_connection_edge_cases.py
+++ b/tests/test_ble_connection_edge_cases.py
@@ -1517,6 +1517,76 @@ def test_connection_orchestrator_uses_discovery_for_non_address_identifier_after
 
 
 @pytest.mark.unit
+def test_connection_orchestrator_derived_current_address_uses_discovery_after_direct_failure() -> (
+    None
+):
+    """Derived current_address targets should still allow discovery fallback."""
+    state_manager = BLEStateManager()
+    state_lock = RLock()
+    validator = ConnectionValidator(state_manager, state_lock, MockBLEError)
+    client_manager = _make_orchestrator_client_manager()
+    direct_client = MagicMock()
+    discovered_client = MagicMock()
+    client_manager.create_client.side_effect = [direct_client, discovered_client]
+    client_manager.connect_client.side_effect = [
+        TimeoutError("direct connect timed out"),
+        None,
+    ]
+
+    interface = MagicMock()
+    interface.BLEError = MockBLEError
+    interface._closed = False
+    derived_current_address = "AA:BB:CC:DD:EE:FF"
+    discovered_device = BLEDevice("11:22:33:44:55:66", "Mesh", details=None)
+    interface.findDevice.return_value = discovered_device
+
+    orchestrator = ConnectionOrchestrator(
+        interface=interface,
+        validator=validator,
+        client_manager=client_manager,
+        discovery_manager=MagicMock(),
+        state_manager=state_manager,
+        state_lock=state_lock,
+        thread_coordinator=MagicMock(),
+    )
+    orchestrator._finalize_connection = MagicMock()  # type: ignore[method-assign]
+
+    result = orchestrator._establish_connection(
+        address=None,
+        current_address=derived_current_address,
+        register_notifications_func=lambda _client: None,
+        on_connected_func=lambda: None,
+        on_disconnect_func=lambda _client: None,
+    )
+
+    assert result is discovered_client
+    interface.findDevice.assert_called_once_with(derived_current_address)
+    assert client_manager.connect_client.call_count == 2
+    direct_timeout = min(DIRECT_CONNECT_TIMEOUT_SECONDS, BLEConfig.CONNECTION_TIMEOUT)
+    discovery_timeout = BLEConfig.CONNECTION_TIMEOUT
+    assert (
+        client_manager.connect_client.call_args_list[0].kwargs["timeout"]
+        == direct_timeout
+    )
+    assert (
+        client_manager.connect_client.call_args_list[1].kwargs["timeout"]
+        == discovery_timeout
+    )
+    assert [
+        call.kwargs["connect_timeout"]
+        for call in client_manager.create_client.call_args_list
+    ] == [direct_timeout, discovery_timeout]
+    assert client_manager.create_client.call_args_list[1].args[0] is discovered_device
+    orchestrator._finalize_connection.assert_called_once_with(
+        discovered_client,
+        "11:22:33:44:55:66",
+        ANY,
+        ANY,
+        emit_connected_side_effects=True,
+    )
+
+
+@pytest.mark.unit
 def test_connection_orchestrator_falls_back_to_find_device_when_findDevice_missing() -> (
     None
 ):

--- a/tests/test_ble_connection_edge_cases.py
+++ b/tests/test_ble_connection_edge_cases.py
@@ -1381,6 +1381,73 @@ def test_connection_orchestrator_skips_scan_after_direct_device_not_found_for_ex
 
 
 @pytest.mark.unit
+def test_connection_orchestrator_skips_scan_after_direct_timeout_for_explicit_address() -> (
+    None
+):
+    """Explicit-address direct timeout should skip discovery scan fallback."""
+    state_manager = BLEStateManager()
+    state_lock = RLock()
+    validator = ConnectionValidator(state_manager, state_lock, MockBLEError)
+    client_manager = _make_orchestrator_client_manager()
+    direct_client = MagicMock()
+    retry_client = MagicMock()
+    client_manager.create_client.side_effect = [direct_client, retry_client]
+    client_manager.connect_client.side_effect = [
+        TimeoutError("direct connect timed out"),
+        None,
+    ]
+
+    interface = MagicMock()
+    interface.BLEError = MockBLEError
+    interface._closed = False
+
+    orchestrator = ConnectionOrchestrator(
+        interface=interface,
+        validator=validator,
+        client_manager=client_manager,
+        discovery_manager=MagicMock(),
+        state_manager=state_manager,
+        state_lock=state_lock,
+        thread_coordinator=MagicMock(),
+    )
+    orchestrator._finalize_connection = MagicMock()  # type: ignore[method-assign]
+
+    result = orchestrator._establish_connection(
+        address="AA:BB:CC:DD:EE:FF",
+        current_address=None,
+        register_notifications_func=lambda _client: None,
+        on_connected_func=lambda: None,
+        on_disconnect_func=lambda _client: None,
+    )
+
+    assert result is retry_client
+    interface.findDevice.assert_not_called()
+    interface.find_device.assert_not_called()
+    interface._find_device.assert_not_called()
+    assert client_manager.connect_client.call_count == 2
+    direct_timeout = min(DIRECT_CONNECT_TIMEOUT_SECONDS, BLEConfig.CONNECTION_TIMEOUT)
+    assert (
+        client_manager.connect_client.call_args_list[0].kwargs["timeout"]
+        == direct_timeout
+    )
+    assert (
+        client_manager.connect_client.call_args_list[1].kwargs["timeout"]
+        == direct_timeout
+    )
+    assert [
+        call.kwargs["connect_timeout"]
+        for call in client_manager.create_client.call_args_list
+    ] == [direct_timeout, direct_timeout]
+    orchestrator._finalize_connection.assert_called_once_with(
+        retry_client,
+        "AA:BB:CC:DD:EE:FF",
+        ANY,
+        ANY,
+        emit_connected_side_effects=True,
+    )
+
+
+@pytest.mark.unit
 def test_connection_orchestrator_uses_discovery_for_non_address_identifier_after_direct_failure() -> (
     None
 ):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR changes BLE connection retry behavior so explicit BLE-address targets use direct-only retries and do not fall back to discovery scans. Identifier/name (or missing-address) targets continue to use discovery fallback. The connection retry path no longer accepts a separate discovery_connect_timeout and now computes skip-discovery from whether the address looks like a BLE address and was provided explicitly; explicit_address is propagated through direct-connect paths.

## Key Changes

Features
- Direct-first explicit-address semantics: when the caller supplies an explicit BLE address, the code attempts direct connects first and, on retry, re-attempts direct-only connects (no discovery scan).
- Propagated explicit_address flag through direct-connect calls so retry logic knows the request originated from an explicit address.
- Documentation (BLE.md) updated to describe distinct timeout/retry guidance for explicit-address (bounded direct retries using DIRECT_CONNECT_TIMEOUT_SECONDS) vs identifier/no-address flows (discovery fallback using BLEConfig.CONNECTION_TIMEOUT).

Fixes
- Added dedicated logs for direct-connect timeouts and explicit-address direct-only retries to make retry behavior observable.
- Adjusted logging wording from implying automatic discovery fallback to indicating preparation for the retry path.
- Tests updated to assert explicit-address retries do not call discovery-resolution code and to validate discovery fallback remains for identifier-derived addresses.

Refactors
- Removed discovery_connect_timeout from _connect_retry_target() signature and its callers; timeout handling simplified and localized.
- Decoupled skip-discovery decision from device-not-found checks: skip_discovery_scan is computed as explicit_address and _looks_like_ble_address(target_address).
- Simplified retry logic: explicit-address direct retry that results in a device-not-found now closes the client and re-raises (no find_device + second connect).
- Refactored tests and helpers to reflect single-path direct retry behavior for explicit-address targets and preserved discovery-path tests for identifier/name targets; tightened call-count and cleanup assertions.

## Breaking Changes / Migration Notes

- Breaking change: explicit BLE-address retries no longer fall back to discovery. Callers who relied on discovery fallback while supplying an explicit address must either:
  - supply an identifier/name (or omit the explicit address) to enable discovery fallback, or
  - implement discovery/fallback externally around explicit-address connects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->