### PR TITLE
Add quiet mode and reduce logging verbosity

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1692,7 +1692,13 @@ def onConnected(interface: MeshInterface) -> None:
 
         # do not print this line if we are exporting the config
         if not args.export_config:
-            print("Connected to radio")
+            stable_path = getattr(interface, "_stable_path", None)
+            if stable_path:
+                dev_path = getattr(interface, "devPath", "")
+                tty_name = os.path.basename(dev_path) if dev_path else "unknown"
+                print(f"Connected to radio on {tty_name} (stable: {stable_path})")
+            else:
+                print("Connected to radio")
 
         if args.set_time is not None:
             interface.getNode(args.dest, False, **getNode_kwargs).setTime(args.set_time)

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -782,7 +782,7 @@ def onConnection(interface: MeshInterface, topic: Any = pub.AUTO_TOPIC) -> None:
     """Notify about a change in the radio connection state."""
     _ = interface
     topic_name = topic.getName() if hasattr(topic, "getName") else str(topic)
-    print(f"Connection changed: {topic_name}")
+    _cli_print(f"Connection changed: {topic_name}")
 
 
 def checkChannel(interface: MeshInterface, channelIndex: int) -> bool:
@@ -1054,7 +1054,7 @@ def traverseConfig(
             else:
                 if not _resolve_pref(icfg, pref_name):
                     parts = pref_name.split(".")
-                    section = parts[-2] if len(parts) >= 2 else parts[0]
+                    section = parts[0]
                     skipped_by_section.setdefault(section, []).append(pref)
                     continue
                 try:
@@ -1200,13 +1200,13 @@ def setPref(config: Any, comp_name: str, raw_val: Any) -> bool:
         config_values = getattr(config, config_type.name)
         if val == 0:
             # clear values
-            print(f"Clearing {pref.name} list")
+            _cli_print(f"Clearing {pref.name} list")
             del getattr(config_values, pref.name)[:]
         else:
             display_value = _redact_pref_value(
                 snake_name, meshtastic.util.toStr(raw_val)
             )
-            print(f"Adding '{display_value}' to the {pref.name} list")
+            _cli_print(f"Adding '{display_value}' to the {pref.name} list")
             cur_vals = [
                 x for x in getattr(config_values, pref.name) if x not in [0, "", b""]
             ]
@@ -1217,7 +1217,7 @@ def setPref(config: Any, comp_name: str, raw_val: Any) -> bool:
 
     prefix = f"{'.'.join(name[0:-1])}." if config_type.message_type is not None else ""
     display_value = _redact_pref_value(snake_name, meshtastic.util.toStr(raw_val))
-    print(f"Set {prefix}{uni_name} to {display_value}")
+    _cli_print(f"Set {prefix}{uni_name} to {display_value}")
 
     return True
 
@@ -1242,12 +1242,12 @@ def _handle_ota_update(
     except meshtastic.ota.OTAError as e:
         _cli_exit(f"OTA update failed: {e}")
 
-    print(f"Triggering OTA update on {interface.hostname}...")
+    _cli_print(f"Triggering OTA update on {interface.hostname}...")
     interface.getNode(ota_dest, requestChannels=False, **getNode_kwargs).startOTA(
         mode=admin_pb2.OTAMode.OTA_WIFI, ota_file_hash=ota.hash_bytes()
     )
 
-    print("Waiting for device to reboot into OTA mode...")
+    _cli_print("Waiting for device to reboot into OTA mode...")
     time.sleep(OTA_REBOOT_WAIT_SECONDS)
 
     retries = OTA_MAX_RETRIES
@@ -1265,7 +1265,7 @@ def _handle_ota_update(
         except meshtastic.ota.OTAError as e:
             _cli_exit(f"OTA update failed: {e}")
 
-    print("\nOTA update completed successfully!")
+    _cli_print("\nOTA update completed successfully!")
 
 
 def _handle_set_command(
@@ -1297,12 +1297,12 @@ def _handle_set_command(
                     break
 
     if any_found:
-        print("Writing modified preferences to device")
+        _cli_print("Writing modified preferences to device")
         if len(fields) > 1:
-            print("Using a configuration transaction")
+            _cli_print("Using a configuration transaction")
             node.beginSettingsTransaction()
         for field in fields:
-            print(f"Writing {field} configuration to device")
+            _cli_print(f"Writing {field} configuration to device")
             node.writeConfig(field)
         if len(fields) > 1:
             node.commitSettingsTransaction()
@@ -1744,7 +1744,7 @@ def onConnected(interface: MeshInterface) -> None:
             closeNow = True
             waitForAckNak = True
 
-            print("Removing fixed position and disabling fixed position setting")
+            _cli_print("Removing fixed position and disabling fixed position setting")
             interface.getNode(args.dest, False, **getNode_kwargs).removeFixedPosition()
         elif args.setlat or args.setlon or args.setalt:
             closeNow = True
@@ -1755,21 +1755,21 @@ def onConnected(interface: MeshInterface) -> None:
             lon = 0.0
             if args.setalt:
                 alt = int(args.setalt)
-                print(f"Fixing altitude at {alt} meters")
+                _cli_print(f"Fixing altitude at {alt} meters")
             if args.setlat:
                 try:
                     lat = int(args.setlat)
                 except ValueError:
                     lat = float(args.setlat)
-                print(f"Fixing latitude at {lat} degrees")
+                _cli_print(f"Fixing latitude at {lat} degrees")
             if args.setlon:
                 try:
                     lon = int(args.setlon)
                 except ValueError:
                     lon = float(args.setlon)
-                print(f"Fixing longitude at {lon} degrees")
+                _cli_print(f"Fixing longitude at {lon} degrees")
 
-            print("Setting device position and enabling fixed position setting")
+            _cli_print("Setting device position and enabling fixed position setting")
             # can include lat/long/alt etc: latitude = 37.5, longitude = -122.1
             interface.getNode(args.dest, False, **getNode_kwargs).setFixedPosition(
                 lat, lon, alt
@@ -1793,13 +1793,13 @@ def onConnected(interface: MeshInterface) -> None:
                 )
 
             if long_name and short_name:
-                print(
+                _cli_print(
                     f"Setting device owner to {long_name} and short name to {short_name}"
                 )
             elif long_name:
-                print(f"Setting device owner to {long_name}")
+                _cli_print(f"Setting device owner to {long_name}")
             elif short_name:
-                print(f"Setting device owner short to {short_name}")
+                _cli_print(f"Setting device owner short to {short_name}")
 
             unmessagable = None
             if args.set_is_unmessageable is not None:
@@ -1808,7 +1808,7 @@ def onConnected(interface: MeshInterface) -> None:
                     if isinstance(args.set_is_unmessageable, str)
                     else args.set_is_unmessageable
                 )
-                print(f"Setting device owner is_unmessageable to {unmessagable}")
+                _cli_print(f"Setting device owner is_unmessageable to {unmessagable}")
 
             interface.getNode(args.dest, False, **getNode_kwargs).setOwner(
                 long_name=long_name, short_name=short_name, is_unmessagable=unmessagable
@@ -1819,20 +1819,24 @@ def onConnected(interface: MeshInterface) -> None:
             waitForAckNak = True
             node = interface.getNode(args.dest, False, **getNode_kwargs)
             if node.module_available(mesh_pb2.CANNEDMSG_CONFIG):
-                print(f"Setting canned plugin message to {args.set_canned_message}")
+                _cli_print(
+                    f"Setting canned plugin message to {args.set_canned_message}"
+                )
                 node.set_canned_message(args.set_canned_message)
             else:
-                print("Canned Message module is excluded by firmware; skipping set.")
+                _cli_print(
+                    "Canned Message module is excluded by firmware; skipping set."
+                )
 
         if args.set_ringtone:
             closeNow = True
             waitForAckNak = True
             node = interface.getNode(args.dest, False, **getNode_kwargs)
             if node.module_available(mesh_pb2.EXTNOTIF_CONFIG):
-                print(f"Setting ringtone to {args.set_ringtone}")
+                _cli_print(f"Setting ringtone to {args.set_ringtone}")
                 node.set_ringtone(args.set_ringtone)
             else:
-                print(
+                _cli_print(
                     "External Notification is excluded by firmware; skipping ringtone set."
                 )
 
@@ -1857,9 +1861,9 @@ def onConnected(interface: MeshInterface) -> None:
                 )
 
             else:
-                print(f"Setting position fields to {allFields}")
+                _cli_print(f"Setting position fields to {allFields}")
                 setPref(positionConfig, "position_flags", f"{allFields:d}")
-                print("Writing modified preferences to device")
+                _cli_print("Writing modified preferences to device")
                 interface.getNode(args.dest, **getNode_kwargs).writeConfig("position")
 
         elif args.pos_fields is not None:
@@ -1882,7 +1886,7 @@ def onConnected(interface: MeshInterface) -> None:
                     "ERROR: Ham radio callsign cannot be empty or contain only whitespace characters"
                 )
             closeNow = True
-            print(f"Setting Ham ID to {ham_id} and turning off encryption")
+            _cli_print(f"Setting Ham ID to {ham_id} and turning off encryption")
             interface.getNode(args.dest, **getNode_kwargs).setOwner(
                 ham_id, is_licensed=True
             )
@@ -2002,7 +2006,7 @@ def onConnected(interface: MeshInterface) -> None:
             closeNow = True
             channelIndex = mt_config.channel_index or 0
             if checkChannel(interface, channelIndex):
-                print(
+                _cli_print(
                     f"Sending text message {args.sendtext} to {args.dest} on channelIndex:{channelIndex}"
                     f" {'using PRIVATE_APP port' if args.private else ''}"
                 )
@@ -2031,7 +2035,7 @@ def onConnected(interface: MeshInterface) -> None:
             dest = str(args.traceroute)
             channelIndex = mt_config.channel_index or 0
             if checkChannel(interface, channelIndex):
-                print(
+                _cli_print(
                     f"Sending traceroute request to {dest} on channelIndex:{channelIndex} (this could take a while)"
                 )
                 interface.sendTraceRoute(dest, hopLimit, channelIndex=channelIndex)
@@ -2052,7 +2056,7 @@ def onConnected(interface: MeshInterface) -> None:
                         "local_stats": "local_stats",
                     }
                     telemType = telemMap.get(args.request_telemetry, "device_metrics")
-                    print(
+                    _cli_print(
                         f"Sending {telemType} telemetry request to {args.dest} on channelIndex:{channelIndex} (this could take a while)"
                     )
                     interface.sendTelemetry(
@@ -2068,7 +2072,7 @@ def onConnected(interface: MeshInterface) -> None:
             else:
                 channelIndex = mt_config.channel_index or 0
                 if checkChannel(interface, channelIndex):
-                    print(
+                    _cli_print(
                         f"Sending position request to {args.dest} on channelIndex:{channelIndex} (this could take a while)"
                     )
                     interface.sendPosition(
@@ -2089,7 +2093,7 @@ def onConnected(interface: MeshInterface) -> None:
                     for wrpair in args.gpio_wrb or []:
                         bitmask |= 1 << int(wrpair[0])
                         bitval |= int(wrpair[1]) << int(wrpair[0])
-                    print(
+                    _cli_print(
                         f"Writing GPIO mask 0x{bitmask:x} with value 0x{bitval:x} to {args.dest}"
                     )
                     rhc.writeGPIOs(args.dest, bitmask, bitval)
@@ -2097,7 +2101,7 @@ def onConnected(interface: MeshInterface) -> None:
 
                 if args.gpio_rd:
                     bitmask = int(args.gpio_rd, 16)
-                    print(f"Reading GPIO mask 0x{bitmask:x} from {args.dest}")
+                    _cli_print(f"Reading GPIO mask 0x{bitmask:x} from {args.dest}")
                     interface.mask = bitmask
                     rhc.readGPIOs(args.dest, bitmask, None)
                     # wait up to X seconds for a response
@@ -2109,7 +2113,7 @@ def onConnected(interface: MeshInterface) -> None:
 
                 if args.gpio_watch:
                     bitmask = int(args.gpio_watch, 16)
-                    print(
+                    _cli_print(
                         f"Watching GPIO mask 0x{bitmask:x} from {args.dest}. Press ctrl-c to exit"
                     )
                     while True:
@@ -2147,7 +2151,7 @@ def onConnected(interface: MeshInterface) -> None:
                 try:
                     with open(args.export_config, "w", encoding="utf-8") as f:
                         f.write(config_txt)
-                    print(f"Exported configuration to {args.export_config}")
+                    _cli_print(f"Exported configuration to {args.export_config}")
                 except Exception as e:
                     _cli_exit(f"ERROR: Failed to write config file: {e}")
 
@@ -2191,9 +2195,9 @@ def onConnected(interface: MeshInterface) -> None:
                 chs.name = args.ch_add
                 ch.settings.CopyFrom(chs)
                 ch.role = channel_pb2.Channel.Role.SECONDARY
-                print("Writing modified channels to device")
+                _cli_print("Writing modified channels to device")
                 n.writeChannel(ch.index)
-                print(
+                _cli_print(
                     f"Setting newly-added channel's {ch.index} as '--ch-index' for further modifications"
                 )
                 mt_config.channel_index = ch.index
@@ -2208,7 +2212,7 @@ def onConnected(interface: MeshInterface) -> None:
                 if ch_del_idx == 0:
                     _cli_exit("Warning: Cannot delete primary channel.", 1)
                 else:
-                    print(f"Deleting channel {ch_del_idx}")
+                    _cli_print(f"Deleting channel {ch_del_idx}")
                     interface.getNode(args.dest, **getNode_kwargs).deleteChannel(
                         ch_del_idx
                     )
@@ -2291,7 +2295,7 @@ def onConnected(interface: MeshInterface) -> None:
 
             enable: bool = True  # default to enable
             if args.ch_enable or args.ch_disable:
-                print(
+                _cli_print(
                     "Warning: --ch-enable and --ch-disable can produce noncontiguous channels, "
                     "which can cause errors in some clients. Whenever possible, use --ch-add and --ch-del instead."
                 )
@@ -2343,7 +2347,7 @@ def onConnected(interface: MeshInterface) -> None:
             else:
                 ch.role = channel_pb2.Channel.Role.DISABLED
 
-            print("Writing modified channels to device")
+            _cli_print("Writing modified channels to device")
             node.writeChannel(_idx)
 
         if args.get_canned_message:
@@ -2389,7 +2393,7 @@ def onConnected(interface: MeshInterface) -> None:
                 found = getPref(node, pref[0])
 
             if found:
-                print("Completed getting preferences")
+                _cli_print("Completed getting preferences")
 
         if args.nodes:
             closeNow = True
@@ -2456,7 +2460,7 @@ def onConnected(interface: MeshInterface) -> None:
         have_tunnel = platform.system() == "Linux"
         if have_tunnel and args.tunnel:
             if args.dest != BROADCAST_ADDR:
-                print("A tunnel can only be created using the local node.")
+                _cli_print("A tunnel can only be created using the local node.")
                 return
             # Even if others said we could close, stay open if the user asked for a tunnel
             closeNow = False
@@ -2473,13 +2477,15 @@ def onConnected(interface: MeshInterface) -> None:
         if not skip_ack_wait and (
             args.ack or (args.dest != BROADCAST_ADDR and waitForAckNak)
         ):
-            print(
+            _cli_print(
                 "Waiting for an acknowledgment from remote node (this could take a while)"
             )
             interface.getNode(args.dest, False, **getNode_kwargs).iface.waitForAckNak()
 
         if args.wait_to_disconnect:
-            print(f"Waiting {args.wait_to_disconnect} seconds before disconnecting")
+            _cli_print(
+                f"Waiting {args.wait_to_disconnect} seconds before disconnecting"
+            )
             time.sleep(int(args.wait_to_disconnect))
 
         # if the user didn't ask for serial debugging output, we might want to exit after we've done our operation
@@ -2551,7 +2557,7 @@ def onNode(node: Any) -> None:
     node : Any
         The node object or identifier that changed; printed to standard output.
     """
-    print(f"Node changed: {node}")
+    _cli_print(f"Node changed: {node}")
 
 
 def subscribe() -> None:

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1715,25 +1715,16 @@ def onConnected(interface: MeshInterface) -> None:
 
         # do not print this line if we are exporting the config
         if not args.export_config:
-            stable_path = getattr(interface, "_stable_path", None)
-            if stable_path:
-                dev_path = getattr(interface, "devPath", "")
-                tty_name = os.path.basename(dev_path) if dev_path else "unknown"
-                # Only show stable-path suffix when it adds new information.
-                try:
-                    dev_resolved = os.path.realpath(dev_path) if dev_path else ""
-                except OSError:
-                    dev_resolved = ""
-                try:
-                    stable_resolved = os.path.realpath(stable_path)
-                except OSError:
-                    stable_resolved = stable_path
-                if dev_resolved == stable_resolved or dev_path == stable_path:
-                    _cli_print(f"Connected to radio on {tty_name}")
-                else:
+            dev_path = getattr(interface, "devPath", "")
+            if dev_path:
+                tty_name = os.path.basename(dev_path)
+                stable_path = getattr(interface, "_stable_path", None)
+                if stable_path and stable_path != dev_path:
                     _cli_print(
                         f"Connected to radio on {tty_name} (stable: {stable_path})"
                     )
+                else:
+                    _cli_print(f"Connected to radio on {tty_name}")
             else:
                 _cli_print("Connected to radio")
 

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -200,6 +200,19 @@ def _cli_exit(message: str, return_value: int = 1) -> NoReturn:
     meshtastic.util.our_exit(message, return_value)
 
 
+def _cli_print(message: str) -> None:
+    """Print a message to stdout unless --quiet is active.
+
+    This helper gates non-essential informational output so that --quiet
+    suppresses ordinary print() calls in addition to lowering the logging
+    level.
+    """
+    args = mt_config.args
+    if args and getattr(args, "quiet", False):
+        return
+    print(message)
+
+
 def supportInfo() -> None:
     """Print troubleshooting guidance and environment details useful for reporting CLI or library issues.
 
@@ -617,6 +630,18 @@ def _channel_url_matches_current_device_state(
     )
 
 
+def _flatten_leaf_paths(prefix: str, mapping: dict[str, Any]) -> list[str]:
+    """Recursively flatten a nested mapping into dotted leaf paths."""
+    paths: list[str] = []
+    for key, value in mapping.items():
+        dotted = f"{prefix}.{key}"
+        if isinstance(value, dict) and value:
+            paths.extend(_flatten_leaf_paths(dotted, value))
+        else:
+            paths.append(dotted)
+    return paths
+
+
 def _verify_config_sections(
     config_fields: dict[str, dict[str, Any]],
     proto_config: Any,
@@ -643,8 +668,7 @@ def _verify_config_sections(
             )
             return False
         if verified_fields is not None:
-            for field_name in yaml_values:
-                verified_fields.append(f"{section_snake}.{field_name}")
+            verified_fields.extend(_flatten_leaf_paths(section_snake, yaml_values))
         logger.debug(
             "%s section %r verified (all requested field values match).",
             label,
@@ -1358,14 +1382,14 @@ def _handle_configure_command(
 
     if "owner" in configuration:
         if not phase1_started:
-            print(CONFIGURE_PHASE1_HEADER)
+            _cli_print(CONFIGURE_PHASE1_HEADER)
             phase1_started = True
         owner_name = str(configuration["owner"]).strip()
         if not owner_name:
             _cli_exit(
                 "ERROR: Long Name cannot be empty or contain only whitespace characters"
             )
-        print(f"Setting device owner to {owner_name}")
+        _cli_print(f"Setting device owner to {owner_name}")
         interface.getNode(args.dest, False, **getNode_kwargs).setOwner(
             long_name=owner_name
         )
@@ -1373,14 +1397,14 @@ def _handle_configure_command(
 
     if "owner_short" in configuration:
         if not phase1_started:
-            print(CONFIGURE_PHASE1_HEADER)
+            _cli_print(CONFIGURE_PHASE1_HEADER)
             phase1_started = True
         owner_short_name = str(configuration["owner_short"]).strip()
         if not owner_short_name:
             _cli_exit(
                 "ERROR: Short Name cannot be empty or contain only whitespace characters"
             )
-        print(f"Setting device owner short to {owner_short_name}")
+        _cli_print(f"Setting device owner short to {owner_short_name}")
         interface.getNode(args.dest, False, **getNode_kwargs).setOwner(
             long_name=None, short_name=owner_short_name
         )
@@ -1388,14 +1412,14 @@ def _handle_configure_command(
 
     if "ownerShort" in configuration:
         if not phase1_started:
-            print(CONFIGURE_PHASE1_HEADER)
+            _cli_print(CONFIGURE_PHASE1_HEADER)
             phase1_started = True
         owner_short_name = str(configuration["ownerShort"]).strip()
         if not owner_short_name:
             _cli_exit(
                 "ERROR: Short Name cannot be empty or contain only whitespace characters"
             )
-        print(f"Setting device owner short to {owner_short_name}")
+        _cli_print(f"Setting device owner short to {owner_short_name}")
         interface.getNode(args.dest, False, **getNode_kwargs).setOwner(
             long_name=None, short_name=owner_short_name
         )
@@ -1403,7 +1427,7 @@ def _handle_configure_command(
 
     if "location" in configuration:
         if not phase1_started:
-            print(CONFIGURE_PHASE1_HEADER)
+            _cli_print(CONFIGURE_PHASE1_HEADER)
             phase1_started = True
         _loc = configuration["location"]
         if not isinstance(_loc, dict) or not _loc:
@@ -1433,10 +1457,10 @@ def _handle_configure_command(
                 alt = int(_loc["alt"])
             except (ValueError, TypeError):
                 _cli_exit(f"location.alt must be an integer, got: {_loc['alt']!r}")
-            print(f"Fixing altitude at {alt} meters")
-        print(f"Fixing latitude at {lat} degrees")
-        print(f"Fixing longitude at {lon} degrees")
-        print("Setting device position")
+            _cli_print(f"Fixing altitude at {alt} meters")
+        _cli_print(f"Fixing latitude at {lat} degrees")
+        _cli_print(f"Fixing longitude at {lon} degrees")
+        _cli_print("Setting device position")
         interface.getNode(args.dest, False, **getNode_kwargs).setFixedPosition(
             lat, lon, alt
         )
@@ -1444,11 +1468,10 @@ def _handle_configure_command(
 
     if "canned_messages" in configuration:
         if not phase1_started:
-            print(CONFIGURE_PHASE1_HEADER)
+            _cli_print(CONFIGURE_PHASE1_HEADER)
             phase1_started = True
-        print(
-            "Setting canned message messages to",
-            configuration["canned_messages"],
+        _cli_print(
+            f"Setting canned message messages to {configuration['canned_messages']}",
         )
         interface.getNode(args.dest, **getNode_kwargs).set_canned_message(
             configuration["canned_messages"]
@@ -1457,9 +1480,9 @@ def _handle_configure_command(
 
     if "ringtone" in configuration:
         if not phase1_started:
-            print(CONFIGURE_PHASE1_HEADER)
+            _cli_print(CONFIGURE_PHASE1_HEADER)
             phase1_started = True
-        print("Setting ringtone to", configuration["ringtone"])
+        _cli_print(f"Setting ringtone to {configuration['ringtone']}")
         interface.getNode(args.dest, **getNode_kwargs).set_ringtone(
             configuration["ringtone"]
         )
@@ -1467,7 +1490,7 @@ def _handle_configure_command(
 
     if "channel_url" in configuration:
         if not phase1_started:
-            print(CONFIGURE_PHASE1_HEADER)
+            _cli_print(CONFIGURE_PHASE1_HEADER)
             phase1_started = True
         raw_channel_url = configuration["channel_url"]
         if not isinstance(raw_channel_url, str):
@@ -1479,18 +1502,18 @@ def _handle_configure_command(
         if _channel_url_matches_current_device_state(
             target_node, requested_channel_url
         ):
-            print("Channel url already matches device state; skipping apply.")
+            _cli_print("Channel url already matches device state; skipping apply.")
             logger.info("Skipping setURL apply because channel URL already matches.")
         else:
             phase1_may_reconnect = True
             seturl_executed = True
-            print("Setting channel url to", requested_channel_url)
+            _cli_print(f"Setting channel url to {requested_channel_url}")
             target_node.setURL(requested_channel_url)
             time.sleep(CONFIG_SETURL_DELAY_SECONDS)
 
     if "channelUrl" in configuration:
         if not phase1_started:
-            print(CONFIGURE_PHASE1_HEADER)
+            _cli_print(CONFIGURE_PHASE1_HEADER)
             phase1_started = True
         raw_channel_url = configuration["channelUrl"]
         if not isinstance(raw_channel_url, str):
@@ -1502,17 +1525,17 @@ def _handle_configure_command(
         if _channel_url_matches_current_device_state(
             target_node, requested_channel_url
         ):
-            print("Channel url already matches device state; skipping apply.")
+            _cli_print("Channel url already matches device state; skipping apply.")
             logger.info("Skipping setURL apply because channel URL already matches.")
         else:
             phase1_may_reconnect = True
             seturl_executed = True
-            print("Setting channel url to", requested_channel_url)
+            _cli_print(f"Setting channel url to {requested_channel_url}")
             target_node.setURL(requested_channel_url)
             time.sleep(CONFIG_SETURL_DELAY_SECONDS)
 
     if phase1_started:
-        print("Phase 1 complete.")
+        _cli_print("Phase 1 complete.")
 
     settings_transaction_started = False
     has_valid_config_section = bool(
@@ -1534,7 +1557,7 @@ def _handle_configure_command(
                 "and configuration in separate operations."
             )
     if has_valid_config_section:
-        print(
+        _cli_print(
             "Phase 2: Applying configuration transaction (may trigger device reboot)..."
         )
         interface.getNode(args.dest, False, **getNode_kwargs).beginSettingsTransaction()
@@ -1617,36 +1640,36 @@ def _handle_configure_command(
                 verify_module_config_fields=_verify_module_config_fields,
             )
             if _reconnect_result == _ConfigureReconnectResult.VERIFIED:
-                print(
+                _cli_print(
                     "Phase 3: Device reconnected and config reloaded. All settings verified."
                 )
             elif _reconnect_result == _ConfigureReconnectResult.VERIFICATION_INCOMPLETE:
-                print(
+                _cli_print(
                     "Phase 3: Device reconnected and config reloaded. "
                     "Could not fully verify applied settings."
                 )
             elif _reconnect_result == _ConfigureReconnectResult.CONFIG_RELOAD_FAILED:
-                print(
+                _cli_print(
                     "Phase 3: Device reconnected but config reload failed. "
                     "Settings may still be applying."
                 )
             elif _reconnect_result == _ConfigureReconnectResult.RECONNECT_FAILED:
-                print(
+                _cli_print(
                     "Phase 3: Device did not reconnect within timeout. "
                     "Configuration may still be applying."
                 )
         else:
-            print(
+            _cli_print(
                 "Phase 3: Reboot/reconnect verification skipped for remote target. "
                 "Local transport state does not confirm remote node reload status."
             )
     else:
         if phase1_may_reconnect:
-            print(
+            _cli_print(
                 "Configuration applied. Channel URL updates may still trigger reconnect/reboot."
             )
         else:
-            print("Configuration applied (no reboot expected).")
+            _cli_print("Configuration applied (no reboot expected).")
 
     return settings_transaction_started, (
         seturl_executed and _is_local_destination(interface, args.dest)
@@ -1696,9 +1719,23 @@ def onConnected(interface: MeshInterface) -> None:
             if stable_path:
                 dev_path = getattr(interface, "devPath", "")
                 tty_name = os.path.basename(dev_path) if dev_path else "unknown"
-                print(f"Connected to radio on {tty_name} (stable: {stable_path})")
+                # Only show stable-path suffix when it adds new information.
+                try:
+                    dev_resolved = os.path.realpath(dev_path) if dev_path else ""
+                except OSError:
+                    dev_resolved = ""
+                try:
+                    stable_resolved = os.path.realpath(stable_path)
+                except OSError:
+                    stable_resolved = stable_path
+                if dev_resolved == stable_resolved or dev_path == stable_path:
+                    _cli_print(f"Connected to radio on {tty_name}")
+                else:
+                    _cli_print(
+                        f"Connected to radio on {tty_name} (stable: {stable_path})"
+                    )
             else:
-                print("Connected to radio")
+                _cli_print("Connected to radio")
 
         if args.set_time is not None:
             interface.getNode(args.dest, False, **getNode_kwargs).setTime(args.set_time)

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1620,7 +1620,7 @@ def _handle_configure_command(
             args.dest, False, **getNode_kwargs
         ).commitSettingsTransaction()
         time.sleep(CONFIG_COMMIT_SETTLE_SECONDS)
-        print(
+        _cli_print(
             "Configuration transaction committed. Device may reboot to apply changes."
         )
 

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1055,7 +1055,8 @@ def traverseConfig(
                 if not _resolve_pref(icfg, pref_name):
                     parts = pref_name.split(".")
                     section = parts[0]
-                    skipped_by_section.setdefault(section, []).append(pref)
+                    relative = ".".join(parts[1:]) if len(parts) > 1 else pref_name
+                    skipped_by_section.setdefault(section, []).append(relative)
                     continue
                 try:
                     ok = setPref(icfg, pref_name, cfg[pref])
@@ -2451,8 +2452,7 @@ def onConnected(interface: MeshInterface) -> None:
         have_tunnel = platform.system() == "Linux"
         if have_tunnel and args.tunnel:
             if args.dest != BROADCAST_ADDR:
-                _cli_print("A tunnel can only be created using the local node.")
-                return
+                _cli_exit("A tunnel can only be created using the local node.", 1)
             # Even if others said we could close, stay open if the user asked for a tunnel
             closeNow = False
             if interface.noProto:
@@ -2936,6 +2936,10 @@ def common() -> None:
         raise RuntimeError(
             "mt_config.parser must be initialized before calling common()"
         )
+
+    # Validate that --quiet is not used with --debug, --listen, or --debuglib
+    if args.quiet and (args.debug or args.listen or args.debuglib):
+        parser.error("--quiet cannot be used with --debug, --listen, or --debuglib")
 
     if args.quiet:
         log_level = logging.WARNING

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -2897,13 +2897,19 @@ def common() -> None:
             "mt_config.parser must be initialized before calling common()"
         )
 
+    if args.quiet:
+        log_level = logging.WARNING
+    elif args.debug or args.listen:
+        log_level = logging.DEBUG
+    else:
+        log_level = logging.INFO
+
     logging.basicConfig(
-        level=logging.DEBUG if (args.debug or args.listen) else logging.INFO,
+        level=log_level,
         format="%(levelname)s file:%(filename)s %(funcName)s line:%(lineno)s %(message)s",
     )
 
-    # set all meshtastic loggers to DEBUG
-    if not (args.debug or args.listen) and args.debuglib:
+    if not (args.debug or args.listen or args.quiet) and args.debuglib:
         logging.getLogger("meshtastic").setLevel(logging.DEBUG)
 
     if len(sys.argv) == 1:
@@ -3904,12 +3910,20 @@ def initParser() -> None:
     )
 
     group.add_argument(
-        "--debug", help="Show API library debug log messages", action="store_true"
+        "--debug",
+        help="Show detailed debug log messages (connection diagnostics, config streaming, retries)",
+        action="store_true",
     )
 
     group.add_argument(
         "--debuglib",
-        help="Show only API library debug log messages",
+        help="Show debug log messages for the meshtastic library only (not dependencies)",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--quiet",
+        help="Suppress non-essential output; show only warnings and errors",
         action="store_true",
     )
 

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1006,36 +1006,45 @@ def traverseConfig(
         `True` when traversal completes and all leaf values are successfully
         applied, `False` if any leaf assignment fails validation.
     """
-    snake_name = meshtastic.util.camel_to_snake(config_root)
-    for pref in config:
-        pref_name = f"{snake_name}.{pref}"
-        if isinstance(config[pref], dict):
-            if not traverseConfig(
-                pref_name,
-                config[pref],
-                interface_config,
-                failed_fields=failed_fields,
-            ):
-                return False
-        else:
-            if not _resolve_pref(interface_config, pref_name):
-                logger.warning(
-                    "Skipping unknown configuration field %s from --configure",
-                    pref_name,
-                )
-                continue
-            try:
-                ok = setPref(interface_config, pref_name, config[pref])
-            except (ValueError, binascii.Error):
-                if failed_fields is not None:
-                    failed_fields.append(pref_name)
-                return False
-            if not ok:
-                if failed_fields is not None:
-                    failed_fields.append(pref_name)
-                return False
+    skipped_by_section: dict[str, list[str]] = {}
 
-    return True
+    def _traverse(root: str, cfg: dict, icfg: Any) -> bool:
+        s_name = meshtastic.util.camel_to_snake(root)
+        for pref in cfg:
+            pref_name = f"{s_name}.{pref}"
+            if isinstance(cfg[pref], dict):
+                if not _traverse(pref_name, cfg[pref], icfg):
+                    return False
+            else:
+                if not _resolve_pref(icfg, pref_name):
+                    parts = pref_name.split(".")
+                    section = parts[-2] if len(parts) >= 2 else parts[0]
+                    skipped_by_section.setdefault(section, []).append(pref)
+                    continue
+                try:
+                    ok = setPref(icfg, pref_name, cfg[pref])
+                except (ValueError, binascii.Error):
+                    if failed_fields is not None:
+                        failed_fields.append(pref_name)
+                    return False
+                if not ok:
+                    if failed_fields is not None:
+                        failed_fields.append(pref_name)
+                    return False
+        return True
+
+    success = _traverse(config_root, config, interface_config)
+
+    for section, fields in skipped_by_section.items():
+        field_list = ", ".join(fields)
+        logger.warning(
+            "Skipping %d unknown field(s) from %s: %s",
+            len(fields),
+            section,
+            field_list,
+        )
+
+    return success
 
 
 def _resolve_pref(config: Any, comp_name: str) -> bool:

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1816,7 +1816,7 @@ def onConnected(interface: MeshInterface) -> None:
                 )
                 node.set_canned_message(args.set_canned_message)
             else:
-                _cli_print(
+                logger.warning(
                     "Canned Message module is excluded by firmware; skipping set."
                 )
 
@@ -1828,7 +1828,7 @@ def onConnected(interface: MeshInterface) -> None:
                 _cli_print(f"Setting ringtone to {args.set_ringtone}")
                 node.set_ringtone(args.set_ringtone)
             else:
-                _cli_print(
+                logger.warning(
                     "External Notification is excluded by firmware; skipping ringtone set."
                 )
 

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -268,7 +268,7 @@ def _post_configure_reconnect_and_verify(
     deadline = time.monotonic() + timeout
 
     disconnect_window = 2.0
-    logger.info(
+    logger.debug(
         "Waiting up to %.1fs for device disconnect (reboot indication)...",
         disconnect_window,
     )
@@ -282,14 +282,14 @@ def _post_configure_reconnect_and_verify(
         time.sleep(0.2)
 
     if not disconnected:
-        logger.info(
+        logger.debug(
             "No disconnect detected within %.1fs; device may not require reboot.",
             disconnect_window,
         )
 
     reconnect_deadline = deadline
     if disconnected:
-        logger.info(
+        logger.debug(
             "Waiting up to %.1fs for device reconnect...",
             reconnect_deadline - time.monotonic(),
         )
@@ -333,7 +333,7 @@ def _post_configure_reconnect_and_verify(
                 verify_module_config_fields=verify_module_config_fields,
             )
             interface.waitForConfig()
-            logger.info(
+            logger.debug(
                 "No disconnect observed; touched config/channel state refreshed before verification."
             )
         except Exception:
@@ -496,7 +496,7 @@ def _post_factory_reset_ready_probe(interface: MeshInterface) -> None:
     if not isinstance(interface, meshtastic.serial_interface.SerialInterface):
         return
 
-    logger.info("Factory reset: closing serial interface to release port.")
+    logger.debug("Factory reset: closing serial interface to release port.")
     try:
         interface.close()
     except Exception:
@@ -505,14 +505,14 @@ def _post_factory_reset_ready_probe(interface: MeshInterface) -> None:
             exc_info=True,
         )
 
-    logger.info(
+    logger.debug(
         "Factory reset: probing reconnect readiness (timeout=%.1fs)...",
         FACTORY_RESET_READY_PROBE_TIMEOUT_SECONDS,
     )
     probe_start = time.monotonic()
     try:
         interface.connect()
-        logger.info(
+        logger.debug(
             "Factory reset: reconnect probe succeeded in %.2fs.",
             time.monotonic() - probe_start,
         )

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -621,6 +621,7 @@ def _verify_config_sections(
     config_fields: dict[str, dict[str, Any]],
     proto_config: Any,
     label: str,
+    verified_fields: list[str] | None = None,
 ) -> bool:
     for section_name, yaml_values in config_fields.items():
         section_snake = meshtastic.util.camel_to_snake(section_name)
@@ -641,7 +642,10 @@ def _verify_config_sections(
                 ", ".join(mismatches),
             )
             return False
-        logger.info(
+        if verified_fields is not None:
+            for field_name in yaml_values:
+                verified_fields.append(f"{section_snake}.{field_name}")
+        logger.debug(
             "%s section %r verified (all requested field values match).",
             label,
             section_name,
@@ -662,6 +666,7 @@ def _verify_post_reconnect_config(
         return _ConfigureReconnectResult.VERIFICATION_INCOMPLETE
 
     target_node = interface.getNode(node_dest)
+    verified_fields: list[str] = []
 
     if verify_channel_url:
         local_config = getattr(target_node, "localConfig", None)
@@ -680,17 +685,21 @@ def _verify_post_reconnect_config(
                 "Channel URL verification: device state does not match requested URL."
             )
             return _ConfigureReconnectResult.VERIFICATION_INCOMPLETE
-        logger.info(
-            "Channel URL verified (channels matched by name; PSK, uplink/downlink, and module settings match)."
-        )
+        verified_fields.append("channel_url")
 
     if verify_config_fields and not _verify_config_sections(
-        verify_config_fields, target_node.localConfig, "Config"
+        verify_config_fields,
+        target_node.localConfig,
+        "Config",
+        verified_fields=verified_fields,
     ):
         return _ConfigureReconnectResult.VERIFICATION_INCOMPLETE
 
     if verify_module_config_fields and not _verify_config_sections(
-        verify_module_config_fields, target_node.moduleConfig, "Module config"
+        verify_module_config_fields,
+        target_node.moduleConfig,
+        "Module config",
+        verified_fields=verified_fields,
     ):
         return _ConfigureReconnectResult.VERIFICATION_INCOMPLETE
 
@@ -699,6 +708,9 @@ def _verify_post_reconnect_config(
             "Post-reconnect verification did not complete: transport disconnected."
         )
         return _ConfigureReconnectResult.VERIFICATION_INCOMPLETE
+
+    if verified_fields:
+        logger.info("Verified: %s", ", ".join(verified_fields))
 
     return _ConfigureReconnectResult.VERIFIED
 
@@ -1606,7 +1618,7 @@ def _handle_configure_command(
             )
             if _reconnect_result == _ConfigureReconnectResult.VERIFIED:
                 print(
-                    "Phase 3: Device reconnected, config reloaded, and requested settings verified."
+                    "Phase 3: Device reconnected and config reloaded. All settings verified."
                 )
             elif _reconnect_result == _ConfigureReconnectResult.VERIFICATION_INCOMPLETE:
                 print(

--- a/meshtastic/mesh_interface_runtime/send_pipeline.py
+++ b/meshtastic/mesh_interface_runtime/send_pipeline.py
@@ -48,6 +48,8 @@ PACKET_ID_GENERATION_MAX_RETRIES = 10
 DEFAULT_HOP_LIMIT = 3
 
 QUEUE_WAIT_DELAY_SECONDS = 0.5
+LORA_CONFIG_WAIT_SECONDS = 15.0
+"""Timeout for waiting for localConfig.lora after initial config stream."""
 
 HEX_NODE_ID_TAIL_CHARS = frozenset("0123456789abcdefABCDEF")
 MISSING_NODE_NUM_ERROR_TEMPLATE = "NodeId {destination_id} has no numeric 'num' in DB"
@@ -749,6 +751,9 @@ class SendPipeline:
         success = (
             self._timeout.waitForSet(self._interface, attrs=("myInfo", "nodes"))
             and self.localNode.waitForConfig()
+            and self.localNode._channel_request_runtime._timeout_for_field(
+                "lora", LORA_CONFIG_WAIT_SECONDS
+            )
         )
         if not success:
             raise self._interface.MeshInterfaceError(

--- a/meshtastic/node_runtime/channel_request_runtime.py
+++ b/meshtastic/node_runtime/channel_request_runtime.py
@@ -5,6 +5,7 @@ from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Protocol, cast
 
 from meshtastic.protobuf import admin_pb2, channel_pb2, mesh_pb2
+from meshtastic.util import Timeout
 
 from .channel_normalization_runtime import _NodeChannelNormalizationRuntime
 from .shared import MAX_CHANNELS
@@ -181,6 +182,30 @@ class _NodeChannelRequestRuntime:
     def wait_for_config(self, *, attribute: str = "channels") -> bool:
         """COMPAT_STABLE_SHIM: Silent alias for waitForConfig."""
         return self.waitForConfig(attribute=attribute)
+
+    def _timeout_for_field(self, field_name: str, max_secs: float) -> bool:
+        """Wait for a localConfig field with a dedicated timeout.
+
+        Returns True if the field is populated within max_secs, False otherwise.
+        If the protobuf doesn't have this field, returns True (skip gracefully
+        for backwards compatibility with old firmware).
+        """
+        local_config = self._node.localConfig
+        desc = getattr(local_config, "DESCRIPTOR", None)
+        if desc is not None:
+            if field_name not in desc.fields_by_name:
+                return True
+
+        has_field = getattr(local_config, "HasField", None)
+        if callable(has_field):
+            probe = _LocalConfigFieldProbe(
+                has_field_fn=has_field,
+                name=field_name,
+            )
+            short_timeout = Timeout(maxSecs=max_secs)
+            return short_timeout.waitForSet(probe, attrs=("is_set",))
+
+        return False
 
     def requestChannel(self, channel_num: int) -> mesh_pb2.MeshPacket | None:
         """Send one get-channel request preserving progress logging behavior."""

--- a/meshtastic/serial_interface.py
+++ b/meshtastic/serial_interface.py
@@ -88,7 +88,7 @@ class SerialInterface(StreamInterface):
 
         # Avoid opening with default asserted control lines.  Some USB/MCU
         # combinations treat DTR/RTS transitions as reset triggers.
-        logger.info(
+        logger.debug(
             "Opening serial stream on %s (baud=%d, exclusive=%s)",
             self.devPath,
             DEFAULT_BAUD_RATE,
@@ -101,7 +101,7 @@ class SerialInterface(StreamInterface):
         # Keep RTS deasserted to avoid accidental reset-line pulses on some adapters.
         stream.rts = False
         stream.open()
-        logger.info(
+        logger.debug(
             "Serial stream opened: port=%s is_open=%s dtr=%s rts=%s",
             self.devPath,
             getattr(stream, "is_open", None),
@@ -157,9 +157,7 @@ class SerialInterface(StreamInterface):
         if len(ports) == 0:
             return None
         if len(ports) > 1:
-            message: str = (
-                "Multiple serial ports were detected; one serial port must be specified with '--port'.\n"
-            )
+            message: str = "Multiple serial ports were detected; one serial port must be specified with '--port'.\n"
             message += (
                 "  Auto-detection cannot disambiguate when multiple compatible devices "
                 "or overlapping USB VID/PID aliases are present.\n"
@@ -257,7 +255,7 @@ class SerialInterface(StreamInterface):
         for attempt in range(1, SERIAL_CONNECT_MAX_ATTEMPTS + 1):
             attempt_start = time.monotonic()
             stream = self.stream
-            logger.info(
+            logger.debug(
                 "Serial connect attempt %d/%d starting: devPath=%s stream_open=%s last_disconnect_source=%s",
                 attempt,
                 SERIAL_CONNECT_MAX_ATTEMPTS,
@@ -267,11 +265,24 @@ class SerialInterface(StreamInterface):
             )
             try:
                 super().connect()
-                logger.info(
-                    "Serial connect attempt %d succeeded in %.2fs (total elapsed %.2fs).",
+                elapsed = time.monotonic() - attempt_start
+                stable_path = getattr(self, "_stable_path", None)
+                if stable_path:
+                    tty_name = (
+                        os.path.basename(self.devPath) if self.devPath else "unknown"
+                    )
+                    logger.info(
+                        "Connected to device on %s (stable: %s)",
+                        tty_name,
+                        stable_path,
+                    )
+                else:
+                    logger.info("Connected to device on %s", self.devPath or "unknown")
+                logger.debug(
+                    "Connect timing: %.2fs (attempt %d/%d)",
+                    elapsed,
                     attempt,
-                    time.monotonic() - attempt_start,
-                    time.monotonic() - connect_start,
+                    SERIAL_CONNECT_MAX_ATTEMPTS,
                 )
                 return
             except Exception as exc:
@@ -299,19 +310,10 @@ class SerialInterface(StreamInterface):
                     retry_delay_base = SERIAL_CONNECT_STREAM_CLOSED_RETRY_DELAY_SECONDS
                 retry_delay = min(retry_delay_base, remaining)
                 logger.warning(
-                    "Serial connect attempt %d/%d failed: %s. Retrying in %.1fs (%.1fs retry budget remaining). "
-                    "stream_open=%s last_disconnect_source=%s",
+                    "Connect attempt %d failed: %s. Retrying in %.1fs...",
                     attempt,
-                    SERIAL_CONNECT_MAX_ATTEMPTS,
                     exc,
                     retry_delay,
-                    remaining,
-                    (
-                        getattr(self.stream, "is_open", None)
-                        if self.stream is not None
-                        else None
-                    ),
-                    disconnect_source,
                 )
                 with self._connect_lock:
                     with contextlib.suppress(

--- a/meshtastic/stream_interface.py
+++ b/meshtastic/stream_interface.py
@@ -1,7 +1,10 @@
 """Stream Interface base class."""
 
 import contextlib
+import glob
 import logging
+import os
+import platform
 import threading
 import time
 from typing import IO, Any, BinaryIO, Callable
@@ -375,10 +378,6 @@ class StreamInterface(MeshInterface):
 
     def _resolve_stable_path(self) -> str | None:
         """Return the stable /dev/serial/by-id/ alias for the current device path."""
-        import glob  # noqa: PLC0415
-        import os  # noqa: PLC0415
-        import platform  # noqa: PLC0415
-
         if platform.system() != "Linux":
             return None
         dev_path = getattr(self, "devPath", None)

--- a/meshtastic/stream_interface.py
+++ b/meshtastic/stream_interface.py
@@ -390,7 +390,7 @@ class StreamInterface(MeshInterface):
             resolved = os.path.realpath(dev_path)
         except OSError:
             return None
-        for alias in glob.glob(f"{by_id_dir}/*"):
+        for alias in sorted(glob.glob(f"{by_id_dir}/*")):
             try:
                 if os.path.realpath(alias) == resolved:
                     return alias

--- a/meshtastic/stream_interface.py
+++ b/meshtastic/stream_interface.py
@@ -376,7 +376,7 @@ class StreamInterface(MeshInterface):
         delay = WINDOWS11_WRITE_DELAY if self.is_windows11 else STANDARD_WRITE_DELAY
         time.sleep(delay)
 
-    def _resolve_stable_path(self) -> str | None:
+    def _resolve_stable_path(self) -> str | None:  # pylint: disable=too-many-return-statements
         """Return the stable /dev/serial/by-id/ alias for the current device path."""
         if platform.system() != "Linux":
             return None
@@ -384,6 +384,8 @@ class StreamInterface(MeshInterface):
         if not dev_path:
             return None
         by_id_dir = "/dev/serial/by-id"
+        if dev_path.startswith(by_id_dir + "/") and os.path.exists(dev_path):
+            return dev_path
         if not os.path.isdir(by_id_dir):
             return None
         try:

--- a/meshtastic/stream_interface.py
+++ b/meshtastic/stream_interface.py
@@ -184,6 +184,7 @@ class StreamInterface(MeshInterface):
 
         self.is_windows11 = is_windows11()
         self.cur_log_line = ""
+        self._stable_path: str | None = None
 
         # daemon=True so the reader thread does not prevent process exit;
         # callers must call close() explicitly for a clean shutdown.
@@ -259,6 +260,7 @@ class StreamInterface(MeshInterface):
             self._start_config()
             if not self.noProto:  # Wait for the db download if using the protocol
                 self._wait_connected()
+                self._stable_path = self._resolve_stable_path()
         except Exception:
             # If protocol startup fails after reader launch, tear down to avoid
             # leaked background threads and partial connection state.
@@ -306,6 +308,7 @@ class StreamInterface(MeshInterface):
 
         with self._connect_lock:
             logger.debug("Closing our port")
+            self._stable_path = None
             self._close_stream_safely()
 
     def _write_bytes(self, b: bytes) -> None:
@@ -369,6 +372,32 @@ class StreamInterface(MeshInterface):
         # Win11 sometimes needs additional settling time after writes.
         delay = WINDOWS11_WRITE_DELAY if self.is_windows11 else STANDARD_WRITE_DELAY
         time.sleep(delay)
+
+    def _resolve_stable_path(self) -> str | None:
+        """Return the stable /dev/serial/by-id/ alias for the current device path."""
+        import glob  # noqa: PLC0415
+        import os  # noqa: PLC0415
+        import platform  # noqa: PLC0415
+
+        if platform.system() != "Linux":
+            return None
+        dev_path = getattr(self, "devPath", None)
+        if not dev_path:
+            return None
+        by_id_dir = "/dev/serial/by-id"
+        if not os.path.isdir(by_id_dir):
+            return None
+        try:
+            resolved = os.path.realpath(dev_path)
+        except OSError:
+            return None
+        for alias in glob.glob(f"{by_id_dir}/*"):
+            try:
+                if os.path.realpath(alias) == resolved:
+                    return alias
+            except OSError:
+                continue
+        return None
 
     def _read_bytes(self, length: int) -> bytes:
         """Read up to the specified number of bytes from the configured underlying stream.

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -5812,9 +5812,11 @@ def test_quiet_flag_parsed_by_argparse(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-def test_quiet_suppresses_connect_banner(capsys: pytest.CaptureFixture[str]) -> None:
+def test_quiet_suppresses_connect_banner(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
     """--quiet suppresses the 'Connected to radio' banner."""
-    sys.argv = ["", "--info", "--quiet"]
+    monkeypatch.setattr(sys, "argv", ["", "--info", "--quiet"])
     mt_config.args = sys.argv  # type: ignore[assignment]
 
     iface = MagicMock(autospec=SerialInterface)
@@ -5888,7 +5890,12 @@ def test_stable_path_banner_omitted_when_already_by_id(
 def test_stable_path_banner_shown_when_different(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Stable-path banner suffix is shown when devPath differs from the by-id alias."""
+    """Stable-path suffix shown when devPath differs from by-id alias.
+
+    Even when both paths resolve to the same device via realpath (the normal
+    Linux /dev/ttyUSB* + /dev/serial/by-id/* case), the stable alias must
+    appear so users can copy-paste it for future connections.
+    """
     sys.argv = ["", "--info"]
     mt_config.args = sys.argv  # type: ignore[assignment]
 
@@ -5902,7 +5909,16 @@ def test_stable_path_banner_shown_when_different(
         print("inside mocked showInfo")
 
     iface.showInfo.side_effect = mock_showInfo
-    with patch("meshtastic.serial_interface.SerialInterface", return_value=iface):
+
+    def fake_realpath(p: str, **_kwargs: object) -> str:
+        if p in ("/dev/ttyUSB0", "/dev/serial/by-id/usb-foo-device"):
+            return "/dev/bus/usb/001/002"
+        return p
+
+    with (
+        patch("meshtastic.serial_interface.SerialInterface", return_value=iface),
+        patch("os.path.realpath", side_effect=fake_realpath),
+    ):
         main()
         out, err = capsys.readouterr()
         assert (

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -2085,7 +2085,7 @@ def test_main_configure_skips_unknown_config_field(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test --configure skips unknown fields with a warning (old-config tolerance)."""
+    """Test --configure skips unknown fields with a batched warning."""
     config_path = tmp_path / "unknown_field.yaml"
     config_path.write_text(
         yaml.safe_dump({"config": {"bluetooth": {"not_a_field": True}}}),
@@ -2096,7 +2096,7 @@ def test_main_configure_skips_unknown_config_field(
     _run_main_configure_file(config_path, iface, monkeypatch)
 
     assert "not_a_field" in caplog.text
-    assert "Skipping unknown configuration field" in caplog.text
+    assert "Skipping 1 unknown field(s) from bluetooth" in caplog.text
     target_node.writeConfig.assert_called_once_with("bluetooth")
     target_node.commitSettingsTransaction.assert_called_once()
 

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -5801,9 +5801,9 @@ def test_post_factory_reset_ready_probe_closes_and_probes_reconnect() -> None:
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-def test_quiet_flag_parsed_by_argparse() -> None:
+def test_quiet_flag_parsed_by_argparse(monkeypatch: pytest.MonkeyPatch) -> None:
     """--quiet flag is recognized by the argument parser."""
-    sys.argv = ["meshtastic", "--quiet"]
+    monkeypatch.setattr(sys, "argv", ["meshtastic", "--quiet"])
     mt_config.args = sys.argv  # type: ignore[assignment]
     main_module.initParser()
     assert mt_config.args is not None

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -5806,4 +5806,5 @@ def test_quiet_flag_parsed_by_argparse() -> None:
     sys.argv = ["meshtastic", "--quiet"]
     mt_config.args = sys.argv  # type: ignore[assignment]
     main_module.initParser()
+    assert mt_config.args is not None
     assert mt_config.args.quiet is True

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -5808,3 +5808,134 @@ def test_quiet_flag_parsed_by_argparse() -> None:
     main_module.initParser()
     assert mt_config.args is not None
     assert mt_config.args.quiet is True
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_quiet_suppresses_connect_banner(capsys: pytest.CaptureFixture[str]) -> None:
+    """--quiet suppresses the 'Connected to radio' banner."""
+    sys.argv = ["", "--info", "--quiet"]
+    mt_config.args = sys.argv  # type: ignore[assignment]
+
+    iface = MagicMock(autospec=SerialInterface)
+    iface.__enter__ = MagicMock(return_value=iface)
+    iface.__exit__ = MagicMock(return_value=None)
+    iface._stable_path = None
+
+    def mock_showInfo() -> None:
+        print("inside mocked showInfo")
+
+    iface.showInfo.side_effect = mock_showInfo
+    with patch("meshtastic.serial_interface.SerialInterface", return_value=iface):
+        main()
+        out, err = capsys.readouterr()
+        assert "Connected to radio" not in out
+        assert "inside mocked showInfo" in out
+        assert err == ""
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_quiet_still_allows_warnings_and_errors(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--quiet does not suppress warnings/errors from _cli_exit."""
+    sys.argv = ["", "--set-owner", "   ", "--quiet"]
+    mt_config.args = sys.argv  # type: ignore[assignment]
+
+    iface = MagicMock(autospec=SerialInterface)
+    iface.__enter__ = MagicMock(return_value=iface)
+    iface.__exit__ = MagicMock(return_value=None)
+
+    with patch("meshtastic.serial_interface.SerialInterface", return_value=iface):
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            main()
+        assert pytest_wrapped_e.value.code == 1
+        out, err = capsys.readouterr()
+        assert "Connected to radio" not in out
+        assert "empty" in err.lower() or "whitespace" in err.lower()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_stable_path_banner_omitted_when_already_by_id(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Stable-path banner suffix is omitted when devPath is already the by-id path."""
+    sys.argv = ["", "--info"]
+    mt_config.args = sys.argv  # type: ignore[assignment]
+
+    iface = MagicMock(autospec=SerialInterface)
+    iface.__enter__ = MagicMock(return_value=iface)
+    iface.__exit__ = MagicMock(return_value=None)
+    iface.devPath = "/dev/serial/by-id/usb-foo-device"
+    iface._stable_path = "/dev/serial/by-id/usb-foo-device"
+
+    def mock_showInfo() -> None:
+        print("inside mocked showInfo")
+
+    iface.showInfo.side_effect = mock_showInfo
+    with patch("meshtastic.serial_interface.SerialInterface", return_value=iface):
+        main()
+        out, err = capsys.readouterr()
+        assert "Connected to radio on usb-foo-device" in out
+        assert "(stable:" not in out
+        assert err == ""
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_stable_path_banner_shown_when_different(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Stable-path banner suffix is shown when devPath differs from the by-id alias."""
+    sys.argv = ["", "--info"]
+    mt_config.args = sys.argv  # type: ignore[assignment]
+
+    iface = MagicMock(autospec=SerialInterface)
+    iface.__enter__ = MagicMock(return_value=iface)
+    iface.__exit__ = MagicMock(return_value=None)
+    iface.devPath = "/dev/ttyUSB0"
+    iface._stable_path = "/dev/serial/by-id/usb-foo-device"
+
+    def mock_showInfo() -> None:
+        print("inside mocked showInfo")
+
+    iface.showInfo.side_effect = mock_showInfo
+    with patch("meshtastic.serial_interface.SerialInterface", return_value=iface):
+        main()
+        out, err = capsys.readouterr()
+        assert (
+            "Connected to radio on ttyUSB0 (stable: /dev/serial/by-id/usb-foo-device)"
+            in out
+        )
+        assert err == ""
+
+
+@pytest.mark.unit
+def test_flatten_leaf_paths_flat_dict() -> None:
+    """_flatten_leaf_paths handles a flat dict."""
+    result = main_module._flatten_leaf_paths(
+        "lora", {"hop_limit": 3, "tx_enabled": True}
+    )
+    assert sorted(result) == ["lora.hop_limit", "lora.tx_enabled"]
+
+
+@pytest.mark.unit
+def test_flatten_leaf_paths_nested_dict() -> None:
+    """_flatten_leaf_paths recursively flattens nested dicts."""
+    result = main_module._flatten_leaf_paths(
+        "display", {"screen_on_secs": 60, "nested": {"foo": 1, "bar": 2}}
+    )
+    assert sorted(result) == [
+        "display.nested.bar",
+        "display.nested.foo",
+        "display.screen_on_secs",
+    ]
+
+
+@pytest.mark.unit
+def test_flatten_leaf_paths_empty_nested_dict() -> None:
+    """_flatten_leaf_paths treats an empty nested dict as a leaf."""
+    result = main_module._flatten_leaf_paths("lora", {"hop_limit": 3, "empty": {}})
+    assert sorted(result) == ["lora.empty", "lora.hop_limit"]

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -5400,7 +5400,7 @@ def test_main_configure_phase3_verified_with_matching_config_values(
     _patch_fast_monotonic(monkeypatch)
     _run_main_configure_file(config_path, iface, monkeypatch)
     out, _ = capsys.readouterr()
-    assert "requested settings verified" in out
+    assert "All settings verified" in out
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -5797,3 +5797,13 @@ def test_post_factory_reset_ready_probe_closes_and_probes_reconnect() -> None:
 
     iface.connect.assert_called_once()
     assert iface.close.call_count >= 2
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_quiet_flag_parsed_by_argparse() -> None:
+    """--quiet flag is recognized by the argument parser."""
+    sys.argv = ["meshtastic", "--quiet"]
+    mt_config.args = sys.argv  # type: ignore[assignment]
+    main_module.initParser()
+    assert mt_config.args.quiet is True

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -4758,9 +4758,12 @@ def test_remove_ignored_node() -> None:
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-def test_main_set_owner_whitespace_only(capsys: pytest.CaptureFixture[str]) -> None:
+def test_main_set_owner_whitespace_only(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Test --set-owner with whitespace-only name."""
-    sys.argv = ["", "--set-owner", "   "]
+    monkeypatch.setattr(sys, "argv", ["", "--set-owner", "   "])
     mt_config.args = sys.argv  # type: ignore[assignment]
 
     iface = MagicMock(autospec=SerialInterface)
@@ -5840,9 +5843,10 @@ def test_quiet_suppresses_connect_banner(
 @pytest.mark.usefixtures("reset_mt_config")
 def test_quiet_still_allows_warnings_and_errors(
     capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """--quiet does not suppress warnings/errors from _cli_exit."""
-    sys.argv = ["", "--set-owner", "   ", "--quiet"]
+    monkeypatch.setattr(sys, "argv", ["", "--set-owner", "   ", "--quiet"])
     mt_config.args = sys.argv  # type: ignore[assignment]
 
     iface = MagicMock(autospec=SerialInterface)
@@ -5855,7 +5859,10 @@ def test_quiet_still_allows_warnings_and_errors(
         assert pytest_wrapped_e.value.code == 1
         out, err = capsys.readouterr()
         assert "Connected to radio" not in out
-        assert "empty" in err.lower() or "whitespace" in err.lower()
+        assert (
+            "ERROR: Long Name cannot be empty or contain only whitespace characters"
+            in err
+        )
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_main_specific_lines.py
+++ b/meshtastic/tests/test_main_specific_lines.py
@@ -21,6 +21,7 @@ import meshtastic.__main__ as main_module
 from meshtastic import mt_config
 from meshtastic.__main__ import (
     _display_pref_name,
+    _flatten_leaf_paths,
     getPref,
     onConnected,
     onReceive,
@@ -305,7 +306,7 @@ def test_traverse_config_leaf_failure_skipped() -> None:
 def test_traverse_config_batches_multiple_sections(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test traverseConfig batches unknown fields from different sections."""
+    """Test traverseConfig batches unknown fields under the root section."""
     interface_config = MagicMock()
 
     config = {
@@ -323,10 +324,90 @@ def test_traverse_config_batches_multiple_sections(
             for r in caplog.records
             if r.name == "meshtastic.__main__" and r.levelno == logging.WARNING
         ]
-        assert len(warning_records) == 2
+        assert len(warning_records) == 1
+        assert "5 unknown field(s) from module_config" in warning_records[0].message
+
+
+@pytest.mark.unit
+def test_traverse_config_groups_by_top_level_section(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """TraverseConfig groups unknown fields by top-level section, not nested subsection."""
+    interface_config = MagicMock()
+
+    config = {
+        "ambient_lighting": {
+            "nested": {"blue": 1, "red": 2},
+            "other_nested": {"green": 3},
+        },
+    }
+
+    with caplog.at_level(logging.WARNING, logger="meshtastic.__main__"):
+        with patch.object(main_module, "_resolve_pref", return_value=False):
+            result = traverseConfig("module_config", config, interface_config)
+            assert result is True
+
+        warning_records = [
+            r
+            for r in caplog.records
+            if r.name == "meshtastic.__main__" and r.levelno == logging.WARNING
+        ]
         texts = [r.message for r in warning_records]
-        assert any("3 unknown field(s) from ambient_lighting" in t for t in texts)
-        assert any("2 unknown field(s) from mqtt" in t for t in texts)
+        assert len(warning_records) == 1
+        assert "3 unknown field(s) from module_config" in texts[0]
+
+
+@pytest.mark.unit
+def test_flatten_leaf_paths_nested() -> None:
+    """_flatten_leaf_paths recursively produces dotted leaf paths for nested config."""
+    mapping = {
+        "lora": {
+            "modem_preset": "LongFast",
+            "hop_limit": 3,
+        },
+        "device": {
+            "role": "CLIENT",
+        },
+    }
+    paths = _flatten_leaf_paths("config", mapping)
+    assert sorted(paths) == [
+        "config.device.role",
+        "config.lora.hop_limit",
+        "config.lora.modem_preset",
+    ]
+
+
+# =============================================================================
+# _cli_print() Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+def test_cli_print_outputs_normally(capsys: pytest.CaptureFixture[str]) -> None:
+    """_cli_print outputs to stdout when quiet is not set."""
+    old_args = mt_config.args
+    mt_config.args = MagicMock(quiet=False)
+    try:
+        main_module._cli_print("hello world")
+        captured = capsys.readouterr()
+        assert "hello world" in captured.out
+    finally:
+        mt_config.args = old_args
+
+
+@pytest.mark.unit
+def test_cli_print_suppressed_when_quiet(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """_cli_print suppresses output when quiet is True."""
+    old_args = mt_config.args
+    mt_config.args = MagicMock(quiet=True)
+    try:
+        main_module._cli_print("should not appear")
+        captured = capsys.readouterr()
+        assert captured.out == ""
+    finally:
+        mt_config.args = old_args
 
 
 # =============================================================================

--- a/meshtastic/tests/test_main_specific_lines.py
+++ b/meshtastic/tests/test_main_specific_lines.py
@@ -525,11 +525,11 @@ def test_on_connected_raises_without_args() -> None:
 
 @pytest.mark.unit
 def test_set_canned_message_module_unavailable(
-    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test --set-canned-message when module unavailable (line 799).
 
-    When CANNEDMSG_CONFIG module is not available, should print skip message.
+    When CANNEDMSG_CONFIG module is not available, a warning is emitted.
     """
     sys.argv = ["", "--set-canned-message", "test message"]
     mt_config.args = sys.argv  # type: ignore[assignment]
@@ -544,22 +544,25 @@ def test_set_canned_message_module_unavailable(
 
     from meshtastic.__main__ import main
 
-    with patch("meshtastic.serial_interface.SerialInterface", return_value=iface):
-        # Just run main() - the code path will be executed even if no SystemExit
-        try:
-            main()
-        except SystemExit:
-            pass  # Expected, but not required for the test
-        _out, _err = capsys.readouterr()
-        # Check if skip message was printed
-        assert "canned message" in _out.lower() or "excluded" in _out.lower()  # noqa
+    with caplog.at_level(logging.WARNING, logger="meshtastic.__main__"):
+        with patch("meshtastic.serial_interface.SerialInterface", return_value=iface):
+            try:
+                main()
+            except SystemExit:
+                pass
+            assert (
+                "canned message" in caplog.text.lower()
+                or "excluded" in caplog.text.lower()
+            )
 
 
 @pytest.mark.unit
-def test_set_ringtone_module_unavailable(capsys: pytest.CaptureFixture[str]) -> None:
+def test_set_ringtone_module_unavailable(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test --set-ringtone when module unavailable (lines 809-811).
 
-    When EXTNOTIF_CONFIG module is not available, should print skip message.
+    When EXTNOTIF_CONFIG module is not available, a warning is emitted.
     """
     sys.argv = ["", "--set-ringtone", "test.mp3"]
     mt_config.args = sys.argv  # type: ignore[assignment]
@@ -574,17 +577,16 @@ def test_set_ringtone_module_unavailable(capsys: pytest.CaptureFixture[str]) -> 
 
     from meshtastic.__main__ import main
 
-    with patch("meshtastic.serial_interface.SerialInterface", return_value=iface):
-        # Just run main() - the code path will be executed even if no SystemExit
-        try:
-            main()
-        except SystemExit:
-            pass  # Expected, but not required for the test
-        _out, _err = capsys.readouterr()
-        # Check if skip message was printed
-        assert (
-            "ringtone" in _out.lower() or "external notification" in _out.lower()  # noqa
-        )
+    with caplog.at_level(logging.WARNING, logger="meshtastic.__main__"):
+        with patch("meshtastic.serial_interface.SerialInterface", return_value=iface):
+            try:
+                main()
+            except SystemExit:
+                pass
+            assert (
+                "ringtone" in caplog.text.lower()
+                or "external notification" in caplog.text.lower()
+            )
 
 
 # =============================================================================

--- a/meshtastic/tests/test_main_specific_lines.py
+++ b/meshtastic/tests/test_main_specific_lines.py
@@ -313,15 +313,20 @@ def test_traverse_config_batches_multiple_sections(
         "mqtt": {"address": "test", "username": "user"},
     }
 
-    with patch.object(main_module, "_resolve_pref", return_value=False):
-        result = traverseConfig("module_config", config, interface_config)
-        assert result is True
+    with caplog.at_level(logging.WARNING, logger="meshtastic.__main__"):
+        with patch.object(main_module, "_resolve_pref", return_value=False):
+            result = traverseConfig("module_config", config, interface_config)
+            assert result is True
 
-    warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
-    assert len(warning_records) == 2
-    texts = [r.message for r in warning_records]
-    assert any("3 unknown field(s) from ambient_lighting" in t for t in texts)
-    assert any("2 unknown field(s) from mqtt" in t for t in texts)
+        warning_records = [
+            r
+            for r in caplog.records
+            if r.name == "meshtastic.__main__" and r.levelno == logging.WARNING
+        ]
+        assert len(warning_records) == 2
+        texts = [r.message for r in warning_records]
+        assert any("3 unknown field(s) from ambient_lighting" in t for t in texts)
+        assert any("2 unknown field(s) from mqtt" in t for t in texts)
 
 
 # =============================================================================

--- a/meshtastic/tests/test_main_specific_lines.py
+++ b/meshtastic/tests/test_main_specific_lines.py
@@ -10,6 +10,7 @@ This module provides targeted tests for specific uncovered code paths:
 
 # pylint: disable=C0302,W0613,R0917,C0415
 
+import logging
 import sys
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -298,6 +299,29 @@ def test_traverse_config_leaf_failure_skipped() -> None:
     with patch.object(main_module, "_resolve_pref", return_value=False):
         result = traverseConfig("root", config, interface_config)
         assert result is True
+
+
+@pytest.mark.unit
+def test_traverse_config_batches_multiple_sections(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test traverseConfig batches unknown fields from different sections."""
+    interface_config = MagicMock()
+
+    config = {
+        "ambient_lighting": {"blue": 1, "red": 2, "green": 3},
+        "mqtt": {"address": "test", "username": "user"},
+    }
+
+    with patch.object(main_module, "_resolve_pref", return_value=False):
+        result = traverseConfig("module_config", config, interface_config)
+        assert result is True
+
+    warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warning_records) == 2
+    texts = [r.message for r in warning_records]
+    assert any("3 unknown field(s) from ambient_lighting" in t for t in texts)
+    assert any("2 unknown field(s) from mqtt" in t for t in texts)
 
 
 # =============================================================================

--- a/meshtastic/tests/test_node_runtime_channel_request.py
+++ b/meshtastic/tests/test_node_runtime_channel_request.py
@@ -378,3 +378,17 @@ def test_timeout_for_field_returns_false_on_timeout(
     mock_node.localConfig = mock_local_config
     result = channel_request_runtime._timeout_for_field("lora", 0.1)
     assert result is False
+
+
+@pytest.mark.unit
+def test_timeout_for_field_hasfield_not_callable(
+    channel_request_runtime: _NodeChannelRequestRuntime,
+    mock_node: MagicMock,
+) -> None:
+    """_timeout_for_field returns False when HasField is absent or non-callable."""
+    mock_local_config = MagicMock()
+    mock_local_config.DESCRIPTOR.fields_by_name = {"lora": MagicMock()}
+    mock_local_config.HasField = None
+    mock_node.localConfig = mock_local_config
+    result = channel_request_runtime._timeout_for_field("lora", 0.1)
+    assert result is False

--- a/meshtastic/tests/test_node_runtime_channel_request.py
+++ b/meshtastic/tests/test_node_runtime_channel_request.py
@@ -337,3 +337,44 @@ def test_request_channel_is_silent_compatibility_shim(
         if issubclass(warning.category, DeprecationWarning)
     ]
     assert len(deprecation_warnings) == 0
+
+
+@pytest.mark.unit
+def test_timeout_for_field_skips_unknown_field(
+    channel_request_runtime: _NodeChannelRequestRuntime,
+    mock_node: MagicMock,
+) -> None:
+    """_timeout_for_field returns True for fields not in protobuf descriptor."""
+    mock_local_config = MagicMock()
+    mock_local_config.DESCRIPTOR.fields_by_name = {}
+    mock_node.localConfig = mock_local_config
+    result = channel_request_runtime._timeout_for_field("nonexistent_field", 0.1)
+    assert result is True
+
+
+@pytest.mark.unit
+def test_timeout_for_field_returns_true_for_populated_field(
+    channel_request_runtime: _NodeChannelRequestRuntime,
+    mock_node: MagicMock,
+) -> None:
+    """_timeout_for_field returns True when field is already populated."""
+    mock_local_config = MagicMock()
+    mock_local_config.DESCRIPTOR.fields_by_name = {"lora": MagicMock()}
+    mock_local_config.HasField.return_value = True
+    mock_node.localConfig = mock_local_config
+    result = channel_request_runtime._timeout_for_field("lora", 0.1)
+    assert result is True
+
+
+@pytest.mark.unit
+def test_timeout_for_field_returns_false_on_timeout(
+    channel_request_runtime: _NodeChannelRequestRuntime,
+    mock_node: MagicMock,
+) -> None:
+    """_timeout_for_field returns False when field is not populated within timeout."""
+    mock_local_config = MagicMock()
+    mock_local_config.DESCRIPTOR.fields_by_name = {"lora": MagicMock()}
+    mock_local_config.HasField.return_value = False
+    mock_node.localConfig = mock_local_config
+    result = channel_request_runtime._timeout_for_field("lora", 0.1)
+    assert result is False

--- a/meshtastic/tests/test_send_pipeline.py
+++ b/meshtastic/tests/test_send_pipeline.py
@@ -1089,6 +1089,7 @@ class TestWaitForConfig:
         """Test successful wait for config."""
         mock_interface._timeout.waitForSet.return_value = True
         mock_interface.localNode.waitForConfig.return_value = True
+        mock_interface.localNode._channel_request_runtime._timeout_for_field.return_value = True
 
         # Should not raise
         send_pipeline.waitForConfig()
@@ -1103,6 +1104,55 @@ class TestWaitForConfig:
 
         with pytest.raises(Exception, match="Timed out"):
             send_pipeline.waitForConfig()
+
+    @pytest.mark.unit
+    def test_wait_for_config_lora_wait_success(
+        self, send_pipeline: SendPipeline, mock_interface: MagicMock
+    ) -> None:
+        """Test success path when the dedicated lora wait returns true."""
+        mock_interface._timeout.waitForSet.return_value = True
+        mock_interface.localNode.waitForConfig.return_value = True
+        mock_interface.localNode._channel_request_runtime._timeout_for_field.return_value = True
+
+        send_pipeline.waitForConfig()
+
+        mock_interface.localNode._channel_request_runtime._timeout_for_field.assert_called_once_with(
+            "lora", 15.0
+        )
+
+    @pytest.mark.unit
+    def test_wait_for_config_lora_wait_failure_raises(
+        self, send_pipeline: SendPipeline, mock_interface: MagicMock
+    ) -> None:
+        """Test failure path when the lora wait returns false and raises timeout error."""
+        mock_interface._timeout.waitForSet.return_value = True
+        mock_interface.localNode.waitForConfig.return_value = True
+        mock_interface.localNode._channel_request_runtime._timeout_for_field.return_value = False
+
+        with pytest.raises(
+            mock_interface.MeshInterfaceError,
+            match="Timed out waiting for interface config",
+        ):
+            send_pipeline.waitForConfig()
+
+    @pytest.mark.unit
+    def test_wait_for_config_lora_field_absent_graceful_success(
+        self, send_pipeline: SendPipeline, mock_interface: MagicMock
+    ) -> None:
+        """Test graceful success when the field is absent from the protobuf descriptor.
+
+        _timeout_for_field returns True for unknown fields, so the overall
+        waitForConfig should succeed even if the lora field doesn't exist.
+        """
+        mock_interface._timeout.waitForSet.return_value = True
+        mock_interface.localNode.waitForConfig.return_value = True
+        mock_interface.localNode._channel_request_runtime._timeout_for_field.return_value = True
+
+        send_pipeline.waitForConfig()
+
+        mock_interface.localNode._channel_request_runtime._timeout_for_field.assert_called_once_with(
+            "lora", 15.0
+        )
 
 
 class TestWaitForAckNak:

--- a/meshtastic/tests/test_send_pipeline.py
+++ b/meshtastic/tests/test_send_pipeline.py
@@ -1128,20 +1128,33 @@ class TestWaitForConfig:
     def test_wait_for_config_lora_field_absent_graceful_success(
         self, send_pipeline: SendPipeline, mock_interface: MagicMock
     ) -> None:
-        """Test graceful success when the field is absent from the protobuf descriptor.
+        """Graceful success when lora is absent from the protobuf descriptor.
 
-        _timeout_for_field returns True for unknown fields, so the overall
-        waitForConfig should succeed even if the lora field doesn't exist.
+        Replaces the mock _channel_request_runtime with a real
+        _NodeChannelRequestRuntime wired to a mock localConfig whose DESCRIPTOR
+        lacks the 'lora' field. This exercises the actual early-return path in
+        _timeout_for_field rather than just stubbing it to True.
         """
+        from meshtastic.node_runtime.channel_request_runtime import (
+            _NodeChannelRequestRuntime,
+        )
+
+        mock_node = MagicMock()
+        desc = MagicMock()
+        desc.fields_by_name = {"bluetooth": MagicMock(), "device": MagicMock()}
+        mock_node.localConfig = MagicMock()
+        mock_node.localConfig.DESCRIPTOR = desc
+
+        mock_norm = MagicMock()
+        real_runtime = _NodeChannelRequestRuntime(
+            mock_node, normalization_runtime=mock_norm
+        )
+
         mock_interface._timeout.waitForSet.return_value = True
         mock_interface.localNode.waitForConfig.return_value = True
-        mock_interface.localNode._channel_request_runtime._timeout_for_field.return_value = True
+        mock_interface.localNode._channel_request_runtime = real_runtime
 
         send_pipeline.waitForConfig()
-
-        mock_interface.localNode._channel_request_runtime._timeout_for_field.assert_called_once_with(
-            "lora", LORA_CONFIG_WAIT_SECONDS
-        )
 
 
 class TestWaitForAckNak:

--- a/meshtastic/tests/test_send_pipeline.py
+++ b/meshtastic/tests/test_send_pipeline.py
@@ -20,6 +20,7 @@ from meshtastic.mesh_interface_runtime.request_wait import (
 from meshtastic.mesh_interface_runtime.send_pipeline import (
     HEX_NODE_ID_TAIL_CHARS,
     LEGACY_UNSCOPED_WAIT_ATTR_BY_PORTNUM,
+    LORA_CONFIG_WAIT_SECONDS,
     MISSING_NODE_NUM_ERROR_TEMPLATE,
     NODE_NOT_FOUND_DB_UNAVAILABLE_ERROR_TEMPLATE,
     NODE_NOT_FOUND_IN_DB_ERROR_TEMPLATE,
@@ -1086,13 +1087,16 @@ class TestWaitForConfig:
     def test_wait_for_config_success(
         self, send_pipeline: SendPipeline, mock_interface: MagicMock
     ) -> None:
-        """Test successful wait for config."""
+        """Test successful wait for config including dedicated lora wait."""
         mock_interface._timeout.waitForSet.return_value = True
         mock_interface.localNode.waitForConfig.return_value = True
         mock_interface.localNode._channel_request_runtime._timeout_for_field.return_value = True
 
-        # Should not raise
         send_pipeline.waitForConfig()
+
+        mock_interface.localNode._channel_request_runtime._timeout_for_field.assert_called_once_with(
+            "lora", LORA_CONFIG_WAIT_SECONDS
+        )
 
     @pytest.mark.unit
     def test_wait_for_config_timeout_raises(
@@ -1104,21 +1108,6 @@ class TestWaitForConfig:
 
         with pytest.raises(Exception, match="Timed out"):
             send_pipeline.waitForConfig()
-
-    @pytest.mark.unit
-    def test_wait_for_config_lora_wait_success(
-        self, send_pipeline: SendPipeline, mock_interface: MagicMock
-    ) -> None:
-        """Test success path when the dedicated lora wait returns true."""
-        mock_interface._timeout.waitForSet.return_value = True
-        mock_interface.localNode.waitForConfig.return_value = True
-        mock_interface.localNode._channel_request_runtime._timeout_for_field.return_value = True
-
-        send_pipeline.waitForConfig()
-
-        mock_interface.localNode._channel_request_runtime._timeout_for_field.assert_called_once_with(
-            "lora", 15.0
-        )
 
     @pytest.mark.unit
     def test_wait_for_config_lora_wait_failure_raises(
@@ -1151,7 +1140,7 @@ class TestWaitForConfig:
         send_pipeline.waitForConfig()
 
         mock_interface.localNode._channel_request_runtime._timeout_for_field.assert_called_once_with(
-            "lora", 15.0
+            "lora", LORA_CONFIG_WAIT_SECONDS
         )
 
 

--- a/meshtastic/tests/test_stream_interface.py
+++ b/meshtastic/tests/test_stream_interface.py
@@ -648,7 +648,7 @@ def test_resolve_stable_path_finds_first_matching_alias() -> None:
     """_resolve_stable_path returns lexicographically first matching alias."""
     iface = StreamInterface(noProto=True, connectNow=False)
     try:
-        iface.devPath = "/dev/ttyUSB0"
+        iface.devPath = "/dev/ttyUSB0"  # type: ignore[attr-defined]
         aliases = [
             "/dev/serial/by-id/usb-foo-device",
             "/dev/serial/by-id/usb-bar-device",

--- a/meshtastic/tests/test_stream_interface.py
+++ b/meshtastic/tests/test_stream_interface.py
@@ -640,4 +640,3 @@ def test_resolve_stable_path_returns_none_on_non_linux() -> None:
         assert result is None
     finally:
         iface.close()
-    iface.close()

--- a/meshtastic/tests/test_stream_interface.py
+++ b/meshtastic/tests/test_stream_interface.py
@@ -607,4 +607,37 @@ def test_connect_succeeds_when_reader_thread_dead() -> None:
         iface.connect()
     assert mock_start.assert_called_once() is None
     assert iface._rxThread is not dead_thread
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_resolve_stable_path_preserves_existing_by_id() -> None:
+    """_resolve_stable_path returns devPath as-is when already under /dev/serial/by-id/."""
+    iface = StreamInterface(noProto=True, connectNow=False)
+    try:
+        stable_path = "/dev/serial/by-id/usb-foo-123"
+        iface.devPath = stable_path  # type: ignore[attr-defined]
+        with patch("os.path.exists", return_value=True):
+            with patch(
+                "meshtastic.stream_interface.platform.system", return_value="Linux"
+            ):
+                result = iface._resolve_stable_path()
+        assert result == stable_path
+    finally:
+        iface.close()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_resolve_stable_path_returns_none_on_non_linux() -> None:
+    """_resolve_stable_path returns None on non-Linux platforms."""
+    iface = StreamInterface(noProto=True, connectNow=False)
+    try:
+        with patch(
+            "meshtastic.stream_interface.platform.system", return_value="Darwin"
+        ):
+            result = iface._resolve_stable_path()
+        assert result is None
+    finally:
+        iface.close()
     iface.close()

--- a/meshtastic/tests/test_stream_interface.py
+++ b/meshtastic/tests/test_stream_interface.py
@@ -640,3 +640,32 @@ def test_resolve_stable_path_returns_none_on_non_linux() -> None:
         assert result is None
     finally:
         iface.close()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_resolve_stable_path_finds_first_matching_alias() -> None:
+    """_resolve_stable_path returns lexicographically first matching alias."""
+    iface = StreamInterface(noProto=True, connectNow=False)
+    try:
+        iface.devPath = "/dev/ttyUSB0"
+        aliases = [
+            "/dev/serial/by-id/usb-foo-device",
+            "/dev/serial/by-id/usb-bar-device",
+        ]
+
+        def mock_realpath(path: str) -> str:
+            if path in aliases or path == "/dev/ttyUSB0":
+                return "/sys/devices/pci0000:00/0000:00:14.0/usb1/1-2/1-2:1.0/ttyUSB0"
+            return path
+
+        with patch("meshtastic.stream_interface.platform.system", return_value="Linux"):
+            with patch("os.path.isdir", return_value=True):
+                with patch("glob.glob", return_value=aliases):
+                    with patch("os.path.realpath", side_effect=mock_realpath):
+                        result = iface._resolve_stable_path()
+
+        # Should return lexicographically first alias (usb-bar-device comes before usb-foo-device)
+        assert result == "/dev/serial/by-id/usb-bar-device"
+    finally:
+        iface.close()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR adds a CLI quiet mode and reduces logging verbosity, refactors configuration verification and device-path handling to be more deterministic and concise, introduces a short LoRA-specific config wait, improves reporting for unknown config fields by batching warnings, and expands unit test coverage for these behaviors.

## Features

- CLI quiet mode
  - Added a --quiet flag and a _cli_print(message: str) helper to gate non-essential stdout. Quiet suppresses user-facing info/debug prints while preserving warnings/errors and normal exit behavior.
  - common() logging initialization respects --quiet by setting the meshtastic logger to WARNING when quiet is enabled; --quiet conflicts with --debug, --listen, and --debuglib.
- Stable device aliasing
  - StreamInterface gains a _stable_path and _resolve_stable_path() to deterministically map devPath to a /dev/serial/by-id alias on Linux (searches aliases, compares os.path.realpath, and picks the lexicographically first match).
  - Connection banner prints the stable alias suffix only when the stable path differs from devPath; otherwise it stays concise.
- LoRA config wait
  - SendPipeline.waitForConfig() waits up to LORA_CONFIG_WAIT_SECONDS (15.0s) for localConfig.lora via the channel-request runtime before continuing to the existing timeout path.
- Flattened config paths & verification reporting
  - Added _flatten_leaf_paths(prefix, mapping) to produce dotted leaf paths for nested configs.
  - Post-reconnect verification accumulates verified leaf paths and emits a single aggregated "Verified: ..." summary rather than multiple per-section info lines.

## Fixes

- Reduced log noise
  - Downgraded many info logs (reconnect/probe, factory-reset readiness, serial connect diagnostics, etc.) to DEBUG to reduce default output.
  - Simplified connect-attempt failure warnings to essential retry information.
- Deterministic alias resolution
  - by-id alias selection is sorted to avoid non-deterministic outcomes across runs.
- Batched unknown-field warnings
  - traverseConfig now aggregates unknown leaf fields by top-level section and emits one warning per section listing names and counts instead of a separate warning per leaf.
- Robustness / lint
  - Addressed mypy/pylint issues and added handling for non-callable localConfig.HasField via a _timeout_for_field helper that returns early when a field is absent.

## Refactors & internal helpers

- Centralized CLI printing via _cli_print(message: str).
- _flatten_leaf_paths(prefix: str, mapping: dict) -> list[str] for dotted-path extraction.
- _verify_config_sections(..., verified_fields: list[str] | None = None) now collects verified leaves for aggregated reporting.
- StreamInterface: new _stable_path field, _resolve_stable_path(), deterministic by-id handling, and cleanup of _stable_path on disconnect.
- Node runtime: _timeout_for_field(field_name: str, max_secs: float) to wait safely for optional fields or return early if absent.
- traverseConfig recursion delegated to an internal _traverse(...) helper to support batching unknowns.
- Tunnel/local-only error path changed to use _cli_exit(..., 1) for non-zero exit on misuse.

## Tests

- Added/updated unit tests covering:
  - --quiet CLI parsing and suppression semantics (stdout suppressed, stderr warnings/errors preserved).
  - _cli_print behavior.
  - Stable-path resolution and banner rendering (when omitted and when shown).
  - _flatten_leaf_paths for flat, nested, and empty mappings.
  - Batched unknown-field warnings grouped by top-level section.
  - _timeout_for_field behavior and SendPipeline.waitForConfig() LoRA wait success/failure cases.
  - Adjusted tests to account for quieter logger targets and aggregated verification messages.

## Breaking changes / migration notes

- No public API or CLI argument removals. Changes are additive or reduce logging verbosity.
- Users or automation that relied on informational logs (per-section verification messages or other info-level outputs) may see fewer lines by default; use --debug or --debuglib when more verbose output is required.
- --quiet is intentionally incompatible with certain flags (--debug, --listen, --debuglib); scripts that combined those flags will need adjustment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->