### PR TITLE
Configure Renovate to track meshtasticd Docker image updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:best-practices"],
   "forkProcessing": "enabled",
   "mode": "full",
-  "enabledManagers": ["poetry", "github-actions", "git-submodules"],
+  "enabledManagers": ["poetry", "github-actions", "git-submodules", "custom.regex"],
   "timezone": "America/Chicago",
   "updateNotScheduled": true,
   "dependencyDashboard": true,

--- a/renovate.json
+++ b/renovate.json
@@ -42,6 +42,29 @@
       "matchDepNames": ["protobufs"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest", "pinDigest"],
       "automerge": true
+    },
+    {
+      "description": "Automerge meshtasticd Docker image updates (digest + version)",
+      "matchManagers": ["regex"],
+      "matchDepNames": ["meshtastic/meshtasticd"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest", "pinDigest"],
+      "automerge": true
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track meshtasticd Docker image in CI workflows and shell scripts",
+      "fileMatch": [
+        "^\\.github/workflows/[^/]+\\.ya?ml$",
+        "^bin/run-.*-with-meshtasticd\\.sh$"
+      ],
+      "matchStrings": [
+        "meshtastic/meshtasticd:(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+      ],
+      "depNameTemplate": "meshtastic/meshtasticd",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
Add customManagers regex to detect meshtasticd image references in CI workflows and shell scripts, and automerge both digest and version updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This pull request extends the Renovate configuration to automatically detect and manage updates for the `meshtastic/meshtasticd` Docker image used across the project's CI workflows and shell scripts.

## Changes

**Configuration Updates**
- Added a custom regex manager (`customManagers`) that scans GitHub Actions workflow YAML files and the `bin/run-*-with-meshtasticd.sh` script to identify `meshtastic/meshtasticd` image references in the format `meshtastic/meshtasticd:<tag>@sha256:<digest>`
- Configured the regex manager to use Docker as the datasource and versioning template, enabling Renovate to resolve version and digest information
- Added a package rule to automatically merge updates for the `meshtastic/meshtasticd` dependency, covering minor, patch, pinned, digest, and pinned digest updates

**Files Modified**
- `renovate.json`: +23 lines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->