### PR TITLE
Update CI/CD config, linters, type directives, and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
       - *checkout_step
       - *setup_python_step
       - name: Install ruff
-        run: python -m pip install --upgrade "ruff==0.15.1"
+        run: python -m pip install --upgrade "ruff==0.15.10"
       - name: Run ruff on tests
         run: ruff check meshtastic/tests
   mypy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: jeremiah-k/mtjk
+          files: ./junit.xml
           report_type: test_results
           fail_ci_if_error: false
   pylint:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -14,6 +14,10 @@ plugins:
 lint:
   disabled:
     - bandit
+    - oxipng
+    - pylint
+    - pyright
+    - renovate
   ignore:
     - linters: [ALL]
       paths:
@@ -77,14 +81,14 @@ lint:
   enabled:
     - actionlint@1.7.12
     - black@26.3.1
-    - checkov@3.2.513
+    - checkov@3.2.521
     - git-diff-check
     - gitleaks@8.30.1
     - isort@8.0.1
     - markdownlint@0.48.0
     - osv-scanner@2.3.5
-    - prettier@3.8.1
-    - ruff@0.15.8
+    - prettier@3.8.2
+    - ruff@0.15.10
     - shellcheck@0.11.0
     - shfmt@3.6.0
     - taplo@0.10.0

--- a/BLE.md
+++ b/BLE.md
@@ -519,7 +519,7 @@ with BLEInterface(address="DD:DD:13:27:74:29") as iface:
 | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Multiple `BLEInterface` instances per address | Reuse one instance; multiple instances collide on the address gate.                                                                                        |
 | Layered reconnect loops                       | Use either the library's `auto_reconnect=True` **or** your own loop, never both.                                                                           |
-| Aggressive retry cadence                      | Include exponential backoff; repeated direct retries or `scan + connect` cycles during rapid retries exhaust BlueZ.                                       |
+| Aggressive retry cadence                      | Include exponential backoff; repeated direct retries or `scan + connect` cycles during rapid retries exhaust BlueZ.                                        |
 | Forgetting to resubscribe notifications       | Use the same instance so `NotificationManager` can call `_resubscribe_all()` automatically after reconnects (non-`FROMNUM_UUID`; dispatcher owns FROMNUM). |
 | Passing only deprecated `adapter=` kwargs     | Prefer `bluez={"adapter": "hci0"}` for Bleak 3; `BLEClient` still translates legacy `adapter=` for compatibility.                                          |
 | Not closing the interface                     | Always call `close()` or use the context-manager pattern; unclosed BLE handles on Linux prevent future connections (BlueZ quirk).                          |

--- a/meshtastic/powermon/ppk2.py
+++ b/meshtastic/powermon/ppk2.py
@@ -7,7 +7,7 @@ import time
 from contextlib import suppress
 from typing import Final
 
-from ppk2_api import ppk2_api  # type: ignore[import-not-found]
+from ppk2_api import ppk2_api  # type: ignore[import-untyped,import-not-found]
 
 from .constants import MICROAMPS_PER_MILLIAMP, MILLIVOLTS_PER_VOLT, MIN_SUPPLY_VOLTAGE_V
 from .power_supply import PowerError, PowerSupply

--- a/meshtastic/powermon/ppk2.py
+++ b/meshtastic/powermon/ppk2.py
@@ -7,7 +7,7 @@ import time
 from contextlib import suppress
 from typing import Final
 
-from ppk2_api import ppk2_api  # type: ignore[import-untyped]
+from ppk2_api import ppk2_api  # type: ignore[import-not-found]
 
 from .constants import MICROAMPS_PER_MILLIAMP, MILLIVOLTS_PER_VOLT, MIN_SUPPLY_VOLTAGE_V
 from .power_supply import PowerError, PowerSupply

--- a/meshtastic/powermon/riden.py
+++ b/meshtastic/powermon/riden.py
@@ -6,7 +6,7 @@ import time
 from datetime import datetime
 from typing import Any, Final, cast
 
-import riden
+import riden  # type: ignore[import-not-found]
 
 from .constants import MILLIAMPS_PER_AMP, SECONDS_PER_HOUR
 from .power_supply import PowerError, PowerSupply
@@ -17,7 +17,7 @@ INVALID_POWER_ON_VOLTAGE_ERROR: Final[str] = (
 DEFAULT_RIDEN_BAUDRATE: Final[int] = 115200
 DEFAULT_RIDEN_ADDRESS: Final[int] = 1
 
-Riden = cast(type[Any], riden.Riden)  # type: ignore[attr-defined]
+Riden = cast(type[Any], riden.Riden)
 
 
 class RidenPowerSupply(PowerSupply):

--- a/meshtastic/powermon/riden.py
+++ b/meshtastic/powermon/riden.py
@@ -6,7 +6,7 @@ import time
 from datetime import datetime
 from typing import Any, Final, cast
 
-import riden  # type: ignore[import-not-found]
+import riden  # type: ignore[import-untyped,import-not-found]
 
 from .constants import MILLIAMPS_PER_AMP, SECONDS_PER_HOUR
 from .power_supply import PowerError, PowerSupply

--- a/meshtastic/slog/slog.py
+++ b/meshtastic/slog/slog.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeAlias
 
-import parse  # type: ignore[import-untyped]
+import parse  # type: ignore[import-not-found]
 import platformdirs
 import pyarrow as pa
 from pubsub import pub

--- a/meshtastic/slog/slog.py
+++ b/meshtastic/slog/slog.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeAlias
 
-import parse  # type: ignore[import-not-found]
+import parse  # type: ignore[import-untyped,import-not-found]
 import platformdirs
 import pyarrow as pa
 from pubsub import pub

--- a/meshtastic/tests/test_slog_coverage.py
+++ b/meshtastic/tests/test_slog_coverage.py
@@ -1023,9 +1023,7 @@ def test_power_logger_store_current_reading_no_lock_fallback() -> None:
         warnings.simplefilter("always")
         logger.store_current_reading()
 
-    assert any(
-        issubclass(item.category, DeprecationWarning) for item in captured
-    )
+    assert any(issubclass(item.category, DeprecationWarning) for item in captured)
 
 
 @pytest.mark.unit


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR updates CI configuration to include JUnit XML test results in Codecov uploads and bumps lint tooling versions. It also refactors several type-checking directives to use `import-not-found` instead of `import-untyped`, simplifies a test assertion, and makes a minor documentation formatting adjustment.

## Key Changes

**CI & Testing**
- Added `junit.xml` file upload to the Codecov "Upload test results" step in the workflow
- Updated Lint Trunk configuration with new versions: `checkov` (3.2.513 → 3.2.521), `prettier` (3.8.1 → 3.8.2), `ruff` (0.15.8 → 0.15.10)
- Disabled additional linters in Trunk configuration: `oxipng`, `pylint`, `pyright`, `renovate`

**Type-Checking & Code Quality**
- Updated static type-ignore directives across multiple modules from `import-untyped` to `import-not-found`:
  - `meshtastic/powermon/ppk2.py`
  - `meshtastic/slog/slog.py`
- Refined type-ignore handling in `meshtastic/powermon/riden.py`: added `import-not-found` ignore on the `riden` import and removed `attr-defined` ignore from the cast assignment

**Tests**
- Simplified the warning assertion in `test_power_logger_store_current_reading_no_lock_fallback` from multi-line to single-line format while maintaining equivalent functionality

**Documentation**
- Minor whitespace adjustment in `BLE.md` documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->