### PR TITLE
Add BLE exception hierarchy and timeout management

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -81,19 +81,19 @@ lint:
   enabled:
     - actionlint@1.7.12
     - black@26.3.1
-    - checkov@3.2.521
+    - checkov@3.2.524
     - git-diff-check
     - gitleaks@8.30.1
     - isort@8.0.1
     - markdownlint@0.48.0
     - osv-scanner@2.3.5
     - prettier@3.8.3
-    - ruff@0.15.10
+    - ruff@0.15.11
     - shellcheck@0.11.0
     - shfmt@3.6.0
     - taplo@0.10.0
-    - trivy@0.69.3
-    - trufflehog@3.93.3
+    - trivy@0.70.0
+    - trufflehog@3.95.2
     - yamllint@1.38.0
     - mypy-poetry
     - pylint-poetry

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1044,7 +1044,7 @@ def traverseConfig(
     """
     skipped_by_section: dict[str, list[str]] = {}
 
-    def _traverse(root: str, cfg: dict, icfg: Any) -> bool:
+    def _traverse(root: str, cfg: dict[str, Any], icfg: Any) -> bool:
         s_name = meshtastic.util.camel_to_snake(root)
         for pref in cfg:
             pref_name = f"{s_name}.{pref}"

--- a/meshtastic/ble_interface.py
+++ b/meshtastic/ble_interface.py
@@ -37,6 +37,12 @@ except ModuleNotFoundError as exc:  # pragma: no cover - dependency guard
 from meshtastic.interfaces import ble as _ble
 from meshtastic.interfaces.ble import (  # noqa: F401  # pylint: disable=unused-import
     BLECLIENT_ERROR_ASYNC_TIMEOUT,
+    BLEAddressMismatchError,
+    BLEConnectionSuppressedError,
+    BLEConnectionTimeoutError,
+    BLEDBusTransportError,
+    BLEDeviceNotFoundError,
+    BLEDiscoveryError,
     ERROR_CONNECTION_FAILED,
     ERROR_MULTIPLE_DEVICES,
     ERROR_NO_PERIPHERAL_FOUND,
@@ -48,11 +54,13 @@ from meshtastic.interfaces.ble import (  # noqa: F401  # pylint: disable=unused-
     FROMRADIO_UUID,
     LEGACY_LOGRADIO_UUID,
     LOGRADIO_UUID,
+    MeshtasticBLEError,
     SERVICE_UUID,
     TORADIO_UUID,
     BLEClient,
     BLEConfig,
     BLEInterface,
+    sanitize_address,
     logger,
 )
 

--- a/meshtastic/ble_interface.py
+++ b/meshtastic/ble_interface.py
@@ -37,12 +37,6 @@ except ModuleNotFoundError as exc:  # pragma: no cover - dependency guard
 from meshtastic.interfaces import ble as _ble
 from meshtastic.interfaces.ble import (  # noqa: F401  # pylint: disable=unused-import
     BLECLIENT_ERROR_ASYNC_TIMEOUT,
-    BLEAddressMismatchError,
-    BLEConnectionSuppressedError,
-    BLEConnectionTimeoutError,
-    BLEDBusTransportError,
-    BLEDeviceNotFoundError,
-    BLEDiscoveryError,
     ERROR_CONNECTION_FAILED,
     ERROR_MULTIPLE_DEVICES,
     ERROR_NO_PERIPHERAL_FOUND,
@@ -54,14 +48,20 @@ from meshtastic.interfaces.ble import (  # noqa: F401  # pylint: disable=unused-
     FROMRADIO_UUID,
     LEGACY_LOGRADIO_UUID,
     LOGRADIO_UUID,
-    MeshtasticBLEError,
     SERVICE_UUID,
     TORADIO_UUID,
+    BLEAddressMismatchError,
     BLEClient,
     BLEConfig,
+    BLEConnectionSuppressedError,
+    BLEConnectionTimeoutError,
+    BLEDBusTransportError,
+    BLEDeviceNotFoundError,
+    BLEDiscoveryError,
     BLEInterface,
-    sanitize_address,
+    MeshtasticBLEError,
     logger,
+    sanitize_address,
 )
 
 _BLE_PUBLIC_ALL = tuple(getattr(_ble, "__all__", ()))

--- a/meshtastic/interfaces/ble/__init__.py
+++ b/meshtastic/interfaces/ble/__init__.py
@@ -39,13 +39,30 @@ from meshtastic.interfaces.ble.constants import (
     BLEConfig,
     logger,
 )
+from meshtastic.interfaces.ble.errors import (
+    BLEAddressMismatchError,
+    BLEConnectionSuppressedError,
+    BLEConnectionTimeoutError,
+    BLEDBusTransportError,
+    BLEDeviceNotFoundError,
+    BLEDiscoveryError,
+    MeshtasticBLEError,
+)
 from meshtastic.interfaces.ble.interface import BLEInterface
+from meshtastic.interfaces.ble.utils import sanitize_address
 
 __all__ = [
     # Main classes
     "BLEInterface",
     "BLEClient",
     "BLEConfig",
+    "MeshtasticBLEError",
+    "BLEDiscoveryError",
+    "BLEDeviceNotFoundError",
+    "BLEConnectionSuppressedError",
+    "BLEConnectionTimeoutError",
+    "BLEAddressMismatchError",
+    "BLEDBusTransportError",
     # UUID constants
     "SERVICE_UUID",
     "TORADIO_UUID",
@@ -64,4 +81,6 @@ __all__ = [
     "BLECLIENT_ERROR_ASYNC_TIMEOUT",
     # Legacy export retained for compatibility with meshtastic.ble_interface.
     "logger",
+    # Utility helpers intended for stable BLE consumers.
+    "sanitize_address",
 ]

--- a/meshtastic/interfaces/ble/client.py
+++ b/meshtastic/interfaces/ble/client.py
@@ -1049,9 +1049,7 @@ class BLEClient:
             # Best effort: disconnect active transport before closing this wrapper.
             if getattr(self, "bleak_client", None) is not None and self.is_connected():
                 disconnect_timeout = (
-                    DISCONNECT_TIMEOUT_SECONDS
-                    if timeout is None
-                    else timeout
+                    DISCONNECT_TIMEOUT_SECONDS if timeout is None else timeout
                 )
                 self._error_handler_safe_cleanup(
                     lambda: self.disconnect(await_timeout=disconnect_timeout),

--- a/meshtastic/interfaces/ble/client.py
+++ b/meshtastic/interfaces/ble/client.py
@@ -1026,10 +1026,21 @@ class BLEClient:
         """
         return self.stopNotify(*args, timeout=timeout, **kwargs)
 
-    def close(self) -> None:
+    def close(self, timeout: float | None = None) -> None:
         """Close the BLEClient and perform a best-effort shutdown.
 
-        If an underlying Bleak client exists and is connected, this attempts a bounded disconnect and suppresses any disconnect errors so shutdown remains best-effort and idempotent. The method is thread-safe (uses an internal close lock), marks the wrapper as closed, and cancels any tracked pending futures to unblock waiting callers. This does not stop or affect the shared BLE event loop used by other clients.
+        If an underlying Bleak client exists and is connected, this attempts a
+        bounded disconnect and suppresses any disconnect errors so shutdown
+        remains best-effort and idempotent. The method is thread-safe (uses an
+        internal close lock), marks the wrapper as closed, and cancels any
+        tracked pending futures to unblock waiting callers. This does not stop
+        or affect the shared BLE event loop used by other clients.
+
+        Parameters
+        ----------
+        timeout : float | None
+            Optional maximum seconds to wait for the disconnect during close.
+            When ``None``, ``DISCONNECT_TIMEOUT_SECONDS`` is used.
         """
         with self._close_lock:
             if getattr(self, "_closed", False):
@@ -1037,8 +1048,13 @@ class BLEClient:
 
             # Best effort: disconnect active transport before closing this wrapper.
             if getattr(self, "bleak_client", None) is not None and self.is_connected():
+                disconnect_timeout = (
+                    DISCONNECT_TIMEOUT_SECONDS
+                    if timeout is None
+                    else timeout
+                )
                 self._error_handler_safe_cleanup(
-                    lambda: self.disconnect(await_timeout=DISCONNECT_TIMEOUT_SECONDS),
+                    lambda: self.disconnect(await_timeout=disconnect_timeout),
                     "client disconnect during close",
                 )
 

--- a/meshtastic/interfaces/ble/client.py
+++ b/meshtastic/interfaces/ble/client.py
@@ -257,6 +257,12 @@ class BLEClient:
         if isinstance(bleak_address, str) and bleak_address:
             self.address = bleak_address
 
+    @property
+    def ble_address(self) -> str | None:
+        """Return the best-known BLE address for this client."""
+        self._sync_address_from_bleak()
+        return self.address
+
     def _resolve_error_handler_hook(
         self, public_name: str, legacy_name: str
     ) -> Callable[..., Any] | None:

--- a/meshtastic/interfaces/ble/client.py
+++ b/meshtastic/interfaces/ble/client.py
@@ -258,10 +258,16 @@ class BLEClient:
             self.address = bleak_address
 
     @property
-    def ble_address(self) -> str | None:
+    def bleAddress(self) -> str | None:
         """Return the best-known BLE address for this client."""
         self._sync_address_from_bleak()
         return self.address
+
+    # COMPAT_STABLE_SHIM
+    @property
+    def ble_address(self) -> str | None:
+        """Compatibility shim for ``bleAddress``."""
+        return self.bleAddress
 
     def _resolve_error_handler_hook(
         self, public_name: str, legacy_name: str

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -747,10 +747,17 @@ class ClientManager:
                     if disconnect_timeout is None
                     else disconnect_timeout
                 )
+
+                def _disconnect_with_timeout() -> None:
+                    try:
+                        client.disconnect(await_timeout=effective_disconnect_timeout)
+                    except TypeError as exc:
+                        if not _is_unexpected_keyword_error(exc, "await_timeout"):
+                            raise
+                        client.disconnect()
+
                 _run_safe_cleanup(
-                    lambda: client.disconnect(
-                        await_timeout=effective_disconnect_timeout
-                    ),
+                    _disconnect_with_timeout,
                     "client disconnect",
                     safe_cleanup_hook,
                 )
@@ -1486,6 +1493,7 @@ class ConnectionOrchestrator:
             pair_on_connect=pair_on_connect,
             connect_timeout=direct_connect_timeout,
         )
+        _retry_succeeded = False
         try:
             self._raise_if_interface_closing()
             self._client_manager_connect_client(
@@ -1505,10 +1513,11 @@ class ConnectionOrchestrator:
                 on_connected_func,
                 emit_connected_side_effects=emit_connected_side_effects,
             )
+            _retry_succeeded = True
             return retry_client
-        except Exception:
-            self._client_manager_safe_close_client(retry_client)
-            raise
+        finally:
+            if not _retry_succeeded:
+                self._client_manager_safe_close_client(retry_client)
 
     def _attempt_direct_connect(
         self,

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -64,12 +64,25 @@ _CONNECT_TIMEOUT_INVALID_MSG: str = (
 )
 _CONNECT_TIMEOUT_FALLBACK_SECONDS: float = 10.0
 _DISPATCH_MISSING: object = object()
-_STABLE_BLUEZ_ERROR_TOKENS: tuple[str, ...] = (
+_STALE_BLUEZ_DBUS_ERROR_NAMES: frozenset[str] = frozenset(
+    {
+        "org.bluez.error.alreadyconnected",
+        "org.bluez.error.inprogress",
+    }
+)
+_STALE_BLUEZ_DETAIL_TOKENS: tuple[str, ...] = (
+    # These phrases appear in BlueZ/DBus transport errors when the adapter has a
+    # stale session or overlapping connect operation. Keep these specific to
+    # avoid false positives from generic "busy" wording in unrelated failures.
     "already connected",
+    "operation already in progress",
+    "device or resource busy",
+)
+_STALE_BLUEZ_FALLBACK_MESSAGE_TOKENS: tuple[str, ...] = (
     "org.bluez.error.alreadyconnected",
     "org.bluez.error.inprogress",
-    "in progress",
-    "busy",
+    "already connected",
+    "operation already in progress",
     "device or resource busy",
 )
 
@@ -1318,8 +1331,13 @@ class ConnectionOrchestrator:
         connected_address = self._extract_client_address(client)
         connected_key = sanitize_address(connected_address)
         if connected_key is None:
+            # Intentional compatibility policy:
+            # Some backends/mocks do not expose a resolved connected peer address
+            # even after a successful explicit-address connect. Treat this as
+            # "cannot verify" rather than a hard mismatch to avoid disconnecting
+            # valid sessions solely due to missing metadata.
             logger.warning(
-                "Connected client address is unavailable for explicit target %s; skipping strict post-connect address verification.",
+                "Cannot enforce explicit-address verification for target %s because the connected peer address is unavailable; proceeding in compatibility mode.",
                 requested_key,
             )
             return
@@ -1334,10 +1352,36 @@ class ConnectionOrchestrator:
     @staticmethod
     def _is_stale_bluez_direct_connect_error(error: BaseException) -> bool:
         """Return whether direct-connect failure looks like stale BlueZ state."""
-        message = str(error).strip().casefold()
-        if not message:
-            return False
-        return any(token in message for token in _STABLE_BLUEZ_ERROR_TOKENS)
+        candidates: list[BaseException] = [error]
+        cause = getattr(error, "cause", None)
+        if isinstance(cause, BaseException):
+            candidates.append(cause)
+
+        for candidate in candidates:
+            dbus_error_name = getattr(candidate, "dbus_error", None)
+            if (
+                isinstance(dbus_error_name, str)
+                and dbus_error_name.casefold() in _STALE_BLUEZ_DBUS_ERROR_NAMES
+            ):
+                return True
+
+            dbus_error_details = getattr(candidate, "dbus_error_details", None)
+            details_text = (
+                dbus_error_details.casefold()
+                if isinstance(dbus_error_details, str)
+                else ""
+            )
+            if details_text and any(
+                token in details_text for token in _STALE_BLUEZ_DETAIL_TOKENS
+            ):
+                return True
+
+            message = str(candidate).strip().casefold()
+            if message and any(
+                token in message for token in _STALE_BLUEZ_FALLBACK_MESSAGE_TOKENS
+            ):
+                return True
+        return False
 
     def _should_attempt_stale_bluez_cleanup(
         self,
@@ -1394,7 +1438,10 @@ class ConnectionOrchestrator:
             return False
         finally:
             if cleanup_client is not None:
-                self._client_manager_safe_close_client(cleanup_client)
+                self._client_manager_safe_close_client(
+                    cleanup_client,
+                    disconnect_timeout=disconnect_timeout,
+                )
 
     def _retry_direct_connect_after_cleanup(
         self,

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -770,7 +770,15 @@ class ClientManager:
                 "Skipping BLE client disconnect during interpreter finalization."
             )
         if not skip_disconnect:
-            _run_safe_cleanup(client.close, "client close", safe_cleanup_hook)
+            try:
+                client.close(timeout=disconnect_timeout)
+            except TypeError as exc:
+                if _is_unexpected_keyword_error(exc, "timeout"):
+                    client.close()
+                else:
+                    raise
+            except Exception:  # noqa: BLE001 - close path best effort
+                logger.debug("Error during client close", exc_info=True)
         else:
             logger.debug("Skipping BLE client close during interpreter finalization.")
         if event:
@@ -1661,13 +1669,13 @@ class ConnectionOrchestrator:
                         OSError,
                         TimeoutError,
                     ) as retry_err:
-                        error_for_fallback = retry_err
                         logger.debug(
                             "Direct reconnect after stale BlueZ cleanup failed for %s: %s",
                             normalized_target,
                             retry_err,
                             exc_info=True,
                         )
+                        raise
             if error_for_fallback is None:
                 error_for_fallback = direct_err
             if isinstance(error_for_fallback, BleakDBusError):

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -701,6 +701,9 @@ class ClientManager:
             BLE client to disconnect and close.
         event : Event | None
             Optional Event that will be set after cleanup completes. (Default value = None)
+        disconnect_timeout : float | None
+            Optional maximum seconds passed to disconnect and close-time
+            disconnect operations.
         """
         is_finalizing = getattr(sys, "is_finalizing", None)
         skip_disconnect = bool(is_finalizing()) if callable(is_finalizing) else False
@@ -812,6 +815,9 @@ class ClientManager:
             Client instance to close.
         event : Event | None
             Optional completion event set after cleanup finishes.
+        disconnect_timeout : float | None
+            Optional maximum seconds passed to disconnect and close-time
+            disconnect operations.
 
         Returns
         -------
@@ -1674,8 +1680,20 @@ class ConnectionOrchestrator:
                         return retried_client, False
                     except BLEAddressMismatchError:
                         raise
+                    except BleakDBusError as retry_dbus_err:
+                        logger.debug(
+                            "Direct reconnect after stale BlueZ cleanup failed for %s: %s",
+                            normalized_target,
+                            retry_dbus_err,
+                            exc_info=True,
+                        )
+                        raise BLEDBusTransportError.from_exception(
+                            retry_dbus_err,
+                            message="BLE DBus transport error during direct connect.",
+                            requested_identifier=target_address,
+                            address=target_address,
+                        ) from retry_dbus_err
                     except (
-                        BleakDBusError,
                         BleakError,
                         BLEClient.BLEError,
                         OSError,
@@ -1688,8 +1706,6 @@ class ConnectionOrchestrator:
                             exc_info=True,
                         )
                         raise
-            if error_for_fallback is None:
-                error_for_fallback = direct_err
             if isinstance(error_for_fallback, BleakDBusError):
                 raise BLEDBusTransportError.from_exception(
                     error_for_fallback,

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -1382,10 +1382,22 @@ class ConnectionOrchestrator:
     @staticmethod
     def _is_stale_bluez_direct_connect_error(error: BaseException) -> bool:
         """Return whether direct-connect failure looks like stale BlueZ state."""
-        candidates: list[BaseException] = [error]
-        cause = getattr(error, "cause", None)
-        if isinstance(cause, BaseException):
-            candidates.append(cause)
+        candidates: list[BaseException] = []
+        pending: list[tuple[BaseException, int]] = [(error, 0)]
+        seen_ids: set[int] = set()
+        while pending:
+            candidate, depth = pending.pop(0)
+            candidate_id = id(candidate)
+            if candidate_id in seen_ids:
+                continue
+            seen_ids.add(candidate_id)
+            candidates.append(candidate)
+            if depth >= 5:
+                continue
+            for attr_name in ("cause", "__cause__", "__context__"):
+                cause = getattr(candidate, attr_name, None)
+                if isinstance(cause, BaseException):
+                    pending.append((cause, depth + 1))
 
         for candidate in candidates:
             dbus_error_name = getattr(candidate, "dbus_error", None)
@@ -1445,6 +1457,10 @@ class ConnectionOrchestrator:
                 on_disconnect_func,
                 pair_on_connect=False,
                 connect_timeout=connect_timeout,
+            )
+            self._client_manager_connect_client(
+                cleanup_client,
+                timeout=connect_timeout,
             )
             disconnect = getattr(cleanup_client, "disconnect", None)
             if callable(disconnect):

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -1366,7 +1366,7 @@ class ConnectionOrchestrator:
             # even after a successful explicit-address connect. Treat this as
             # "cannot verify" rather than a hard mismatch to avoid disconnecting
             # valid sessions solely due to missing metadata.
-            logger.warning(
+            logger.debug(
                 "Cannot enforce explicit-address verification for target %s because the connected peer address is unavailable; proceeding in compatibility mode.",
                 requested_key,
             )

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -770,15 +770,20 @@ class ClientManager:
                 "Skipping BLE client disconnect during interpreter finalization."
             )
         if not skip_disconnect:
-            try:
-                client.close(timeout=disconnect_timeout)
-            except TypeError as exc:
-                if _is_unexpected_keyword_error(exc, "timeout"):
+
+            def _close_with_timeout() -> None:
+                try:
+                    client.close(timeout=disconnect_timeout)
+                except TypeError as exc:
+                    if not _is_unexpected_keyword_error(exc, "timeout"):
+                        raise
                     client.close()
-                else:
-                    raise
-            except Exception:  # noqa: BLE001 - close path best effort
-                logger.debug("Error during client close", exc_info=True)
+
+            _run_safe_cleanup(
+                _close_with_timeout,
+                "client close",
+                safe_cleanup_hook,
+            )
         else:
             logger.debug("Skipping BLE client close during interpreter finalization.")
         if event:

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -28,7 +28,13 @@ from meshtastic.interfaces.ble.constants import (
 )
 from meshtastic.interfaces.ble.coordination import ThreadCoordinator, ThreadLike
 from meshtastic.interfaces.ble.discovery import _looks_like_ble_address
-from meshtastic.interfaces.ble.errors import BLEErrorHandler
+from meshtastic.interfaces.ble.errors import (
+    BLEAddressMismatchError,
+    BLEConnectionTimeoutError,
+    BLEDBusTransportError,
+    BLEDeviceNotFoundError as MeshtasticBLEDeviceNotFoundError,
+    BLEErrorHandler,
+)
 from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
 from meshtastic.interfaces.ble.utils import (
     _is_unconfigured_mock_callable,
@@ -58,6 +64,14 @@ _CONNECT_TIMEOUT_INVALID_MSG: str = (
 )
 _CONNECT_TIMEOUT_FALLBACK_SECONDS: float = 10.0
 _DISPATCH_MISSING: object = object()
+_STABLE_BLUEZ_ERROR_TOKENS: tuple[str, ...] = (
+    "already connected",
+    "org.bluez.error.alreadyconnected",
+    "org.bluez.error.inprogress",
+    "in progress",
+    "busy",
+    "device or resource busy",
+)
 
 
 def _is_device_not_found_error(err: Exception) -> bool:
@@ -655,7 +669,13 @@ class ClientManager:
         """
         self._update_client_reference(new_client, old_client)
 
-    def _safe_close_client(self, client: BLEClient, event: Event | None = None) -> None:
+    def _safe_close_client(
+        self,
+        client: BLEClient,
+        event: Event | None = None,
+        *,
+        disconnect_timeout: float | None = None,
+    ) -> None:
         """Attempt to disconnect and close the given BLE client, suppressing any errors and optionally signal completion.
 
         Parameters
@@ -705,8 +725,15 @@ class ClientManager:
                     if is_connected:
                         break
             if is_connected:
+                effective_disconnect_timeout = (
+                    DISCONNECT_TIMEOUT_SECONDS
+                    if disconnect_timeout is None
+                    else disconnect_timeout
+                )
                 _run_safe_cleanup(
-                    lambda: client.disconnect(await_timeout=DISCONNECT_TIMEOUT_SECONDS),
+                    lambda: client.disconnect(
+                        await_timeout=effective_disconnect_timeout
+                    ),
                     "client disconnect",
                     safe_cleanup_hook,
                 )
@@ -725,7 +752,13 @@ class ClientManager:
         if event:
             event.set()
 
-    def safe_close_client(self, client: BLEClient, event: Event | None = None) -> None:
+    def safe_close_client(
+        self,
+        client: BLEClient,
+        event: Event | None = None,
+        *,
+        disconnect_timeout: float | None = None,
+    ) -> None:
         # Internal adapter alias for collaborator migration; delegates to _safe_close_client.
         """Close a BLE client using best-effort shutdown semantics.
 
@@ -747,9 +780,26 @@ class ClientManager:
             Internal close implementation with guarded cleanup.
         """
         if event is None:
-            self._safe_close_client(client)
+            try:
+                self._safe_close_client(
+                    client,
+                    disconnect_timeout=disconnect_timeout,
+                )
+            except TypeError as exc:
+                if not _is_unexpected_keyword_error(exc, "disconnect_timeout"):
+                    raise
+                self._safe_close_client(client)
             return
-        self._safe_close_client(client, event=event)
+        try:
+            self._safe_close_client(
+                client,
+                event=event,
+                disconnect_timeout=disconnect_timeout,
+            )
+        except TypeError as exc:
+            if not _is_unexpected_keyword_error(exc, "disconnect_timeout"):
+                raise
+            self._safe_close_client(client, event=event)
 
 
 class ConnectionOrchestrator:
@@ -1240,6 +1290,156 @@ class ConnectionOrchestrator:
         )
         return direct_connect_timeout, discovery_connect_timeout
 
+    @staticmethod
+    def _extract_client_address(client: BLEClient) -> str | None:
+        """Return the best-known connected address from a BLE client."""
+        bleak_client = getattr(client, "bleak_client", None)
+        bleak_address = getattr(bleak_client, "address", None)
+        if isinstance(bleak_address, str) and bleak_address:
+            return bleak_address
+        client_address = getattr(client, "address", None)
+        return client_address if isinstance(client_address, str) else None
+
+    def _validate_explicit_address_connection(
+        self,
+        *,
+        client: BLEClient,
+        target_address: str | None,
+        explicit_address: bool,
+    ) -> None:
+        """Enforce post-connect address verification for explicit BLE-address connects."""
+        if not explicit_address or not target_address:
+            return
+        if not _looks_like_ble_address(target_address):
+            return
+        requested_key = sanitize_address(target_address)
+        if requested_key is None:
+            return
+        connected_address = self._extract_client_address(client)
+        connected_key = sanitize_address(connected_address)
+        if connected_key is None:
+            logger.warning(
+                "Connected client address is unavailable for explicit target %s; skipping strict post-connect address verification.",
+                requested_key,
+            )
+            return
+        if connected_key != requested_key:
+            raise BLEAddressMismatchError(
+                "Connected BLE address does not match explicit target address.",
+                requested_identifier=target_address,
+                connected_address=connected_address,
+                address=target_address,
+            )
+
+    @staticmethod
+    def _is_stale_bluez_direct_connect_error(error: BaseException) -> bool:
+        """Return whether direct-connect failure looks like stale BlueZ state."""
+        message = str(error).strip().casefold()
+        if not message:
+            return False
+        return any(token in message for token in _STABLE_BLUEZ_ERROR_TOKENS)
+
+    def _should_attempt_stale_bluez_cleanup(
+        self,
+        *,
+        target_address: str | None,
+        explicit_address: bool,
+        error: BaseException,
+    ) -> bool:
+        """Return whether stale BlueZ disconnect cleanup should be attempted."""
+        if not sys.platform.startswith("linux"):
+            return False
+        if not explicit_address or not target_address:
+            return False
+        if not _looks_like_ble_address(target_address):
+            return False
+        return self._is_stale_bluez_direct_connect_error(error)
+
+    def _attempt_stale_bluez_cleanup(
+        self,
+        *,
+        target_address: str,
+        on_disconnect_func: Callable[["BleakRootClient"], None],
+        connect_timeout: float,
+    ) -> bool:
+        """Best-effort stale connection cleanup for Linux/BlueZ direct connects."""
+        cleanup_client: BLEClient | None = None
+        disconnect_timeout = min(connect_timeout, DISCONNECT_TIMEOUT_SECONDS)
+        try:
+            cleanup_client = self._client_manager_create_client(
+                target_address,
+                on_disconnect_func,
+                pair_on_connect=False,
+                connect_timeout=connect_timeout,
+            )
+            disconnect = getattr(cleanup_client, "disconnect", None)
+            if callable(disconnect):
+                try:
+                    disconnect(await_timeout=disconnect_timeout)
+                except TypeError as exc:
+                    if not _is_unexpected_keyword_error(exc, "await_timeout"):
+                        raise
+                    disconnect()
+            logger.debug(
+                "Completed stale BlueZ cleanup probe for explicit address %s",
+                sanitize_address(target_address) or target_address,
+            )
+            return True
+        except Exception:  # noqa: BLE001 - stale cleanup is best effort
+            logger.debug(
+                "Stale BlueZ cleanup probe failed for %s",
+                sanitize_address(target_address) or target_address,
+                exc_info=True,
+            )
+            return False
+        finally:
+            if cleanup_client is not None:
+                self._client_manager_safe_close_client(cleanup_client)
+
+    def _retry_direct_connect_after_cleanup(
+        self,
+        *,
+        target_address: str,
+        explicit_address: bool,
+        on_disconnect_func: Callable[["BleakRootClient"], None],
+        pair_on_connect: bool,
+        direct_connect_timeout: float,
+        register_notifications_func: Callable[[BLEClient], None],
+        on_connected_func: Callable[[], None],
+        emit_connected_side_effects: bool,
+    ) -> BLEClient:
+        """Retry one explicit-address direct connect after stale cleanup."""
+        self._raise_if_interface_closing()
+        retry_client = self._client_manager_create_client(
+            target_address,
+            on_disconnect_func,
+            pair_on_connect=pair_on_connect,
+            connect_timeout=direct_connect_timeout,
+        )
+        try:
+            self._raise_if_interface_closing()
+            self._client_manager_connect_client(
+                retry_client,
+                timeout=direct_connect_timeout,
+            )
+            self._raise_if_interface_closing()
+            self._validate_explicit_address_connection(
+                client=retry_client,
+                target_address=target_address,
+                explicit_address=explicit_address,
+            )
+            self._finalize_connection(
+                retry_client,
+                target_address,
+                register_notifications_func,
+                on_connected_func,
+                emit_connected_side_effects=emit_connected_side_effects,
+            )
+            return retry_client
+        except Exception:
+            self._client_manager_safe_close_client(retry_client)
+            raise
+
     def _attempt_direct_connect(
         self,
         *,
@@ -1307,34 +1507,86 @@ class ConnectionOrchestrator:
             pair_on_connect=pair_on_connect,
             connect_timeout=direct_connect_timeout,
         )
+        error_for_fallback: (
+            BleakError | BLEClient.BLEError | OSError | TimeoutError | BleakDBusError
+        ) | None = None
         try:
             self._raise_if_interface_closing()
             self._client_manager_connect_client(client, timeout=direct_connect_timeout)
         except (SystemExit, KeyboardInterrupt):  # pylint: disable=W0706
             self._client_manager_safe_close_client(client)
             raise
-        except BleakDBusError:
-            self._client_manager_safe_close_client(client)
-            raise
         except (
+            BleakDBusError,
             BleakError,
             BLEClient.BLEError,
             OSError,
             TimeoutError,
         ) as direct_err:
+            error_for_fallback = direct_err
+            self._client_manager_safe_close_client(client)
             logger.debug(
                 "Direct connect to %s failed; preparing retry path: %s",
                 normalized_target,
                 direct_err,
                 exc_info=True,
             )
+            if self._should_attempt_stale_bluez_cleanup(
+                target_address=target_address,
+                explicit_address=explicit_address,
+                error=direct_err,
+            ):
+                logger.warning(
+                    "Direct connect to %s failed; attempting one stale BlueZ cleanup + retry.",
+                    normalized_target,
+                )
+                if self._attempt_stale_bluez_cleanup(
+                    target_address=target_address,
+                    on_disconnect_func=on_disconnect_func,
+                    connect_timeout=direct_connect_timeout,
+                ):
+                    try:
+                        retried_client = self._retry_direct_connect_after_cleanup(
+                            target_address=target_address,
+                            explicit_address=explicit_address,
+                            on_disconnect_func=on_disconnect_func,
+                            pair_on_connect=pair_on_connect,
+                            direct_connect_timeout=direct_connect_timeout,
+                            register_notifications_func=register_notifications_func,
+                            on_connected_func=on_connected_func,
+                            emit_connected_side_effects=emit_connected_side_effects,
+                        )
+                        return retried_client, False
+                    except (
+                        BleakDBusError,
+                        BleakError,
+                        BLEClient.BLEError,
+                        OSError,
+                        TimeoutError,
+                    ) as retry_err:
+                        error_for_fallback = retry_err
+                        logger.debug(
+                            "Direct reconnect after stale BlueZ cleanup failed for %s: %s",
+                            normalized_target,
+                            retry_err,
+                            exc_info=True,
+                        )
+            if error_for_fallback is None:
+                error_for_fallback = direct_err
+            if isinstance(error_for_fallback, BleakDBusError):
+                raise BLEDBusTransportError.from_exception(
+                    error_for_fallback,
+                    message="BLE DBus transport error during direct connect.",
+                    requested_identifier=target_address,
+                    address=target_address,
+                ) from error_for_fallback
             # Preserve strict direct-only retries only for caller-explicit BLE
             # addresses. Derived targets (for example current_address carried
             # into reconnect flows) are still allowed to use discovery fallback.
             skip_discovery_scan = explicit_address and _looks_like_ble_address(
                 target_address
             )
-            if skip_discovery_scan and _is_device_not_found_error(direct_err):
+            if skip_discovery_scan and _is_device_not_found_error(error_for_fallback):
                 logger.debug(
                     "Direct connect reported device-not-found for %s; skipping discovery scan and retrying explicit address connect.",
                     normalized_target,
@@ -1349,7 +1601,6 @@ class ConnectionOrchestrator:
                     "Direct connect to derived address %s failed; allowing discovery fallback.",
                     normalized_target,
                 )
-            self._client_manager_safe_close_client(client)
             return None, skip_discovery_scan
         except Exception:
             self._client_manager_safe_close_client(client)
@@ -1357,6 +1608,11 @@ class ConnectionOrchestrator:
 
         try:
             self._raise_if_interface_closing()
+            self._validate_explicit_address_connection(
+                client=client,
+                target_address=target_address,
+                explicit_address=explicit_address,
+            )
             self._finalize_connection(
                 client,
                 target_address,
@@ -1406,7 +1662,14 @@ class ConnectionOrchestrator:
             return target_address, target_address, direct_connect_timeout
 
         self._raise_if_interface_closing()
-        device = self._compat_find_device(target_address)
+        try:
+            device = self._compat_find_device(target_address)
+        except BleakDeviceNotFoundError as error:
+            raise MeshtasticBLEDeviceNotFoundError(
+                "No Meshtastic BLE device matched the requested identifier.",
+                requested_identifier=target_address,
+                cause=error,
+            ) from error
         return device, device.address, discovery_connect_timeout
 
     def _connect_retry_target(
@@ -1470,14 +1733,26 @@ class ConnectionOrchestrator:
         except (SystemExit, KeyboardInterrupt):  # pylint: disable=W0706
             self._client_manager_safe_close_client(client)
             raise
-        except BleakDBusError:
+        except BleakDBusError as dbus_err:
             self._client_manager_safe_close_client(client)
-            raise
+            raise BLEDBusTransportError.from_exception(
+                dbus_err,
+                message="BLE DBus transport error during retry connect.",
+                requested_identifier=target_address or resolved_address,
+                address=resolved_address,
+            ) from dbus_err
+        except TimeoutError as timeout_err:
+            self._client_manager_safe_close_client(client)
+            raise BLEConnectionTimeoutError.from_exception(
+                timeout_err,
+                message="BLE connection timed out during retry connect.",
+                requested_identifier=target_address or resolved_address,
+                timeout=retry_connect_timeout,
+            ) from timeout_err
         except (
             BleakError,
             BLEClient.BLEError,
             OSError,
-            TimeoutError,
         ) as retry_err:
             if (
                 skip_discovery_scan
@@ -1772,6 +2047,11 @@ class ConnectionOrchestrator:
             )
 
             self._raise_if_interface_closing()
+            self._validate_explicit_address_connection(
+                client=client,
+                target_address=target_address,
+                explicit_address=explicit_address,
+            )
             self._finalize_connection(
                 client,
                 resolved_address,
@@ -1780,6 +2060,21 @@ class ConnectionOrchestrator:
                 emit_connected_side_effects=emit_connected_side_effects,
             )
             return client
+        except BLEConnectionTimeoutError:
+            if client:
+                self._client_manager_safe_close_client(client)
+            self._transition_failure_to_disconnected("Timeout during connect")
+            raise
+        except TimeoutError as timeout_err:
+            if client:
+                self._client_manager_safe_close_client(client)
+            self._transition_failure_to_disconnected("Timeout during connect")
+            raise BLEConnectionTimeoutError.from_exception(
+                timeout_err,
+                message="BLE connection timed out.",
+                requested_identifier=target_address or current_address,
+                timeout=connect_timeout,
+            ) from timeout_err
         except BleakDBusError:
             if client:
                 self._client_manager_safe_close_client(client)

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -714,76 +714,87 @@ class ClientManager:
         ):
             safe_cleanup_hook = None
 
-        if (
-            not skip_disconnect
-            and not getattr(client, "_closed", False)
-            and getattr(client, "bleak_client", None)
-        ):
-            is_connected = False
-            for probe_name in ("is_connected", "isConnected", "_is_connected"):
-                is_connected_probe = getattr(client, probe_name, None)
-                if callable(is_connected_probe) and not _is_unconfigured_mock_callable(
-                    is_connected_probe
-                ):
-                    try:
-                        is_connected = bool(is_connected_probe())
-                    except Exception:  # noqa: BLE001 - shutdown must remain best effort
-                        logger.debug(
-                            "Failed to read BLE client connected state via %s during shutdown.",
-                            probe_name,
-                            exc_info=True,
-                        )
-                    if is_connected:
-                        break
-                elif isinstance(
-                    is_connected_probe, bool
-                ) and not _is_unconfigured_mock_member(is_connected_probe):
-                    is_connected = is_connected_probe
-                    if is_connected:
-                        break
-            if is_connected:
-                effective_disconnect_timeout = (
-                    DISCONNECT_TIMEOUT_SECONDS
-                    if disconnect_timeout is None
-                    else disconnect_timeout
-                )
+        try:
+            if (
+                not skip_disconnect
+                and not getattr(client, "_closed", False)
+                and getattr(client, "bleak_client", None)
+            ):
+                is_connected = False
+                for probe_name in ("is_connected", "isConnected", "_is_connected"):
+                    is_connected_probe = getattr(client, probe_name, None)
+                    if callable(
+                        is_connected_probe
+                    ) and not _is_unconfigured_mock_callable(is_connected_probe):
+                        try:
+                            is_connected = bool(is_connected_probe())
+                        except Exception:  # noqa: BLE001 - shutdown must remain best effort
+                            logger.debug(
+                                "Failed to read BLE client connected state via %s during shutdown.",
+                                probe_name,
+                                exc_info=True,
+                            )
+                        if is_connected:
+                            break
+                    elif isinstance(
+                        is_connected_probe, bool
+                    ) and not _is_unconfigured_mock_member(is_connected_probe):
+                        is_connected = is_connected_probe
+                        if is_connected:
+                            break
+                if is_connected:
+                    effective_disconnect_timeout = (
+                        DISCONNECT_TIMEOUT_SECONDS
+                        if disconnect_timeout is None
+                        else disconnect_timeout
+                    )
 
-                def _disconnect_with_timeout() -> None:
+                    def _disconnect_with_timeout() -> None:
+                        try:
+                            client.disconnect(await_timeout=effective_disconnect_timeout)
+                        except TypeError as exc:
+                            if not _is_unexpected_keyword_error(exc, "await_timeout"):
+                                raise
+                            client.disconnect()
+
+                    _run_safe_cleanup(
+                        _disconnect_with_timeout,
+                        "client disconnect",
+                        safe_cleanup_hook,
+                    )
+                else:
+                    logger.debug(
+                        "Skipping BLE client disconnect during shutdown: client is not connected."
+                    )
+            elif skip_disconnect:
+                logger.debug(
+                    "Skipping BLE client disconnect during interpreter finalization."
+                )
+            if not skip_disconnect:
+                close_error: TypeError | None = None
+
+                def _close_with_timeout() -> None:
+                    nonlocal close_error
                     try:
-                        client.disconnect(await_timeout=effective_disconnect_timeout)
+                        client.close(timeout=disconnect_timeout)
                     except TypeError as exc:
-                        if not _is_unexpected_keyword_error(exc, "await_timeout"):
+                        if not _is_unexpected_keyword_error(exc, "timeout"):
+                            close_error = exc
                             raise
-                        client.disconnect()
+                        client.close()
 
                 _run_safe_cleanup(
-                    _disconnect_with_timeout,
-                    "client disconnect",
+                    _close_with_timeout,
+                    "client close",
                     safe_cleanup_hook,
                 )
+                if close_error is not None:
+                    raise close_error
             else:
-                logger.debug(
-                    "Skipping BLE client disconnect during shutdown: client is not connected."
-                )
-        elif skip_disconnect:
-            logger.debug(
-                "Skipping BLE client disconnect during interpreter finalization."
-            )
-        if not skip_disconnect:
-
-            def _close_with_timeout() -> None:
-                try:
-                    client.close(timeout=disconnect_timeout)
-                except TypeError as exc:
-                    if not _is_unexpected_keyword_error(exc, "timeout"):
-                        raise
-                    client.close()
-
-            _close_with_timeout()
-        else:
-            logger.debug("Skipping BLE client close during interpreter finalization.")
-        if event:
-            event.set()
+                logger.debug("Skipping BLE client close during interpreter finalization.")
+        finally:
+            if event:
+                event.set()
 
     def safe_close_client(
         self,

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -1636,6 +1636,8 @@ class ConnectionOrchestrator:
                             emit_connected_side_effects=emit_connected_side_effects,
                         )
                         return retried_client, False
+                    except BLEAddressMismatchError:
+                        raise
                     except (
                         BleakDBusError,
                         BleakError,

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -779,11 +779,7 @@ class ClientManager:
                         raise
                     client.close()
 
-            _run_safe_cleanup(
-                _close_with_timeout,
-                "client close",
-                safe_cleanup_hook,
-            )
+            _close_with_timeout()
         else:
             logger.debug("Skipping BLE client close during interpreter finalization.")
         if event:

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -32,7 +32,11 @@ from meshtastic.interfaces.ble.errors import (
     BLEAddressMismatchError,
     BLEConnectionTimeoutError,
     BLEDBusTransportError,
+)
+from meshtastic.interfaces.ble.errors import (
     BLEDeviceNotFoundError as MeshtasticBLEDeviceNotFoundError,
+)
+from meshtastic.interfaces.ble.errors import (
     BLEErrorHandler,
 )
 from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
@@ -1112,16 +1116,35 @@ class ConnectionOrchestrator:
                 kwargs={},
             )
 
-    def _client_manager_safe_close_client(self, client: BLEClient) -> None:
+    def _client_manager_safe_close_client(
+        self,
+        client: BLEClient,
+        *,
+        disconnect_timeout: float | None = None,
+    ) -> None:
         """Close client via public API with underscore-compatible fallback for mocks/test doubles."""
-        self._dispatch_public_or_underscore(
-            target=self.client_manager,
-            public_name="safe_close_client",
-            underscore_name="_safe_close_client",
-            prefer_instance_type=ClientManager,
-            call_member=True,
-            args=(client,),
-        )
+        try:
+            self._dispatch_public_or_underscore(
+                target=self.client_manager,
+                public_name="safe_close_client",
+                underscore_name="_safe_close_client",
+                prefer_instance_type=ClientManager,
+                call_member=True,
+                args=(client,),
+                kwargs={"disconnect_timeout": disconnect_timeout},
+            )
+        except TypeError as exc:
+            if not _is_unexpected_keyword_error(exc, "disconnect_timeout"):
+                raise
+            self._dispatch_public_or_underscore(
+                target=self.client_manager,
+                public_name="safe_close_client",
+                underscore_name="_safe_close_client",
+                prefer_instance_type=ClientManager,
+                call_member=True,
+                args=(client,),
+                kwargs={},
+            )
 
     @staticmethod
     def _get_connect_timeout(*, pair_on_connect: bool) -> float:

--- a/meshtastic/interfaces/ble/errors.py
+++ b/meshtastic/interfaces/ble/errors.py
@@ -161,7 +161,15 @@ class BLEDBusTransportError(MeshtasticBLEError, BleakDBusError):
             body_items = [dbus_error_details]
         else:
             body_items = []
-        BleakDBusError.__init__(self, resolved_error, body_items)
+        # Preserve caller-facing string details by passing single-string bodies
+        # wrapped in a list to BleakDBusError. BleakDBusError unpacks positional
+        # args, so a bare string would be split into individual characters.
+        if len(body_items) == 1 and isinstance(body_items[0], str):
+            BleakDBusError.__init__(self, resolved_error, [body_items[0]])
+        elif body_items:
+            BleakDBusError.__init__(self, resolved_error, body_items)
+        else:
+            BleakDBusError.__init__(self, resolved_error, [])
         # Mirror MeshtasticBLEError structured context fields while preserving
         # BleakDBusError args-backed properties for dbus_error/details.
         self.message = message
@@ -207,10 +215,24 @@ class BLEDBusTransportError(MeshtasticBLEError, BleakDBusError):
         """
         dbus_error = getattr(error, "dbus_error", None)
         dbus_error_details = getattr(error, "dbus_error_details", None)
+        # Normalize list-wrapped details to a plain string when possible.
+        if (
+            isinstance(dbus_error_details, (list, tuple))
+            and len(dbus_error_details) == 1
+            and isinstance(dbus_error_details[0], str)
+        ):
+            dbus_error_details = dbus_error_details[0]
         dbus_error_body: tuple[Any, ...] | None = None
         error_args = getattr(error, "args", ())
         if isinstance(error_args, tuple) and len(error_args) > 1:
-            dbus_error_body = tuple(error_args[1:])
+            remainder = error_args[1:]
+            # Flatten a single list/tuple wrapper so BleakDBusError-style args
+            # ("org.bluez.Error.Failed", ["Device or resource busy"]) produce
+            # a string detail instead of a nested list.
+            if len(remainder) == 1 and isinstance(remainder[0], (list, tuple)):
+                dbus_error_body = tuple(remainder[0])
+            else:
+                dbus_error_body = tuple(remainder)
         elif dbus_error_details is not None:
             dbus_error_body = (dbus_error_details,)
         return cls(

--- a/meshtastic/interfaces/ble/errors.py
+++ b/meshtastic/interfaces/ble/errors.py
@@ -3,9 +3,10 @@
 from concurrent.futures import TimeoutError as FutureTimeoutError
 from typing import Any, Callable, TypeVar
 
-from bleak.exc import BleakError
+from bleak.exc import BleakDBusError, BleakDeviceNotFoundError, BleakError
 
 from meshtastic.interfaces.ble.constants import logger
+from meshtastic.mesh_interface import MeshInterface
 
 # Import DecodeError from protobuf, or create a fallback if not available
 DecodeError: type[Exception]
@@ -25,9 +26,103 @@ else:
 
 
 # Public exports for BLE error handling utilities.
-__all__ = ["BLEErrorHandler", "DecodeError"]
+__all__ = [
+    "MeshtasticBLEError",
+    "BLEDiscoveryError",
+    "BLEDeviceNotFoundError",
+    "BLEConnectionSuppressedError",
+    "BLEConnectionTimeoutError",
+    "BLEAddressMismatchError",
+    "BLEDBusTransportError",
+    "BLEErrorHandler",
+    "DecodeError",
+]
 
 T = TypeVar("T")
+
+
+class MeshtasticBLEError(MeshInterface.MeshInterfaceError):
+    """Base exception for structured Meshtastic BLE failures."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        address: str | None = None,
+        requested_identifier: str | None = None,
+        timeout: float | None = None,
+        connected_address: str | None = None,
+        cause: BaseException | None = None,
+    ) -> None:
+        """Create a BLE error with optional structured context attributes."""
+        # Avoid cooperative super() here so multiple-inheritance variants
+        # (for example BleakDBusError mixins) do not require foreign
+        # constructor signatures.
+        self.message = message
+        Exception.__init__(self, message)
+        self.address = address
+        self.requested_identifier = requested_identifier
+        self.timeout = timeout
+        self.connected_address = connected_address
+        self.cause = cause
+
+
+class BLEDiscoveryError(MeshtasticBLEError):
+    """Raised when BLE discovery cannot resolve a usable target."""
+
+
+class BLEDeviceNotFoundError(BLEDiscoveryError, BleakDeviceNotFoundError):
+    """Raised when a specific BLE target cannot be located."""
+
+
+class BLEConnectionSuppressedError(MeshtasticBLEError):
+    """Raised when duplicate-connect gating suppresses a connection attempt."""
+
+
+class BLEConnectionTimeoutError(MeshtasticBLEError, TimeoutError):
+    """Raised when BLE connection setup exceeds a timeout budget."""
+
+    @classmethod
+    def from_exception(
+        cls,
+        error: BaseException,
+        *,
+        message: str,
+        requested_identifier: str | None = None,
+        timeout: float | None = None,
+    ) -> "BLEConnectionTimeoutError":
+        """Normalize a timeout failure with structured metadata."""
+        return cls(
+            message,
+            requested_identifier=requested_identifier,
+            timeout=timeout,
+            cause=error,
+        )
+
+
+class BLEAddressMismatchError(MeshtasticBLEError):
+    """Raised when explicit-address connect resolves to a different peer."""
+
+
+class BLEDBusTransportError(MeshtasticBLEError, BleakDBusError):
+    """Raised for normalized BlueZ/DBus transport failures."""
+
+    @classmethod
+    def from_exception(
+        cls,
+        error: BaseException,
+        *,
+        message: str,
+        requested_identifier: str | None = None,
+        address: str | None = None,
+    ) -> "BLEDBusTransportError":
+        """Normalize DBus transport failures while preserving the original cause."""
+        return cls(
+            message,
+            requested_identifier=requested_identifier,
+            address=address,
+            cause=error,
+        )
 
 
 class BLEErrorHandler:

--- a/meshtastic/interfaces/ble/errors.py
+++ b/meshtastic/interfaces/ble/errors.py
@@ -215,6 +215,15 @@ class BLEDBusTransportError(MeshtasticBLEError, BleakDBusError):
         """
         dbus_error = getattr(error, "dbus_error", None)
         dbus_error_details = getattr(error, "dbus_error_details", None)
+        error_args = getattr(error, "args", ())
+        if (
+            not isinstance(dbus_error, str)
+            and isinstance(error_args, tuple)
+            and error_args
+            and isinstance(error_args[0], str)
+            and error_args[0].startswith("org.")
+        ):
+            dbus_error = error_args[0]
         # Normalize list-wrapped details to a plain string when possible.
         if (
             isinstance(dbus_error_details, (list, tuple))
@@ -223,7 +232,6 @@ class BLEDBusTransportError(MeshtasticBLEError, BleakDBusError):
         ):
             dbus_error_details = dbus_error_details[0]
         dbus_error_body: tuple[Any, ...] | None = None
-        error_args = getattr(error, "args", ())
         if isinstance(error_args, tuple) and len(error_args) > 1:
             remainder = error_args[1:]
             # Flatten a single list/tuple wrapper so BleakDBusError-style args

--- a/meshtastic/interfaces/ble/errors.py
+++ b/meshtastic/interfaces/ble/errors.py
@@ -102,7 +102,19 @@ class BLEConnectionTimeoutError(MeshtasticBLEError, TimeoutError):
         requested_identifier: str | None = None,
         timeout: float | None = None,
     ) -> "BLEConnectionTimeoutError":
-        """Normalize a timeout failure with structured metadata."""
+        """Normalize a timeout failure with structured metadata.
+
+        Parameters
+        ----------
+        error : BaseException
+            Original timeout or transport exception.
+        message : str
+            Meshtastic-facing error message.
+        requested_identifier : str | None, optional
+            Caller-supplied device identifier involved in the failure.
+        timeout : float | None, optional
+            Timeout budget associated with the failed operation.
+        """
         return cls(
             message,
             requested_identifier=requested_identifier,
@@ -168,7 +180,19 @@ class BLEDBusTransportError(MeshtasticBLEError, BleakDBusError):
         requested_identifier: str | None = None,
         address: str | None = None,
     ) -> "BLEDBusTransportError":
-        """Normalize DBus transport failures while preserving DBus metadata."""
+        """Normalize DBus transport failures while preserving DBus metadata.
+
+        Parameters
+        ----------
+        error : BaseException
+            Original DBus or transport exception.
+        message : str
+            Meshtastic-facing error message.
+        requested_identifier : str | None, optional
+            Caller-supplied device identifier involved in the failure.
+        address : str | None, optional
+            BLE address associated with the failed operation.
+        """
         dbus_error = getattr(error, "dbus_error", None)
         dbus_error_details = getattr(error, "dbus_error_details", None)
         dbus_error_body: tuple[Any, ...] | None = None

--- a/meshtastic/interfaces/ble/errors.py
+++ b/meshtastic/interfaces/ble/errors.py
@@ -74,8 +74,14 @@ class BLEDiscoveryError(MeshtasticBLEError):
 class BLEDeviceNotFoundError(BLEDiscoveryError, BleakDeviceNotFoundError):
     """Raised when a specific BLE target cannot be located."""
 
+    # BleakDeviceNotFoundError declares ``identifier: str`` as a writable attribute.
+    # We expose ``requested_identifier`` through this property so callers can read
+    # the identifier even though our ``MeshtasticBLEError`` constructor does not
+    # invoke ``BleakDeviceNotFoundError.__init__``.  The ``[override]`` ignores are
+    # required because our return type is ``str | None`` (matching
+    # ``requested_identifier``) rather than Bleak's narrower ``str``.
     @property
-    def identifier(self) -> str | None:
+    def identifier(self) -> str | None:  # type: ignore[override]
         """Return the requested identifier for BleakDeviceNotFoundError compatibility."""
         return self.requested_identifier
 

--- a/meshtastic/interfaces/ble/errors.py
+++ b/meshtastic/interfaces/ble/errors.py
@@ -155,6 +155,10 @@ class BLEDBusTransportError(MeshtasticBLEError, BleakDBusError):
         self.dbus_error_name = self.dbus_error
         self.dbus_error_body = tuple(body_items)
 
+    def __str__(self) -> str:
+        """Return the normalized Meshtastic-facing transport message."""
+        return self.message
+
     @classmethod
     def from_exception(
         cls,

--- a/meshtastic/interfaces/ble/errors.py
+++ b/meshtastic/interfaces/ble/errors.py
@@ -74,6 +74,11 @@ class BLEDiscoveryError(MeshtasticBLEError):
 class BLEDeviceNotFoundError(BLEDiscoveryError, BleakDeviceNotFoundError):
     """Raised when a specific BLE target cannot be located."""
 
+    @property
+    def identifier(self) -> str | None:
+        """Return the requested identifier for BleakDeviceNotFoundError compatibility."""
+        return self.requested_identifier
+
 
 class BLEConnectionSuppressedError(MeshtasticBLEError):
     """Raised when duplicate-connect gating suppresses a connection attempt."""

--- a/meshtastic/interfaces/ble/errors.py
+++ b/meshtastic/interfaces/ble/errors.py
@@ -114,6 +114,12 @@ class BLEConnectionTimeoutError(MeshtasticBLEError, TimeoutError):
             Caller-supplied device identifier involved in the failure.
         timeout : float | None, optional
             Timeout budget associated with the failed operation.
+
+        Returns
+        -------
+        BLEConnectionTimeoutError
+            New error instance carrying the original exception as ``cause``
+            together with the provided structured metadata.
         """
         return cls(
             message,
@@ -192,6 +198,12 @@ class BLEDBusTransportError(MeshtasticBLEError, BleakDBusError):
             Caller-supplied device identifier involved in the failure.
         address : str | None, optional
             BLE address associated with the failed operation.
+
+        Returns
+        -------
+        BLEDBusTransportError
+            New error instance preserving DBus error name, body, and structured
+            Meshtastic context fields.
         """
         dbus_error = getattr(error, "dbus_error", None)
         dbus_error_details = getattr(error, "dbus_error_details", None)

--- a/meshtastic/interfaces/ble/errors.py
+++ b/meshtastic/interfaces/ble/errors.py
@@ -107,6 +107,43 @@ class BLEAddressMismatchError(MeshtasticBLEError):
 class BLEDBusTransportError(MeshtasticBLEError, BleakDBusError):
     """Raised for normalized BlueZ/DBus transport failures."""
 
+    _DEFAULT_DBUS_ERROR = "org.bluez.Error.Failed"
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        address: str | None = None,
+        requested_identifier: str | None = None,
+        cause: BaseException | None = None,
+        dbus_error: str | None = None,
+        dbus_error_details: Any | None = None,
+        dbus_error_body: tuple[Any, ...] | None = None,
+    ) -> None:
+        """Create a normalized DBus transport error with preserved DBus context."""
+        resolved_error = (
+            dbus_error
+            if isinstance(dbus_error, str) and dbus_error
+            else self._DEFAULT_DBUS_ERROR
+        )
+        if dbus_error_body is not None:
+            body_items: list[Any] = list(dbus_error_body)
+        elif dbus_error_details is not None:
+            body_items = [dbus_error_details]
+        else:
+            body_items = []
+        BleakDBusError.__init__(self, resolved_error, body_items)
+        # Mirror MeshtasticBLEError structured context fields while preserving
+        # BleakDBusError args-backed properties for dbus_error/details.
+        self.message = message
+        self.address = address
+        self.requested_identifier = requested_identifier
+        self.timeout = None
+        self.connected_address = None
+        self.cause = cause
+        self.dbus_error_name = self.dbus_error
+        self.dbus_error_body = tuple(body_items)
+
     @classmethod
     def from_exception(
         cls,
@@ -116,12 +153,23 @@ class BLEDBusTransportError(MeshtasticBLEError, BleakDBusError):
         requested_identifier: str | None = None,
         address: str | None = None,
     ) -> "BLEDBusTransportError":
-        """Normalize DBus transport failures while preserving the original cause."""
+        """Normalize DBus transport failures while preserving DBus metadata."""
+        dbus_error = getattr(error, "dbus_error", None)
+        dbus_error_details = getattr(error, "dbus_error_details", None)
+        dbus_error_body: tuple[Any, ...] | None = None
+        error_args = getattr(error, "args", ())
+        if isinstance(error_args, tuple) and len(error_args) > 1:
+            dbus_error_body = tuple(error_args[1:])
+        elif dbus_error_details is not None:
+            dbus_error_body = (dbus_error_details,)
         return cls(
             message,
             requested_identifier=requested_identifier,
             address=address,
             cause=error,
+            dbus_error=dbus_error if isinstance(dbus_error, str) else None,
+            dbus_error_details=dbus_error_details,
+            dbus_error_body=dbus_error_body,
         )
 
 

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -1028,12 +1028,12 @@ class BLEInterface(MeshInterface):
         def _format_device_list(devices: list[BLEDevice]) -> str:
             return "\n".join(f"- {d.name or 'Unknown'} ({d.address})" for d in devices)
 
-        if address and len(addressed_devices) > 1:
+        if target and len(addressed_devices) > 1:
             # Build a list of found devices for the error message
             device_list = _format_device_list(addressed_devices)
             raise BLEDiscoveryError(
-                ERROR_MULTIPLE_DEVICES.format(address, device_list),
-                requested_identifier=address,
+                ERROR_MULTIPLE_DEVICES.format(target, device_list),
+                requested_identifier=target,
             )
         if len(addressed_devices) > 1:
             device_list = _format_device_list(addressed_devices)

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -3271,9 +3271,6 @@ class BLEInterface(MeshInterface):
         timeout : float | None
             Optional total shutdown budget in seconds, forwarded to ``close()``.
         """
-        if timeout is None:
-            self.close()
-            return
         self.close(timeout=timeout)
 
     def close(self, timeout: float | None = None) -> None:

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -1037,7 +1037,9 @@ class BLEInterface(MeshInterface):
             )
         if len(addressed_devices) > 1:
             device_list = _format_device_list(addressed_devices)
-            raise BLEDiscoveryError(ERROR_MULTIPLE_DEVICES_DISCOVERY.format(device_list))
+            raise BLEDiscoveryError(
+                ERROR_MULTIPLE_DEVICES_DISCOVERY.format(device_list)
+            )
         raise AssertionError(UNREACHABLE_ADDRESSED_DEVICES_MSG)
 
     # COMPAT_STABLE_SHIM: historical public BLEInterface API.

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -3232,7 +3232,13 @@ class BLEInterface(MeshInterface):
     # COMPAT_STABLE_SHIM: historical public BLEInterface API alias.
     # Keep callable without deprecation warning.
     def disconnect(self, timeout: float | None = None) -> None:
-        """Compatibility alias for callers that expect an explicit disconnect API."""
+        """Compatibility alias for callers that expect an explicit disconnect API.
+
+        Parameters
+        ----------
+        timeout : float | None
+            Optional total shutdown budget in seconds, forwarded to ``close()``.
+        """
         if timeout is None:
             self.close()
             return
@@ -3244,8 +3250,11 @@ class BLEInterface(MeshInterface):
         Parameters
         ----------
         timeout : float | None
-            Optional total close-budget in seconds. When ``None``, use
-            lifecycle defaults for each shutdown stage. (Default value = None)
+            Optional total close-budget in seconds. When provided, the budget is
+            sliced across blocking shutdown phases (management wait, receive
+            thread join, ``MeshInterface.close``, disconnect-notification wait,
+            and client disconnect/close). When ``None``, lifecycle defaults are
+            used for each stage. (Default value = None)
         """
         if timeout is not None:
             if isinstance(timeout, bool) or not isinstance(timeout, numbers.Real):

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -1069,7 +1069,7 @@ class BLEInterface(MeshInterface):
         return cast(str | None, bleak_address or getattr(client, "address", None))
 
     @property
-    def ble_address(self) -> str | None:
+    def bleAddress(self) -> str | None:
         """Return the best-known BLE address for the active interface client."""
         client = getattr(self, "client", None)
         active_client_address = self._extract_client_address(client)
@@ -1077,6 +1077,12 @@ class BLEInterface(MeshInterface):
             return active_client_address
         interface_address = getattr(self, "address", None)
         return interface_address if isinstance(interface_address, str) else None
+
+    # COMPAT_STABLE_SHIM
+    @property
+    def ble_address(self) -> str | None:
+        """Compatibility shim for ``bleAddress``."""
+        return self.bleAddress
 
     def _resolve_target_address_for_management(self, address: str | None) -> str:
         """Resolve management target through the management collaborator."""

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -2173,13 +2173,25 @@ class BLEInterface(MeshInterface):
             and not is_self_connected
         )
 
-    def _raise_if_duplicate_connect(self, connection_key: str | None) -> None:
+    def _raise_if_duplicate_connect(
+        self,
+        connection_key: str | None,
+        *,
+        requested_identifier: str | None = None,
+        resolved_address: str | None = None,
+    ) -> None:
         """Raise BLEError when connect should be suppressed for a duplicate address claim.
 
         Parameters
         ----------
         connection_key : str | None
             Address registry key for this connect attempt.
+        requested_identifier : str | None
+            Original requested identifier (address or device name) used for
+            exception context.
+        resolved_address : str | None
+            Concrete BLE address resolved from the requested identifier, if
+            available.
 
         Raises
         ------
@@ -2193,8 +2205,8 @@ class BLEInterface(MeshInterface):
             )
             raise BLEConnectionSuppressedError(
                 ERROR_CONNECTION_SUPPRESSED,
-                address=connection_key,
-                requested_identifier=connection_key,
+                address=resolved_address or connection_key,
+                requested_identifier=requested_identifier or connection_key,
             )
 
     def _get_existing_client_if_valid(
@@ -3007,7 +3019,11 @@ class BLEInterface(MeshInterface):
 
                 with contextlib.ExitStack() as stack:
                     for reservation_key in reservation_keys:
-                        self._raise_if_duplicate_connect(reservation_key)
+                        self._raise_if_duplicate_connect(
+                            reservation_key,
+                            requested_identifier=requested_identifier,
+                            resolved_address=resolved_connect_target,
+                        )
                     # Acquire per-address locks without holding _REGISTRY_LOCK
                     # to avoid lock-order inversion with paths that hold
                     # address locks and then mark ownership in registry state.
@@ -3018,7 +3034,11 @@ class BLEInterface(MeshInterface):
                         stack.enter_context(addr_lock)
                     for reservation_key in reservation_keys:
                         # Re-check after lock acquisition to close TOCTOU windows.
-                        self._raise_if_duplicate_connect(reservation_key)
+                        self._raise_if_duplicate_connect(
+                            reservation_key,
+                            requested_identifier=requested_identifier,
+                            resolved_address=resolved_connect_target,
+                        )
 
                     with self._connect_lock:
                         with management_lock:

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -1073,7 +1073,9 @@ class BLEInterface(MeshInterface):
         """Return the best-known BLE address for the active interface client."""
         client = getattr(self, "client", None)
         active_client_address = self._extract_client_address(client)
-        if active_client_address:
+        if isinstance(active_client_address, str) and _looks_like_ble_address(
+            active_client_address
+        ):
             return active_client_address
         interface_address = getattr(self, "address", None)
         if isinstance(interface_address, str) and _looks_like_ble_address(

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -85,7 +85,13 @@ from meshtastic.interfaces.ble.discovery import (
     _looks_like_ble_address,
     _parse_scan_response,
 )
-from meshtastic.interfaces.ble.errors import BLEErrorHandler
+from meshtastic.interfaces.ble.errors import (
+    BLEConnectionSuppressedError,
+    BLEDeviceNotFoundError,
+    BLEDiscoveryError,
+    BLEErrorHandler,
+    MeshtasticBLEError,
+)
 from meshtastic.interfaces.ble.gating import (
     _addr_key,
     _addr_lock_context,
@@ -154,6 +160,9 @@ _TRUST_HEX_BLOB_RE = re.compile(r"\b[0-9A-Fa-f]{16,}\b")
 _TRUST_TOKEN_RE = re.compile(r"\b[A-Za-z0-9+/=_-]{40,}\b")
 ERROR_PAIR_ON_CONNECT_BOOL: str = "pair_on_connect must be a bool."
 ERROR_PAIR_BOOL: str = "pair must be a bool when provided."
+ERROR_CLOSE_TIMEOUT: str = (
+    "close() timeout must be a finite non-negative number of seconds."
+)
 ERROR_RETRY_POLICY_MISSING_SHOULD_RETRY: str = (
     "Retry policy missing should_retry/_should_retry"
 )
@@ -210,8 +219,7 @@ class BLEInterface(MeshInterface):
     need platform-specific setup for BLE operations.
     """
 
-    class BLEError(MeshInterface.MeshInterfaceError):
-        """An exception class for BLE errors."""
+    BLEError = MeshtasticBLEError
 
     def __init__(
         self,
@@ -989,13 +997,19 @@ class BLEInterface(MeshInterface):
         if len(addressed_devices) == 0:
             if target:
                 if not _looks_like_ble_address(target):
-                    raise self.BLEError(ERROR_NO_PERIPHERALS_FOUND)
+                    raise BLEDeviceNotFoundError(
+                        ERROR_NO_PERIPHERALS_FOUND,
+                        requested_identifier=target,
+                    )
                 logger.warning(
                     "No peripherals found for %s via scan; attempting direct address connect",
                     target,
                 )
                 if not sanitized:
-                    raise self.BLEError(ERROR_ADDRESS_RESOLUTION_FAILED)
+                    raise BLEDiscoveryError(
+                        ERROR_ADDRESS_RESOLUTION_FAILED,
+                        requested_identifier=target,
+                    )
                 # Create a synthetic BLEDevice for direct address connection.
                 # This allows the connection logic to attempt direct connect without
                 # verification, supporting pre-bonded devices (e.g., via bluetoothctl).
@@ -1007,7 +1021,7 @@ class BLEInterface(MeshInterface):
                 # Use the backend-usable raw address as the BLEDevice identity.
                 # `sanitized` remains for registry/discovery key normalization.
                 return BLEDevice(target, target, {})
-            raise self.BLEError(ERROR_NO_PERIPHERALS_FOUND)
+            raise BLEDiscoveryError(ERROR_NO_PERIPHERALS_FOUND)
         if len(addressed_devices) == 1:
             return addressed_devices[0]
 
@@ -1017,10 +1031,13 @@ class BLEInterface(MeshInterface):
         if address and len(addressed_devices) > 1:
             # Build a list of found devices for the error message
             device_list = _format_device_list(addressed_devices)
-            raise self.BLEError(ERROR_MULTIPLE_DEVICES.format(address, device_list))
+            raise BLEDiscoveryError(
+                ERROR_MULTIPLE_DEVICES.format(address, device_list),
+                requested_identifier=address,
+            )
         if len(addressed_devices) > 1:
             device_list = _format_device_list(addressed_devices)
-            raise self.BLEError(ERROR_MULTIPLE_DEVICES_DISCOVERY.format(device_list))
+            raise BLEDiscoveryError(ERROR_MULTIPLE_DEVICES_DISCOVERY.format(device_list))
         raise AssertionError(UNREACHABLE_ADDRESSED_DEVICES_MSG)
 
     # COMPAT_STABLE_SHIM: historical public BLEInterface API.
@@ -1048,6 +1065,16 @@ class BLEInterface(MeshInterface):
         bleak_client = getattr(client, "bleak_client", None)
         bleak_address = getattr(bleak_client, "address", None)
         return cast(str | None, bleak_address or getattr(client, "address", None))
+
+    @property
+    def ble_address(self) -> str | None:
+        """Return the best-known BLE address for the active interface client."""
+        client = getattr(self, "client", None)
+        active_client_address = self._extract_client_address(client)
+        if active_client_address:
+            return active_client_address
+        interface_address = getattr(self, "address", None)
+        return interface_address if isinstance(interface_address, str) else None
 
     def _resolve_target_address_for_management(self, address: str | None) -> str:
         """Resolve management target through the management collaborator."""
@@ -1860,7 +1887,12 @@ class BLEInterface(MeshInterface):
             )
         return cast(BLEClient, result)
 
-    def _client_manager_safe_close_client(self, client: BLEClient) -> None:
+    def _client_manager_safe_close_client(
+        self,
+        client: BLEClient,
+        *,
+        disconnect_timeout: float | None = None,
+    ) -> None:
         # COMPAT_STABLE_SHIM: compatibility wrapper for collaborator API migration.
         """Close a BLE client via client-manager compatibility dispatch.
 
@@ -1879,14 +1911,27 @@ class BLEInterface(MeshInterface):
         AttributeError
             If no supported client-close helper exists on the manager.
         """
-        self._compat_dispatch_callable(
-            self._client_manager,
-            public_name="safe_close_client",
-            legacy_name="_safe_close_client",
-            fallback_attr_name="safe_close_client",
-            error_message=ERROR_CLIENT_MANAGER_MISSING_SAFE_CLOSE_CLIENT,
-            args=(client,),
-        )
+        try:
+            self._compat_dispatch_callable(
+                self._client_manager,
+                public_name="safe_close_client",
+                legacy_name="_safe_close_client",
+                fallback_attr_name="safe_close_client",
+                error_message=ERROR_CLIENT_MANAGER_MISSING_SAFE_CLOSE_CLIENT,
+                args=(client,),
+                kwargs={"disconnect_timeout": disconnect_timeout},
+            )
+        except TypeError as exc:
+            if not _is_unexpected_keyword_error(exc, "disconnect_timeout"):
+                raise
+            self._compat_dispatch_callable(
+                self._client_manager,
+                public_name="safe_close_client",
+                legacy_name="_safe_close_client",
+                fallback_attr_name="safe_close_client",
+                error_message=ERROR_CLIENT_MANAGER_MISSING_SAFE_CLOSE_CLIENT,
+                args=(client,),
+            )
 
     def _client_manager_update_client_reference(
         self, client: BLEClient, previous_client: BLEClient
@@ -2134,7 +2179,11 @@ class BLEInterface(MeshInterface):
                 "Suppressing duplicate connect to %s: recently connected elsewhere.",
                 connection_key or "unknown",
             )
-            raise self.BLEError(ERROR_CONNECTION_SUPPRESSED)
+            raise BLEConnectionSuppressedError(
+                ERROR_CONNECTION_SUPPRESSED,
+                address=connection_key,
+                requested_identifier=connection_key,
+            )
 
     def _get_existing_client_if_valid(
         self, normalized_request: str | None
@@ -3182,12 +3231,28 @@ class BLEInterface(MeshInterface):
 
     # COMPAT_STABLE_SHIM: historical public BLEInterface API alias.
     # Keep callable without deprecation warning.
-    def disconnect(self) -> None:
+    def disconnect(self, timeout: float | None = None) -> None:
         """Compatibility alias for callers that expect an explicit disconnect API."""
-        self.close()
+        if timeout is None:
+            self.close()
+            return
+        self.close(timeout=timeout)
 
-    def close(self) -> None:
-        """Shut down the BLE interface and release associated resources."""
+    def close(self, timeout: float | None = None) -> None:
+        """Shut down the BLE interface and release associated resources.
+
+        Parameters
+        ----------
+        timeout : float | None
+            Optional total close-budget in seconds. When ``None``, use
+            lifecycle defaults for each shutdown stage. (Default value = None)
+        """
+        if timeout is not None:
+            if isinstance(timeout, bool) or not isinstance(timeout, numbers.Real):
+                raise self.BLEError(ERROR_CLOSE_TIMEOUT)
+            if not math.isfinite(timeout) or timeout < 0:
+                raise self.BLEError(ERROR_CLOSE_TIMEOUT)
+            timeout = float(timeout)
         # Clear any provisional connecting state before shutdown to prevent
         # orphaned gate claims when connection threads are forcibly terminated.
         # This clears all provisional keys owned by this interface, not just
@@ -3212,10 +3277,18 @@ class BLEInterface(MeshInterface):
             lifecycle_controller, "_close", getattr(lifecycle_controller, "close", None)
         )
         if callable(close):
-            close(
-                management_shutdown_wait_timeout=_MANAGEMENT_SHUTDOWN_WAIT_TIMEOUT_SECONDS,
-                management_wait_poll_seconds=_MANAGEMENT_CONNECT_WAIT_POLL_SECONDS,
-            )
+            close_kwargs: dict[str, float | None] = {
+                "management_shutdown_wait_timeout": _MANAGEMENT_SHUTDOWN_WAIT_TIMEOUT_SECONDS,
+                "management_wait_poll_seconds": _MANAGEMENT_CONNECT_WAIT_POLL_SECONDS,
+                "timeout": timeout,
+            }
+            try:
+                close(**close_kwargs)
+            except TypeError as exc:
+                if not _is_unexpected_keyword_error(exc, "timeout"):
+                    raise
+                close_kwargs.pop("timeout", None)
+                close(**close_kwargs)
 
     def _get_publishing_thread(self) -> object:
         """Resolve the publishing-thread adapter used for compatibility events.
@@ -3242,7 +3315,9 @@ class BLEInterface(MeshInterface):
         """
         self._get_compatibility_publisher().wait_for_disconnect_notifications(timeout)
 
-    def _disconnect_and_close_client(self, client: BLEClient) -> None:
+    def _disconnect_and_close_client(
+        self, client: BLEClient, *, timeout: float | None = None
+    ) -> None:
         """Ensure the given BLE client is disconnected and its resources are released.
 
         Parameters
@@ -3257,7 +3332,12 @@ class BLEInterface(MeshInterface):
             getattr(lifecycle_controller, "disconnect_and_close_client", None),
         )
         if callable(disconnect_and_close_client):
-            disconnect_and_close_client(client)
+            try:
+                disconnect_and_close_client(client, timeout=timeout)
+            except TypeError as exc:
+                if not _is_unexpected_keyword_error(exc, "timeout"):
+                    raise
+                disconnect_and_close_client(client)
 
     def _drain_publish_queue(self, flush_event: Event) -> None:
         """Drain and run pending publish callbacks on the current thread until the queue is empty or the provided event is set.

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -1076,7 +1076,11 @@ class BLEInterface(MeshInterface):
         if active_client_address:
             return active_client_address
         interface_address = getattr(self, "address", None)
-        return interface_address if isinstance(interface_address, str) else None
+        if isinstance(interface_address, str) and _looks_like_ble_address(
+            interface_address
+        ):
+            return interface_address
+        return None
 
     # COMPAT_STABLE_SHIM
     @property

--- a/meshtastic/interfaces/ble/lifecycle_compat_service.py
+++ b/meshtastic/interfaces/ble/lifecycle_compat_service.py
@@ -1284,6 +1284,7 @@ class BLELifecycleService:
         *,
         management_shutdown_wait_timeout: float,
         management_wait_poll_seconds: float,
+        timeout: float | None = None,
     ) -> None:
         """Shut down BLE interface resources and finalize lifecycle state.
 
@@ -1304,6 +1305,7 @@ class BLELifecycleService:
         BLEShutdownLifecycleCoordinator(iface).close(
             management_shutdown_wait_timeout=management_shutdown_wait_timeout,
             management_wait_poll_seconds=management_wait_poll_seconds,
+            timeout=timeout,
         )
 
     @staticmethod

--- a/meshtastic/interfaces/ble/lifecycle_compat_service.py
+++ b/meshtastic/interfaces/ble/lifecycle_compat_service.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from inspect import signature
+from inspect import Parameter, signature
 from typing import TYPE_CHECKING, NoReturn, cast
 
 from bleak import BleakClient as BleakRootClient
@@ -38,6 +38,23 @@ from meshtastic.interfaces.ble.utils import (
 if TYPE_CHECKING:
     from meshtastic.interfaces.ble.client import BLEClient
     from meshtastic.interfaces.ble.interface import BLEInterface
+
+
+def _callable_accepts_timeout_kwarg(func: Callable[..., object]) -> bool:
+    """Return whether ``func`` can receive a ``timeout`` keyword."""
+    try:
+        parameters = signature(func).parameters
+    except (TypeError, ValueError):
+        return True
+    timeout_parameter = parameters.get("timeout")
+    if timeout_parameter is not None:
+        return timeout_parameter.kind in (
+            Parameter.POSITIONAL_OR_KEYWORD,
+            Parameter.KEYWORD_ONLY,
+        )
+    return any(
+        parameter.kind is Parameter.VAR_KEYWORD for parameter in parameters.values()
+    )
 
 
 @dataclass(frozen=True)
@@ -535,6 +552,8 @@ class BLELifecycleService:
             ).is_connection_closing()
         )
 
+    # COMPAT_STABLE_SHIM: guarded dispatch so legacy overrides without timeout
+    # do not break when called through the compatibility surface.
     @staticmethod
     def _disconnect_and_close_client(
         iface: "BLEInterface",
@@ -558,9 +577,13 @@ class BLELifecycleService:
         None
             Returns ``None`` after cleanup is attempted.
         """
-        BLEDisconnectLifecycleCoordinator(iface).disconnect_and_close_client(
-            client, timeout=timeout
-        )
+        disconnect_and_close = BLEDisconnectLifecycleCoordinator(
+            iface
+        ).disconnect_and_close_client
+        if _callable_accepts_timeout_kwarg(disconnect_and_close):
+            disconnect_and_close(client, timeout=timeout)
+        else:
+            disconnect_and_close(client)
 
     @staticmethod
     def _compute_disconnect_keys(
@@ -1285,6 +1308,8 @@ class BLELifecycleService:
         """
         BLEShutdownLifecycleCoordinator(iface)._cleanup_thread_coordinator()
 
+    # COMPAT_STABLE_SHIM: guarded dispatch so legacy overrides without timeout
+    # do not break when called through the compatibility surface.
     @staticmethod
     def _close(
         iface: "BLEInterface",
@@ -1315,11 +1340,18 @@ class BLELifecycleService:
         None
             Returns ``None`` after best-effort shutdown cleanup.
         """
-        BLEShutdownLifecycleCoordinator(iface).close(
-            management_shutdown_wait_timeout=management_shutdown_wait_timeout,
-            management_wait_poll_seconds=management_wait_poll_seconds,
-            timeout=timeout,
-        )
+        shutdown_close = BLEShutdownLifecycleCoordinator(iface).close
+        if _callable_accepts_timeout_kwarg(shutdown_close):
+            shutdown_close(
+                management_shutdown_wait_timeout=management_shutdown_wait_timeout,
+                management_wait_poll_seconds=management_wait_poll_seconds,
+                timeout=timeout,
+            )
+        else:
+            shutdown_close(
+                management_shutdown_wait_timeout=management_shutdown_wait_timeout,
+                management_wait_poll_seconds=management_wait_poll_seconds,
+            )
 
     @staticmethod
     def _finalize_connection_gates(

--- a/meshtastic/interfaces/ble/lifecycle_compat_service.py
+++ b/meshtastic/interfaces/ble/lifecycle_compat_service.py
@@ -537,7 +537,10 @@ class BLELifecycleService:
 
     @staticmethod
     def _disconnect_and_close_client(
-        iface: "BLEInterface", client: "BLEClient"
+        iface: "BLEInterface",
+        client: "BLEClient",
+        *,
+        timeout: float | None = None,
     ) -> None:
         """Release BLE client resources with best-effort disconnect/close handling.
 
@@ -547,13 +550,17 @@ class BLELifecycleService:
             Interface exposing client-manager cleanup helpers.
         client : BLEClient
             Client to disconnect and close.
+        timeout : float | None, optional
+            Optional maximum seconds to wait for disconnect/close completion.
 
         Returns
         -------
         None
             Returns ``None`` after cleanup is attempted.
         """
-        BLEDisconnectLifecycleCoordinator(iface).disconnect_and_close_client(client)
+        BLEDisconnectLifecycleCoordinator(iface).disconnect_and_close_client(
+            client, timeout=timeout
+        )
 
     @staticmethod
     def _compute_disconnect_keys(

--- a/meshtastic/interfaces/ble/lifecycle_compat_service.py
+++ b/meshtastic/interfaces/ble/lifecycle_compat_service.py
@@ -1296,6 +1296,12 @@ class BLELifecycleService:
             Maximum seconds to wait for inflight management operations.
         management_wait_poll_seconds : float
             Poll interval used while waiting for management completion.
+        timeout : float | None
+            Optional total timeout budget in seconds. When provided, each
+            blocking shutdown stage (management wait, receive-thread join,
+            ``MeshInterface.close``, client disconnect/close, and notification
+            waits) receives a remaining-budget slice so ``close()`` does not
+            block indefinitely.
 
         Returns
         -------

--- a/meshtastic/interfaces/ble/lifecycle_compat_service.py
+++ b/meshtastic/interfaces/ble/lifecycle_compat_service.py
@@ -205,6 +205,33 @@ class BLELifecycleService:
         return _LifecycleErrorAccess(iface).resolve_hook(public_name, legacy_name)
 
     @staticmethod
+    def _get_shutdown_lifecycle_coordinator(
+        iface: "BLEInterface",
+    ) -> BLEShutdownLifecycleCoordinator:
+        """Return the shared shutdown lifecycle coordinator when available."""
+        get_or_create = getattr(iface, "_get_or_create_collaborator", None)
+        if callable(get_or_create) and not _is_unconfigured_mock_callable(
+            get_or_create
+        ):
+            try:
+                signature(get_or_create).bind(
+                    "_ble_shutdown_lifecycle_coordinator",
+                    lambda: BLEShutdownLifecycleCoordinator(iface),
+                )
+            except (AttributeError, NotImplementedError, TypeError, ValueError):
+                pass
+            else:
+                coordinator = get_or_create(
+                    "_ble_shutdown_lifecycle_coordinator",
+                    lambda: BLEShutdownLifecycleCoordinator(iface),
+                )
+                if coordinator is not None and not _is_unconfigured_mock_member(
+                    coordinator
+                ):
+                    return cast(BLEShutdownLifecycleCoordinator, coordinator)
+        return BLEShutdownLifecycleCoordinator(iface)
+
+    @staticmethod
     def _error_handler_safe_cleanup(
         iface: "BLEInterface",
         cleanup: Callable[[], object],
@@ -1340,7 +1367,9 @@ class BLELifecycleService:
         None
             Returns ``None`` after best-effort shutdown cleanup.
         """
-        shutdown_close = BLEShutdownLifecycleCoordinator(iface).close
+        shutdown_close = BLELifecycleService._get_shutdown_lifecycle_coordinator(
+            iface
+        ).close
         if _callable_accepts_timeout_kwarg(shutdown_close):
             shutdown_close(
                 management_shutdown_wait_timeout=management_shutdown_wait_timeout,

--- a/meshtastic/interfaces/ble/lifecycle_controller_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_controller_runtime.py
@@ -359,10 +359,7 @@ class BLELifecycleController:
                 timeout=timeout,
             )
         except TypeError as exc:
-            timeout_kw_rejected = _is_unexpected_keyword_error(exc, "timeout") or (
-                "keyword" in str(exc).casefold() and "argument" in str(exc).casefold()
-            )
-            if not timeout_kw_rejected:
+            if not _is_unexpected_keyword_error(exc, "timeout"):
                 raise
             self._shutdown.close(
                 management_shutdown_wait_timeout=management_shutdown_wait_timeout,
@@ -379,9 +376,6 @@ class BLELifecycleController:
         try:
             self._disconnect.disconnect_and_close_client(client, timeout=timeout)
         except TypeError as exc:
-            timeout_kw_rejected = _is_unexpected_keyword_error(exc, "timeout") or (
-                "keyword" in str(exc).casefold() and "argument" in str(exc).casefold()
-            )
-            if not timeout_kw_rejected:
+            if not _is_unexpected_keyword_error(exc, "timeout"):
                 raise
             self._disconnect.disconnect_and_close_client(client)

--- a/meshtastic/interfaces/ble/lifecycle_controller_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_controller_runtime.py
@@ -26,7 +26,10 @@ from meshtastic.interfaces.ble.lifecycle_shutdown_runtime import (
     BLEShutdownLifecycleCoordinator,
 )
 from meshtastic.interfaces.ble.state import ConnectionState
-from meshtastic.interfaces.ble.utils import _is_unconfigured_mock_callable
+from meshtastic.interfaces.ble.utils import (
+    _is_unconfigured_mock_callable,
+    _is_unexpected_keyword_error,
+)
 
 if TYPE_CHECKING:
     from meshtastic.interfaces.ble.client import BLEClient
@@ -346,13 +349,39 @@ class BLELifecycleController:
         *,
         management_shutdown_wait_timeout: float,
         management_wait_poll_seconds: float,
+        timeout: float | None = None,
     ) -> None:
         """Close the bound interface and lifecycle resources."""
-        self._shutdown.close(
-            management_shutdown_wait_timeout=management_shutdown_wait_timeout,
-            management_wait_poll_seconds=management_wait_poll_seconds,
-        )
+        try:
+            self._shutdown.close(
+                management_shutdown_wait_timeout=management_shutdown_wait_timeout,
+                management_wait_poll_seconds=management_wait_poll_seconds,
+                timeout=timeout,
+            )
+        except TypeError as exc:
+            timeout_kw_rejected = _is_unexpected_keyword_error(exc, "timeout") or (
+                "keyword" in str(exc).casefold() and "argument" in str(exc).casefold()
+            )
+            if not timeout_kw_rejected:
+                raise
+            self._shutdown.close(
+                management_shutdown_wait_timeout=management_shutdown_wait_timeout,
+                management_wait_poll_seconds=management_wait_poll_seconds,
+            )
 
-    def _disconnect_and_close_client(self, client: "BLEClient") -> None:
+    def _disconnect_and_close_client(
+        self,
+        client: "BLEClient",
+        *,
+        timeout: float | None = None,
+    ) -> None:
         """Disconnect and close the provided client for the bound interface."""
-        self._disconnect.disconnect_and_close_client(client)
+        try:
+            self._disconnect.disconnect_and_close_client(client, timeout=timeout)
+        except TypeError as exc:
+            timeout_kw_rejected = _is_unexpected_keyword_error(exc, "timeout") or (
+                "keyword" in str(exc).casefold() and "argument" in str(exc).casefold()
+            )
+            if not timeout_kw_rejected:
+                raise
+            self._disconnect.disconnect_and_close_client(client)

--- a/meshtastic/interfaces/ble/lifecycle_controller_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_controller_runtime.py
@@ -372,13 +372,13 @@ class BLELifecycleController:
         """Close the bound interface and lifecycle resources."""
         shutdown_close = self._shutdown.close
         if _callable_accepts_timeout_kwarg(shutdown_close):
-            self._shutdown.close(
+            shutdown_close(
                 management_shutdown_wait_timeout=management_shutdown_wait_timeout,
                 management_wait_poll_seconds=management_wait_poll_seconds,
                 timeout=timeout,
             )
         else:
-            self._shutdown.close(
+            shutdown_close(
                 management_shutdown_wait_timeout=management_shutdown_wait_timeout,
                 management_wait_poll_seconds=management_wait_poll_seconds,
             )

--- a/meshtastic/interfaces/ble/lifecycle_controller_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_controller_runtime.py
@@ -1,5 +1,6 @@
 """Top-level lifecycle controller runtime ownership for BLE."""
 
+import inspect
 from collections.abc import Callable
 from typing import TYPE_CHECKING, TypeVar, cast
 
@@ -28,7 +29,6 @@ from meshtastic.interfaces.ble.lifecycle_shutdown_runtime import (
 from meshtastic.interfaces.ble.state import ConnectionState
 from meshtastic.interfaces.ble.utils import (
     _is_unconfigured_mock_callable,
-    _is_unexpected_keyword_error,
 )
 
 if TYPE_CHECKING:
@@ -36,6 +36,24 @@ if TYPE_CHECKING:
     from meshtastic.interfaces.ble.interface import BLEInterface
 
 _HookT = TypeVar("_HookT", bound=Callable[..., object])
+
+
+def _callable_accepts_timeout_kwarg(func: Callable[..., object]) -> bool:
+    """Return whether ``func`` can receive a ``timeout`` keyword."""
+    try:
+        parameters = inspect.signature(func).parameters
+    except (TypeError, ValueError):
+        return True
+    timeout_parameter = parameters.get("timeout")
+    if timeout_parameter is not None:
+        return timeout_parameter.kind in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        )
+    return any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters.values()
+    )
 
 
 class BLELifecycleController:
@@ -352,15 +370,14 @@ class BLELifecycleController:
         timeout: float | None = None,
     ) -> None:
         """Close the bound interface and lifecycle resources."""
-        try:
+        shutdown_close = self._shutdown.close
+        if _callable_accepts_timeout_kwarg(shutdown_close):
             self._shutdown.close(
                 management_shutdown_wait_timeout=management_shutdown_wait_timeout,
                 management_wait_poll_seconds=management_wait_poll_seconds,
                 timeout=timeout,
             )
-        except TypeError as exc:
-            if not _is_unexpected_keyword_error(exc, "timeout"):
-                raise
+        else:
             self._shutdown.close(
                 management_shutdown_wait_timeout=management_shutdown_wait_timeout,
                 management_wait_poll_seconds=management_wait_poll_seconds,
@@ -373,9 +390,8 @@ class BLELifecycleController:
         timeout: float | None = None,
     ) -> None:
         """Disconnect and close the provided client for the bound interface."""
-        try:
-            self._disconnect.disconnect_and_close_client(client, timeout=timeout)
-        except TypeError as exc:
-            if not _is_unexpected_keyword_error(exc, "timeout"):
-                raise
+        disconnect_and_close = self._disconnect.disconnect_and_close_client
+        if _callable_accepts_timeout_kwarg(disconnect_and_close):
+            disconnect_and_close(client, timeout=timeout)
+        else:
             self._disconnect.disconnect_and_close_client(client)

--- a/meshtastic/interfaces/ble/lifecycle_controller_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_controller_runtime.py
@@ -394,4 +394,4 @@ class BLELifecycleController:
         if _callable_accepts_timeout_kwarg(disconnect_and_close):
             disconnect_and_close(client, timeout=timeout)
         else:
-            self._disconnect.disconnect_and_close_client(client)
+            disconnect_and_close(client)

--- a/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
@@ -87,7 +87,15 @@ class BLEDisconnectLifecycleCoordinator:
         *,
         timeout: float | None = None,
     ) -> None:
-        """Release BLE client resources with best-effort disconnect/close handling."""
+        """Release BLE client resources with best-effort disconnect/close handling.
+
+        Parameters
+        ----------
+        client : BLEClient
+            Client to disconnect and close.
+        timeout : float | None, optional
+            Optional maximum seconds to wait for client disconnect/close.
+        """
         self._iface._client_manager_safe_close_client(
             client,
             disconnect_timeout=timeout,

--- a/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
@@ -81,9 +81,17 @@ class BLEDisconnectLifecycleCoordinator:
             raise AttributeError(RECONNECT_SCHEDULER_MISSING_MSG)
         schedule_reconnect(iface.auto_reconnect, iface._shutdown_event)
 
-    def disconnect_and_close_client(self, client: "BLEClient") -> None:
+    def disconnect_and_close_client(
+        self,
+        client: "BLEClient",
+        *,
+        timeout: float | None = None,
+    ) -> None:
         """Release BLE client resources with best-effort disconnect/close handling."""
-        self._iface._client_manager_safe_close_client(client)
+        self._iface._client_manager_safe_close_client(
+            client,
+            disconnect_timeout=timeout,
+        )
 
     def on_ble_disconnect(self, client: BleakRootClient) -> None:
         """Handle a Bleak disconnect callback from the active transport client."""

--- a/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
@@ -3,6 +3,7 @@
 import atexit
 import contextlib
 import inspect
+import math
 import threading
 import time
 from collections.abc import Callable
@@ -575,6 +576,7 @@ class BLEShutdownLifecycleCoordinator:
         unsubscribe_timeout: float | None = NOTIFICATION_START_TIMEOUT,
         disconnect_notification_wait_timeout: float | None = DISCONNECT_TIMEOUT_SECONDS,
         client_disconnect_timeout: float | None = DISCONNECT_TIMEOUT_SECONDS,
+        bounded_close_timeout_active: bool = False,
     ) -> None:
         """Shutdown active client resources and notification publication state.
 
@@ -594,6 +596,10 @@ class BLEShutdownLifecycleCoordinator:
             Maximum seconds to wait for disconnect notification publication.
         client_disconnect_timeout : float | None
             Maximum seconds to wait for BLE client disconnect/close.
+        bounded_close_timeout_active : bool
+            Whether these stage timeouts were derived from a caller-provided
+            finite ``close(timeout=...)`` budget. Legacy no-timeout fallbacks
+            are skipped only when this is true.
 
         Returns
         -------
@@ -610,6 +616,9 @@ class BLEShutdownLifecycleCoordinator:
         client, publish_pending = detach_client()
         client_address = iface._extract_client_address(client)
         notification_manager = iface._notification_manager
+
+        def _has_finite_timeout(timeout: float | None) -> bool:
+            return timeout is not None and math.isfinite(timeout)
 
         def _resolve_notification_cleanup(
             method_name: str,
@@ -636,36 +645,61 @@ class BLEShutdownLifecycleCoordinator:
             with gate_context:
                 unsubscribe_all = _resolve_notification_cleanup("_unsubscribe_all")
                 if unsubscribe_all is not None:
+                    unsubscribe_error: TypeError | None = None
 
                     def _unsubscribe_with_timeout() -> None:
+                        nonlocal unsubscribe_error
                         try:
                             unsubscribe_all(client, timeout=unsubscribe_timeout)
                         except TypeError as exc:
                             if not _is_unexpected_keyword_error(exc, "timeout"):
+                                unsubscribe_error = exc
                                 raise
+                            if bounded_close_timeout_active and _has_finite_timeout(
+                                unsubscribe_timeout
+                            ):
+                                logger.warning(
+                                    "Skipping legacy notification unsubscribe_all() fallback: close timeout budget is active and the callable does not accept timeout."
+                                )
+                                return
                             unsubscribe_all(client)
 
                     run_safe_cleanup(
                         _unsubscribe_with_timeout,
                         "notification unsubscribe_all",
                     )
+                    if unsubscribe_error is not None:
+                        raise unsubscribe_error
                 else:
                     logger.debug("Notification manager is missing _unsubscribe_all")
 
+                disconnect_error: TypeError | None = None
+
                 def _disconnect_client_with_timeout() -> None:
+                    nonlocal disconnect_error
                     try:
                         iface._disconnect_and_close_client(
                             client, timeout=client_disconnect_timeout
                         )
                     except TypeError as exc:
                         if not _is_unexpected_keyword_error(exc, "timeout"):
+                            disconnect_error = exc
                             raise
+                        if bounded_close_timeout_active and _has_finite_timeout(
+                            client_disconnect_timeout
+                        ):
+                            logger.warning(
+                                "Skipping legacy BLE client disconnect/close fallback: close timeout budget is active and the callable does not accept timeout."
+                            )
+                            return
                         iface._disconnect_and_close_client(client)
 
                 run_safe_cleanup(
                     _disconnect_client_with_timeout,
                     "BLE client disconnect/close",
                 )
+                if disconnect_error is not None:
+                    raise disconnect_error
         cleanup_all = _resolve_notification_cleanup("_cleanup_all")
         if cleanup_all is not None:
             run_safe_cleanup(cleanup_all, "notification manager cleanup")
@@ -681,6 +715,13 @@ class BLEShutdownLifecycleCoordinator:
             except TypeError as exc:
                 if not _is_unexpected_keyword_error(exc, "timeout"):
                     raise
+                if bounded_close_timeout_active and _has_finite_timeout(
+                    disconnect_notification_wait_timeout
+                ):
+                    logger.warning(
+                        "Skipping legacy disconnect notification wait fallback: close timeout budget is active and the callable does not accept timeout."
+                    )
+                    return
                 iface._wait_for_disconnect_notifications()
 
     def _finalize_close_state(
@@ -807,6 +848,7 @@ class BLEShutdownLifecycleCoordinator:
                 client_disconnect_timeout=_remaining_optional_timeout(
                     DISCONNECT_TIMEOUT_SECONDS
                 ),
+                bounded_close_timeout_active=timeout is not None,
             )
         finally:
             try:

--- a/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
@@ -130,19 +130,6 @@ class BLEShutdownLifecycleCoordinator:
                 hook_name,
             )
             return
-        with self._bounded_thread_lock:
-            previous_thread = self._bounded_cleanup_thread
-            if previous_thread is not None and previous_thread.is_alive():
-                logger.warning(
-                    "Skipping thread coordinator %s(): previous bounded cleanup thread is still running.",
-                    hook_name,
-                )
-            else:
-                previous_thread = None
-                self._bounded_cleanup_thread = None
-        if previous_thread is not None:
-            previous_thread.join(timeout=timeout)
-            return
 
         def _run_cleanup() -> None:
             try:
@@ -165,8 +152,15 @@ class BLEShutdownLifecycleCoordinator:
         )
         try:
             with self._bounded_thread_lock:
+                previous_thread = self._bounded_cleanup_thread
+                if previous_thread is not None and previous_thread.is_alive():
+                    logger.warning(
+                        "Skipping thread coordinator %s(): previous bounded cleanup thread is still running.",
+                        hook_name,
+                    )
+                    return
                 self._bounded_cleanup_thread = cleanup_thread
-            cleanup_thread.start()
+                cleanup_thread.start()
         except Exception:  # noqa: BLE001 - shutdown cleanup is best effort
             with self._bounded_thread_lock:
                 if self._bounded_cleanup_thread is cleanup_thread:
@@ -477,18 +471,6 @@ class BLEShutdownLifecycleCoordinator:
                 "Skipping MeshInterface.close(): close timeout budget exhausted."
             )
             return
-        with self._bounded_thread_lock:
-            previous_thread = self._bounded_mesh_close_thread
-            if previous_thread is not None and previous_thread.is_alive():
-                logger.warning(
-                    "Skipping MeshInterface.close(): previous bounded close thread is still running."
-                )
-            else:
-                previous_thread = None
-                self._bounded_mesh_close_thread = None
-        if previous_thread is not None:
-            previous_thread.join(timeout=timeout)
-            return
 
         def _run_mesh_close() -> None:
             try:
@@ -505,8 +487,14 @@ class BLEShutdownLifecycleCoordinator:
         )
         try:
             with self._bounded_thread_lock:
+                previous_thread = self._bounded_mesh_close_thread
+                if previous_thread is not None and previous_thread.is_alive():
+                    logger.warning(
+                        "Skipping MeshInterface.close(): previous bounded close thread is still running."
+                    )
+                    return
                 self._bounded_mesh_close_thread = close_thread
-            close_thread.start()
+                close_thread.start()
         except Exception:  # noqa: BLE001 - close must remain best effort
             with self._bounded_thread_lock:
                 if self._bounded_mesh_close_thread is close_thread:
@@ -648,8 +636,17 @@ class BLEShutdownLifecycleCoordinator:
             with gate_context:
                 unsubscribe_all = _resolve_notification_cleanup("_unsubscribe_all")
                 if unsubscribe_all is not None:
+
+                    def _unsubscribe_with_timeout() -> None:
+                        try:
+                            unsubscribe_all(client, timeout=unsubscribe_timeout)
+                        except TypeError as exc:
+                            if not _is_unexpected_keyword_error(exc, "timeout"):
+                                raise
+                            unsubscribe_all(client)
+
                     run_safe_cleanup(
-                        lambda: unsubscribe_all(client, timeout=unsubscribe_timeout),
+                        _unsubscribe_with_timeout,
                         "notification unsubscribe_all",
                     )
                 else:

--- a/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
@@ -26,6 +26,7 @@ from meshtastic.interfaces.ble.state import ConnectionState
 from meshtastic.interfaces.ble.utils import (
     _is_unconfigured_mock_callable,
     _is_unconfigured_mock_member,
+    _is_unexpected_keyword_error,
     _thread_start_probe,
 )
 from meshtastic.mesh_interface import MeshInterface
@@ -607,11 +608,7 @@ class BLEShutdownLifecycleCoordinator:
                             client, timeout=client_disconnect_timeout
                         )
                     except TypeError as exc:
-                        timeout_kw_rejected = (
-                            "timeout" in str(exc).casefold()
-                            and "keyword" in str(exc).casefold()
-                        )
-                        if not timeout_kw_rejected:
+                        if not _is_unexpected_keyword_error(exc, "timeout"):
                             raise
                         iface._disconnect_and_close_client(client)
 
@@ -632,11 +629,7 @@ class BLEShutdownLifecycleCoordinator:
                     timeout=disconnect_notification_wait_timeout
                 )
             except TypeError as exc:
-                timeout_kw_rejected = (
-                    "timeout" in str(exc).casefold()
-                    and "keyword" in str(exc).casefold()
-                )
-                if not timeout_kw_rejected:
+                if not _is_unexpected_keyword_error(exc, "timeout"):
                     raise
                 iface._wait_for_disconnect_notifications()
 

--- a/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
@@ -63,6 +63,9 @@ class BLEShutdownLifecycleCoordinator:
         self._state_access = _LifecycleStateAccess(iface)
         self._thread_access = _LifecycleThreadAccess(iface)
         self._error_access = _LifecycleErrorAccess(iface)
+        self._bounded_cleanup_thread: threading.Thread | None = None
+        self._bounded_mesh_close_thread: threading.Thread | None = None
+        self._bounded_thread_lock = threading.Lock()
 
     def is_connection_closing(self) -> bool:
         """Return whether this interface is closing or already closed.
@@ -127,6 +130,19 @@ class BLEShutdownLifecycleCoordinator:
                 hook_name,
             )
             return
+        with self._bounded_thread_lock:
+            previous_thread = self._bounded_cleanup_thread
+            if previous_thread is not None and previous_thread.is_alive():
+                logger.warning(
+                    "Skipping thread coordinator %s(): previous bounded cleanup thread is still running.",
+                    hook_name,
+                )
+            else:
+                previous_thread = None
+                self._bounded_cleanup_thread = None
+        if previous_thread is not None:
+            previous_thread.join(timeout=timeout)
+            return
 
         def _run_cleanup() -> None:
             try:
@@ -137,6 +153,10 @@ class BLEShutdownLifecycleCoordinator:
                     hook_name,
                     exc_info=True,
                 )
+            finally:
+                with self._bounded_thread_lock:
+                    if self._bounded_cleanup_thread is threading.current_thread():
+                        self._bounded_cleanup_thread = None
 
         cleanup_thread = threading.Thread(
             target=_run_cleanup,
@@ -144,8 +164,13 @@ class BLEShutdownLifecycleCoordinator:
             daemon=True,
         )
         try:
+            with self._bounded_thread_lock:
+                self._bounded_cleanup_thread = cleanup_thread
             cleanup_thread.start()
         except Exception:  # noqa: BLE001 - shutdown cleanup is best effort
+            with self._bounded_thread_lock:
+                if self._bounded_cleanup_thread is cleanup_thread:
+                    self._bounded_cleanup_thread = None
             logger.warning(
                 "Failed to start thread coordinator cleanup thread; skipping bounded cleanup stage to preserve timeout contract.",
                 exc_info=True,
@@ -299,6 +324,8 @@ class BLEShutdownLifecycleCoordinator:
             Optional wake helper used to release receive-loop waiters.
         join_thread : Callable[..., None] | None, optional
             Optional thread-join helper used for compatibility/test injection.
+        join_timeout : float
+            Maximum seconds to wait for the receive thread to exit.
 
         Returns
         -------
@@ -450,9 +477,26 @@ class BLEShutdownLifecycleCoordinator:
                 "Skipping MeshInterface.close(): close timeout budget exhausted."
             )
             return
+        with self._bounded_thread_lock:
+            previous_thread = self._bounded_mesh_close_thread
+            if previous_thread is not None and previous_thread.is_alive():
+                logger.warning(
+                    "Skipping MeshInterface.close(): previous bounded close thread is still running."
+                )
+            else:
+                previous_thread = None
+                self._bounded_mesh_close_thread = None
+        if previous_thread is not None:
+            previous_thread.join(timeout=timeout)
+            return
 
         def _run_mesh_close() -> None:
-            run_safe_execute(lambda: MeshInterface.close(iface))
+            try:
+                run_safe_execute(lambda: MeshInterface.close(iface))
+            finally:
+                with self._bounded_thread_lock:
+                    if self._bounded_mesh_close_thread is threading.current_thread():
+                        self._bounded_mesh_close_thread = None
 
         close_thread = threading.Thread(
             target=_run_mesh_close,
@@ -460,8 +504,13 @@ class BLEShutdownLifecycleCoordinator:
             daemon=True,
         )
         try:
+            with self._bounded_thread_lock:
+                self._bounded_mesh_close_thread = close_thread
             close_thread.start()
         except Exception:  # noqa: BLE001 - close must remain best effort
+            with self._bounded_thread_lock:
+                if self._bounded_mesh_close_thread is close_thread:
+                    self._bounded_mesh_close_thread = None
             logger.warning(
                 "Failed to start MeshInterface.close thread; skipping bounded close stage to preserve timeout contract.",
                 exc_info=True,
@@ -551,6 +600,12 @@ class BLEShutdownLifecycleCoordinator:
             Optional safe-cleanup wrapper override.
         consume_disconnect_notification_state : Callable[[], bool] | None, optional
             Optional publish-state consumer override.
+        unsubscribe_timeout : float | None
+            Maximum seconds to wait for notification unsubscribe cleanup.
+        disconnect_notification_wait_timeout : float | None
+            Maximum seconds to wait for disconnect notification publication.
+        client_disconnect_timeout : float | None
+            Maximum seconds to wait for BLE client disconnect/close.
 
         Returns
         -------

--- a/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, cast
 
 from meshtastic.interfaces.ble.constants import (
+    DISCONNECT_TIMEOUT_SECONDS,
     NOTIFICATION_START_TIMEOUT,
     READ_TRIGGER_EVENT,
     RECEIVE_THREAD_JOIN_TIMEOUT,
@@ -237,6 +238,7 @@ class BLEShutdownLifecycleCoordinator:
         *,
         wake_waiting_threads: Callable[..., None] | None = None,
         join_thread: Callable[..., None] | None = None,
+        join_timeout: float = RECEIVE_THREAD_JOIN_TIMEOUT,
     ) -> None:  # noqa: PLR0912,PLR0915
         """Wake and join receive thread, then clear cached thread reference.
 
@@ -334,7 +336,7 @@ class BLEShutdownLifecycleCoordinator:
             try:
                 join_runtime_thread(
                     receive_thread,
-                    timeout=RECEIVE_THREAD_JOIN_TIMEOUT,
+                    timeout=join_timeout,
                 )
             except Exception:  # noqa: BLE001 - close must remain best effort
                 logger.debug(
@@ -345,7 +347,7 @@ class BLEShutdownLifecycleCoordinator:
             if post_join_is_alive:
                 logger.warning(
                     "BLE receive thread did not exit within %.1fs",
-                    RECEIVE_THREAD_JOIN_TIMEOUT,
+                    join_timeout,
                 )
             thread_ident = post_join_ident
             thread_is_alive = post_join_is_alive
@@ -446,6 +448,9 @@ class BLEShutdownLifecycleCoordinator:
         ) = None,
         safe_cleanup: Callable[[Callable[[], object], str], None] | None = None,
         consume_disconnect_notification_state: Callable[[], bool] | None = None,
+        unsubscribe_timeout: float | None = NOTIFICATION_START_TIMEOUT,
+        disconnect_notification_wait_timeout: float | None = DISCONNECT_TIMEOUT_SECONDS,
+        client_disconnect_timeout: float | None = DISCONNECT_TIMEOUT_SECONDS,
     ) -> None:
         """Shutdown active client resources and notification publication state.
 
@@ -503,14 +508,29 @@ class BLEShutdownLifecycleCoordinator:
                 if unsubscribe_all is not None:
                     run_safe_cleanup(
                         lambda: unsubscribe_all(
-                            client, timeout=NOTIFICATION_START_TIMEOUT
+                            client, timeout=unsubscribe_timeout
                         ),
                         "notification unsubscribe_all",
                     )
                 else:
                     logger.debug("Notification manager is missing _unsubscribe_all")
+
+                def _disconnect_client_with_timeout() -> None:
+                    try:
+                        iface._disconnect_and_close_client(
+                            client, timeout=client_disconnect_timeout
+                        )
+                    except TypeError as exc:
+                        timeout_kw_rejected = (
+                            "timeout" in str(exc).casefold()
+                            and "keyword" in str(exc).casefold()
+                        )
+                        if not timeout_kw_rejected:
+                            raise
+                        iface._disconnect_and_close_client(client)
+
                 run_safe_cleanup(
-                    lambda: iface._disconnect_and_close_client(client),
+                    _disconnect_client_with_timeout,
                     "BLE client disconnect/close",
                 )
         cleanup_all = _resolve_notification_cleanup("_cleanup_all")
@@ -521,7 +541,18 @@ class BLEShutdownLifecycleCoordinator:
 
         if consume_disconnect_state():
             iface._disconnected()
-            iface._wait_for_disconnect_notifications()
+            try:
+                iface._wait_for_disconnect_notifications(
+                    timeout=disconnect_notification_wait_timeout
+                )
+            except TypeError as exc:
+                timeout_kw_rejected = (
+                    "timeout" in str(exc).casefold()
+                    and "keyword" in str(exc).casefold()
+                )
+                if not timeout_kw_rejected:
+                    raise
+                iface._wait_for_disconnect_notifications()
 
     def _finalize_close_state(
         self,
@@ -583,10 +614,35 @@ class BLEShutdownLifecycleCoordinator:
         *,
         management_shutdown_wait_timeout: float,
         management_wait_poll_seconds: float,
+        timeout: float | None = None,
     ) -> None:
         """Shut down BLE interface resources and finalize lifecycle state."""
+        deadline: float | None = None
+        if timeout is not None:
+            deadline = time.monotonic() + max(0.0, timeout)
+
+        def _remaining_timeout(default_timeout: float) -> float:
+            if deadline is None:
+                return default_timeout
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return 0.0
+            return min(default_timeout, remaining)
+
+        def _remaining_optional_timeout(
+            default_timeout: float | None,
+        ) -> float | None:
+            if deadline is None:
+                return default_timeout
+            remaining = max(0.0, deadline - time.monotonic())
+            if default_timeout is None:
+                return remaining
+            return min(default_timeout, remaining)
+
         management_wait_timed_out = self._await_management_shutdown(
-            management_shutdown_wait_timeout=management_shutdown_wait_timeout,
+            management_shutdown_wait_timeout=_remaining_timeout(
+                management_shutdown_wait_timeout
+            ),
             management_wait_poll_seconds=management_wait_poll_seconds,
         )
         if management_wait_timed_out is None:
@@ -597,10 +653,23 @@ class BLEShutdownLifecycleCoordinator:
             if iface._shutdown_event is not None:
                 iface._shutdown_event.set()
             self._shutdown_discovery()
-            self._shutdown_receive_thread()
+            self._shutdown_receive_thread(
+                join_timeout=_remaining_timeout(RECEIVE_THREAD_JOIN_TIMEOUT)
+            )
             self._close_mesh_interface()
             self._unregister_exit_handler()
-            self._shutdown_client(management_wait_timed_out=management_wait_timed_out)
+            self._shutdown_client(
+                management_wait_timed_out=management_wait_timed_out,
+                unsubscribe_timeout=_remaining_optional_timeout(
+                    NOTIFICATION_START_TIMEOUT
+                ),
+                disconnect_notification_wait_timeout=_remaining_optional_timeout(
+                    DISCONNECT_TIMEOUT_SECONDS
+                ),
+                client_disconnect_timeout=_remaining_optional_timeout(
+                    DISCONNECT_TIMEOUT_SECONDS
+                ),
+            )
         finally:
             try:
                 self._cleanup_thread_coordinator()

--- a/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
@@ -595,9 +595,7 @@ class BLEShutdownLifecycleCoordinator:
                 unsubscribe_all = _resolve_notification_cleanup("_unsubscribe_all")
                 if unsubscribe_all is not None:
                     run_safe_cleanup(
-                        lambda: unsubscribe_all(
-                            client, timeout=unsubscribe_timeout
-                        ),
+                        lambda: unsubscribe_all(client, timeout=unsubscribe_timeout),
                         "notification unsubscribe_all",
                     )
                 else:

--- a/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
@@ -76,8 +76,18 @@ class BLEShutdownLifecycleCoordinator:
         with iface._state_lock:
             return self._state_access.is_closing() or iface._closed
 
-    def _cleanup_thread_coordinator(self) -> None:
+    def _cleanup_thread_coordinator(
+        self,
+        *,
+        timeout: float | None = None,
+    ) -> None:
         """Run thread-coordinator cleanup via public/legacy compatibility hooks.
+
+        Parameters
+        ----------
+        timeout : float | None, optional
+            Optional maximum seconds to wait for cleanup completion. When
+            ``None``, cleanup runs inline without an additional wait budget.
 
         Returns
         -------
@@ -85,29 +95,70 @@ class BLEShutdownLifecycleCoordinator:
             Cleanup is best effort and intentionally suppresses hook failures.
         """
         iface = self._iface
-        cleanup = getattr(iface.thread_coordinator, "cleanup", None)
-        if callable(cleanup) and not _is_unconfigured_mock_callable(cleanup):
+        cleanup_hook = getattr(iface.thread_coordinator, "cleanup", None)
+        if callable(cleanup_hook) and not _is_unconfigured_mock_callable(cleanup_hook):
+            hook_name = "cleanup"
+        else:
+            legacy_cleanup = getattr(iface.thread_coordinator, "_cleanup", None)
+            if callable(legacy_cleanup) and not _is_unconfigured_mock_callable(
+                legacy_cleanup
+            ):
+                cleanup_hook = legacy_cleanup
+                hook_name = "_cleanup"
+            else:
+                logger.debug("Thread coordinator is missing cleanup/_cleanup")
+                return
+
+        if timeout is None:
             try:
-                cleanup()
+                cleanup_hook()
             except Exception:  # noqa: BLE001 - shutdown cleanup is best effort
                 logger.debug(
-                    "Error running thread coordinator cleanup()", exc_info=True
+                    "Error running thread coordinator %s()",
+                    hook_name,
+                    exc_info=True,
                 )
             return
 
-        legacy_cleanup = getattr(iface.thread_coordinator, "_cleanup", None)
-        if callable(legacy_cleanup) and not _is_unconfigured_mock_callable(
-            legacy_cleanup
-        ):
-            try:
-                legacy_cleanup()
-            except Exception:  # noqa: BLE001 - shutdown cleanup is best effort
-                logger.debug(
-                    "Error running thread coordinator _cleanup()", exc_info=True
-                )
+        if timeout <= 0:
+            logger.warning(
+                "Skipping thread coordinator %s(): close timeout budget exhausted.",
+                hook_name,
+            )
             return
 
-        logger.debug("Thread coordinator is missing cleanup/_cleanup")
+        def _run_cleanup() -> None:
+            try:
+                cleanup_hook()
+            except Exception:  # noqa: BLE001 - shutdown cleanup is best effort
+                logger.debug(
+                    "Error running thread coordinator %s()",
+                    hook_name,
+                    exc_info=True,
+                )
+
+        cleanup_thread = threading.Thread(
+            target=_run_cleanup,
+            name="BLEThreadCoordinatorCleanup",
+            daemon=True,
+        )
+        try:
+            cleanup_thread.start()
+        except Exception:  # noqa: BLE001 - shutdown cleanup is best effort
+            logger.debug(
+                "Failed to start thread coordinator cleanup thread; running inline.",
+                exc_info=True,
+            )
+            _run_cleanup()
+            return
+
+        cleanup_thread.join(timeout=timeout)
+        if cleanup_thread.is_alive():
+            logger.warning(
+                "Timed out waiting %.3fs for thread coordinator %s() cleanup.",
+                timeout,
+                hook_name,
+            )
 
     def _await_management_shutdown(
         self,
@@ -366,6 +417,7 @@ class BLEShutdownLifecycleCoordinator:
         self,
         *,
         safe_execute: Callable[[Callable[[], object]], object | None] | None = None,
+        timeout: float | None = None,
     ) -> None:
         """Run ``MeshInterface.close`` through guarded error-handler execution.
 
@@ -373,6 +425,9 @@ class BLEShutdownLifecycleCoordinator:
         ----------
         safe_execute : Callable[[Callable[[], object]], object | None] | None, optional
             Optional safe-execute wrapper used for close invocation.
+        timeout : float | None, optional
+            Optional maximum seconds to wait for ``MeshInterface.close``. When
+            ``None``, close runs inline without an additional wait budget.
 
         Returns
         -------
@@ -386,7 +441,40 @@ class BLEShutdownLifecycleCoordinator:
                 error_msg="Error closing mesh interface",
             )
         )
-        run_safe_execute(lambda: MeshInterface.close(iface))
+        if timeout is None:
+            run_safe_execute(lambda: MeshInterface.close(iface))
+            return
+
+        if timeout <= 0:
+            logger.warning(
+                "Skipping MeshInterface.close(): close timeout budget exhausted."
+            )
+            return
+
+        def _run_mesh_close() -> None:
+            run_safe_execute(lambda: MeshInterface.close(iface))
+
+        close_thread = threading.Thread(
+            target=_run_mesh_close,
+            name="BLEMeshInterfaceClose",
+            daemon=True,
+        )
+        try:
+            close_thread.start()
+        except Exception:  # noqa: BLE001 - close must remain best effort
+            logger.debug(
+                "Failed to start MeshInterface.close thread; running close inline.",
+                exc_info=True,
+            )
+            run_safe_execute(lambda: MeshInterface.close(iface))
+            return
+
+        close_thread.join(timeout=timeout)
+        if close_thread.is_alive():
+            logger.warning(
+                "Timed out waiting %.3fs for MeshInterface.close(); continuing BLE shutdown.",
+                timeout,
+            )
 
     def _unregister_exit_handler(self) -> None:
         """Unregister process exit handler when present."""
@@ -616,7 +704,14 @@ class BLEShutdownLifecycleCoordinator:
         management_wait_poll_seconds: float,
         timeout: float | None = None,
     ) -> None:
-        """Shut down BLE interface resources and finalize lifecycle state."""
+        """Shut down BLE resources within an optional total timeout budget.
+
+        When ``timeout`` is provided, remaining-budget slices are applied to
+        each blocking shutdown phase (management wait, receive-thread join,
+        ``MeshInterface.close``, disconnect-notification waits, and client
+        disconnect/close). Best-effort final state cleanup still runs after
+        teardown stages complete or time out.
+        """
         deadline: float | None = None
         if timeout is not None:
             deadline = time.monotonic() + max(0.0, timeout)
@@ -656,7 +751,9 @@ class BLEShutdownLifecycleCoordinator:
             self._shutdown_receive_thread(
                 join_timeout=_remaining_timeout(RECEIVE_THREAD_JOIN_TIMEOUT)
             )
-            self._close_mesh_interface()
+            self._close_mesh_interface(
+                timeout=_remaining_optional_timeout(None),
+            )
             self._unregister_exit_handler()
             self._shutdown_client(
                 management_wait_timed_out=management_wait_timed_out,
@@ -672,6 +769,8 @@ class BLEShutdownLifecycleCoordinator:
             )
         finally:
             try:
-                self._cleanup_thread_coordinator()
+                self._cleanup_thread_coordinator(
+                    timeout=_remaining_optional_timeout(None),
+                )
             finally:
                 self._finalize_close_state()

--- a/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
@@ -146,11 +146,10 @@ class BLEShutdownLifecycleCoordinator:
         try:
             cleanup_thread.start()
         except Exception:  # noqa: BLE001 - shutdown cleanup is best effort
-            logger.debug(
-                "Failed to start thread coordinator cleanup thread; running inline.",
+            logger.warning(
+                "Failed to start thread coordinator cleanup thread; skipping bounded cleanup stage to preserve timeout contract.",
                 exc_info=True,
             )
-            _run_cleanup()
             return
 
         cleanup_thread.join(timeout=timeout)
@@ -463,11 +462,10 @@ class BLEShutdownLifecycleCoordinator:
         try:
             close_thread.start()
         except Exception:  # noqa: BLE001 - close must remain best effort
-            logger.debug(
-                "Failed to start MeshInterface.close thread; running close inline.",
+            logger.warning(
+                "Failed to start MeshInterface.close thread; skipping bounded close stage to preserve timeout contract.",
                 exc_info=True,
             )
-            run_safe_execute(lambda: MeshInterface.close(iface))
             return
 
         close_thread.join(timeout=timeout)

--- a/meshtastic/interfaces/ble/reconnection.py
+++ b/meshtastic/interfaces/ble/reconnection.py
@@ -10,6 +10,7 @@ from bleak.exc import BleakDBusError, BleakDeviceNotFoundError, BleakError
 
 from meshtastic.interfaces.ble.constants import DBUS_ERROR_RECONNECT_DELAY, BLEConfig
 from meshtastic.interfaces.ble.coordination import ThreadCoordinator, ThreadLike
+from meshtastic.interfaces.ble.errors import BLEDBusTransportError
 from meshtastic.interfaces.ble.gating import (
     _addr_key,
     _is_currently_connected_elsewhere,
@@ -551,6 +552,15 @@ class ReconnectWorker:
                         err.method_name,
                     )
                     return
+                except BLEDBusTransportError:
+                    if self._should_abort_reconnect(context="DBusError"):
+                        return
+                    logger.warning(
+                        "DBus error during auto-reconnect attempt %d",
+                        attempt_num,
+                        exc_info=True,
+                    )
+                    override_delay = DBUS_ERROR_RECONNECT_DELAY
                 except interface.BLEError as err:
                     if self._should_abort_reconnect(context="BLEError"):
                         return

--- a/meshtastic/interfaces/ble/reconnection.py
+++ b/meshtastic/interfaces/ble/reconnection.py
@@ -572,7 +572,8 @@ class ReconnectWorker:
                 except BleakDBusError:
                     if self._should_abort_reconnect(context="DBusError"):
                         return
-                    # DBus errors are often transient on Linux; log as warning since we'll retry
+                    # Safety net for raw BleakDBusError paths that have not
+                    # been normalized to BLEDBusTransportError yet.
                     logger.warning(
                         "DBus error during auto-reconnect attempt %d",
                         attempt_num,

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -109,7 +109,9 @@ NODE_NOT_FOUND_DB_UNAVAILABLE_ERROR_TEMPLATE = (
     "NodeId {destination_id} not found and node DB is unavailable"
 )
 HEX_NODE_ID_TAIL_CHARS = frozenset("0123456789abcdefABCDEF")
-NO_RESPONSE_FIRMWARE_ERROR: str = "No response from node. At least firmware 2.1.22 is required on the destination node."
+NO_RESPONSE_FIRMWARE_ERROR: str = (
+    "No response from node. At least firmware 2.1.22 is required on the destination node."
+)
 
 JSONValue: TypeAlias = (
     None | bool | int | float | str | list["JSONValue"] | dict[str, "JSONValue"]
@@ -553,9 +555,9 @@ class MeshInterface:  # pylint: disable=R0902
         # _handle_packet_from_radio (receive thread). Use this lock to serialize
         # responseHandlers access across those call sites.
         self._response_handlers_lock = threading.RLock()
-        self.responseHandlers: dict[
-            int, ResponseHandler
-        ] = {}  # A map from request ID to the handler
+        self.responseHandlers: dict[int, ResponseHandler] = (
+            {}
+        )  # A map from request ID to the handler
         self._response_wait_errors: dict[tuple[str, int], str] = {}
         self._response_wait_acks: set[tuple[str, int]] = set()
         self._active_wait_request_ids: dict[str, set[int]] = {}
@@ -1751,7 +1753,8 @@ class MeshInterface:  # pylint: disable=R0902
                 next_packet_id & PACKET_ID_COUNTER_MASK
             )  # Keep only low 10-bit counter (clear upper 22 bits)
             random_part = (
-                random.randint(0, PACKET_ID_RANDOM_MAX) << PACKET_ID_RANDOM_SHIFT_BITS  # noqa: S311
+                random.randint(0, PACKET_ID_RANDOM_MAX)
+                << PACKET_ID_RANDOM_SHIFT_BITS  # noqa: S311
             ) & PACKET_ID_MASK  # generate number with 10 zeros at end
             self.currentPacketId = next_packet_id | random_part  # combine
             return self.currentPacketId
@@ -1869,7 +1872,9 @@ class MeshInterface:  # pylint: disable=R0902
             self.myInfo = None
             self.nodes = {}  # nodes keyed by ID
             self.nodesByNum = {}  # nodes keyed by nodenum
-            self._localChannels = []  # empty until we start getting channels pushed from the device (during config)
+            self._localChannels = (
+                []
+            )  # empty until we start getting channels pushed from the device (during config)
             config_id = self.configId
             if config_id is None or not self.noNodes:
                 # Keep config_complete_id zero reserved as an unset sentinel.
@@ -2601,9 +2606,9 @@ class MeshInterface:  # pylint: disable=R0902
                 DECODE_ERROR_KEY: decode_error
             }
             if handler.name == "routing":
-                packet_context.packet_dict["decoded"][handler.name]["errorReason"] = (
-                    decode_error
-                )
+                packet_context.packet_dict["decoded"][handler.name][
+                    "errorReason"
+                ] = decode_error
             if handler.name == "admin":
                 # Admin callbacks frequently expect decoded.admin.raw.
                 # Avoid dispatching malformed payloads through that path.

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -692,21 +692,22 @@ class MeshInterface:  # pylint: disable=R0902
                 with heartbeat_lock:
                     while self._heartbeat_inflight > 0:
                         heartbeat_idle_condition.wait()
-            try:
-                self._send_disconnect()
-            except (OSError, MeshInterface.MeshInterfaceError):
-                logger.debug(
-                    "Failed to send disconnect during close(); continuing shutdown.",
-                    exc_info=True,
-                )
-            except TypeError:
-                is_finalizing = getattr(sys, "is_finalizing", None)
-                if not (callable(is_finalizing) and is_finalizing()):
-                    raise
-                logger.debug(
-                    "Failed to send disconnect during interpreter finalization; continuing shutdown.",
-                    exc_info=True,
-                )
+            if not self.noProto:
+                try:
+                    self._send_disconnect()
+                except (OSError, MeshInterface.MeshInterfaceError):
+                    logger.debug(
+                        "Failed to send disconnect during close(); continuing shutdown.",
+                        exc_info=True,
+                    )
+                except TypeError:
+                    is_finalizing = getattr(sys, "is_finalizing", None)
+                    if not (callable(is_finalizing) and is_finalizing()):
+                        raise
+                    logger.debug(
+                        "Failed to send disconnect during interpreter finalization; continuing shutdown.",
+                        exc_info=True,
+                    )
         # debugOut is caller-owned (often shared via outer context managers);
         # do not close it here. Only clear our reference on shutdown.
         if hasattr(self, "debugOut"):

--- a/meshtastic/node_runtime/seturl/coordinator.py
+++ b/meshtastic/node_runtime/seturl/coordinator.py
@@ -89,7 +89,9 @@ class _SetUrlTransactionCoordinator:
             self._node._raise_interface_error(  # noqa: SLF001
                 "Interface localNode not initialized"
             )
-        admin_index_for_write = admin_write_node._get_admin_channel_index()  # noqa: SLF001
+        admin_index_for_write = (
+            admin_write_node._get_admin_channel_index()
+        )  # noqa: SLF001
         named_admin_index_for_write = (
             admin_write_node._get_named_admin_channel_index()  # noqa: SLF001
         )

--- a/meshtastic/powermon/ppk2.py
+++ b/meshtastic/powermon/ppk2.py
@@ -7,7 +7,7 @@ import time
 from contextlib import suppress
 from typing import Final
 
-from ppk2_api import ppk2_api  # type: ignore[import-untyped,import-not-found]
+from ppk2_api import ppk2_api  # type: ignore[import-untyped]
 
 from .constants import MICROAMPS_PER_MILLIAMP, MILLIVOLTS_PER_VOLT, MIN_SUPPLY_VOLTAGE_V
 from .power_supply import PowerError, PowerSupply

--- a/meshtastic/powermon/riden.py
+++ b/meshtastic/powermon/riden.py
@@ -6,7 +6,7 @@ import time
 from datetime import datetime
 from typing import Any, Final, cast
 
-import riden  # type: ignore[import-untyped,import-not-found]
+import riden
 
 from .constants import MILLIAMPS_PER_AMP, SECONDS_PER_HOUR
 from .power_supply import PowerError, PowerSupply
@@ -17,7 +17,7 @@ INVALID_POWER_ON_VOLTAGE_ERROR: Final[str] = (
 DEFAULT_RIDEN_BAUDRATE: Final[int] = 115200
 DEFAULT_RIDEN_ADDRESS: Final[int] = 1
 
-Riden = cast(type[Any], riden.Riden)
+Riden = cast(type[Any], riden.Riden)  # type: ignore[attr-defined]
 
 
 class RidenPowerSupply(PowerSupply):

--- a/meshtastic/powermon/riden.py
+++ b/meshtastic/powermon/riden.py
@@ -6,7 +6,7 @@ import time
 from datetime import datetime
 from typing import Any, Final, cast
 
-import riden
+import riden  # type: ignore[import-untyped]
 
 from .constants import MILLIAMPS_PER_AMP, SECONDS_PER_HOUR
 from .power_supply import PowerError, PowerSupply

--- a/meshtastic/serial_interface.py
+++ b/meshtastic/serial_interface.py
@@ -157,7 +157,9 @@ class SerialInterface(StreamInterface):
         if len(ports) == 0:
             return None
         if len(ports) > 1:
-            message: str = "Multiple serial ports were detected; one serial port must be specified with '--port'.\n"
+            message: str = (
+                "Multiple serial ports were detected; one serial port must be specified with '--port'.\n"
+            )
             message += (
                 "  Auto-detection cannot disambiguate when multiple compatible devices "
                 "or overlapping USB VID/PID aliases are present.\n"

--- a/meshtastic/slog/slog.py
+++ b/meshtastic/slog/slog.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeAlias
 
-import parse  # type: ignore[import-untyped,import-not-found]
+import parse  # type: ignore[import-untyped]
 import platformdirs
 import pyarrow as pa
 from pubsub import pub

--- a/meshtastic/stream_interface.py
+++ b/meshtastic/stream_interface.py
@@ -376,13 +376,16 @@ class StreamInterface(MeshInterface):
         delay = WINDOWS11_WRITE_DELAY if self.is_windows11 else STANDARD_WRITE_DELAY
         time.sleep(delay)
 
-    def _resolve_stable_path(self) -> str | None:  # pylint: disable=too-many-return-statements
+    def _resolve_stable_path(
+        self,
+    ) -> str | None:  # pylint: disable=too-many-return-statements
         """Return the stable /dev/serial/by-id/ alias for the current device path."""
         if platform.system() != "Linux":
             return None
-        dev_path = getattr(self, "devPath", None)
-        if not dev_path:
+        dev_path_raw = getattr(self, "devPath", None)
+        if not isinstance(dev_path_raw, str) or not dev_path_raw:
             return None
+        dev_path = dev_path_raw
         by_id_dir = "/dev/serial/by-id"
         if dev_path.startswith(by_id_dir + "/") and os.path.exists(dev_path):
             return dev_path
@@ -392,13 +395,15 @@ class StreamInterface(MeshInterface):
             resolved = os.path.realpath(dev_path)
         except OSError:
             return None
+        stable_alias: str | None = None
         for alias in sorted(glob.glob(f"{by_id_dir}/*")):
             try:
                 if os.path.realpath(alias) == resolved:
-                    return alias
+                    stable_alias = alias
+                    break
             except OSError:
                 continue
-        return None
+        return stable_alias
 
     def _read_bytes(self, length: int) -> bytes:
         """Read up to the specified number of bytes from the configured underlying stream.

--- a/meshtastic/tests/test_ble_compat_services_coverage.py
+++ b/meshtastic/tests/test_ble_compat_services_coverage.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, Mock, NonCallableMock, patch
 import pytest
 
 from meshtastic.interfaces.ble.client import BLEClient
+from meshtastic.interfaces.ble.lifecycle_compat_service import BLELifecycleService
 from meshtastic.interfaces.ble.management_compat_service import (
     BLEManagementCommandsService,
 )
@@ -1303,6 +1304,93 @@ class TestBLECompatServicesIntegration:
         iface._state_lock = None
         result = BLEReceiveRecoveryService._controller_for_shim(iface)
         assert isinstance(result, BLEReceiveRecoveryController)
+
+
+class TestBLELifecycleServiceGuardedDispatch:
+    """Test signature-based guarded dispatch for lifecycle compat shims."""
+
+    def test_disconnect_and_close_client_passes_timeout_when_supported(self):
+        """Timeout should be forwarded when the callee accepts it."""
+        iface = MagicMock()
+        client = MagicMock(spec=BLEClient)
+        coordinator = MagicMock()
+        disconnect_and_close = MagicMock()
+        coordinator.disconnect_and_close_client = disconnect_and_close
+        iface._disconnect_lifecycle_coordinator = coordinator
+
+        with patch(
+            "meshtastic.interfaces.ble.lifecycle_compat_service.BLEDisconnectLifecycleCoordinator",
+            return_value=coordinator,
+        ):
+            BLELifecycleService._disconnect_and_close_client(
+                iface, client, timeout=7.5
+            )
+
+        disconnect_and_close.assert_called_once_with(client, timeout=7.5)
+
+    def test_disconnect_and_close_client_skips_timeout_for_legacy_callable(self):
+        """Legacy callee without timeout parameter must be called without it."""
+        iface = MagicMock()
+        client = MagicMock(spec=BLEClient)
+
+        def legacy_disconnect_and_close(c):
+            pass
+
+        coordinator = MagicMock()
+        coordinator.disconnect_and_close_client = legacy_disconnect_and_close
+
+        with patch(
+            "meshtastic.interfaces.ble.lifecycle_compat_service.BLEDisconnectLifecycleCoordinator",
+            return_value=coordinator,
+        ):
+            BLELifecycleService._disconnect_and_close_client(
+                iface, client, timeout=7.5
+            )
+
+    def test_close_passes_timeout_when_supported(self):
+        """Timeout should be forwarded to shutdown close when supported."""
+        iface = MagicMock()
+        shutdown_close = MagicMock()
+        coordinator = MagicMock()
+        coordinator.close = shutdown_close
+
+        with patch(
+            "meshtastic.interfaces.ble.lifecycle_compat_service.BLEShutdownLifecycleCoordinator",
+            return_value=coordinator,
+        ):
+            BLELifecycleService._close(
+                iface,
+                management_shutdown_wait_timeout=30.0,
+                management_wait_poll_seconds=0.5,
+                timeout=10.0,
+            )
+
+        shutdown_close.assert_called_once_with(
+            management_shutdown_wait_timeout=30.0,
+            management_wait_poll_seconds=0.5,
+            timeout=10.0,
+        )
+
+    def test_close_skips_timeout_for_legacy_callable(self):
+        """Legacy shutdown close without timeout must not receive it."""
+        iface = MagicMock()
+
+        def legacy_close(management_shutdown_wait_timeout, management_wait_poll_seconds):
+            pass
+
+        coordinator = MagicMock()
+        coordinator.close = legacy_close
+
+        with patch(
+            "meshtastic.interfaces.ble.lifecycle_compat_service.BLEShutdownLifecycleCoordinator",
+            return_value=coordinator,
+        ):
+            BLELifecycleService._close(
+                iface,
+                management_shutdown_wait_timeout=30.0,
+                management_wait_poll_seconds=0.5,
+                timeout=10.0,
+            )
 
 
 if __name__ == "__main__":

--- a/meshtastic/tests/test_ble_compat_services_coverage.py
+++ b/meshtastic/tests/test_ble_compat_services_coverage.py
@@ -1322,9 +1322,7 @@ class TestBLELifecycleServiceGuardedDispatch:
             "meshtastic.interfaces.ble.lifecycle_compat_service.BLEDisconnectLifecycleCoordinator",
             return_value=coordinator,
         ):
-            BLELifecycleService._disconnect_and_close_client(
-                iface, client, timeout=7.5
-            )
+            BLELifecycleService._disconnect_and_close_client(iface, client, timeout=7.5)
 
         disconnect_and_close.assert_called_once_with(client, timeout=7.5)
 
@@ -1343,9 +1341,7 @@ class TestBLELifecycleServiceGuardedDispatch:
             "meshtastic.interfaces.ble.lifecycle_compat_service.BLEDisconnectLifecycleCoordinator",
             return_value=coordinator,
         ):
-            BLELifecycleService._disconnect_and_close_client(
-                iface, client, timeout=7.5
-            )
+            BLELifecycleService._disconnect_and_close_client(iface, client, timeout=7.5)
 
     def test_close_passes_timeout_when_supported(self):
         """Timeout should be forwarded to shutdown close when supported."""
@@ -1375,7 +1371,9 @@ class TestBLELifecycleServiceGuardedDispatch:
         """Legacy shutdown close without timeout must not receive it."""
         iface = MagicMock()
 
-        def legacy_close(management_shutdown_wait_timeout, management_wait_poll_seconds):
+        def legacy_close(
+            management_shutdown_wait_timeout, management_wait_poll_seconds
+        ):
             pass
 
         coordinator = MagicMock()

--- a/meshtastic/tests/test_ble_connection_runtime.py
+++ b/meshtastic/tests/test_ble_connection_runtime.py
@@ -8,8 +8,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from bleak.exc import BleakDBusError
+
 from meshtastic.interfaces.ble.client import BLEClient
-from meshtastic.interfaces.ble.connection import ClientManager
+from meshtastic.interfaces.ble.connection import (
+    ClientManager,
+    ConnectionOrchestrator,
+)
 from meshtastic.interfaces.ble.constants import DISCONNECT_TIMEOUT_SECONDS
 from meshtastic.interfaces.ble.errors import BLEErrorHandler
 
@@ -27,8 +32,32 @@ class _ErrorHandler:
 class _DummyClient:
     """Minimal BLE client double for shutdown behavior tests."""
 
-    def __init__(self, *, connected: bool) -> None:
+    def __init__(self, *, connected: bool, close_accepts_timeout: bool = True) -> None:
         self._closed = False
+        self._connected = connected
+        self.bleak_client = object()
+        self.disconnect_calls = 0
+        self.close_calls = 0
+        self.last_disconnect_timeout: float | None = None
+        self.last_close_timeout: float | None = None
+        self._close_accepts_timeout = close_accepts_timeout
+
+    def is_connected(self) -> bool:
+        return self._connected
+
+    def disconnect(self, *, await_timeout: float) -> None:
+        self.disconnect_calls += 1
+        self.last_disconnect_timeout = await_timeout
+
+    def close(self, timeout: float | None = None) -> None:  # type: ignore[no-untyped-def]
+        self.close_calls += 1
+        self.last_close_timeout = timeout
+
+
+class _LegacyDummyClient:
+    """Legacy BLE client double that does not accept timeout in close()."""
+
+    def __init__(self, *, connected: bool) -> None:
         self._connected = connected
         self.bleak_client = object()
         self.disconnect_calls = 0
@@ -80,3 +109,154 @@ def test_safe_close_client_disconnects_connected_client_before_close() -> None:
     assert client.disconnect_calls == 1
     assert client.last_disconnect_timeout == DISCONNECT_TIMEOUT_SECONDS
     assert client.close_calls == 1
+
+
+def test_safe_close_client_passes_timeout_to_close() -> None:
+    """Bounded disconnect timeout should flow through to client.close()."""
+    manager = _make_client_manager()
+    client = _DummyClient(connected=True)
+    done = Event()
+    custom_timeout = 3.5
+
+    manager._safe_close_client(
+        cast(BLEClient, client),
+        event=done,
+        disconnect_timeout=custom_timeout,
+    )
+
+    assert done.is_set()
+    assert client.disconnect_calls == 1
+    assert client.last_disconnect_timeout == custom_timeout
+    assert client.close_calls == 1
+    assert client.last_close_timeout == custom_timeout
+
+
+def test_safe_close_client_fallback_for_legacy_close() -> None:
+    """Legacy client.close() without timeout should still be called once."""
+    manager = _make_client_manager()
+    client = _LegacyDummyClient(connected=True)
+    done = Event()
+
+    manager._safe_close_client(
+        cast(BLEClient, client),
+        event=done,
+        disconnect_timeout=2.0,
+    )
+
+    assert done.is_set()
+    assert client.disconnect_calls == 1
+    assert client.close_calls == 1
+
+
+def test_safe_close_client_reraises_unrelated_typeerror() -> None:
+    """Unrelated TypeError from close() should propagate, not be swallowed."""
+    manager = _make_client_manager()
+
+    class _BadClient:
+        def __init__(self) -> None:
+            self.bleak_client = object()
+            self._closed = False
+
+        def is_connected(self) -> bool:
+            return True
+
+        def disconnect(self, *, await_timeout: float) -> None:
+            pass
+
+        def close(self, timeout: float | None = None) -> None:
+            raise TypeError("something else broke")
+
+    client = _BadClient()
+    done = Event()
+
+    with pytest.raises(TypeError, match="something else broke"):
+        manager._safe_close_client(cast(BLEClient, client), event=done)
+
+
+def test_stale_cleanup_retry_failure_does_not_fall_through() -> None:
+    """Stale-cleanup retry failure must propagate, not trigger generic retry."""
+    orchestrator = ConnectionOrchestrator(
+        interface=MagicMock(),
+        validator=MagicMock(),
+        client_manager=MagicMock(),
+        discovery_manager=MagicMock(),
+        state_manager=MagicMock(),
+        state_lock=RLock(),
+        thread_coordinator=MagicMock(),
+    )
+
+    client = MagicMock()
+    retry_err = BleakDBusError("org.bluez.Error.Failed", ["Device or resource busy"])
+
+    orchestrator._raise_if_interface_closing = MagicMock()  # type: ignore[method-assign]
+    orchestrator._client_manager_create_client = MagicMock(return_value=client)  # type: ignore[method-assign]
+    orchestrator._client_manager_connect_client = MagicMock(  # type: ignore[method-assign]
+        side_effect=BleakDBusError(
+            "org.bluez.Error.InProgress", ["operation already in progress"]
+        )
+    )
+    orchestrator._client_manager_safe_close_client = MagicMock()  # type: ignore[method-assign]
+    orchestrator._should_attempt_stale_bluez_cleanup = MagicMock(return_value=True)  # type: ignore[method-assign]
+    orchestrator._attempt_stale_bluez_cleanup = MagicMock(return_value=True)  # type: ignore[method-assign]
+    orchestrator._retry_direct_connect_after_cleanup = MagicMock(  # type: ignore[method-assign]
+        side_effect=retry_err
+    )
+
+    with pytest.raises(BleakDBusError, match="Device or resource busy"):
+        orchestrator._attempt_direct_connect(
+            target_address="AA:BB:CC:DD:EE:FF",
+            explicit_address=True,
+            normalized_target="aabbccddeeff",
+            on_disconnect_func=MagicMock(),
+            pair_on_connect=False,
+            direct_connect_timeout=5.0,
+            register_notifications_func=MagicMock(),
+            on_connected_func=MagicMock(),
+            emit_connected_side_effects=True,
+        )
+
+    # Generic retry path must not be reached.
+    orchestrator._client_manager_safe_close_client.assert_called_with(client)
+
+
+def test_stale_cleanup_retry_mismatch_still_propagates() -> None:
+    """BLEAddressMismatchError from stale-cleanup retry must propagate."""
+    from meshtastic.interfaces.ble.errors import BLEAddressMismatchError
+
+    orchestrator = ConnectionOrchestrator(
+        interface=MagicMock(),
+        validator=MagicMock(),
+        client_manager=MagicMock(),
+        discovery_manager=MagicMock(),
+        state_manager=MagicMock(),
+        state_lock=RLock(),
+        thread_coordinator=MagicMock(),
+    )
+
+    client = MagicMock()
+    mismatch = BLEAddressMismatchError("address mismatch")
+
+    orchestrator._raise_if_interface_closing = MagicMock()  # type: ignore[method-assign]
+    orchestrator._client_manager_create_client = MagicMock(return_value=client)  # type: ignore[method-assign]
+    orchestrator._client_manager_connect_client = MagicMock(  # type: ignore[method-assign]
+        side_effect=BleakDBusError("org.bluez.Error.InProgress", ["in progress"])
+    )
+    orchestrator._client_manager_safe_close_client = MagicMock()  # type: ignore[method-assign]
+    orchestrator._should_attempt_stale_bluez_cleanup = MagicMock(return_value=True)  # type: ignore[method-assign]
+    orchestrator._attempt_stale_bluez_cleanup = MagicMock(return_value=True)  # type: ignore[method-assign]
+    orchestrator._retry_direct_connect_after_cleanup = MagicMock(  # type: ignore[method-assign]
+        side_effect=mismatch
+    )
+
+    with pytest.raises(BLEAddressMismatchError, match="address mismatch"):
+        orchestrator._attempt_direct_connect(
+            target_address="AA:BB:CC:DD:EE:FF",
+            explicit_address=True,
+            normalized_target="aabbccddeeff",
+            on_disconnect_func=MagicMock(),
+            pair_on_connect=False,
+            direct_connect_timeout=5.0,
+            register_notifications_func=MagicMock(),
+            on_connected_func=MagicMock(),
+            emit_connected_side_effects=True,
+        )

--- a/meshtastic/tests/test_ble_connection_runtime.py
+++ b/meshtastic/tests/test_ble_connection_runtime.py
@@ -15,7 +15,7 @@ from meshtastic.interfaces.ble.connection import (
     ConnectionOrchestrator,
 )
 from meshtastic.interfaces.ble.constants import DISCONNECT_TIMEOUT_SECONDS
-from meshtastic.interfaces.ble.errors import BLEErrorHandler
+from meshtastic.interfaces.ble.errors import BLEDBusTransportError, BLEErrorHandler
 
 pytestmark = pytest.mark.unit
 
@@ -31,7 +31,7 @@ class _ErrorHandler:
 class _DummyClient:
     """Minimal BLE client double for shutdown behavior tests."""
 
-    def __init__(self, *, connected: bool, close_accepts_timeout: bool = True) -> None:
+    def __init__(self, *, connected: bool) -> None:
         self._closed = False
         self._connected = connected
         self.bleak_client = object()
@@ -39,7 +39,6 @@ class _DummyClient:
         self.close_calls = 0
         self.last_disconnect_timeout: float | None = None
         self.last_close_timeout: float | None = None
-        self._close_accepts_timeout = close_accepts_timeout
 
     def is_connected(self) -> bool:
         return self._connected
@@ -202,7 +201,7 @@ def test_stale_cleanup_retry_failure_does_not_fall_through() -> None:
         side_effect=retry_err
     )
 
-    with pytest.raises(BleakDBusError, match="Device or resource busy"):
+    with pytest.raises(BLEDBusTransportError, match="BLE DBus transport error"):
         orchestrator._attempt_direct_connect(
             target_address="AA:BB:CC:DD:EE:FF",
             explicit_address=True,
@@ -216,7 +215,7 @@ def test_stale_cleanup_retry_failure_does_not_fall_through() -> None:
         )
 
     # Generic retry path must not be reached.
-    orchestrator._client_manager_safe_close_client.assert_called_with(client)
+    orchestrator._client_manager_safe_close_client.assert_called_once_with(client)
 
 
 def test_stale_cleanup_retry_mismatch_still_propagates() -> None:

--- a/meshtastic/tests/test_ble_connection_runtime.py
+++ b/meshtastic/tests/test_ble_connection_runtime.py
@@ -7,7 +7,6 @@ from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
-
 from bleak.exc import BleakDBusError
 
 from meshtastic.interfaces.ble.client import BLEClient

--- a/meshtastic/tests/test_ble_connection_runtime.py
+++ b/meshtastic/tests/test_ble_connection_runtime.py
@@ -170,6 +170,7 @@ def test_safe_close_client_reraises_unrelated_typeerror() -> None:
 
     with pytest.raises(TypeError, match="something else broke"):
         manager._safe_close_client(cast(BLEClient, client), event=done)
+    assert done.is_set()
 
 
 def test_stale_cleanup_retry_failure_does_not_fall_through() -> None:

--- a/meshtastic/tests/test_ble_errors_coverage.py
+++ b/meshtastic/tests/test_ble_errors_coverage.py
@@ -11,11 +11,69 @@ import pytest
 from bleak.exc import BleakError
 from google.protobuf.message import DecodeError as ProtobufDecodeError
 
+from bleak.exc import BleakDBusError
+
 from meshtastic.interfaces.ble import errors as ble_errors_module
 from meshtastic.interfaces.ble.constants import logger
-from meshtastic.interfaces.ble.errors import BLEErrorHandler, DecodeError
+from meshtastic.interfaces.ble.errors import (
+    BLEDBusTransportError,
+    BLEErrorHandler,
+    DecodeError,
+)
 
 pytestmark = pytest.mark.unit
+
+
+class TestBLEDBusTransportErrorFlattening:
+    """Test BLEDBusTransportError.from_exception flattens nested DBus args."""
+
+    def test_flatten_single_list_wrapper(self) -> None:
+        """BleakDBusError-style args with a list body should produce string details."""
+        original = BleakDBusError(
+            "org.bluez.Error.Failed",
+            ["Device or resource busy"],
+        )
+        err = BLEDBusTransportError.from_exception(
+            original,
+            message="BLE DBus transport error during direct connect.",
+            requested_identifier="AA:BB:CC:DD:EE:FF",
+            address="AA:BB:CC:DD:EE:FF",
+        )
+        assert err.dbus_error_details == "Device or resource busy"
+        assert err.dbus_error_body == ("Device or resource busy",)
+
+    def test_flatten_single_tuple_wrapper(self) -> None:
+        """A tuple-wrapped body should also be flattened."""
+        original = Exception("wrapper")
+        original.args = ("org.bluez.Error.Failed", ("Operation already in progress",))
+        err = BLEDBusTransportError.from_exception(
+            original,
+            message="transport failed",
+        )
+        assert err.dbus_error_body == ("Operation already in progress",)
+
+    def test_no_flatten_for_multiple_args(self) -> None:
+        """Multiple positional args should remain as-is."""
+        original = Exception("wrapper")
+        original.args = ("org.bluez.Error.Failed", "arg1", "arg2")
+        err = BLEDBusTransportError.from_exception(
+            original,
+            message="transport failed",
+        )
+        assert err.dbus_error_body == ("arg1", "arg2")
+
+    def test_stale_bluez_detection_matches_normalized_wrapper(self) -> None:
+        """Stale-BlueZ token matching should work against the flattened detail."""
+        original = BleakDBusError(
+            "org.bluez.Error.Failed",
+            ["Device or resource busy"],
+        )
+        err = BLEDBusTransportError.from_exception(
+            original,
+            message="transport failed",
+        )
+        # The detail string must be lowercase-matchable for stale-BlueZ detection.
+        assert "device or resource busy" in str(err.dbus_error_details).casefold()
 
 
 class TestDecodeErrorImport:

--- a/meshtastic/tests/test_ble_errors_coverage.py
+++ b/meshtastic/tests/test_ble_errors_coverage.py
@@ -8,10 +8,8 @@ from concurrent.futures import TimeoutError as FutureTimeoutError
 from unittest.mock import Mock, patch
 
 import pytest
-from bleak.exc import BleakError
+from bleak.exc import BleakDBusError, BleakError
 from google.protobuf.message import DecodeError as ProtobufDecodeError
-
-from bleak.exc import BleakDBusError
 
 from meshtastic.interfaces.ble import errors as ble_errors_module
 from meshtastic.interfaces.ble.constants import logger

--- a/meshtastic/tests/test_ble_errors_coverage.py
+++ b/meshtastic/tests/test_ble_errors_coverage.py
@@ -48,7 +48,19 @@ class TestBLEDBusTransportErrorFlattening:
             original,
             message="transport failed",
         )
+        assert err.dbus_error_name == "org.bluez.Error.Failed"
         assert err.dbus_error_body == ("Operation already in progress",)
+
+    def test_args_zero_dbus_name_is_preserved_without_attr(self) -> None:
+        """DBus error names in args[0] should be preserved when attr is absent."""
+        original = Exception("wrapper")
+        original.args = ("org.bluez.Error.InProgress", ["Operation in progress"])
+        err = BLEDBusTransportError.from_exception(
+            original,
+            message="transport failed",
+        )
+        assert err.dbus_error_name == "org.bluez.Error.InProgress"
+        assert err.dbus_error_details == "Operation in progress"
 
     def test_no_flatten_for_multiple_args(self) -> None:
         """Multiple positional args should remain as-is."""

--- a/meshtastic/tests/test_ble_runner_coverage.py
+++ b/meshtastic/tests/test_ble_runner_coverage.py
@@ -22,27 +22,37 @@ from meshtastic.interfaces.ble.runner import (
     BLECoroutineRunner,
     get_zombie_runner_count,
 )
+from meshtastic.interfaces.ble import runner as _runner_module
 
 
 @pytest.fixture(autouse=True)
 def reset_runner_singleton() -> Generator[None, None, None]:
     """Reset the BLECoroutineRunner singleton between tests."""
-    # Store original state
     original_instance = BLECoroutineRunner._instance
 
-    # Reset singleton
+    with _runner_module._zombie_lock:
+        saved_zombie_count = _runner_module._zombie_runner_count
+        _runner_module._zombie_runner_count = 0
+
     BLECoroutineRunner._instance = None
 
     try:
         yield
     finally:
-        # Cleanup: stop any running runner and restore singleton
-        if BLECoroutineRunner._instance is not None:
+        current = BLECoroutineRunner._instance
+        if current is not None and current is not original_instance:
             try:
-                BLECoroutineRunner._instance._stop(timeout=0.5)
+                handler = getattr(current, "_atexit_handler", None)
+                if callable(handler):
+                    _runner_module.atexit.unregister(handler)
+                if hasattr(current, "_atexit_registered"):
+                    current._atexit_registered = False
+                current._stop(timeout=0.5)
             except Exception:
-                pass  # Best effort cleanup
+                pass
         BLECoroutineRunner._instance = original_instance
+        with _runner_module._zombie_lock:
+            _runner_module._zombie_runner_count = saved_zombie_count
 
 
 @pytest.fixture
@@ -1001,10 +1011,9 @@ class TestGetZombieRunnerCount:
 
     def test_returns_zero_initially(self) -> None:
         """Test get_zombie_runner_count returns 0 initially."""
-        # Note: This test may fail if other tests leave zombies
         count = get_zombie_runner_count()
         assert isinstance(count, int)
-        assert count >= 0
+        assert count == 0
 
     def test_thread_safe_access(self) -> None:
         """Test get_zombie_runner_count is thread-safe."""

--- a/meshtastic/tests/test_ble_shutdown_runtime.py
+++ b/meshtastic/tests/test_ble_shutdown_runtime.py
@@ -1,0 +1,237 @@
+"""Tests for BLE shutdown lifecycle runtime behavior.
+
+Covers unsubscribe_all legacy fallback, bounded-thread TOCTOU fixes,
+and shutdown client teardown paths.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from meshtastic.interfaces.ble.client import BLEClient
+from meshtastic.interfaces.ble.lifecycle_shutdown_runtime import (
+    BLEShutdownLifecycleCoordinator,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _ImmediateThread:
+    """Run thread targets inline for deterministic unit tests."""
+
+    def __init__(self, *, target: Any, **_kwargs: Any) -> None:
+        self._target = target
+
+    def start(self) -> None:
+        self._target()
+
+    def is_alive(self) -> bool:
+        return False
+
+    def join(self, timeout: float | None = None) -> None:
+        pass
+
+
+class TestShutdownClientUnsubscribeFallback:
+    """Test legacy unsubscribe_all fallback in _shutdown_client."""
+
+    def test_legacy_unsubscribe_all_without_timeout_is_called(self):
+        """When unsubscribe_all does not accept timeout, retry without it."""
+        iface = MagicMock()
+        iface.client = None
+        iface._management_inflight = 0
+        iface._management_target_gate.return_value.__enter__ = MagicMock(
+            return_value=MagicMock()
+        )
+        iface._management_target_gate.return_value.__exit__ = MagicMock(
+            return_value=None
+        )
+
+        coordinator = BLEShutdownLifecycleCoordinator(iface)
+
+        called_with: list[tuple[Any, ...]] = []
+
+        def legacy_unsubscribe(client: Any) -> None:
+            called_with.append((client,))
+
+        notification_manager = MagicMock()
+        notification_manager._unsubscribe_all = None
+        notification_manager.unsubscribe_all = legacy_unsubscribe
+        iface._notification_manager = notification_manager
+
+        with patch.object(
+            coordinator,
+            "_detach_client_for_shutdown",
+            return_value=(MagicMock(spec=BLEClient), False),
+        ):
+            coordinator._shutdown_client(
+                management_wait_timed_out=False,
+                unsubscribe_timeout=5.0,
+            )
+
+        assert len(called_with) == 1
+        # The call should be unsubscribe_all(client) without timeout
+        assert len(called_with[0]) == 1
+
+    def test_unsubscribe_all_unrelated_typeerror_propagates(self):
+        """Unrelated TypeError from unsubscribe_all should propagate through safe-cleanup."""
+        iface = MagicMock()
+        iface.client = None
+        iface._management_inflight = 0
+        iface._management_target_gate.return_value.__enter__ = MagicMock(
+            return_value=MagicMock()
+        )
+        iface._management_target_gate.return_value.__exit__ = MagicMock(
+            return_value=None
+        )
+
+        coordinator = BLEShutdownLifecycleCoordinator(iface)
+
+        def bad_unsubscribe(client: Any, timeout: float | None = None) -> None:
+            raise TypeError("unexpected type problem")
+
+        notification_manager = MagicMock()
+        notification_manager._unsubscribe_all = None
+        notification_manager.unsubscribe_all = bad_unsubscribe
+        iface._notification_manager = notification_manager
+
+        with patch.object(
+            coordinator,
+            "_detach_client_for_shutdown",
+            return_value=(MagicMock(spec=BLEClient), False),
+        ):
+            # The error should propagate through safe-cleanup, which suppresses
+            # it by default. We verify it does not hang or mask as a kwargs error.
+            coordinator._shutdown_client(
+                management_wait_timed_out=False,
+                unsubscribe_timeout=5.0,
+            )
+
+
+class TestBoundedThreadTOCTOU:
+    """Test bounded cleanup thread TOCTOU race fixes."""
+
+    def test_concurrent_cleanup_cannot_spawn_duplicate_threads(self):
+        """Two concurrent close calls must not both start cleanup threads."""
+        iface = MagicMock()
+        iface._closed = True
+        iface._management_inflight = 0
+        iface._management_idle_condition.wait.return_value = True
+
+        blocker = threading.Event()
+
+        # Use a real function so _is_unconfigured_mock_callable does not skip it.
+        def slow_cleanup() -> None:
+            blocker.wait()
+
+        iface.thread_coordinator.cleanup = slow_cleanup
+
+        coordinator = BLEShutdownLifecycleCoordinator(iface)
+        started_threads: list[threading.Thread] = []
+        original_thread = threading.Thread
+
+        def tracking_thread(*, target: Any, **kwargs: Any) -> threading.Thread:
+            t = original_thread(target=target, **kwargs)
+            started_threads.append(t)
+            return t
+
+        with patch("threading.Thread", side_effect=tracking_thread):
+            # First call should start a thread
+            coordinator._cleanup_thread_coordinator(timeout=1.0)
+            # Second concurrent call should skip because previous is still alive
+            coordinator._cleanup_thread_coordinator(timeout=1.0)
+
+        # Only one thread should have been started (the second may be constructed
+        # but must not be started because the check happens under the same lock).
+        started_count = sum(1 for t in started_threads if t.ident is not None)
+        assert started_count == 1
+        blocker.set()
+
+    def test_start_failure_clears_stored_ref(self):
+        """If thread.start() fails, the stored ref must be cleared under lock."""
+        iface = MagicMock()
+        iface._closed = True
+        iface._management_inflight = 0
+        iface._management_idle_condition.wait.return_value = True
+
+        def real_cleanup() -> None:
+            pass
+
+        iface.thread_coordinator.cleanup = real_cleanup
+
+        coordinator = BLEShutdownLifecycleCoordinator(iface)
+
+        class FailingThread(threading.Thread):
+            def start(self) -> None:
+                raise RuntimeError("start failed")
+
+        with patch("threading.Thread", side_effect=FailingThread):
+            coordinator._cleanup_thread_coordinator(timeout=1.0)
+
+        # The ref should be cleared
+        assert coordinator._bounded_cleanup_thread is None
+
+    def test_existing_skip_warning_behavior_intact(self):
+        """When a previous bounded thread is alive, warn and skip without starting."""
+        iface = MagicMock()
+        iface._closed = True
+        iface._management_inflight = 0
+        iface._management_idle_condition.wait.return_value = True
+
+        def real_cleanup() -> None:
+            pass
+
+        iface.thread_coordinator.cleanup = real_cleanup
+
+        coordinator = BLEShutdownLifecycleCoordinator(iface)
+
+        # Pretend a previous thread is still alive
+        previous = MagicMock()
+        previous.is_alive.return_value = True
+        coordinator._bounded_cleanup_thread = previous
+
+        coordinator._cleanup_thread_coordinator(timeout=1.0)
+
+        # No new thread should be started; previous.join is NOT called in the new design,
+        # but the warning behavior is preserved (skip + warn).
+        previous.join.assert_not_called()
+
+    def test_mesh_close_start_failure_clears_ref(self):
+        """MeshInterface.close thread start failure clears the stored ref."""
+        iface = MagicMock()
+        iface._closed = True
+        iface._management_inflight = 0
+        iface._management_idle_condition.wait.return_value = True
+
+        coordinator = BLEShutdownLifecycleCoordinator(iface)
+
+        class FailingThread(threading.Thread):
+            def start(self) -> None:
+                raise RuntimeError("start failed")
+
+        with patch("threading.Thread", side_effect=FailingThread):
+            coordinator._close_mesh_interface(timeout=1.0)
+
+        assert coordinator._bounded_mesh_close_thread is None
+
+    def test_mesh_close_skip_when_previous_alive(self):
+        """MeshInterface.close should skip when a previous bounded thread is alive."""
+        iface = MagicMock()
+        iface._closed = True
+        iface._management_inflight = 0
+        iface._management_idle_condition.wait.return_value = True
+
+        coordinator = BLEShutdownLifecycleCoordinator(iface)
+
+        previous = MagicMock()
+        previous.is_alive.return_value = True
+        coordinator._bounded_mesh_close_thread = previous
+
+        coordinator._close_mesh_interface(timeout=1.0)
+
+        previous.join.assert_not_called()

--- a/meshtastic/tests/test_ble_shutdown_runtime.py
+++ b/meshtastic/tests/test_ble_shutdown_runtime.py
@@ -7,7 +7,6 @@ and shutdown client teardown paths.
 from __future__ import annotations
 
 import threading
-import time
 from typing import Any
 from unittest.mock import MagicMock, patch
 

--- a/meshtastic/tests/test_ble_shutdown_runtime.py
+++ b/meshtastic/tests/test_ble_shutdown_runtime.py
@@ -39,8 +39,8 @@ class _ImmediateThread:
 class TestShutdownClientUnsubscribeFallback:
     """Test legacy unsubscribe_all fallback in _shutdown_client."""
 
-    def test_legacy_unsubscribe_all_without_timeout_is_called(self):
-        """When unsubscribe_all does not accept timeout, retry without it."""
+    def test_legacy_unsubscribe_all_with_finite_timeout_is_skipped(self):
+        """When timeout is finite, do not retry legacy unsubscribe inline."""
         iface = MagicMock()
         iface.client = None
         iface._management_inflight = 0
@@ -71,10 +71,48 @@ class TestShutdownClientUnsubscribeFallback:
             coordinator._shutdown_client(
                 management_wait_timed_out=False,
                 unsubscribe_timeout=5.0,
+                bounded_close_timeout_active=True,
+            )
+
+        assert called_with == []
+
+    def test_legacy_unsubscribe_all_without_timeout_is_called(self):
+        """When no timeout is active, retry legacy unsubscribe without it."""
+        iface = MagicMock()
+        iface.client = None
+        iface._management_inflight = 0
+        iface._management_target_gate.return_value.__enter__ = MagicMock(
+            return_value=MagicMock()
+        )
+        iface._management_target_gate.return_value.__exit__ = MagicMock(
+            return_value=None
+        )
+
+        coordinator = BLEShutdownLifecycleCoordinator(iface)
+
+        called_with: list[tuple[Any, ...]] = []
+
+        def legacy_unsubscribe(client: Any) -> None:
+            called_with.append((client,))
+
+        notification_manager = MagicMock()
+        notification_manager._unsubscribe_all = None
+        notification_manager.unsubscribe_all = legacy_unsubscribe
+        iface._notification_manager = notification_manager
+
+        with patch.object(
+            coordinator,
+            "_detach_client_for_shutdown",
+            return_value=(MagicMock(spec=BLEClient), False),
+        ):
+            coordinator._shutdown_client(
+                management_wait_timed_out=False,
+                unsubscribe_timeout=None,
+                client_disconnect_timeout=None,
+                disconnect_notification_wait_timeout=None,
             )
 
         assert len(called_with) == 1
-        # The call should be unsubscribe_all(client) without timeout
         assert len(called_with[0]) == 1
 
     def test_unsubscribe_all_unrelated_typeerror_propagates(self):
@@ -104,12 +142,12 @@ class TestShutdownClientUnsubscribeFallback:
             "_detach_client_for_shutdown",
             return_value=(MagicMock(spec=BLEClient), False),
         ):
-            # The error should propagate through safe-cleanup, which suppresses
-            # it by default. We verify it does not hang or mask as a kwargs error.
-            coordinator._shutdown_client(
-                management_wait_timed_out=False,
-                unsubscribe_timeout=5.0,
-            )
+            with pytest.raises(TypeError, match="unexpected type problem"):
+                coordinator._shutdown_client(
+                    management_wait_timed_out=False,
+                    unsubscribe_timeout=5.0,
+                    bounded_close_timeout_active=True,
+                )
 
 
 class TestBoundedThreadTOCTOU:

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -638,7 +638,7 @@ def test_close_suppresses_disconnect_send_failures(
     disconnect_error: BaseException,
 ) -> None:
     """close() should continue cleanup if sending disconnect fails."""
-    iface = MeshInterface(noProto=True)
+    iface = MeshInterface(noProto=False)
     try:
         iface.debugOut = io.StringIO()
         with (
@@ -663,7 +663,7 @@ def test_close_raises_disconnect_type_error_when_not_finalizing(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """close() should surface TypeError disconnect failures during normal runtime."""
-    iface = MeshInterface(noProto=True)
+    iface = MeshInterface(noProto=False)
     try:
         iface.debugOut = io.StringIO()
         with (
@@ -688,7 +688,7 @@ def test_close_suppresses_disconnect_type_error_during_finalization(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """close() should swallow TypeError disconnect failures during finalization."""
-    iface = MeshInterface(noProto=True)
+    iface = MeshInterface(noProto=False)
     try:
         iface.debugOut = io.StringIO()
         with (

--- a/meshtastic/tests/test_send_pipeline.py
+++ b/meshtastic/tests/test_send_pipeline.py
@@ -1090,7 +1090,9 @@ class TestWaitForConfig:
         """Test successful wait for config including dedicated lora wait."""
         mock_interface._timeout.waitForSet.return_value = True
         mock_interface.localNode.waitForConfig.return_value = True
-        mock_interface.localNode._channel_request_runtime._timeout_for_field.return_value = True
+        mock_interface.localNode._channel_request_runtime._timeout_for_field.return_value = (
+            True
+        )
 
         send_pipeline.waitForConfig()
 
@@ -1116,7 +1118,9 @@ class TestWaitForConfig:
         """Test failure path when the lora wait returns false and raises timeout error."""
         mock_interface._timeout.waitForSet.return_value = True
         mock_interface.localNode.waitForConfig.return_value = True
-        mock_interface.localNode._channel_request_runtime._timeout_for_field.return_value = False
+        mock_interface.localNode._channel_request_runtime._timeout_for_field.return_value = (
+            False
+        )
 
         with pytest.raises(
             mock_interface.MeshInterfaceError,

--- a/meshtastic/tests/test_util.py
+++ b/meshtastic/tests/test_util.py
@@ -692,9 +692,9 @@ def test_messageToJson_shows_all() -> None:
         "nodedbCount": 0,
     }
     for key, value in expected.items():
-        assert actual.get(key) == value, (
-            f"Key {key}: expected {value}, got {actual.get(key)}"
-        )
+        assert (
+            actual.get(key) == value
+        ), f"Key {key}: expected {value}, got {actual.get(key)}"
     # firmwareEdition presence only — value depends on proto enum default name
     assert "firmwareEdition" in actual
 
@@ -1005,15 +1005,15 @@ def test_tdeck_vid_pid_mapping() -> None:
         for d in supported_devices
         if d.usb_vendor_id_in_hex == "303a" and d.usb_product_id_in_hex == "1001"
     ]
-    assert len(tdeck_devices) == 1, (
-        "Expected exactly one T-Deck device with VID 303a and PID 1001"
-    )
-    assert tdeck_devices[0].name == "T-Deck", (
-        f"Expected device name 'T-Deck', got '{tdeck_devices[0].name}'"
-    )
-    assert tdeck_devices[0].for_firmware == "t-deck", (
-        f"Expected for_firmware 't-deck', got '{tdeck_devices[0].for_firmware}'"
-    )
+    assert (
+        len(tdeck_devices) == 1
+    ), "Expected exactly one T-Deck device with VID 303a and PID 1001"
+    assert (
+        tdeck_devices[0].name == "T-Deck"
+    ), f"Expected device name 'T-Deck', got '{tdeck_devices[0].name}'"
+    assert (
+        tdeck_devices[0].for_firmware == "t-deck"
+    ), f"Expected for_firmware 't-deck', got '{tdeck_devices[0].for_firmware}'"
 
 
 @pytest.mark.unit

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared pytest fixtures for BLE tests."""
 
+import atexit as _atexit
 import logging
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any
@@ -60,12 +61,24 @@ def _stop_ble_runner_at_session_end() -> Iterator[None]:
         return
 
     try:
+        from meshtastic.interfaces.ble import runner as _runner_module
+    except ImportError:
+        return
+
+    try:
         runner = BLECoroutineRunner()
         stop_runner = getattr(runner, "_stop", None)
         if callable(stop_runner):
             stop_runner(timeout=2.0)
+        handler = getattr(runner, "_atexit_handler", None)
+        if callable(handler):
+            _atexit.unregister(handler)
+        runner._atexit_registered = False
     except Exception as exc:  # noqa: BLE001 - teardown must not raise
         logger.debug(
             "Failed to stop BLECoroutineRunner during test cleanup: %s",
             exc,
         )
+
+    with _runner_module._zombie_lock:
+        _runner_module._zombie_runner_count = 0

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -917,8 +917,12 @@ def test_orchestrator_attempt_stale_cleanup_forwards_disconnect_timeout(
     with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
         cleanup_client = DummyClient()
         observed_timeout: list[float | None] = []
+        connect_calls: list[tuple[object, float | None]] = []
         orchestrator._client_manager_create_client = (
             lambda *_args, **_kwargs: cleanup_client
+        )
+        orchestrator._client_manager_connect_client = (
+            lambda client, timeout=None: connect_calls.append((client, timeout))
         )
         orchestrator._client_manager_safe_close_client = (
             lambda _client, disconnect_timeout=None: observed_timeout.append(
@@ -931,7 +935,62 @@ def test_orchestrator_attempt_stale_cleanup_forwards_disconnect_timeout(
             on_disconnect_func=lambda _client: None,
             connect_timeout=2.0,
         )
+        assert connect_calls == [(cleanup_client, 2.0)]
+        assert cleanup_client.disconnect_calls == 1
         assert observed_timeout == [min(2.0, connection_mod.DISCONNECT_TIMEOUT_SECONDS)]
+
+
+def test_orchestrator_attempt_stale_cleanup_connect_failure_is_best_effort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stale-cleanup connect failure should return False and still safe-close."""
+    with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
+        cleanup_client = DummyClient()
+        closed_clients: list[object] = []
+        orchestrator._client_manager_create_client = (
+            lambda *_args, **_kwargs: cleanup_client
+        )
+
+        def _fail_connect(_client: object, *, timeout: float | None = None) -> None:
+            del timeout
+            raise TimeoutError("cleanup connect timed out")
+
+        orchestrator._client_manager_connect_client = _fail_connect
+        orchestrator._client_manager_safe_close_client = (
+            lambda client, disconnect_timeout=None: closed_clients.append(client)
+        )
+
+        assert not orchestrator._attempt_stale_bluez_cleanup(
+            target_address=TEST_BLE_ADDRESS,
+            on_disconnect_func=lambda _client: None,
+            connect_timeout=2.0,
+        )
+        assert cleanup_client.disconnect_calls == 0
+        assert closed_clients == [cleanup_client]
+
+
+def test_orchestrator_attempt_stale_cleanup_safe_close_runs_after_disconnect_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stale-cleanup safe close should run even when disconnect fails."""
+    with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
+        cleanup_client = DummyClient(disconnect_exception=BleakError("disconnect failed"))
+        closed_clients: list[object] = []
+        orchestrator._client_manager_create_client = (
+            lambda *_args, **_kwargs: cleanup_client
+        )
+        orchestrator._client_manager_connect_client = lambda *_args, **_kwargs: None
+        orchestrator._client_manager_safe_close_client = (
+            lambda client, disconnect_timeout=None: closed_clients.append(client)
+        )
+
+        assert not orchestrator._attempt_stale_bluez_cleanup(
+            target_address=TEST_BLE_ADDRESS,
+            on_disconnect_func=lambda _client: None,
+            connect_timeout=2.0,
+        )
+        assert cleanup_client.disconnect_calls == 1
+        assert closed_clients == [cleanup_client]
 
 
 def test_orchestrator_stale_bluez_error_classifier_prefers_specific_tokens(
@@ -957,6 +1016,35 @@ def test_orchestrator_stale_bluez_error_classifier_prefers_specific_tokens(
         assert not orchestrator._is_stale_bluez_direct_connect_error(
             RuntimeError("operation in progress without BlueZ context")
         )
+
+
+def test_orchestrator_stale_bluez_error_classifier_walks_wrapped_causes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stale BlueZ classifier should inspect nested cause/context chains."""
+    with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
+        stale = BleakDBusError(
+            "org.bluez.Error.AlreadyConnected",
+            ["Already connected"],
+        )
+        mid = RuntimeError("wrapper")
+        mid.__cause__ = stale
+        outer = RuntimeError("outer")
+        outer.__context__ = mid
+
+        assert orchestrator._is_stale_bluez_direct_connect_error(outer)
+
+
+def test_orchestrator_stale_bluez_error_classifier_rejects_non_stale_wrappers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Wrapped non-BlueZ errors should not be classified as stale BlueZ state."""
+    with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
+        inner = RuntimeError("adapter busy")
+        outer = RuntimeError("operation in progress without BlueZ context")
+        outer.__cause__ = inner
+
+        assert not orchestrator._is_stale_bluez_direct_connect_error(outer)
 
 
 def test_orchestrator_attempt_direct_connect_rejects_explicit_address_mismatch(

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -821,14 +821,19 @@ def test_orchestrator_attempt_direct_connect_maps_dbus_error_to_typed_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Direct-connect DBus failures should normalize to BLEDBusTransportError."""
-    with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
+    with _make_orchestrator(monkeypatch) as (iface, orchestrator):
         direct_client = DummyClient()
         orchestrator._client_manager_create_client = (
             lambda *_args, **_kwargs: direct_client
         )
         orchestrator._client_manager_connect_client = lambda *_args, **_kwargs: (
             _ for _ in ()
-        ).throw(BleakDBusError("dbus", "busy"))
+        ).throw(
+            BleakDBusError(
+                "org.bluez.Error.InProgress",
+                ["Device busy"],
+            )
+        )
         orchestrator._should_attempt_stale_bluez_cleanup = (
             lambda **_kwargs: False
         )
@@ -847,6 +852,11 @@ def test_orchestrator_attempt_direct_connect_maps_dbus_error_to_typed_error(
                 emit_connected_side_effects=True,
             )
         assert exc_info.value.requested_identifier == TEST_BLE_ADDRESS
+        assert exc_info.value.dbus_error == "org.bluez.Error.InProgress"
+        assert exc_info.value.dbus_error_details == "Device busy"
+        assert exc_info.value.dbus_error_body == ("Device busy",)
+        assert isinstance(exc_info.value.cause, BleakDBusError)
+        assert isinstance(exc_info.value, iface.BLEError)
 
 
 def test_orchestrator_attempt_direct_connect_uses_stale_cleanup_retry(
@@ -866,11 +876,22 @@ def test_orchestrator_attempt_direct_connect_uses_stale_cleanup_retry(
         orchestrator._client_manager_safe_close_client = (
             lambda client: closed_clients.append(client)
         )
+        cleanup_attempts = 0
+        retry_attempts = 0
         orchestrator._should_attempt_stale_bluez_cleanup = lambda **_kwargs: True
-        orchestrator._attempt_stale_bluez_cleanup = lambda **_kwargs: True
-        orchestrator._retry_direct_connect_after_cleanup = (
-            lambda **_kwargs: retried_client
-        )
+
+        def _cleanup_once(**_kwargs: object) -> bool:
+            nonlocal cleanup_attempts
+            cleanup_attempts += 1
+            return True
+
+        def _retry_once(**_kwargs: object) -> DummyClient:
+            nonlocal retry_attempts
+            retry_attempts += 1
+            return retried_client
+
+        orchestrator._attempt_stale_bluez_cleanup = _cleanup_once
+        orchestrator._retry_direct_connect_after_cleanup = _retry_once
 
         connected_client, skip_discovery_scan = orchestrator._attempt_direct_connect(
             target_address=TEST_BLE_ADDRESS,
@@ -887,13 +908,66 @@ def test_orchestrator_attempt_direct_connect_uses_stale_cleanup_retry(
         assert connected_client is retried_client
         assert skip_discovery_scan is False
         assert closed_clients == [direct_client]
+        assert cleanup_attempts == 1
+        assert retry_attempts == 1
+
+
+def test_orchestrator_attempt_stale_cleanup_forwards_disconnect_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stale-cleanup client close should reuse the cleanup disconnect timeout budget."""
+    with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
+        cleanup_client = DummyClient()
+        observed_timeout: list[float | None] = []
+        orchestrator._client_manager_create_client = (
+            lambda *_args, **_kwargs: cleanup_client
+        )
+        orchestrator._client_manager_safe_close_client = (
+            lambda _client, disconnect_timeout=None: observed_timeout.append(
+                disconnect_timeout
+            )
+        )
+
+        assert orchestrator._attempt_stale_bluez_cleanup(
+            target_address=TEST_BLE_ADDRESS,
+            on_disconnect_func=lambda _client: None,
+            connect_timeout=2.0,
+        )
+        assert observed_timeout == [
+            min(2.0, connection_mod.DISCONNECT_TIMEOUT_SECONDS)
+        ]
+
+
+def test_orchestrator_stale_bluez_error_classifier_prefers_specific_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stale BlueZ classifier should key off BlueZ-specific names/details, not generic busy wording."""
+    with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
+        assert orchestrator._is_stale_bluez_direct_connect_error(
+            BleakDBusError(
+                "org.bluez.Error.AlreadyConnected",
+                ["Already connected"],
+            )
+        )
+        assert orchestrator._is_stale_bluez_direct_connect_error(
+            BleakDBusError(
+                "org.bluez.Error.InProgress",
+                ["Operation already in progress"],
+            )
+        )
+        assert not orchestrator._is_stale_bluez_direct_connect_error(
+            RuntimeError("adapter busy waiting for unrelated operation")
+        )
+        assert not orchestrator._is_stale_bluez_direct_connect_error(
+            RuntimeError("operation in progress without BlueZ context")
+        )
 
 
 def test_orchestrator_attempt_direct_connect_rejects_explicit_address_mismatch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Explicit-address direct connect should fail when connected peer mismatches."""
-    with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
+    with _make_orchestrator(monkeypatch) as (iface, orchestrator):
         mismatch_client = DummyClient()
         mismatch_client.address = "11:22:33:44:55:66"
         mismatch_client.bleak_client = SimpleNamespace(address="11:22:33:44:55:66")
@@ -921,6 +995,7 @@ def test_orchestrator_attempt_direct_connect_rejects_explicit_address_mismatch(
             )
         assert exc_info.value.requested_identifier == TEST_BLE_ADDRESS
         assert exc_info.value.connected_address == "11:22:33:44:55:66"
+        assert isinstance(exc_info.value, iface.BLEError)
         assert closed_clients == [mismatch_client]
         orchestrator._finalize_connection.assert_not_called()
 
@@ -945,7 +1020,7 @@ def test_orchestrator_retry_target_timeout_and_discovery_typing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Retry connect timeouts and discovery misses should map to typed BLE errors."""
-    with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
+    with _make_orchestrator(monkeypatch) as (iface, orchestrator):
         retry_client = DummyClient()
         orchestrator._client_manager_create_client = (
             lambda *_args, **_kwargs: retry_client
@@ -967,6 +1042,8 @@ def test_orchestrator_retry_target_timeout_and_discovery_typing(
             )
         assert timeout_exc.value.requested_identifier == TEST_BLE_ADDRESS
         assert timeout_exc.value.timeout == 2.5
+        assert isinstance(timeout_exc.value, TimeoutError)
+        assert isinstance(timeout_exc.value, iface.BLEError)
 
         orchestrator._compat_find_device = lambda _target: (_ for _ in ()).throw(
             BleakDeviceNotFoundError("missing")
@@ -978,6 +1055,45 @@ def test_orchestrator_retry_target_timeout_and_discovery_typing(
                 direct_connect_timeout=1.0,
                 discovery_connect_timeout=3.0,
             )
+
+
+def test_establish_connection_preserves_typed_timeout_without_rewrapping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_establish_connection should not wrap BLEConnectionTimeoutError a second time."""
+    with _make_orchestrator(monkeypatch) as (iface, orchestrator):
+        timeout_error = BLEConnectionTimeoutError(
+            "timed out",
+            requested_identifier=TEST_BLE_ADDRESS,
+            timeout=1.5,
+        )
+        orchestrator._validator_validate_connection_request = lambda: None
+        orchestrator._raise_if_interface_closing = lambda: None
+        orchestrator._prepare_connection_target = lambda **_kwargs: (
+            TEST_BLE_ADDRESS,
+            "aabbccddeeff",
+            True,
+        )
+        orchestrator._resolve_connection_timeouts = lambda **_kwargs: (1.5, 1.5)
+        orchestrator._state_transition_to = lambda _state: True
+        orchestrator._attempt_direct_connect = lambda **_kwargs: (_ for _ in ()).throw(
+            timeout_error
+        )
+        orchestrator._transition_failure_to_disconnected = lambda _ctx: None
+        orchestrator._client_manager_safe_close_client = lambda *_args, **_kwargs: None
+
+        with pytest.raises(BLEConnectionTimeoutError) as exc_info:
+            orchestrator._establish_connection(
+                address=TEST_BLE_ADDRESS,
+                current_address=None,
+                register_notifications_func=lambda _client: None,
+                on_connected_func=lambda: None,
+                on_disconnect_func=lambda _client: None,
+            )
+
+        assert exc_info.value is timeout_error
+        assert isinstance(exc_info.value, TimeoutError)
+        assert isinstance(exc_info.value, iface.BLEError)
 
 
 def test_orchestrator_finalize_and_establish_remaining_branches(

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -834,9 +834,7 @@ def test_orchestrator_attempt_direct_connect_maps_dbus_error_to_typed_error(
                 ["Device busy"],
             )
         )
-        orchestrator._should_attempt_stale_bluez_cleanup = (
-            lambda **_kwargs: False
-        )
+        orchestrator._should_attempt_stale_bluez_cleanup = lambda **_kwargs: False
         orchestrator._client_manager_safe_close_client = lambda *_args, **_kwargs: None
 
         with pytest.raises(BLEDBusTransportError) as exc_info:
@@ -933,9 +931,7 @@ def test_orchestrator_attempt_stale_cleanup_forwards_disconnect_timeout(
             on_disconnect_func=lambda _client: None,
             connect_timeout=2.0,
         )
-        assert observed_timeout == [
-            min(2.0, connection_mod.DISCONNECT_TIMEOUT_SECONDS)
-        ]
+        assert observed_timeout == [min(2.0, connection_mod.DISCONNECT_TIMEOUT_SECONDS)]
 
 
 def test_orchestrator_stale_bluez_error_classifier_prefers_specific_tokens(

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -21,7 +21,13 @@ from meshtastic.interfaces.ble.connection import (
     ConnectionValidator,
 )
 from meshtastic.interfaces.ble.discovery import DiscoveryClientError, DiscoveryManager
-from meshtastic.interfaces.ble.errors import BLEErrorHandler
+from meshtastic.interfaces.ble.errors import (
+    BLEAddressMismatchError,
+    BLEConnectionTimeoutError,
+    BLEDBusTransportError,
+    BLEDeviceNotFoundError,
+    BLEErrorHandler,
+)
 from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
 from tests.test_ble_interface_fixtures import DummyClient, _build_interface
 
@@ -329,6 +335,8 @@ def test_connection_orchestrator_direct_and_retry_exception_paths(
             pass
 
         created_client = _SimpleClient()
+        created_client.address = TEST_BLE_ADDRESS
+        created_client.bleak_client = SimpleNamespace(address=TEST_BLE_ADDRESS)
         orchestrator._client_manager_create_client = (
             lambda *_args, **_kwargs: created_client
         )
@@ -807,6 +815,169 @@ def test_orchestrator_create_connect_direct_retry_remaining_branches(
                 retry_connect_timeout=1.0,
             )
         assert closed_clients == [first_retry_client]
+
+
+def test_orchestrator_attempt_direct_connect_maps_dbus_error_to_typed_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct-connect DBus failures should normalize to BLEDBusTransportError."""
+    with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
+        direct_client = DummyClient()
+        orchestrator._client_manager_create_client = (
+            lambda *_args, **_kwargs: direct_client
+        )
+        orchestrator._client_manager_connect_client = lambda *_args, **_kwargs: (
+            _ for _ in ()
+        ).throw(BleakDBusError("dbus", "busy"))
+        orchestrator._should_attempt_stale_bluez_cleanup = (
+            lambda **_kwargs: False
+        )
+        orchestrator._client_manager_safe_close_client = lambda *_args, **_kwargs: None
+
+        with pytest.raises(BLEDBusTransportError) as exc_info:
+            orchestrator._attempt_direct_connect(
+                target_address=TEST_BLE_ADDRESS,
+                explicit_address=True,
+                normalized_target="aabbccddeeff",
+                on_disconnect_func=lambda _client: None,
+                pair_on_connect=False,
+                direct_connect_timeout=1.0,
+                register_notifications_func=lambda _client: None,
+                on_connected_func=lambda: None,
+                emit_connected_side_effects=True,
+            )
+        assert exc_info.value.requested_identifier == TEST_BLE_ADDRESS
+
+
+def test_orchestrator_attempt_direct_connect_uses_stale_cleanup_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct-connect failure should retry once after stale BlueZ cleanup."""
+    with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
+        direct_client = DummyClient()
+        retried_client = DummyClient()
+        closed_clients: list[object] = []
+        orchestrator._client_manager_create_client = (
+            lambda *_args, **_kwargs: direct_client
+        )
+        orchestrator._client_manager_connect_client = lambda *_args, **_kwargs: (
+            _ for _ in ()
+        ).throw(BleakDBusError("dbus", "busy"))
+        orchestrator._client_manager_safe_close_client = (
+            lambda client: closed_clients.append(client)
+        )
+        orchestrator._should_attempt_stale_bluez_cleanup = lambda **_kwargs: True
+        orchestrator._attempt_stale_bluez_cleanup = lambda **_kwargs: True
+        orchestrator._retry_direct_connect_after_cleanup = (
+            lambda **_kwargs: retried_client
+        )
+
+        connected_client, skip_discovery_scan = orchestrator._attempt_direct_connect(
+            target_address=TEST_BLE_ADDRESS,
+            explicit_address=True,
+            normalized_target="aabbccddeeff",
+            on_disconnect_func=lambda _client: None,
+            pair_on_connect=False,
+            direct_connect_timeout=1.0,
+            register_notifications_func=lambda _client: None,
+            on_connected_func=lambda: None,
+            emit_connected_side_effects=True,
+        )
+
+        assert connected_client is retried_client
+        assert skip_discovery_scan is False
+        assert closed_clients == [direct_client]
+
+
+def test_orchestrator_attempt_direct_connect_rejects_explicit_address_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit-address direct connect should fail when connected peer mismatches."""
+    with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
+        mismatch_client = DummyClient()
+        mismatch_client.address = "11:22:33:44:55:66"
+        mismatch_client.bleak_client = SimpleNamespace(address="11:22:33:44:55:66")
+        closed_clients: list[object] = []
+        orchestrator._client_manager_create_client = (
+            lambda *_args, **_kwargs: mismatch_client
+        )
+        orchestrator._client_manager_connect_client = lambda *_args, **_kwargs: None
+        orchestrator._client_manager_safe_close_client = (
+            lambda client: closed_clients.append(client)
+        )
+        orchestrator._finalize_connection = MagicMock()
+
+        with pytest.raises(BLEAddressMismatchError) as exc_info:
+            orchestrator._attempt_direct_connect(
+                target_address=TEST_BLE_ADDRESS,
+                explicit_address=True,
+                normalized_target="aabbccddeeff",
+                on_disconnect_func=lambda _client: None,
+                pair_on_connect=False,
+                direct_connect_timeout=1.0,
+                register_notifications_func=lambda _client: None,
+                on_connected_func=lambda: None,
+                emit_connected_side_effects=True,
+            )
+        assert exc_info.value.requested_identifier == TEST_BLE_ADDRESS
+        assert exc_info.value.connected_address == "11:22:33:44:55:66"
+        assert closed_clients == [mismatch_client]
+        orchestrator._finalize_connection.assert_not_called()
+
+
+def test_orchestrator_validate_explicit_address_allows_unknown_connected_address(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit-address verification remains permissive when address is unavailable."""
+    with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
+        unknown_client = DummyClient()
+        unknown_client.address = None
+        unknown_client.bleak_client = SimpleNamespace(address=None)
+
+        orchestrator._validate_explicit_address_connection(
+            client=cast(BLEClient, unknown_client),
+            target_address=TEST_BLE_ADDRESS,
+            explicit_address=True,
+        )
+
+
+def test_orchestrator_retry_target_timeout_and_discovery_typing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Retry connect timeouts and discovery misses should map to typed BLE errors."""
+    with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
+        retry_client = DummyClient()
+        orchestrator._client_manager_create_client = (
+            lambda *_args, **_kwargs: retry_client
+        )
+        orchestrator._client_manager_connect_client = lambda *_args, **_kwargs: (
+            _ for _ in ()
+        ).throw(TimeoutError("timed out"))
+        orchestrator._client_manager_safe_close_client = lambda *_args, **_kwargs: None
+
+        with pytest.raises(BLEConnectionTimeoutError) as timeout_exc:
+            orchestrator._connect_retry_target(
+                connection_target=TEST_BLE_ADDRESS,
+                resolved_address=TEST_BLE_ADDRESS,
+                target_address=TEST_BLE_ADDRESS,
+                skip_discovery_scan=True,
+                on_disconnect_func=lambda _client: None,
+                pair_on_connect=False,
+                retry_connect_timeout=2.5,
+            )
+        assert timeout_exc.value.requested_identifier == TEST_BLE_ADDRESS
+        assert timeout_exc.value.timeout == 2.5
+
+        orchestrator._compat_find_device = lambda _target: (_ for _ in ()).throw(
+            BleakDeviceNotFoundError("missing")
+        )
+        with pytest.raises(BLEDeviceNotFoundError):
+            orchestrator._resolve_retry_target(
+                target_address="name-only",
+                skip_discovery_scan=False,
+                direct_connect_timeout=1.0,
+                discovery_connect_timeout=3.0,
+            )
 
 
 def test_orchestrator_finalize_and_establish_remaining_branches(

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -974,7 +974,9 @@ def test_orchestrator_attempt_stale_cleanup_safe_close_runs_after_disconnect_fai
 ) -> None:
     """Stale-cleanup safe close should run even when disconnect fails."""
     with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
-        cleanup_client = DummyClient(disconnect_exception=BleakError("disconnect failed"))
+        cleanup_client = DummyClient(
+            disconnect_exception=BleakError("disconnect failed")
+        )
         closed_clients: list[object] = []
         orchestrator._client_manager_create_client = (
             lambda *_args, **_kwargs: cleanup_client

--- a/tests/test_ble_connection_edge_cases.py
+++ b/tests/test_ble_connection_edge_cases.py
@@ -2105,7 +2105,7 @@ def test_stale_cleanup_retry_propagates_address_mismatch(
         del kwargs
         raise mismatch
 
-    orchestrator._validate_explicit_address_connection = _raise_mismatch
+    orchestrator._validate_explicit_address_connection = _raise_mismatch  # type: ignore[method-assign]
 
     with pytest.raises(BLEAddressMismatchError):
         orchestrator._establish_connection(

--- a/tests/test_ble_connection_edge_cases.py
+++ b/tests/test_ble_connection_edge_cases.py
@@ -2025,9 +2025,9 @@ def test_retry_direct_connect_skips_cleanup_on_successful_return() -> None:
     )
 
     # Stub all downstream steps so the retry path succeeds
-    orchestrator._raise_if_interface_closing = lambda: None
-    orchestrator._validate_explicit_address_connection = lambda **kwargs: None
-    orchestrator._finalize_connection = lambda *args, **kwargs: None
+    orchestrator._raise_if_interface_closing = lambda: None  # type: ignore[method-assign]
+    orchestrator._validate_explicit_address_connection = lambda **kwargs: None  # type: ignore[method-assign]
+    orchestrator._finalize_connection = lambda *args, **kwargs: None  # type: ignore[method-assign]
 
     result = orchestrator._retry_direct_connect_after_cleanup(
         target_address="AA:BB:CC:DD:EE:FF",

--- a/tests/test_ble_connection_edge_cases.py
+++ b/tests/test_ble_connection_edge_cases.py
@@ -2101,9 +2101,11 @@ def test_stale_cleanup_retry_propagates_address_mismatch(
         connected_address="11:22:33:44:55:66",
         address="AA:BB:CC:DD:EE:FF",
     )
-    orchestrator._validate_explicit_address_connection = (
-        lambda **kwargs: (_ for _ in ()).throw(mismatch)
-    )
+    def _raise_mismatch(**kwargs: object) -> None:
+        del kwargs
+        raise mismatch
+
+    orchestrator._validate_explicit_address_connection = _raise_mismatch
 
     with pytest.raises(BLEAddressMismatchError):
         orchestrator._establish_connection(

--- a/tests/test_ble_connection_edge_cases.py
+++ b/tests/test_ble_connection_edge_cases.py
@@ -15,7 +15,7 @@ import pytest
 pytest.importorskip("bleak")
 
 from bleak.backends.device import BLEDevice
-from bleak.exc import BleakDBusError, BleakDeviceNotFoundError
+from bleak.exc import BleakDBusError, BleakDeviceNotFoundError, BleakError
 
 from meshtastic.interfaces.ble.connection import (
     ClientManager,
@@ -2042,3 +2042,154 @@ def test_retry_direct_connect_skips_cleanup_on_successful_return() -> None:
 
     assert result is retry_client
     client_manager.safe_close_client.assert_not_called()
+
+
+@pytest.mark.unit
+def test_stale_cleanup_retry_propagates_address_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BLEAddressMismatchError from stale-cleanup retry must propagate immediately."""
+    from meshtastic.interfaces.ble.errors import BLEAddressMismatchError
+
+    state_manager = BLEStateManager()
+    state_lock = RLock()
+    validator = ConnectionValidator(state_manager, state_lock, MockBLEError)
+    client_manager = _make_orchestrator_client_manager()
+    direct_client = MagicMock()
+    retry_client = MagicMock()
+    client_manager.create_client.side_effect = [direct_client, retry_client]
+    client_manager.connect_client.side_effect = [
+        OSError("stale bluez"),
+        None,
+    ]
+
+    interface = MagicMock()
+    interface.BLEError = MockBLEError
+    interface._closed = False
+
+    orchestrator = ConnectionOrchestrator(
+        interface=interface,
+        validator=validator,
+        client_manager=client_manager,
+        discovery_manager=MagicMock(),
+        state_manager=state_manager,
+        state_lock=state_lock,
+        thread_coordinator=MagicMock(),
+    )
+
+    # Force stale BlueZ cleanup path
+    monkeypatch.setattr(
+        orchestrator,
+        "_is_stale_bluez_direct_connect_error",
+        lambda _error: True,
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "_should_attempt_stale_bluez_cleanup",
+        lambda *, target_address, explicit_address, error: True,
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "_attempt_stale_bluez_cleanup",
+        lambda **kwargs: True,
+    )
+
+    # Make the retry raise BLEAddressMismatchError during finalization
+    mismatch = BLEAddressMismatchError(
+        "address mismatch",
+        requested_identifier="AA:BB:CC:DD:EE:FF",
+        connected_address="11:22:33:44:55:66",
+        address="AA:BB:CC:DD:EE:FF",
+    )
+    orchestrator._validate_explicit_address_connection = (
+        lambda **kwargs: (_ for _ in ()).throw(mismatch)
+    )
+
+    with pytest.raises(BLEAddressMismatchError):
+        orchestrator._establish_connection(
+            address="AA:BB:CC:DD:EE:FF",
+            current_address=None,
+            register_notifications_func=lambda _client: None,
+            on_connected_func=lambda: None,
+            on_disconnect_func=lambda _client: None,
+        )
+
+    client_manager.safe_close_client.assert_any_call(
+        direct_client, disconnect_timeout=None
+    )
+    client_manager.safe_close_client.assert_any_call(
+        retry_client, disconnect_timeout=None
+    )
+
+
+@pytest.mark.unit
+def test_stale_cleanup_retry_fallback_on_generic_retry_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Generic retry failures after stale cleanup should follow existing fallback path."""
+    state_manager = BLEStateManager()
+    state_lock = RLock()
+    validator = ConnectionValidator(state_manager, state_lock, MockBLEError)
+    client_manager = _make_orchestrator_client_manager()
+    direct_client = MagicMock()
+    retry_client = MagicMock()
+    fallback_client = MagicMock()
+    client_manager.create_client.side_effect = [
+        direct_client,
+        retry_client,
+        fallback_client,
+    ]
+    client_manager.connect_client.side_effect = [
+        OSError("stale bluez"),
+        BleakError("retry failed"),
+        BleakError("retry failed"),
+    ]
+
+    interface = MagicMock()
+    interface.BLEError = MockBLEError
+    interface._closed = False
+
+    orchestrator = ConnectionOrchestrator(
+        interface=interface,
+        validator=validator,
+        client_manager=client_manager,
+        discovery_manager=MagicMock(),
+        state_manager=state_manager,
+        state_lock=state_lock,
+        thread_coordinator=MagicMock(),
+    )
+
+    monkeypatch.setattr(
+        orchestrator,
+        "_is_stale_bluez_direct_connect_error",
+        lambda _error: True,
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "_should_attempt_stale_bluez_cleanup",
+        lambda *, target_address, explicit_address, error: True,
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "_attempt_stale_bluez_cleanup",
+        lambda **kwargs: True,
+    )
+
+    with pytest.raises(BleakError, match="retry failed"):
+        orchestrator._establish_connection(
+            address="AA:BB:CC:DD:EE:FF",
+            current_address=None,
+            register_notifications_func=lambda _client: None,
+            on_connected_func=lambda: None,
+            on_disconnect_func=lambda _client: None,
+        )
+
+    client_manager.safe_close_client.assert_any_call(
+        direct_client, disconnect_timeout=None
+    )
+    client_manager.safe_close_client.assert_any_call(
+        retry_client, disconnect_timeout=None
+    )
+    client_manager.safe_close_client.assert_any_call(
+        fallback_client, disconnect_timeout=None
+    )

--- a/tests/test_ble_connection_edge_cases.py
+++ b/tests/test_ble_connection_edge_cases.py
@@ -1901,3 +1901,144 @@ def test_reconnect_worker_returns_when_interface_already_connected() -> None:
     worker._attempt_reconnect_loop(Event(), on_exit=on_exit)
 
     on_exit.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_client_manager_safe_close_client_fallback_on_unsupported_await_timeout() -> None:
+    """_safe_close_client should fallback to no-arg disconnect when await_timeout is unsupported."""
+    state_manager = BLEStateManager()
+    lock = RLock()
+    thread_coordinator = MagicMock()
+    error_handler = MagicMock()
+
+    manager = ClientManager(state_manager, lock, thread_coordinator, error_handler)
+
+    mock_client = MagicMock()
+    mock_client._closed = False
+    mock_client.bleak_client = object()
+    mock_client.is_connected.return_value = True
+
+    def _reject_await_timeout(*, await_timeout: float | None = None) -> None:
+        if await_timeout is not None:
+            raise TypeError(
+                "disconnect() got an unexpected keyword argument 'await_timeout'"
+            )
+
+    mock_client.disconnect.side_effect = _reject_await_timeout
+
+    manager._safe_close_client(mock_client)
+
+    assert mock_client.disconnect.call_count == 2
+    mock_client.close.assert_called_once()
+
+
+@pytest.mark.unit
+def test_client_manager_safe_close_client_does_not_fallback_on_unrelated_typeerror() -> None:
+    """_safe_close_client should NOT attempt no-arg disconnect fallback for unrelated TypeError."""
+    state_manager = BLEStateManager()
+    lock = RLock()
+    thread_coordinator = MagicMock()
+    error_handler = MagicMock()
+
+    manager = ClientManager(state_manager, lock, thread_coordinator, error_handler)
+
+    mock_client = MagicMock()
+    mock_client._closed = False
+    mock_client.bleak_client = object()
+    mock_client.is_connected.return_value = True
+
+    def _raise_unrelated(*, await_timeout: float | None = None) -> None:
+        del await_timeout
+        raise TypeError("takes 1 positional argument but 2 were given")
+
+    mock_client.disconnect.side_effect = _raise_unrelated
+
+    # _safe_close_client should swallow the error and still run close()
+    manager._safe_close_client(mock_client)
+
+    assert mock_client.disconnect.call_count == 1
+    mock_client.close.assert_called_once()
+
+
+@pytest.mark.unit
+def test_retry_direct_connect_cleans_up_retry_client_on_interrupt() -> None:
+    """_retry_direct_connect_after_cleanup must close retry_client on KeyboardInterrupt."""
+    state_manager = BLEStateManager()
+    state_lock = RLock()
+    validator = ConnectionValidator(state_manager, state_lock, MockBLEError)
+    client_manager = _make_orchestrator_client_manager()
+    retry_client = MagicMock()
+    client_manager.create_client.return_value = retry_client
+    client_manager.connect_client.side_effect = KeyboardInterrupt("stop")
+
+    interface = MagicMock()
+    interface.BLEError = MockBLEError
+
+    orchestrator = ConnectionOrchestrator(
+        interface=interface,
+        validator=validator,
+        client_manager=client_manager,
+        discovery_manager=MagicMock(),
+        state_manager=state_manager,
+        state_lock=state_lock,
+        thread_coordinator=MagicMock(),
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        orchestrator._retry_direct_connect_after_cleanup(
+            target_address="AA:BB:CC:DD:EE:FF",
+            explicit_address=True,
+            on_disconnect_func=lambda _client: None,
+            pair_on_connect=False,
+            direct_connect_timeout=1.0,
+            register_notifications_func=lambda _client: None,
+            on_connected_func=lambda: None,
+            emit_connected_side_effects=True,
+        )
+
+    client_manager.safe_close_client.assert_called_once_with(
+        retry_client, disconnect_timeout=None
+    )
+
+
+@pytest.mark.unit
+def test_retry_direct_connect_skips_cleanup_on_successful_return() -> None:
+    """_retry_direct_connect_after_cleanup must NOT close retry_client on successful return."""
+    state_manager = BLEStateManager()
+    state_lock = RLock()
+    validator = ConnectionValidator(state_manager, state_lock, MockBLEError)
+    client_manager = _make_orchestrator_client_manager()
+    retry_client = MagicMock()
+    client_manager.create_client.return_value = retry_client
+
+    interface = MagicMock()
+    interface.BLEError = MockBLEError
+
+    orchestrator = ConnectionOrchestrator(
+        interface=interface,
+        validator=validator,
+        client_manager=client_manager,
+        discovery_manager=MagicMock(),
+        state_manager=state_manager,
+        state_lock=state_lock,
+        thread_coordinator=MagicMock(),
+    )
+
+    # Stub all downstream steps so the retry path succeeds
+    orchestrator._raise_if_interface_closing = lambda: None
+    orchestrator._validate_explicit_address_connection = lambda **kwargs: None
+    orchestrator._finalize_connection = lambda *args, **kwargs: None
+
+    result = orchestrator._retry_direct_connect_after_cleanup(
+        target_address="AA:BB:CC:DD:EE:FF",
+        explicit_address=True,
+        on_disconnect_func=lambda _client: None,
+        pair_on_connect=False,
+        direct_connect_timeout=1.0,
+        register_notifications_func=lambda _client: None,
+        on_connected_func=lambda: None,
+        emit_connected_side_effects=True,
+    )
+
+    assert result is retry_client
+    client_manager.safe_close_client.assert_not_called()

--- a/tests/test_ble_connection_edge_cases.py
+++ b/tests/test_ble_connection_edge_cases.py
@@ -1904,7 +1904,9 @@ def test_reconnect_worker_returns_when_interface_already_connected() -> None:
 
 
 @pytest.mark.unit
-def test_client_manager_safe_close_client_fallback_on_unsupported_await_timeout() -> None:
+def test_client_manager_safe_close_client_fallback_on_unsupported_await_timeout() -> (
+    None
+):
     """_safe_close_client should fallback to no-arg disconnect when await_timeout is unsupported."""
     state_manager = BLEStateManager()
     lock = RLock()
@@ -1933,7 +1935,9 @@ def test_client_manager_safe_close_client_fallback_on_unsupported_await_timeout(
 
 
 @pytest.mark.unit
-def test_client_manager_safe_close_client_does_not_fallback_on_unrelated_typeerror() -> None:
+def test_client_manager_safe_close_client_does_not_fallback_on_unrelated_typeerror() -> (
+    None
+):
     """_safe_close_client should NOT attempt no-arg disconnect fallback for unrelated TypeError."""
     state_manager = BLEStateManager()
     lock = RLock()
@@ -2101,6 +2105,7 @@ def test_stale_cleanup_retry_propagates_address_mismatch(
         connected_address="11:22:33:44:55:66",
         address="AA:BB:CC:DD:EE:FF",
     )
+
     def _raise_mismatch(**kwargs: object) -> None:
         del kwargs
         raise mismatch
@@ -2135,15 +2140,12 @@ def test_stale_cleanup_retry_fallback_on_generic_retry_failure(
     client_manager = _make_orchestrator_client_manager()
     direct_client = MagicMock()
     retry_client = MagicMock()
-    fallback_client = MagicMock()
     client_manager.create_client.side_effect = [
         direct_client,
         retry_client,
-        fallback_client,
     ]
     client_manager.connect_client.side_effect = [
         OSError("stale bluez"),
-        BleakError("retry failed"),
         BleakError("retry failed"),
     ]
 
@@ -2191,7 +2193,4 @@ def test_stale_cleanup_retry_fallback_on_generic_retry_failure(
     )
     client_manager.safe_close_client.assert_any_call(
         retry_client, disconnect_timeout=None
-    )
-    client_manager.safe_close_client.assert_any_call(
-        fallback_client, disconnect_timeout=None
     )

--- a/tests/test_ble_connection_edge_cases.py
+++ b/tests/test_ble_connection_edge_cases.py
@@ -593,7 +593,9 @@ def test_connection_orchestrator_interrupt_resets_state_and_closes_client() -> N
         )
 
     assert state_manager._current_state == ConnectionState.DISCONNECTED
-    client_manager.safe_close_client.assert_called_once_with(mock_client)
+    client_manager.safe_close_client.assert_called_once_with(
+        mock_client, disconnect_timeout=None
+    )
 
 
 @pytest.mark.unit
@@ -650,7 +652,9 @@ def test_connection_orchestrator_aborts_fallback_when_interface_closing() -> Non
     interface.findDevice.assert_not_called()
     interface.find_device.assert_not_called()
     interface._find_device.assert_not_called()
-    client_manager.safe_close_client.assert_called_once_with(direct_client)
+    client_manager.safe_close_client.assert_called_once_with(
+        direct_client, disconnect_timeout=None
+    )
     assert state_manager._current_state == ConnectionState.DISCONNECTED
 
 
@@ -916,8 +920,12 @@ def test_connection_orchestrator_reraises_retry_ble_dbus_error(
             on_disconnect_func=lambda _client: None,
         )
 
-    client_manager.safe_close_client.assert_any_call(direct_client)
-    client_manager.safe_close_client.assert_any_call(retry_client)
+    client_manager.safe_close_client.assert_any_call(
+        direct_client, disconnect_timeout=None
+    )
+    client_manager.safe_close_client.assert_any_call(
+        retry_client, disconnect_timeout=None
+    )
 
 
 @pytest.mark.unit

--- a/tests/test_ble_interface_advanced.py
+++ b/tests/test_ble_interface_advanced.py
@@ -972,10 +972,12 @@ def test_rapid_connect_disconnect_stress_test(
             kwargs == {"pair": True, "connect_timeout": 3.5}
             for kwargs in reconnect_kwargs
         )
-        observed_client, attempted_clients, republished_clients = _wait_for_latest_stress_client(
-            iface,
-            baseline_attempts=baseline_attempts,
-            baseline_clients=baseline_client_objects,
+        observed_client, attempted_clients, republished_clients = (
+            _wait_for_latest_stress_client(
+                iface,
+                baseline_attempts=baseline_attempts,
+                baseline_clients=baseline_client_objects,
+            )
         )
         assert len(republished_clients) >= baseline_clients + 1
         latest_successful_attempt = _latest_successful_stress_attempt(
@@ -1043,10 +1045,12 @@ def test_rapid_connect_disconnect_stress_test(
             kwargs == {"pair": False, "connect_timeout": 7.0}
             for kwargs in reconnect_kwargs
         )
-        observed_client2, attempted_clients, republished_clients = _wait_for_latest_stress_client(
-            iface2,
-            baseline_attempts=baseline_attempts,
-            baseline_clients=baseline_client_objects,
+        observed_client2, attempted_clients, republished_clients = (
+            _wait_for_latest_stress_client(
+                iface2,
+                baseline_attempts=baseline_attempts,
+                baseline_clients=baseline_client_objects,
+            )
         )
         assert len(republished_clients) >= baseline_clients + 1
         latest_successful_attempt = _latest_successful_stress_attempt(

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -2575,7 +2575,9 @@ def test_ble_interface_connect_uses_pair_override_for_orchestrator(
 
     monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
     monkeypatch.setattr(iface, "_get_existing_client_if_valid", lambda _req: None)
-    monkeypatch.setattr(iface, "_raise_if_duplicate_connect", lambda _key, **_kwargs: None)
+    monkeypatch.setattr(
+        iface, "_raise_if_duplicate_connect", lambda _key, **_kwargs: None
+    )
     monkeypatch.setattr(iface, "_finalize_connection_gates", lambda *_args: None)
     connected_callbacks: list[bool] = []
     monkeypatch.setattr(iface, "_connected", lambda: connected_callbacks.append(True))
@@ -2628,7 +2630,9 @@ def test_connect_wraps_invalid_connect_timeout_as_ble_error(
 
     monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
     monkeypatch.setattr(iface, "_get_existing_client_if_valid", lambda _req: None)
-    monkeypatch.setattr(iface, "_raise_if_duplicate_connect", lambda _key, **_kwargs: None)
+    monkeypatch.setattr(
+        iface, "_raise_if_duplicate_connect", lambda _key, **_kwargs: None
+    )
 
     with pytest.raises(
         BLEInterface.BLEError,
@@ -2753,7 +2757,9 @@ def test_connect_waits_for_inflight_management_before_establishing(
     )
     monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
     monkeypatch.setattr(iface, "_get_existing_client_if_valid", lambda _req: None)
-    monkeypatch.setattr(iface, "_raise_if_duplicate_connect", lambda _key, **_kwargs: None)
+    monkeypatch.setattr(
+        iface, "_raise_if_duplicate_connect", lambda _key, **_kwargs: None
+    )
     monkeypatch.setattr(iface, "_finalize_connection_gates", lambda *_args: None)
     monkeypatch.setattr(
         iface,
@@ -3131,7 +3137,9 @@ def test_connect_returns_existing_client_after_lock_recheck(
         "_resolve_target_address_for_connect",
         lambda identifier: cast(str, identifier),
     )
-    monkeypatch.setattr(iface, "_raise_if_duplicate_connect", lambda _key, **_kwargs: None)
+    monkeypatch.setattr(
+        iface, "_raise_if_duplicate_connect", lambda _key, **_kwargs: None
+    )
 
     assert iface.connect("AA:BB:CC:DD:EE:10") is existing_client
 
@@ -3148,7 +3156,9 @@ def test_connect_raises_when_establish_returns_no_client(
         "_resolve_target_address_for_connect",
         lambda identifier: cast(str, identifier),
     )
-    monkeypatch.setattr(iface, "_raise_if_duplicate_connect", lambda _key, **_kwargs: None)
+    monkeypatch.setattr(
+        iface, "_raise_if_duplicate_connect", lambda _key, **_kwargs: None
+    )
     monkeypatch.setattr(
         iface,
         "_establish_and_update_client",
@@ -3172,7 +3182,9 @@ def test_connect_does_not_relabel_unrelated_establish_connection_value_error(
 
     monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
     monkeypatch.setattr(iface, "_get_existing_client_if_valid", lambda _req: None)
-    monkeypatch.setattr(iface, "_raise_if_duplicate_connect", lambda _key, **_kwargs: None)
+    monkeypatch.setattr(
+        iface, "_raise_if_duplicate_connect", lambda _key, **_kwargs: None
+    )
 
     with pytest.raises(ValueError, match="boom"):
         iface.connect("AA:BB:CC:DD:EE:10", connect_timeout=4.5)
@@ -3975,7 +3987,10 @@ def test_connect_finalizes_gates_after_address_lock_scope(
         ble_iface_mod, "_addr_lock_context", _fake_addr_lock_context, raising=True
     )
     monkeypatch.setattr(
-        iface, "_raise_if_duplicate_connect", lambda _connection_key, **_kwargs: None, raising=True
+        iface,
+        "_raise_if_duplicate_connect",
+        lambda _connection_key, **_kwargs: None,
+        raising=True,
     )
     monkeypatch.setattr(
         iface, "_get_existing_client_if_valid", lambda _request: None, raising=True
@@ -4033,7 +4048,10 @@ def test_connect_marks_provisional_claims_before_gate_release(
 
     monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
     monkeypatch.setattr(
-        iface, "_raise_if_duplicate_connect", lambda _connection_key, **_kwargs: None, raising=True
+        iface,
+        "_raise_if_duplicate_connect",
+        lambda _connection_key, **_kwargs: None,
+        raising=True,
     )
     monkeypatch.setattr(
         iface, "_get_existing_client_if_valid", lambda _request: None, raising=True
@@ -4110,6 +4128,7 @@ def test_connect_name_target_reserves_requested_and_resolved_keys(
         ),
         raising=True,
     )
+
     def _record_duplicate_check(_key: str | None, **_kwargs: object) -> None:
         if _key is not None:
             duplicate_checks.append(_key)
@@ -4207,7 +4226,10 @@ def test_connect_raises_when_client_becomes_stale_after_gate_finalization(
     monkeypatch.setattr(iface, "_connected", lambda: connected_callbacks.append(True))
     monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
     monkeypatch.setattr(
-        iface, "_raise_if_duplicate_connect", lambda _connection_key, **_kwargs: None, raising=True
+        iface,
+        "_raise_if_duplicate_connect",
+        lambda _connection_key, **_kwargs: None,
+        raising=True,
     )
     monkeypatch.setattr(
         iface, "_get_existing_client_if_valid", lambda _request: None, raising=True
@@ -4295,7 +4317,10 @@ def test_connect_preserves_reclaimed_keys_for_newer_client_after_gate_finalizati
 
     monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
     monkeypatch.setattr(
-        iface, "_raise_if_duplicate_connect", lambda _connection_key, **_kwargs: None, raising=True
+        iface,
+        "_raise_if_duplicate_connect",
+        lambda _connection_key, **_kwargs: None,
+        raising=True,
     )
     monkeypatch.setattr(
         iface, "_get_existing_client_if_valid", lambda _request: None, raising=True
@@ -4383,7 +4408,10 @@ def test_connect_raises_when_registry_ownership_is_lost_after_gate_finalization(
     monkeypatch.setattr(iface, "_connected", lambda: connected_callbacks.append(True))
     monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
     monkeypatch.setattr(
-        iface, "_raise_if_duplicate_connect", lambda _connection_key, **_kwargs: None, raising=True
+        iface,
+        "_raise_if_duplicate_connect",
+        lambda _connection_key, **_kwargs: None,
+        raising=True,
     )
     monkeypatch.setattr(
         iface, "_get_existing_client_if_valid", lambda _request: None, raising=True
@@ -4465,7 +4493,10 @@ def test_connect_restores_requested_identifier_after_name_target_loses_ownership
 
     monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
     monkeypatch.setattr(
-        iface, "_raise_if_duplicate_connect", lambda _connection_key, **_kwargs: None, raising=True
+        iface,
+        "_raise_if_duplicate_connect",
+        lambda _connection_key, **_kwargs: None,
+        raising=True,
     )
     monkeypatch.setattr(
         iface, "_get_existing_client_if_valid", lambda _request: None, raising=True
@@ -4542,7 +4573,10 @@ def test_connect_rechecks_ownership_before_publishing_connected(
     monkeypatch.setattr(iface, "_connected", lambda: connected_callbacks.append(True))
     monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
     monkeypatch.setattr(
-        iface, "_raise_if_duplicate_connect", lambda _connection_key, **_kwargs: None, raising=True
+        iface,
+        "_raise_if_duplicate_connect",
+        lambda _connection_key, **_kwargs: None,
+        raising=True,
     )
     monkeypatch.setattr(
         iface, "_get_existing_client_if_valid", lambda _request: None, raising=True
@@ -4621,7 +4655,10 @@ def test_connect_raises_when_shutdown_wins_after_gate_finalization(
     monkeypatch.setattr(iface, "_connected", lambda: connected_callbacks.append(True))
     monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
     monkeypatch.setattr(
-        iface, "_raise_if_duplicate_connect", lambda _connection_key, **_kwargs: None, raising=True
+        iface,
+        "_raise_if_duplicate_connect",
+        lambda _connection_key, **_kwargs: None,
+        raising=True,
     )
     monkeypatch.setattr(
         iface, "_get_existing_client_if_valid", lambda _request: None, raising=True

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -2575,7 +2575,7 @@ def test_ble_interface_connect_uses_pair_override_for_orchestrator(
 
     monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
     monkeypatch.setattr(iface, "_get_existing_client_if_valid", lambda _req: None)
-    monkeypatch.setattr(iface, "_raise_if_duplicate_connect", lambda _key: None)
+    monkeypatch.setattr(iface, "_raise_if_duplicate_connect", lambda _key, **_kwargs: None)
     monkeypatch.setattr(iface, "_finalize_connection_gates", lambda *_args: None)
     connected_callbacks: list[bool] = []
     monkeypatch.setattr(iface, "_connected", lambda: connected_callbacks.append(True))
@@ -2628,7 +2628,7 @@ def test_connect_wraps_invalid_connect_timeout_as_ble_error(
 
     monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
     monkeypatch.setattr(iface, "_get_existing_client_if_valid", lambda _req: None)
-    monkeypatch.setattr(iface, "_raise_if_duplicate_connect", lambda _key: None)
+    monkeypatch.setattr(iface, "_raise_if_duplicate_connect", lambda _key, **_kwargs: None)
 
     with pytest.raises(
         BLEInterface.BLEError,
@@ -2753,7 +2753,7 @@ def test_connect_waits_for_inflight_management_before_establishing(
     )
     monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
     monkeypatch.setattr(iface, "_get_existing_client_if_valid", lambda _req: None)
-    monkeypatch.setattr(iface, "_raise_if_duplicate_connect", lambda _key: None)
+    monkeypatch.setattr(iface, "_raise_if_duplicate_connect", lambda _key, **_kwargs: None)
     monkeypatch.setattr(iface, "_finalize_connection_gates", lambda *_args: None)
     monkeypatch.setattr(
         iface,
@@ -2967,7 +2967,7 @@ def test_connect_management_wait_timeout_resets_between_wait_cycles(
         iface._management_inflight = 0
         return True
 
-    def _raise_if_duplicate(_key: str | None) -> None:
+    def _raise_if_duplicate(_key: str | None, **_kwargs: object) -> None:
         """
         Increment the duplicate-check counter and, on the second invocation, mark the interface as having one inflight management operation.
 
@@ -3056,7 +3056,7 @@ def test_connect_retries_when_management_becomes_inflight_inside_connect_lock(
         iface._management_inflight = 0
         return True
 
-    def _raise_if_duplicate(_key: str | None) -> None:
+    def _raise_if_duplicate(_key: str | None, **_kwargs: object) -> None:
         nonlocal duplicate_checks
         duplicate_checks += 1
         if duplicate_checks == 2:
@@ -3131,7 +3131,7 @@ def test_connect_returns_existing_client_after_lock_recheck(
         "_resolve_target_address_for_connect",
         lambda identifier: cast(str, identifier),
     )
-    monkeypatch.setattr(iface, "_raise_if_duplicate_connect", lambda _key: None)
+    monkeypatch.setattr(iface, "_raise_if_duplicate_connect", lambda _key, **_kwargs: None)
 
     assert iface.connect("AA:BB:CC:DD:EE:10") is existing_client
 
@@ -3148,7 +3148,7 @@ def test_connect_raises_when_establish_returns_no_client(
         "_resolve_target_address_for_connect",
         lambda identifier: cast(str, identifier),
     )
-    monkeypatch.setattr(iface, "_raise_if_duplicate_connect", lambda _key: None)
+    monkeypatch.setattr(iface, "_raise_if_duplicate_connect", lambda _key, **_kwargs: None)
     monkeypatch.setattr(
         iface,
         "_establish_and_update_client",
@@ -3172,7 +3172,7 @@ def test_connect_does_not_relabel_unrelated_establish_connection_value_error(
 
     monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
     monkeypatch.setattr(iface, "_get_existing_client_if_valid", lambda _req: None)
-    monkeypatch.setattr(iface, "_raise_if_duplicate_connect", lambda _key: None)
+    monkeypatch.setattr(iface, "_raise_if_duplicate_connect", lambda _key, **_kwargs: None)
 
     with pytest.raises(ValueError, match="boom"):
         iface.connect("AA:BB:CC:DD:EE:10", connect_timeout=4.5)
@@ -3975,7 +3975,7 @@ def test_connect_finalizes_gates_after_address_lock_scope(
         ble_iface_mod, "_addr_lock_context", _fake_addr_lock_context, raising=True
     )
     monkeypatch.setattr(
-        iface, "_raise_if_duplicate_connect", lambda _connection_key: None, raising=True
+        iface, "_raise_if_duplicate_connect", lambda _connection_key, **_kwargs: None, raising=True
     )
     monkeypatch.setattr(
         iface, "_get_existing_client_if_valid", lambda _request: None, raising=True
@@ -4033,7 +4033,7 @@ def test_connect_marks_provisional_claims_before_gate_release(
 
     monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
     monkeypatch.setattr(
-        iface, "_raise_if_duplicate_connect", lambda _connection_key: None, raising=True
+        iface, "_raise_if_duplicate_connect", lambda _connection_key, **_kwargs: None, raising=True
     )
     monkeypatch.setattr(
         iface, "_get_existing_client_if_valid", lambda _request: None, raising=True
@@ -4110,8 +4110,11 @@ def test_connect_name_target_reserves_requested_and_resolved_keys(
         ),
         raising=True,
     )
+    def _record_duplicate_check(_key: str | None, **_kwargs: object) -> None:
+        duplicate_checks.append(_key)
+
     monkeypatch.setattr(
-        iface, "_raise_if_duplicate_connect", duplicate_checks.append, raising=True
+        iface, "_raise_if_duplicate_connect", _record_duplicate_check, raising=True
     )
     monkeypatch.setattr(iface, "_finalize_connection_gates", lambda *_args: None)
     monkeypatch.setattr(iface, "_connected", lambda: None, raising=True)
@@ -4203,7 +4206,7 @@ def test_connect_raises_when_client_becomes_stale_after_gate_finalization(
     monkeypatch.setattr(iface, "_connected", lambda: connected_callbacks.append(True))
     monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
     monkeypatch.setattr(
-        iface, "_raise_if_duplicate_connect", lambda _connection_key: None, raising=True
+        iface, "_raise_if_duplicate_connect", lambda _connection_key, **_kwargs: None, raising=True
     )
     monkeypatch.setattr(
         iface, "_get_existing_client_if_valid", lambda _request: None, raising=True
@@ -4291,7 +4294,7 @@ def test_connect_preserves_reclaimed_keys_for_newer_client_after_gate_finalizati
 
     monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
     monkeypatch.setattr(
-        iface, "_raise_if_duplicate_connect", lambda _connection_key: None, raising=True
+        iface, "_raise_if_duplicate_connect", lambda _connection_key, **_kwargs: None, raising=True
     )
     monkeypatch.setattr(
         iface, "_get_existing_client_if_valid", lambda _request: None, raising=True
@@ -4379,7 +4382,7 @@ def test_connect_raises_when_registry_ownership_is_lost_after_gate_finalization(
     monkeypatch.setattr(iface, "_connected", lambda: connected_callbacks.append(True))
     monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
     monkeypatch.setattr(
-        iface, "_raise_if_duplicate_connect", lambda _connection_key: None, raising=True
+        iface, "_raise_if_duplicate_connect", lambda _connection_key, **_kwargs: None, raising=True
     )
     monkeypatch.setattr(
         iface, "_get_existing_client_if_valid", lambda _request: None, raising=True
@@ -4461,7 +4464,7 @@ def test_connect_restores_requested_identifier_after_name_target_loses_ownership
 
     monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
     monkeypatch.setattr(
-        iface, "_raise_if_duplicate_connect", lambda _connection_key: None, raising=True
+        iface, "_raise_if_duplicate_connect", lambda _connection_key, **_kwargs: None, raising=True
     )
     monkeypatch.setattr(
         iface, "_get_existing_client_if_valid", lambda _request: None, raising=True
@@ -4538,7 +4541,7 @@ def test_connect_rechecks_ownership_before_publishing_connected(
     monkeypatch.setattr(iface, "_connected", lambda: connected_callbacks.append(True))
     monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
     monkeypatch.setattr(
-        iface, "_raise_if_duplicate_connect", lambda _connection_key: None, raising=True
+        iface, "_raise_if_duplicate_connect", lambda _connection_key, **_kwargs: None, raising=True
     )
     monkeypatch.setattr(
         iface, "_get_existing_client_if_valid", lambda _request: None, raising=True
@@ -4617,7 +4620,7 @@ def test_connect_raises_when_shutdown_wins_after_gate_finalization(
     monkeypatch.setattr(iface, "_connected", lambda: connected_callbacks.append(True))
     monkeypatch.setattr(iface, "_validate_connection_preconditions", lambda: None)
     monkeypatch.setattr(
-        iface, "_raise_if_duplicate_connect", lambda _connection_key: None, raising=True
+        iface, "_raise_if_duplicate_connect", lambda _connection_key, **_kwargs: None, raising=True
     )
     monkeypatch.setattr(
         iface, "_get_existing_client_if_valid", lambda _request: None, raising=True

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -6858,6 +6858,19 @@ def test_close_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
     assert client.close_calls == 1
 
 
+def test_close_with_timeout_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """close(timeout=...) should remain idempotent across repeated calls."""
+    client = DummyClient()
+    iface = _build_interface(monkeypatch, client)
+
+    iface.close(timeout=1.0)
+    iface.close(timeout=0.2)
+    iface.close(timeout=0.0)
+
+    assert client.disconnect_calls == 1
+    assert client.close_calls == 1
+
+
 @pytest.mark.parametrize("exc_cls", [BleakError, RuntimeError, OSError])
 def test_close_handles_errors(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_ble_interface_core.py
+++ b/tests/test_ble_interface_core.py
@@ -4111,7 +4111,8 @@ def test_connect_name_target_reserves_requested_and_resolved_keys(
         raising=True,
     )
     def _record_duplicate_check(_key: str | None, **_kwargs: object) -> None:
-        duplicate_checks.append(_key)
+        if _key is not None:
+            duplicate_checks.append(_key)
 
     monkeypatch.setattr(
         iface, "_raise_if_duplicate_connect", _record_duplicate_check, raising=True

--- a/tests/test_ble_interface_coverage.py
+++ b/tests/test_ble_interface_coverage.py
@@ -97,6 +97,17 @@ class FailingDiscoveryManager:
         return []
 
 
+class MultipleDiscoveryManager:
+    """Discovery manager that returns multiple matching devices."""
+
+    def _discover_devices(self, address: str | None) -> list[BLEDevice]:
+        del address
+        return [
+            _create_ble_device("AA:BB:CC:DD:EE:01", "Mesh One"),
+            _create_ble_device("AA:BB:CC:DD:EE:02", "Mesh Two"),
+        ]
+
+
 class _FakeDiscoveryClient:
     """Context-manager BLE client stub used by discovery tests."""
 
@@ -244,7 +255,7 @@ def test_ble_address_property_returns_none_without_known_address() -> None:
 
 
 def test_ble_address_property_returns_none_for_non_address_identifier() -> None:
-    """bleAddress should return None when interface address is a name, not a BLE MAC."""
+    """BleAddress should return None when interface address is a name, not a BLE MAC."""
     iface = _build_minimal_interface()
     iface.client = None
     iface.address = "MyMeshDevice"
@@ -254,7 +265,7 @@ def test_ble_address_property_returns_none_for_non_address_identifier() -> None:
 
 
 def test_ble_address_property_returns_valid_mac_fallback() -> None:
-    """bleAddress and ble_address should return the interface address when it is a valid BLE MAC."""
+    """BleAddress and ble_address should return the interface address when it is a valid BLE MAC."""
     iface = _build_minimal_interface()
     iface.client = None
     iface.address = "AA:BB:CC:DD:EE:FF"
@@ -285,8 +296,8 @@ def test_close_rejects_invalid_timeout_type() -> None:
         iface.close(timeout=cast(Any, "invalid"))
 
 
-def test_close_is_idempotent_across_repeated_calls() -> None:
-    """Multiple close(timeout=...) calls should not raise or duplicate work."""
+def test_close_delegates_across_repeated_calls() -> None:
+    """Multiple close(timeout=...) calls should remain safe and delegate cleanup."""
     iface = _build_minimal_interface()
     close_calls: list[dict[str, object]] = []
     iface._get_lifecycle_controller = lambda: SimpleNamespace(
@@ -494,6 +505,33 @@ def test_find_device_raises_when_sanitization_fails(
     # Use an invalid address that looks like a BLE address but can't be sanitized
     with pytest.raises(BLEInterface.BLEError):
         iface.findDevice("invalid-address-string")
+
+
+def test_find_device_with_self_address_multiple_matches_uses_requested_identifier() -> (
+    None
+):
+    """findDevice(None) should report the resolved self.address for multiple matches."""
+    iface = _build_minimal_interface()
+    iface.address = "target-name"
+    iface._discovery_manager = MultipleDiscoveryManager()
+
+    with pytest.raises(BLEInterface.BLEError) as exc_info:
+        iface.findDevice(None)
+
+    assert exc_info.value.requested_identifier == "target-name"
+
+
+def test_find_device_explicit_target_multiple_matches_uses_requested_identifier() -> (
+    None
+):
+    """findDevice(address) should continue reporting the explicit requested target."""
+    iface = _build_minimal_interface()
+    iface._discovery_manager = MultipleDiscoveryManager()
+
+    with pytest.raises(BLEInterface.BLEError) as exc_info:
+        iface.findDevice("explicit-name")
+
+    assert exc_info.value.requested_identifier == "explicit-name"
 
 
 # ============================================================================

--- a/tests/test_ble_interface_coverage.py
+++ b/tests/test_ble_interface_coverage.py
@@ -22,7 +22,11 @@ import pytest
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakDBusError, BleakError
 
-from meshtastic.interfaces.ble import BLEClient, BLEInterface
+from meshtastic.interfaces.ble import (
+    BLEClient,
+    BLEConnectionSuppressedError,
+    BLEInterface,
+)
 from meshtastic.interfaces.ble.constants import (
     ERROR_INTERFACE_CLOSING,
     ERROR_NO_PERIPHERALS_FOUND,
@@ -1272,8 +1276,9 @@ def test_raise_if_duplicate_connect_raises_when_suppressed(
         lambda key: True,
     )
 
-    with pytest.raises(BLEInterface.BLEError, match="Connection suppressed"):
+    with pytest.raises(BLEInterface.BLEError, match="Connection suppressed") as exc_info:
         iface._raise_if_duplicate_connect("test-key")
+    assert isinstance(exc_info.value, BLEConnectionSuppressedError)
 
 
 def test_get_existing_client_if_valid_returns_none_when_not_connected() -> None:

--- a/tests/test_ble_interface_coverage.py
+++ b/tests/test_ble_interface_coverage.py
@@ -319,7 +319,9 @@ def test_close_timeout_budget_propagates_to_shutdown_stages() -> None:
     iface = _build_minimal_interface()
     budgets: list[float | None] = []
     iface._get_lifecycle_controller = lambda: SimpleNamespace(
-        _close=lambda *, management_shutdown_wait_timeout=5.0, management_wait_poll_seconds=0.5, timeout=None: budgets.append(timeout)
+        _close=lambda *, management_shutdown_wait_timeout=5.0, management_wait_poll_seconds=0.5, timeout=None: budgets.append(
+            timeout
+        )
     )
 
     iface.close(timeout=5.0)

--- a/tests/test_ble_interface_coverage.py
+++ b/tests/test_ble_interface_coverage.py
@@ -236,6 +236,16 @@ def test_ble_address_property_prefers_active_client_address() -> None:
     assert iface.ble_address == "11:22:33:44:55:66"
 
 
+def test_ble_address_property_ignores_invalid_active_client_address() -> None:
+    """ble_address should not expose active-client sentinel identifiers."""
+    iface = _build_minimal_interface()
+    iface.address = None
+    iface.client = DummyClient(address="unknown")
+
+    assert iface.bleAddress is None
+    assert iface.ble_address is None
+
+
 def test_ble_address_property_falls_back_to_interface_address() -> None:
     """ble_address and bleAddress should fall back to the interface-level address when no client is active."""
     iface = _build_minimal_interface()

--- a/tests/test_ble_interface_coverage.py
+++ b/tests/test_ble_interface_coverage.py
@@ -243,6 +243,26 @@ def test_ble_address_property_returns_none_without_known_address() -> None:
     assert iface.ble_address is None
 
 
+def test_ble_address_property_returns_none_for_non_address_identifier() -> None:
+    """bleAddress should return None when interface address is a name, not a BLE MAC."""
+    iface = _build_minimal_interface()
+    iface.client = None
+    iface.address = "MyMeshDevice"
+
+    assert iface.bleAddress is None
+    assert iface.ble_address is None
+
+
+def test_ble_address_property_returns_valid_mac_fallback() -> None:
+    """bleAddress should return the interface address when it is a valid BLE MAC."""
+    iface = _build_minimal_interface()
+    iface.client = None
+    iface.address = "AA:BB:CC:DD:EE:FF"
+
+    assert iface.bleAddress == "AA:BB:CC:DD:EE:FF"
+    assert iface.ble_address == "AA:BB:CC:DD:EE:FF"
+
+
 def test_close_forwards_timeout_to_lifecycle_controller() -> None:
     """close(timeout=...) should pass the caller budget to lifecycle shutdown."""
     iface = _build_minimal_interface()
@@ -295,8 +315,6 @@ def test_close_timeout_budget_propagates_to_shutdown_stages() -> None:
     assert budgets == [5.0]
 
 
-# ============================================================================
-# Error Handling Tests
 # ============================================================================
 # Error Handling Tests
 # ============================================================================

--- a/tests/test_ble_interface_coverage.py
+++ b/tests/test_ble_interface_coverage.py
@@ -1333,6 +1333,49 @@ def test_raise_if_duplicate_connect_raises_when_suppressed(
     assert isinstance(exc_info.value, BLEConnectionSuppressedError)
 
 
+@pytest.mark.unit
+def test_raise_if_duplicate_connect_uses_real_request_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_raise_if_duplicate_connect should populate exception with real request context."""
+    iface = _build_minimal_interface()
+
+    monkeypatch.setattr(
+        iface,
+        "_should_suppress_duplicate_connect",
+        lambda key: True,
+    )
+
+    with pytest.raises(BLEConnectionSuppressedError) as exc_info:
+        iface._raise_if_duplicate_connect(
+            "registry-key",
+            requested_identifier="MyDevice",
+            resolved_address="AA:BB:CC:DD:EE:FF",
+        )
+    assert exc_info.value.requested_identifier == "MyDevice"
+    assert exc_info.value.address == "AA:BB:CC:DD:EE:FF"
+
+
+@pytest.mark.unit
+def test_raise_if_duplicate_connect_fallback_to_key_when_context_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_raise_if_duplicate_connect should fallback to registry key when real context is absent."""
+    iface = _build_minimal_interface()
+
+    monkeypatch.setattr(
+        iface,
+        "_should_suppress_duplicate_connect",
+        lambda key: True,
+    )
+
+    with pytest.raises(BLEConnectionSuppressedError) as exc_info:
+        iface._raise_if_duplicate_connect("test-key")
+    assert exc_info.value.requested_identifier == "test-key"
+    assert exc_info.value.address == "test-key"
+
+
+@pytest.mark.unit
 def test_get_existing_client_if_valid_returns_none_when_not_connected() -> None:
     """_get_existing_client_if_valid should return None when not connected."""
     iface = _build_minimal_interface()

--- a/tests/test_ble_interface_coverage.py
+++ b/tests/test_ble_interface_coverage.py
@@ -261,10 +261,42 @@ def test_close_rejects_invalid_timeout_type() -> None:
     """close(timeout=...) should validate timeout input shape."""
     iface = _build_minimal_interface()
 
-    with pytest.raises(BLEInterface.BLEError, match="close\\(\\) timeout"):
+    with pytest.raises(BLEInterface.BLEError, match="close\(\) timeout"):
         iface.close(timeout=cast(Any, "invalid"))
 
 
+def test_close_is_idempotent_across_repeated_calls() -> None:
+    """Multiple close(timeout=...) calls should not raise or duplicate work."""
+    iface = _build_minimal_interface()
+    close_calls: list[dict[str, object]] = []
+    iface._get_lifecycle_controller = lambda: SimpleNamespace(
+        _close=lambda **kwargs: close_calls.append(dict(kwargs))
+    )
+
+    iface.close(timeout=2.0)
+    iface.close(timeout=2.0)
+    iface.close()
+
+    assert len(close_calls) == 3
+    assert close_calls[0]["timeout"] == 2.0
+    assert close_calls[1]["timeout"] == 2.0
+    assert close_calls[2]["timeout"] is None
+
+
+def test_close_timeout_budget_propagates_to_shutdown_stages() -> None:
+    """close(timeout=...) should propagate the total budget to lifecycle shutdown."""
+    iface = _build_minimal_interface()
+    budgets: list[float | None] = []
+    iface._get_lifecycle_controller = lambda: SimpleNamespace(
+        _close=lambda *, management_shutdown_wait_timeout=5.0, management_wait_poll_seconds=0.5, timeout=None: budgets.append(timeout)
+    )
+
+    iface.close(timeout=5.0)
+    assert budgets == [5.0]
+
+
+# ============================================================================
+# Error Handling Tests
 # ============================================================================
 # Error Handling Tests
 # ============================================================================

--- a/tests/test_ble_interface_coverage.py
+++ b/tests/test_ble_interface_coverage.py
@@ -226,7 +226,7 @@ def test_ble_address_property_prefers_active_client_address() -> None:
 
 
 def test_ble_address_property_falls_back_to_interface_address() -> None:
-    """ble_address should fall back to the interface-level address when no client is active."""
+    """ble_address and bleAddress should fall back to the interface-level address when no client is active."""
     iface = _build_minimal_interface()
     iface.client = None
     iface.address = "AA:BB:CC:DD:EE:FF"
@@ -254,7 +254,7 @@ def test_ble_address_property_returns_none_for_non_address_identifier() -> None:
 
 
 def test_ble_address_property_returns_valid_mac_fallback() -> None:
-    """bleAddress should return the interface address when it is a valid BLE MAC."""
+    """bleAddress and ble_address should return the interface address when it is a valid BLE MAC."""
     iface = _build_minimal_interface()
     iface.client = None
     iface.address = "AA:BB:CC:DD:EE:FF"
@@ -281,7 +281,7 @@ def test_close_rejects_invalid_timeout_type() -> None:
     """close(timeout=...) should validate timeout input shape."""
     iface = _build_minimal_interface()
 
-    with pytest.raises(BLEInterface.BLEError, match="close\(\) timeout"):
+    with pytest.raises(BLEInterface.BLEError, match=r"close\(\) timeout"):
         iface.close(timeout=cast(Any, "invalid"))
 
 

--- a/tests/test_ble_interface_coverage.py
+++ b/tests/test_ble_interface_coverage.py
@@ -208,6 +208,60 @@ def _build_minimal_interface() -> BLEInterface:
 
 
 # ============================================================================
+# Public API Surface Tests
+# ============================================================================
+
+
+def test_ble_address_property_prefers_active_client_address() -> None:
+    """ble_address should use the connected client's concrete address when available."""
+    iface = _build_minimal_interface()
+    iface.address = "AA:BB:CC:DD:EE:FF"
+    iface.client = DummyClient(address="11:22:33:44:55:66")
+
+    assert iface.ble_address == "11:22:33:44:55:66"
+
+
+def test_ble_address_property_falls_back_to_interface_address() -> None:
+    """ble_address should fall back to the interface-level address when no client is active."""
+    iface = _build_minimal_interface()
+    iface.client = None
+    iface.address = "AA:BB:CC:DD:EE:FF"
+
+    assert iface.ble_address == "AA:BB:CC:DD:EE:FF"
+
+
+def test_ble_address_property_returns_none_without_known_address() -> None:
+    """ble_address should return None when no address can be resolved."""
+    iface = _build_minimal_interface()
+    iface.client = None
+    iface.address = None
+
+    assert iface.ble_address is None
+
+
+def test_close_forwards_timeout_to_lifecycle_controller() -> None:
+    """close(timeout=...) should pass the caller budget to lifecycle shutdown."""
+    iface = _build_minimal_interface()
+    close_calls: list[dict[str, object]] = []
+    iface._get_lifecycle_controller = lambda: SimpleNamespace(
+        _close=lambda **kwargs: close_calls.append(dict(kwargs))
+    )
+
+    iface.close(timeout=3.0)
+
+    kwargs = close_calls[0]
+    assert kwargs["timeout"] == 3.0
+
+
+def test_close_rejects_invalid_timeout_type() -> None:
+    """close(timeout=...) should validate timeout input shape."""
+    iface = _build_minimal_interface()
+
+    with pytest.raises(BLEInterface.BLEError, match="close\\(\\) timeout"):
+        iface.close(timeout=cast(Any, "invalid"))
+
+
+# ============================================================================
 # Error Handling Tests
 # ============================================================================
 
@@ -2102,7 +2156,9 @@ def test_disconnect_and_close_client_delegates() -> None:
 
     iface._disconnect_and_close_client(cast(BLEClient, client))
 
-    disconnect_and_close_client.assert_called_once_with(cast(BLEClient, client))
+    disconnect_and_close_client.assert_called_once_with(
+        cast(BLEClient, client), timeout=None
+    )
 
 
 # ============================================================================

--- a/tests/test_ble_interface_coverage.py
+++ b/tests/test_ble_interface_coverage.py
@@ -1276,7 +1276,9 @@ def test_raise_if_duplicate_connect_raises_when_suppressed(
         lambda key: True,
     )
 
-    with pytest.raises(BLEInterface.BLEError, match="Connection suppressed") as exc_info:
+    with pytest.raises(
+        BLEInterface.BLEError, match="Connection suppressed"
+    ) as exc_info:
         iface._raise_if_duplicate_connect("test-key")
     assert isinstance(exc_info.value, BLEConnectionSuppressedError)
 

--- a/tests/test_ble_interface_disconnect_alias.py
+++ b/tests/test_ble_interface_disconnect_alias.py
@@ -11,7 +11,7 @@ def test_disconnect_delegates_to_close() -> None:
 
     BLEInterface.disconnect(iface)
 
-    iface.close.assert_called_once_with()
+    iface.close.assert_called_once_with(timeout=None)
 
 
 def test_disconnect_forwards_timeout_to_close() -> None:

--- a/tests/test_ble_interface_disconnect_alias.py
+++ b/tests/test_ble_interface_disconnect_alias.py
@@ -14,6 +14,15 @@ def test_disconnect_delegates_to_close() -> None:
     iface.close.assert_called_once_with()
 
 
+def test_disconnect_forwards_timeout_to_close() -> None:
+    iface = object.__new__(BLEInterface)
+    iface.close = MagicMock()
+
+    BLEInterface.disconnect(iface, timeout=1.25)
+
+    iface.close.assert_called_once_with(timeout=1.25)
+
+
 def test_disconnect_propagates_close_errors() -> None:
     iface = object.__new__(BLEInterface)
     iface.close = MagicMock(side_effect=RuntimeError("close failed"))

--- a/tests/test_ble_lifecycle_controller.py
+++ b/tests/test_ble_lifecycle_controller.py
@@ -666,21 +666,23 @@ class TestBLELifecycleControllerClientManagement:
 
         assert calls == [(mock_client, None)]
 
-    def test_close_fallback_when_timeout_kwarg_unsupported(self) -> None:
-        """_close should fallback to no-timeout call when timeout is rejected."""
+    def test_close_without_timeout_parameter_invoked_once(self) -> None:
+        """_close should omit timeout when the shutdown callable does not accept it."""
         calls: list[dict[str, object]] = []
 
-        def _raise_on_timeout(
+        def _close_without_timeout(
             *,
             management_shutdown_wait_timeout: float,
             management_wait_poll_seconds: float,
-            timeout: float | None = None,
         ) -> None:
-            if timeout is not None:
-                raise TypeError("close() got an unexpected keyword argument 'timeout'")
-            calls.append({"timeout": timeout, "fallback": True})
+            calls.append(
+                {
+                    "management_shutdown_wait_timeout": management_shutdown_wait_timeout,
+                    "management_wait_poll_seconds": management_wait_poll_seconds,
+                }
+            )
 
-        mock_shutdown = SimpleNamespace(close=_raise_on_timeout)
+        mock_shutdown = SimpleNamespace(close=_close_without_timeout)
         mock_iface = SimpleNamespace()
         controller = BLELifecycleController(mock_iface)
         controller._shutdown = mock_shutdown  # type: ignore[assignment]
@@ -691,9 +693,12 @@ class TestBLELifecycleControllerClientManagement:
             timeout=1.25,
         )
 
-        assert len(calls) == 1
-        assert calls[0]["fallback"] is True
-        assert calls[0]["timeout"] is None
+        assert calls == [
+            {
+                "management_shutdown_wait_timeout": 5.0,
+                "management_wait_poll_seconds": 0.5,
+            }
+        ]
 
     def test_close_propagates_unrelated_type_error(self) -> None:
         """_close should NOT swallow unrelated TypeError during shutdown."""
@@ -719,18 +724,18 @@ class TestBLELifecycleControllerClientManagement:
                 timeout=1.25,
             )
 
-    def test_disconnect_and_close_client_fallback_when_timeout_unsupported(self) -> None:
-        """_disconnect_and_close_client should fallback when timeout is rejected."""
+    def test_disconnect_and_close_client_without_timeout_parameter_invoked_once(
+        self,
+    ) -> None:
+        """_disconnect_and_close_client should omit timeout when unsupported."""
         calls: list[tuple[object, ...]] = []
 
-        def _raise_on_timeout(client: object, *, timeout: float | None = None) -> None:
-            if timeout is not None:
-                raise TypeError(
-                    "disconnect_and_close_client() got an unexpected keyword argument 'timeout'"
-                )
-            calls.append((client, timeout))
+        def _disconnect_without_timeout(client: object) -> None:
+            calls.append((client,))
 
-        mock_disconnect = SimpleNamespace(disconnect_and_close_client=_raise_on_timeout)
+        mock_disconnect = SimpleNamespace(
+            disconnect_and_close_client=_disconnect_without_timeout
+        )
         mock_iface = SimpleNamespace()
         controller = BLELifecycleController(mock_iface)
         controller._disconnect = mock_disconnect  # type: ignore[assignment]
@@ -738,8 +743,7 @@ class TestBLELifecycleControllerClientManagement:
         mock_client = SimpleNamespace()
         controller._disconnect_and_close_client(mock_client, timeout=3.0)
 
-        assert len(calls) == 1
-        assert calls[0] == (mock_client, None)
+        assert calls == [(mock_client,)]
 
     def test_disconnect_and_close_client_propagates_unrelated_type_error(self) -> None:
         """_disconnect_and_close_client should NOT swallow unrelated TypeError."""

--- a/tests/test_ble_lifecycle_controller.py
+++ b/tests/test_ble_lifecycle_controller.py
@@ -651,8 +651,12 @@ class TestBLELifecycleControllerClientManagement:
         self,
     ) -> None:
         """_disconnect_and_close_client should delegate to _disconnect coordinator."""
-        calls: list[object] = []
-        mock_disconnect = SimpleNamespace(disconnect_and_close_client=calls.append)
+        calls: list[tuple[object, float | None]] = []
+
+        def _capture_disconnect(client: object, *, timeout: float | None = None) -> None:
+            calls.append((client, timeout))
+
+        mock_disconnect = SimpleNamespace(disconnect_and_close_client=_capture_disconnect)
         mock_iface = SimpleNamespace()
         controller = BLELifecycleController(mock_iface)
         controller._disconnect = mock_disconnect  # type: ignore[assignment]
@@ -660,7 +664,100 @@ class TestBLELifecycleControllerClientManagement:
         mock_client = SimpleNamespace()
         controller._disconnect_and_close_client(mock_client)
 
-        assert calls == [mock_client]
+        assert calls == [(mock_client, None)]
+
+    def test_close_fallback_when_timeout_kwarg_unsupported(self) -> None:
+        """_close should fallback to no-timeout call when timeout is rejected."""
+        calls: list[dict[str, object]] = []
+
+        def _raise_on_timeout(
+            *,
+            management_shutdown_wait_timeout: float,
+            management_wait_poll_seconds: float,
+            timeout: float | None = None,
+        ) -> None:
+            if timeout is not None:
+                raise TypeError("close() got an unexpected keyword argument 'timeout'")
+            calls.append({"timeout": timeout, "fallback": True})
+
+        mock_shutdown = SimpleNamespace(close=_raise_on_timeout)
+        mock_iface = SimpleNamespace()
+        controller = BLELifecycleController(mock_iface)
+        controller._shutdown = mock_shutdown  # type: ignore[assignment]
+
+        controller._close(
+            management_shutdown_wait_timeout=5.0,
+            management_wait_poll_seconds=0.5,
+            timeout=1.25,
+        )
+
+        assert len(calls) == 1
+        assert calls[0]["fallback"] is True
+        assert calls[0]["timeout"] is None
+
+    def test_close_propagates_unrelated_type_error(self) -> None:
+        """_close should NOT swallow unrelated TypeError during shutdown."""
+
+        def _raise_unrelated(
+            *,
+            management_shutdown_wait_timeout: float,
+            management_wait_poll_seconds: float,
+            timeout: float | None = None,
+        ) -> None:
+            del management_shutdown_wait_timeout, management_wait_poll_seconds, timeout
+            raise TypeError("takes 1 positional argument but 2 were given")
+
+        mock_shutdown = SimpleNamespace(close=_raise_unrelated)
+        mock_iface = SimpleNamespace()
+        controller = BLELifecycleController(mock_iface)
+        controller._shutdown = mock_shutdown  # type: ignore[assignment]
+
+        with pytest.raises(TypeError, match="takes 1 positional argument"):
+            controller._close(
+                management_shutdown_wait_timeout=5.0,
+                management_wait_poll_seconds=0.5,
+                timeout=1.25,
+            )
+
+    def test_disconnect_and_close_client_fallback_when_timeout_unsupported(self) -> None:
+        """_disconnect_and_close_client should fallback when timeout is rejected."""
+        calls: list[tuple[object, ...]] = []
+
+        def _raise_on_timeout(client: object, *, timeout: float | None = None) -> None:
+            if timeout is not None:
+                raise TypeError(
+                    "disconnect_and_close_client() got an unexpected keyword argument 'timeout'"
+                )
+            calls.append((client, timeout))
+
+        mock_disconnect = SimpleNamespace(disconnect_and_close_client=_raise_on_timeout)
+        mock_iface = SimpleNamespace()
+        controller = BLELifecycleController(mock_iface)
+        controller._disconnect = mock_disconnect  # type: ignore[assignment]
+
+        mock_client = SimpleNamespace()
+        controller._disconnect_and_close_client(mock_client, timeout=3.0)
+
+        assert len(calls) == 1
+        assert calls[0] == (mock_client, None)
+
+    def test_disconnect_and_close_client_propagates_unrelated_type_error(self) -> None:
+        """_disconnect_and_close_client should NOT swallow unrelated TypeError."""
+
+        def _raise_unrelated(client: object, *, timeout: float | None = None) -> None:
+            del client, timeout
+            raise TypeError("takes 1 positional argument but 2 were given")
+
+        mock_disconnect = SimpleNamespace(
+            disconnect_and_close_client=_raise_unrelated
+        )
+        mock_iface = SimpleNamespace()
+        controller = BLELifecycleController(mock_iface)
+        controller._disconnect = mock_disconnect  # type: ignore[assignment]
+
+        mock_client = SimpleNamespace()
+        with pytest.raises(TypeError, match="takes 1 positional argument"):
+            controller._disconnect_and_close_client(mock_client, timeout=3.0)
 
     def test_has_ever_connected_session_delegates_to_ownership_coordinator(
         self,

--- a/tests/test_ble_lifecycle_controller.py
+++ b/tests/test_ble_lifecycle_controller.py
@@ -653,10 +653,14 @@ class TestBLELifecycleControllerClientManagement:
         """_disconnect_and_close_client should delegate to _disconnect coordinator."""
         calls: list[tuple[object, float | None]] = []
 
-        def _capture_disconnect(client: object, *, timeout: float | None = None) -> None:
+        def _capture_disconnect(
+            client: object, *, timeout: float | None = None
+        ) -> None:
             calls.append((client, timeout))
 
-        mock_disconnect = SimpleNamespace(disconnect_and_close_client=_capture_disconnect)
+        mock_disconnect = SimpleNamespace(
+            disconnect_and_close_client=_capture_disconnect
+        )
         mock_iface = SimpleNamespace()
         controller = BLELifecycleController(mock_iface)
         controller._disconnect = mock_disconnect  # type: ignore[assignment]
@@ -752,9 +756,7 @@ class TestBLELifecycleControllerClientManagement:
             del client, timeout
             raise TypeError("takes 1 positional argument but 2 were given")
 
-        mock_disconnect = SimpleNamespace(
-            disconnect_and_close_client=_raise_unrelated
-        )
+        mock_disconnect = SimpleNamespace(disconnect_and_close_client=_raise_unrelated)
         mock_iface = SimpleNamespace()
         controller = BLELifecycleController(mock_iface)
         controller._disconnect = mock_disconnect  # type: ignore[assignment]

--- a/tests/test_ble_lifecycle_controller.py
+++ b/tests/test_ble_lifecycle_controller.py
@@ -612,6 +612,37 @@ class TestBLELifecycleControllerShutdownDelegation:
 
         assert calls == [{"timeout": 5.0, "poll": 0.5}]
 
+    def test_close_forwards_optional_total_timeout(self) -> None:
+        """_close should forward timeout budget to shutdown coordinator when provided."""
+        calls: list[dict[str, float | None]] = []
+
+        def _capture_close(
+            *,
+            management_shutdown_wait_timeout: float,
+            management_wait_poll_seconds: float,
+            timeout: float | None = None,
+        ) -> None:
+            calls.append(
+                {
+                    "timeout": management_shutdown_wait_timeout,
+                    "poll": management_wait_poll_seconds,
+                    "total": timeout,
+                }
+            )
+
+        mock_shutdown = SimpleNamespace(close=_capture_close)
+        mock_iface = SimpleNamespace()
+        controller = BLELifecycleController(mock_iface)
+        controller._shutdown = mock_shutdown  # type: ignore[assignment]
+
+        controller._close(
+            management_shutdown_wait_timeout=5.0,
+            management_wait_poll_seconds=0.5,
+            timeout=1.25,
+        )
+
+        assert calls == [{"timeout": 5.0, "poll": 0.5, "total": 1.25}]
+
 
 class TestBLELifecycleControllerClientManagement:
     """Test cases for client management methods."""

--- a/tests/test_ble_lifecycle_receive_targets.py
+++ b/tests/test_ble_lifecycle_receive_targets.py
@@ -161,70 +161,70 @@ def test_lifecycle_thread_dispatch_helpers_cover_legacy_and_missing(
 ) -> None:
     """Lifecycle thread dispatch helpers should exercise public/legacy/missing paths."""
     iface = _make_iface(monkeypatch)
-
-    created_thread = SimpleNamespace(name="created-thread")
-    iface.thread_coordinator = SimpleNamespace(
-        create_thread=lambda **_kwargs: created_thread,
-        _create_thread=None,
-    )
-    assert (
-        BLELifecycleService._thread_create_thread(
-            iface,
-            target=lambda: None,
-            name="name",
-            daemon=True,
+    try:
+        created_thread = SimpleNamespace(name="created-thread")
+        iface.thread_coordinator = SimpleNamespace(
+            create_thread=lambda **_kwargs: created_thread,
+            _create_thread=None,
         )
-        is created_thread
-    )
-
-    iface.thread_coordinator = SimpleNamespace()
-    with pytest.raises(AttributeError):
-        BLELifecycleService._thread_create_thread(
-            iface,
-            target=lambda: None,
-            name="name",
-            daemon=True,
+        assert (
+            BLELifecycleService._thread_create_thread(
+                iface,
+                target=lambda: None,
+                name="name",
+                daemon=True,
+            )
+            is created_thread
         )
 
-    started: list[object] = []
-    iface.thread_coordinator = SimpleNamespace(
-        _start_thread=lambda thread: started.append(thread),
-    )
-    marker_thread = SimpleNamespace(name="legacy-start")
-    BLELifecycleService._thread_start_thread(iface, marker_thread)
-    assert started == [marker_thread]
+        iface.thread_coordinator = SimpleNamespace()
+        with pytest.raises(AttributeError):
+            BLELifecycleService._thread_create_thread(
+                iface,
+                target=lambda: None,
+                name="name",
+                daemon=True,
+            )
 
-    iface.thread_coordinator = SimpleNamespace()
-    with pytest.raises(AttributeError):
+        started: list[object] = []
+        iface.thread_coordinator = SimpleNamespace(
+            _start_thread=lambda thread: started.append(thread),
+        )
+        marker_thread = SimpleNamespace(name="legacy-start")
         BLELifecycleService._thread_start_thread(iface, marker_thread)
+        assert started == [marker_thread]
 
-    join_calls: list[float | None] = []
-    iface.thread_coordinator = SimpleNamespace()
-    BLELifecycleService._thread_join_thread(
-        iface,
-        SimpleNamespace(join=lambda timeout=None: join_calls.append(timeout)),
-        timeout=1.5,
-    )
-    assert join_calls == [1.5]
+        iface.thread_coordinator = SimpleNamespace()
+        with pytest.raises(AttributeError):
+            BLELifecycleService._thread_start_thread(iface, marker_thread)
 
-    iface.thread_coordinator = SimpleNamespace(
-        _set_event=lambda event_name: started.append(event_name),
-        _clear_events=lambda *names: started.extend(names),
-        _wake_waiting_threads=lambda *names: started.extend(names),
-    )
-    BLELifecycleService._thread_set_event(iface, "event-a")
-    BLELifecycleService._thread_clear_events(iface, "event-b")
-    BLELifecycleService._thread_wake_waiting_threads(iface, "event-c")
-    assert "event-a" in started
-    assert "event-b" in started
-    assert "event-c" in started
+        join_calls: list[float | None] = []
+        iface.thread_coordinator = SimpleNamespace()
+        BLELifecycleService._thread_join_thread(
+            iface,
+            SimpleNamespace(join=lambda timeout=None: join_calls.append(timeout)),
+            timeout=1.5,
+        )
+        assert join_calls == [1.5]
 
-    iface.thread_coordinator = SimpleNamespace()
-    BLELifecycleService._thread_set_event(iface, "missing")
-    BLELifecycleService._thread_clear_events(iface, "missing")
-    BLELifecycleService._thread_wake_waiting_threads(iface, "missing")
+        iface.thread_coordinator = SimpleNamespace(
+            _set_event=lambda event_name: started.append(event_name),
+            _clear_events=lambda *names: started.extend(names),
+            _wake_waiting_threads=lambda *names: started.extend(names),
+        )
+        BLELifecycleService._thread_set_event(iface, "event-a")
+        BLELifecycleService._thread_clear_events(iface, "event-b")
+        BLELifecycleService._thread_wake_waiting_threads(iface, "event-c")
+        assert "event-a" in started
+        assert "event-b" in started
+        assert "event-c" in started
 
-    iface.close()
+        iface.thread_coordinator = SimpleNamespace()
+        BLELifecycleService._thread_set_event(iface, "missing")
+        BLELifecycleService._thread_clear_events(iface, "missing")
+        BLELifecycleService._thread_wake_waiting_threads(iface, "missing")
+    finally:
+        iface.close()
 
 
 def test_lifecycle_start_receive_and_schedule_auto_reconnect_branches(
@@ -232,61 +232,62 @@ def test_lifecycle_start_receive_and_schedule_auto_reconnect_branches(
 ) -> None:
     """Receive-thread start and reconnect scheduling should cover skip/error paths."""
     iface = _make_iface(monkeypatch)
-    with iface._state_lock:
-        iface._want_receive = True
-        iface._closed = False
-        iface._receiveThread = SimpleNamespace(
-            name="existing",
-            ident=None,
-            is_alive=lambda: False,
+    try:
+        with iface._state_lock:
+            iface._want_receive = True
+            iface._closed = False
+            iface._receiveThread = SimpleNamespace(
+                name="existing",
+                ident=None,
+                is_alive=lambda: False,
+            )
+
+        BLELifecycleService._start_receive_thread(iface, name="skip-existing")
+        with iface._state_lock:
+            iface._receiveThread = None
+
+        new_thread = SimpleNamespace(name="new-thread", ident=None, is_alive=lambda: False)
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_thread_create_thread",
+            staticmethod(lambda *_args, **_kwargs: new_thread),
         )
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_thread_start_thread",
+            staticmethod(lambda *_args, **_kwargs: (_ for _ in ()).throw(SystemExit())),
+        )
+        with pytest.raises(SystemExit):
+            BLELifecycleService._start_receive_thread(iface, name="failing-start")
+        assert iface._receiveThread is None
 
-    BLELifecycleService._start_receive_thread(iface, name="skip-existing")
-    with iface._state_lock:
-        iface._receiveThread = None
-
-    new_thread = SimpleNamespace(name="new-thread", ident=None, is_alive=lambda: False)
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_thread_create_thread",
-        staticmethod(lambda *_args, **_kwargs: new_thread),
-    )
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_thread_start_thread",
-        staticmethod(lambda *_args, **_kwargs: (_ for _ in ()).throw(SystemExit())),
-    )
-    with pytest.raises(SystemExit):
-        BLELifecycleService._start_receive_thread(iface, name="failing-start")
-    assert iface._receiveThread is None
-
-    iface.auto_reconnect = False
-    BLELifecycleService._schedule_auto_reconnect(iface)
-
-    iface.auto_reconnect = True
-    with iface._state_lock:
-        iface._closed = True
-    BLELifecycleService._schedule_auto_reconnect(iface)
-
-    with iface._state_lock:
-        iface._closed = False
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_state_manager_is_closing",
-        staticmethod(lambda _iface: True),
-    )
-    BLELifecycleService._schedule_auto_reconnect(iface)
-
-    monkeypatch.setattr(
-        BLELifecycleService,
-        "_state_manager_is_closing",
-        staticmethod(lambda _iface: False),
-    )
-    iface._reconnect_scheduler = SimpleNamespace()
-    with pytest.raises(AttributeError):
+        iface.auto_reconnect = False
         BLELifecycleService._schedule_auto_reconnect(iface)
 
-    iface.close()
+        iface.auto_reconnect = True
+        with iface._state_lock:
+            iface._closed = True
+        BLELifecycleService._schedule_auto_reconnect(iface)
+
+        with iface._state_lock:
+            iface._closed = False
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_state_manager_is_closing",
+            staticmethod(lambda _iface: True),
+        )
+        BLELifecycleService._schedule_auto_reconnect(iface)
+
+        monkeypatch.setattr(
+            BLELifecycleService,
+            "_state_manager_is_closing",
+            staticmethod(lambda _iface: False),
+        )
+        iface._reconnect_scheduler = SimpleNamespace()
+        with pytest.raises(AttributeError):
+            BLELifecycleService._schedule_auto_reconnect(iface)
+    finally:
+        iface.close()
 
 
 def test_lifecycle_receive_shim_preserves_method_scoped_collaborators(
@@ -994,6 +995,7 @@ def test_shutdown_close_timeout_budget_rolls_forward_to_later_stages(
     assert captured["disconnect_notification_wait_timeout"] == pytest.approx(0.001)
     assert captured["unsubscribe_timeout"] == pytest.approx(0.001)
     assert captured["cleanup_timeout"] == pytest.approx(0.001)
+    iface.close()
 
 
 def test_close_mesh_interface_timeout_limits_blocking_wait(
@@ -1023,6 +1025,7 @@ def test_close_mesh_interface_timeout_limits_blocking_wait(
 
     assert close_called.is_set()
     assert elapsed < 0.1
+    iface.close()
 
 
 def test_lifecycle_shutdown_receive_thread_skips_self_join_by_ident(
@@ -2918,3 +2921,91 @@ def test_receive_remaining_branches(
         iface._shutdown_event = threading.Event()
     finally:
         iface.close()
+
+
+def test_shutdown_disconnect_client_fallback_on_unsupported_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_shutdown_client should fallback when disconnect timeout is unsupported."""
+    iface = _make_iface(monkeypatch)
+    coordinator = BLEShutdownLifecycleCoordinator(iface)
+    calls: list[tuple[object, dict[str, object]]] = []
+
+    def _disconnect_and_close_client(client: object, *, timeout: float | None = None) -> None:
+        if timeout is not None:
+            raise TypeError(
+                "_disconnect_and_close_client() got an unexpected keyword argument 'timeout'"
+            )
+        calls.append((client, {"timeout": timeout}))
+
+    iface._disconnect_and_close_client = _disconnect_and_close_client  # type: ignore[assignment]
+    monkeypatch.setattr(
+        coordinator,
+        "_await_management_shutdown",
+        lambda **kwargs: True,
+    )
+    coordinator._shutdown_client(
+        management_wait_timed_out=True,
+        client_disconnect_timeout=1.0,
+        disconnect_notification_wait_timeout=0.5,
+        unsubscribe_timeout=0.1,
+    )
+    assert len(calls) == 1
+    assert calls[0][1]["timeout"] is None
+
+
+def test_shutdown_wait_for_disconnect_notifications_fallback_on_unsupported_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_shutdown_client should fallback when wait timeout is unsupported."""
+    iface = _make_iface(monkeypatch)
+    coordinator = BLEShutdownLifecycleCoordinator(iface)
+    calls: list[dict[str, object]] = []
+
+    def _wait_for_disconnect_notifications(*, timeout: float | None = None) -> None:
+        if timeout is not None:
+            raise TypeError(
+                "_wait_for_disconnect_notifications() got an unexpected keyword argument 'timeout'"
+            )
+        calls.append({"timeout": timeout})
+
+    iface._wait_for_disconnect_notifications = _wait_for_disconnect_notifications  # type: ignore[assignment]
+    monkeypatch.setattr(
+        coordinator,
+        "_await_management_shutdown",
+        lambda **kwargs: True,
+    )
+    coordinator._shutdown_client(
+        management_wait_timed_out=True,
+        client_disconnect_timeout=1.0,
+        disconnect_notification_wait_timeout=0.5,
+        unsubscribe_timeout=0.1,
+    )
+    assert len(calls) == 1
+    assert calls[0]["timeout"] is None
+
+
+def test_shutdown_wait_for_disconnect_notifications_propagates_unrelated_type_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_shutdown_client should NOT swallow unrelated TypeError from wait."""
+    iface = _make_iface(monkeypatch)
+    coordinator = BLEShutdownLifecycleCoordinator(iface)
+
+    def _raise_unrelated(*, timeout: float | None = None) -> None:
+        del timeout
+        raise TypeError("takes 1 positional argument but 2 were given")
+
+    iface._wait_for_disconnect_notifications = _raise_unrelated  # type: ignore[assignment]
+    monkeypatch.setattr(
+        coordinator,
+        "_await_management_shutdown",
+        lambda **kwargs: True,
+    )
+    with pytest.raises(TypeError, match="takes 1 positional argument"):
+        coordinator._shutdown_client(
+            management_wait_timed_out=True,
+            client_disconnect_timeout=1.0,
+            disconnect_notification_wait_timeout=0.5,
+            unsubscribe_timeout=0.1,
+        )

--- a/tests/test_ble_lifecycle_receive_targets.py
+++ b/tests/test_ble_lifecycle_receive_targets.py
@@ -2948,10 +2948,10 @@ def test_receive_remaining_branches(
         iface.close()
 
 
-def test_shutdown_disconnect_client_fallback_on_unsupported_timeout(
+def test_shutdown_disconnect_client_skips_legacy_fallback_with_finite_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """_shutdown_client should fallback when disconnect timeout is unsupported."""
+    """_shutdown_client should not call unbounded legacy disconnect under a finite budget."""
     iface = _make_iface(monkeypatch)
     coordinator = BLEShutdownLifecycleCoordinator(iface)
     calls: list[tuple[object, dict[str, object]]] = []
@@ -2977,6 +2977,42 @@ def test_shutdown_disconnect_client_fallback_on_unsupported_timeout(
             client_disconnect_timeout=1.0,
             disconnect_notification_wait_timeout=0.5,
             unsubscribe_timeout=0.1,
+            bounded_close_timeout_active=True,
+        )
+        assert calls == []
+    finally:
+        iface.close()
+
+
+def test_shutdown_disconnect_client_legacy_fallback_without_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_shutdown_client should permit legacy disconnect fallback without a timeout budget."""
+    iface = _make_iface(monkeypatch)
+    coordinator = BLEShutdownLifecycleCoordinator(iface)
+    calls: list[tuple[object, dict[str, object]]] = []
+
+    def _disconnect_and_close_client(
+        client: object, *, timeout: float | None = None
+    ) -> None:
+        if timeout is not None:
+            raise TypeError(
+                "_disconnect_and_close_client() got an unexpected keyword argument 'timeout'"
+            )
+        calls.append((client, {"timeout": timeout}))
+
+    iface._disconnect_and_close_client = _disconnect_and_close_client  # type: ignore[assignment]
+    monkeypatch.setattr(
+        coordinator,
+        "_await_management_shutdown",
+        lambda **kwargs: True,
+    )
+    try:
+        coordinator._shutdown_client(
+            management_wait_timed_out=True,
+            client_disconnect_timeout=None,
+            disconnect_notification_wait_timeout=None,
+            unsubscribe_timeout=None,
         )
         assert len(calls) == 1
         assert calls[0][1]["timeout"] is None
@@ -2984,10 +3020,42 @@ def test_shutdown_disconnect_client_fallback_on_unsupported_timeout(
         iface.close()
 
 
-def test_shutdown_wait_for_disconnect_notifications_fallback_on_unsupported_timeout(
+def test_shutdown_disconnect_client_propagates_unrelated_type_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """_shutdown_client should fallback when wait timeout is unsupported."""
+    """_shutdown_client should NOT swallow unrelated TypeError from disconnect."""
+    iface = _make_iface(monkeypatch)
+    coordinator = BLEShutdownLifecycleCoordinator(iface)
+
+    def _disconnect_and_close_client(
+        _client: object, *, timeout: float | None = None
+    ) -> None:
+        del timeout
+        raise TypeError("disconnect broke for another reason")
+
+    iface._disconnect_and_close_client = _disconnect_and_close_client  # type: ignore[assignment]
+    monkeypatch.setattr(
+        coordinator,
+        "_await_management_shutdown",
+        lambda **kwargs: True,
+    )
+    try:
+        with pytest.raises(TypeError, match="disconnect broke"):
+            coordinator._shutdown_client(
+                management_wait_timed_out=True,
+                client_disconnect_timeout=1.0,
+                disconnect_notification_wait_timeout=0.5,
+                unsubscribe_timeout=0.1,
+                bounded_close_timeout_active=True,
+            )
+    finally:
+        iface.close()
+
+
+def test_shutdown_wait_for_disconnect_notifications_skips_legacy_fallback_with_finite_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_shutdown_client should not call unbounded legacy wait under a finite budget."""
     iface = _make_iface(monkeypatch)
     coordinator = BLEShutdownLifecycleCoordinator(iface)
     calls: list[dict[str, object]] = []
@@ -3011,6 +3079,40 @@ def test_shutdown_wait_for_disconnect_notifications_fallback_on_unsupported_time
             client_disconnect_timeout=1.0,
             disconnect_notification_wait_timeout=0.5,
             unsubscribe_timeout=0.1,
+            bounded_close_timeout_active=True,
+        )
+        assert calls == []
+    finally:
+        iface.close()
+
+
+def test_shutdown_wait_for_disconnect_notifications_legacy_fallback_without_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_shutdown_client should permit legacy wait fallback without a timeout budget."""
+    iface = _make_iface(monkeypatch)
+    coordinator = BLEShutdownLifecycleCoordinator(iface)
+    calls: list[dict[str, object]] = []
+
+    def _wait_for_disconnect_notifications(*, timeout: float | None = None) -> None:
+        if timeout is not None:
+            raise TypeError(
+                "_wait_for_disconnect_notifications() got an unexpected keyword argument 'timeout'"
+            )
+        calls.append({"timeout": timeout})
+
+    iface._wait_for_disconnect_notifications = _wait_for_disconnect_notifications  # type: ignore[assignment]
+    monkeypatch.setattr(
+        coordinator,
+        "_await_management_shutdown",
+        lambda **kwargs: True,
+    )
+    try:
+        coordinator._shutdown_client(
+            management_wait_timed_out=True,
+            client_disconnect_timeout=None,
+            disconnect_notification_wait_timeout=None,
+            unsubscribe_timeout=None,
         )
         assert len(calls) == 1
         assert calls[0]["timeout"] is None
@@ -3042,6 +3144,7 @@ def test_shutdown_wait_for_disconnect_notifications_propagates_unrelated_type_er
                 client_disconnect_timeout=1.0,
                 disconnect_notification_wait_timeout=0.5,
                 unsubscribe_timeout=0.1,
+                bounded_close_timeout_active=True,
             )
     finally:
         iface.close()
@@ -3127,7 +3230,7 @@ def test_shutdown_cleanup_thread_not_duplicated_when_previous_alive(
     iface = _make_iface(monkeypatch)
     coordinator = BLEShutdownLifecycleCoordinator(iface)
     iface.thread_coordinator = SimpleNamespace(cleanup=lambda: None)
-    created_threads: list[object] = []
+    started_threads: list[object] = []
 
     class _AliveThread:
         def __init__(self, *, target: object, name: str, daemon: bool) -> None:
@@ -3135,10 +3238,10 @@ def test_shutdown_cleanup_thread_not_duplicated_when_previous_alive(
             self.name = name
             self.daemon = daemon
             self.started = False
-            created_threads.append(self)
 
         def start(self) -> None:
             self.started = True
+            started_threads.append(self)
 
         def join(self, timeout: float | None = None) -> None:
             del timeout
@@ -3156,8 +3259,7 @@ def test_shutdown_cleanup_thread_not_duplicated_when_previous_alive(
         with caplog.at_level(logging.WARNING):
             coordinator._cleanup_thread_coordinator(timeout=0.01)
 
-        assert len(created_threads) == 2
-        assert sum(1 for t in created_threads if t.started) == 1
+        assert len(started_threads) == 1
         assert "previous bounded cleanup thread is still running" in caplog.text
     finally:
         iface.close()
@@ -3170,7 +3272,7 @@ def test_shutdown_mesh_close_thread_not_duplicated_when_previous_alive(
     """A stuck bounded MeshInterface.close thread should suppress later spawns."""
     iface = _make_iface(monkeypatch)
     coordinator = BLEShutdownLifecycleCoordinator(iface)
-    created_threads: list[object] = []
+    started_threads: list[object] = []
 
     class _AliveThread:
         def __init__(self, *, target: object, name: str, daemon: bool) -> None:
@@ -3178,10 +3280,10 @@ def test_shutdown_mesh_close_thread_not_duplicated_when_previous_alive(
             self.name = name
             self.daemon = daemon
             self.started = False
-            created_threads.append(self)
 
         def start(self) -> None:
             self.started = True
+            started_threads.append(self)
 
         def join(self, timeout: float | None = None) -> None:
             del timeout
@@ -3199,8 +3301,7 @@ def test_shutdown_mesh_close_thread_not_duplicated_when_previous_alive(
         with caplog.at_level(logging.WARNING):
             coordinator._close_mesh_interface(timeout=0.01)
 
-        assert len(created_threads) == 2
-        assert sum(1 for t in created_threads if t.started) == 1
+        assert len(started_threads) == 1
         assert "previous bounded close thread is still running" in caplog.text
     finally:
         iface.close()

--- a/tests/test_ble_lifecycle_receive_targets.py
+++ b/tests/test_ble_lifecycle_receive_targets.py
@@ -40,6 +40,24 @@ class _FatalReceiveError(RuntimeError):
     """Used by receive-loop tests."""
 
 
+class _StartFailingThread:
+    """Thread stub that raises from start() for bounded-shutdown tests."""
+
+    def __init__(self, *, target: object, name: str, daemon: bool) -> None:
+        self.target = target
+        self.name = name
+        self.daemon = daemon
+
+    def start(self) -> None:
+        raise RuntimeError("thread start failure")
+
+    def join(self, timeout: float | None = None) -> None:
+        del timeout
+
+    def is_alive(self) -> bool:
+        return False
+
+
 class _IfaceWithStateManager(Protocol):
     _state_manager: object
 
@@ -1028,7 +1046,7 @@ def test_close_mesh_interface_timeout_limits_blocking_wait(
         elapsed = time.monotonic() - started
 
         assert close_called.is_set()
-        assert elapsed < 0.1
+        assert elapsed < 0.5
     finally:
         iface.close()
 
@@ -2949,14 +2967,17 @@ def test_shutdown_disconnect_client_fallback_on_unsupported_timeout(
         "_await_management_shutdown",
         lambda **kwargs: True,
     )
-    coordinator._shutdown_client(
-        management_wait_timed_out=True,
-        client_disconnect_timeout=1.0,
-        disconnect_notification_wait_timeout=0.5,
-        unsubscribe_timeout=0.1,
-    )
-    assert len(calls) == 1
-    assert calls[0][1]["timeout"] is None
+    try:
+        coordinator._shutdown_client(
+            management_wait_timed_out=True,
+            client_disconnect_timeout=1.0,
+            disconnect_notification_wait_timeout=0.5,
+            unsubscribe_timeout=0.1,
+        )
+        assert len(calls) == 1
+        assert calls[0][1]["timeout"] is None
+    finally:
+        iface.close()
 
 
 def test_shutdown_wait_for_disconnect_notifications_fallback_on_unsupported_timeout(
@@ -2980,14 +3001,17 @@ def test_shutdown_wait_for_disconnect_notifications_fallback_on_unsupported_time
         "_await_management_shutdown",
         lambda **kwargs: True,
     )
-    coordinator._shutdown_client(
-        management_wait_timed_out=True,
-        client_disconnect_timeout=1.0,
-        disconnect_notification_wait_timeout=0.5,
-        unsubscribe_timeout=0.1,
-    )
-    assert len(calls) == 1
-    assert calls[0]["timeout"] is None
+    try:
+        coordinator._shutdown_client(
+            management_wait_timed_out=True,
+            client_disconnect_timeout=1.0,
+            disconnect_notification_wait_timeout=0.5,
+            unsubscribe_timeout=0.1,
+        )
+        assert len(calls) == 1
+        assert calls[0]["timeout"] is None
+    finally:
+        iface.close()
 
 
 def test_shutdown_wait_for_disconnect_notifications_propagates_unrelated_type_error(
@@ -3007,13 +3031,16 @@ def test_shutdown_wait_for_disconnect_notifications_propagates_unrelated_type_er
         "_await_management_shutdown",
         lambda **kwargs: True,
     )
-    with pytest.raises(TypeError, match="takes 1 positional argument"):
-        coordinator._shutdown_client(
-            management_wait_timed_out=True,
-            client_disconnect_timeout=1.0,
-            disconnect_notification_wait_timeout=0.5,
-            unsubscribe_timeout=0.1,
-        )
+    try:
+        with pytest.raises(TypeError, match="takes 1 positional argument"):
+            coordinator._shutdown_client(
+                management_wait_timed_out=True,
+                client_disconnect_timeout=1.0,
+                disconnect_notification_wait_timeout=0.5,
+                unsubscribe_timeout=0.1,
+            )
+    finally:
+        iface.close()
 
 
 def test_shutdown_cleanup_thread_skips_stage_when_start_fails_with_timeout(
@@ -3031,24 +3058,9 @@ def test_shutdown_cleanup_thread_skips_stage_when_start_fails_with_timeout(
 
     original_thread = threading.Thread
 
-    class _FailingThread:
-        def __init__(self, *, target: object, name: str, daemon: bool) -> None:
-            self.target = target
-            self.name = name
-            self.daemon = daemon
-
-        def start(self) -> None:
-            raise RuntimeError("thread start failure")
-
-        def join(self, timeout: float | None = None) -> None:
-            pass
-
-        def is_alive(self) -> bool:
-            return False
-
     monkeypatch.setattr(
         "meshtastic.interfaces.ble.lifecycle_shutdown_runtime.threading.Thread",
-        _FailingThread,
+        _StartFailingThread,
     )
 
     try:
@@ -3084,24 +3096,9 @@ def test_shutdown_mesh_close_skips_stage_when_start_fails_with_timeout(
 
     original_thread = threading.Thread
 
-    class _FailingThread:
-        def __init__(self, *, target: object, name: str, daemon: bool) -> None:
-            self.target = target
-            self.name = name
-            self.daemon = daemon
-
-        def start(self) -> None:
-            raise RuntimeError("thread start failure")
-
-        def join(self, timeout: float | None = None) -> None:
-            pass
-
-        def is_alive(self) -> bool:
-            return False
-
     monkeypatch.setattr(
         "meshtastic.interfaces.ble.lifecycle_shutdown_runtime.threading.Thread",
-        _FailingThread,
+        _StartFailingThread,
     )
 
     try:
@@ -3115,4 +3112,111 @@ def test_shutdown_mesh_close_skips_stage_when_start_fails_with_timeout(
             "meshtastic.interfaces.ble.lifecycle_shutdown_runtime.threading.Thread",
             original_thread,
         )
+        iface.close()
+
+
+def test_shutdown_cleanup_thread_not_duplicated_when_previous_alive(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A stuck bounded cleanup thread should suppress later cleanup spawns."""
+    iface = _make_iface(monkeypatch)
+    coordinator = BLEShutdownLifecycleCoordinator(iface)
+    iface.thread_coordinator = SimpleNamespace(cleanup=lambda: None)
+    created_threads: list[object] = []
+
+    class _AliveThread:
+        def __init__(self, *, target: object, name: str, daemon: bool) -> None:
+            self.target = target
+            self.name = name
+            self.daemon = daemon
+            self.started = False
+            created_threads.append(self)
+
+        def start(self) -> None:
+            self.started = True
+
+        def join(self, timeout: float | None = None) -> None:
+            del timeout
+
+        def is_alive(self) -> bool:
+            return True
+
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.lifecycle_shutdown_runtime.threading.Thread",
+        _AliveThread,
+    )
+
+    try:
+        coordinator._cleanup_thread_coordinator(timeout=0.01)
+        with caplog.at_level(logging.WARNING):
+            coordinator._cleanup_thread_coordinator(timeout=0.01)
+
+        assert len(created_threads) == 1
+        assert "previous bounded cleanup thread is still running" in caplog.text
+    finally:
+        iface.close()
+
+
+def test_shutdown_mesh_close_thread_not_duplicated_when_previous_alive(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A stuck bounded MeshInterface.close thread should suppress later spawns."""
+    iface = _make_iface(monkeypatch)
+    coordinator = BLEShutdownLifecycleCoordinator(iface)
+    created_threads: list[object] = []
+
+    class _AliveThread:
+        def __init__(self, *, target: object, name: str, daemon: bool) -> None:
+            self.target = target
+            self.name = name
+            self.daemon = daemon
+            self.started = False
+            created_threads.append(self)
+
+        def start(self) -> None:
+            self.started = True
+
+        def join(self, timeout: float | None = None) -> None:
+            del timeout
+
+        def is_alive(self) -> bool:
+            return True
+
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.lifecycle_shutdown_runtime.threading.Thread",
+        _AliveThread,
+    )
+
+    try:
+        coordinator._close_mesh_interface(timeout=0.01)
+        with caplog.at_level(logging.WARNING):
+            coordinator._close_mesh_interface(timeout=0.01)
+
+        assert len(created_threads) == 1
+        assert "previous bounded close thread is still running" in caplog.text
+    finally:
+        iface.close()
+
+
+def test_shutdown_bounded_thread_references_clear_after_completion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bounded cleanup and mesh-close thread references should clear on completion."""
+    iface = _make_iface(monkeypatch)
+    coordinator = BLEShutdownLifecycleCoordinator(iface)
+    iface.thread_coordinator = SimpleNamespace(cleanup=lambda: None)
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.lifecycle_shutdown_runtime.MeshInterface.close",
+        lambda _iface: None,
+    )
+
+    try:
+        coordinator._cleanup_thread_coordinator(timeout=1.0)
+        coordinator._close_mesh_interface(timeout=1.0)
+
+        assert coordinator._bounded_cleanup_thread is None
+        assert coordinator._bounded_mesh_close_thread is None
+    finally:
         iface.close()

--- a/tests/test_ble_lifecycle_receive_targets.py
+++ b/tests/test_ble_lifecycle_receive_targets.py
@@ -6,8 +6,9 @@ import contextlib
 import importlib
 import itertools
 import threading
+import time
 from types import SimpleNamespace
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -22,6 +23,9 @@ from meshtastic.interfaces.ble.constants import ERROR_INTERFACE_CLOSING
 from meshtastic.interfaces.ble.lifecycle_primitives import (
     _DisconnectPlan,
     _OwnershipSnapshot,
+)
+from meshtastic.interfaces.ble.lifecycle_shutdown_runtime import (
+    BLEShutdownLifecycleCoordinator,
 )
 from meshtastic.interfaces.ble.lifecycle_service import BLELifecycleService
 from meshtastic.interfaces.ble.receive_service import BLEReceiveRecoveryService
@@ -919,6 +923,106 @@ def test_lifecycle_shutdown_and_finalize_close_paths(
     finally:
         _reset_state_manager(iface)
         iface.close()
+
+
+def test_shutdown_close_timeout_budget_rolls_forward_to_later_stages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Earlier shutdown work should reduce remaining timeout budgets for later blocking stages."""
+    iface = _make_iface(monkeypatch)
+    coordinator = BLEShutdownLifecycleCoordinator(iface)
+    now = {"value": 100.0}
+    captured: dict[str, float | None] = {}
+
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.lifecycle_shutdown_runtime.time.monotonic",
+        lambda: now["value"],
+    )
+
+    def _await_management_shutdown(**kwargs: object) -> bool:
+        captured["management_timeout"] = cast(
+            float, kwargs["management_shutdown_wait_timeout"]
+        )
+        now["value"] += 0.045
+        return False
+
+    def _shutdown_receive_thread(*, join_timeout: float) -> None:
+        captured["join_timeout"] = join_timeout
+        now["value"] += 0.003
+
+    def _close_mesh_interface(
+        *,
+        timeout: float | None = None,
+        safe_execute: object | None = None,
+    ) -> None:
+        _ = safe_execute
+        captured["mesh_close_timeout"] = timeout
+        now["value"] += 0.001
+
+    def _shutdown_client(**kwargs: object) -> None:
+        captured["client_disconnect_timeout"] = cast(
+            float | None, kwargs["client_disconnect_timeout"]
+        )
+        captured["disconnect_notification_wait_timeout"] = cast(
+            float | None, kwargs["disconnect_notification_wait_timeout"]
+        )
+        captured["unsubscribe_timeout"] = cast(
+            float | None, kwargs["unsubscribe_timeout"]
+        )
+
+    coordinator._await_management_shutdown = _await_management_shutdown
+    coordinator._shutdown_discovery = lambda: None
+    coordinator._shutdown_receive_thread = _shutdown_receive_thread
+    coordinator._close_mesh_interface = _close_mesh_interface
+    coordinator._unregister_exit_handler = lambda: None
+    coordinator._shutdown_client = _shutdown_client
+    coordinator._cleanup_thread_coordinator = lambda *, timeout=None: captured.setdefault(
+        "cleanup_timeout", timeout
+    )
+    coordinator._finalize_close_state = lambda: None
+
+    coordinator.close(
+        management_shutdown_wait_timeout=0.2,
+        management_wait_poll_seconds=0.01,
+        timeout=0.05,
+    )
+
+    assert captured["management_timeout"] == pytest.approx(0.05)
+    assert captured["join_timeout"] == pytest.approx(0.005)
+    assert captured["mesh_close_timeout"] == pytest.approx(0.002)
+    assert captured["client_disconnect_timeout"] == pytest.approx(0.001)
+    assert captured["disconnect_notification_wait_timeout"] == pytest.approx(0.001)
+    assert captured["unsubscribe_timeout"] == pytest.approx(0.001)
+    assert captured["cleanup_timeout"] == pytest.approx(0.001)
+
+
+def test_close_mesh_interface_timeout_limits_blocking_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_close_mesh_interface should stop waiting once its per-stage timeout is exhausted."""
+    iface = _make_iface(monkeypatch)
+    coordinator = BLEShutdownLifecycleCoordinator(iface)
+    release_close = threading.Event()
+    close_called = threading.Event()
+
+    def _blocking_mesh_close(_iface: object) -> None:
+        close_called.set()
+        release_close.wait(timeout=0.5)
+
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.lifecycle_shutdown_runtime.MeshInterface.close",
+        _blocking_mesh_close,
+    )
+
+    started = time.monotonic()
+    try:
+        coordinator._close_mesh_interface(timeout=0.01)
+    finally:
+        release_close.set()
+    elapsed = time.monotonic() - started
+
+    assert close_called.is_set()
+    assert elapsed < 0.1
 
 
 def test_lifecycle_shutdown_receive_thread_skips_self_join_by_ident(

--- a/tests/test_ble_lifecycle_receive_targets.py
+++ b/tests/test_ble_lifecycle_receive_targets.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import importlib
 import itertools
+import logging
 import threading
 import time
 from types import SimpleNamespace
@@ -3013,3 +3014,105 @@ def test_shutdown_wait_for_disconnect_notifications_propagates_unrelated_type_er
             disconnect_notification_wait_timeout=0.5,
             unsubscribe_timeout=0.1,
         )
+
+
+def test_shutdown_cleanup_thread_skips_stage_when_start_fails_with_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """_cleanup_thread_coordinator should skip bounded stage when thread start fails."""
+    iface = _make_iface(monkeypatch)
+    coordinator = BLEShutdownLifecycleCoordinator(iface)
+    cleanup_calls: list[str] = []
+
+    iface.thread_coordinator = SimpleNamespace(
+        cleanup=lambda: cleanup_calls.append("cleanup")
+    )
+
+    original_thread = threading.Thread
+
+    class _FailingThread:
+        def __init__(self, *, target: object, name: str, daemon: bool) -> None:
+            self.target = target
+            self.name = name
+            self.daemon = daemon
+
+        def start(self) -> None:
+            raise RuntimeError("thread start failure")
+
+        def join(self, timeout: float | None = None) -> None:
+            pass
+
+        def is_alive(self) -> bool:
+            return False
+
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.lifecycle_shutdown_runtime.threading.Thread",
+        _FailingThread,
+    )
+
+    try:
+        with caplog.at_level(logging.WARNING):
+            coordinator._cleanup_thread_coordinator(timeout=0.5)
+        assert cleanup_calls == []
+        assert "Failed to start thread coordinator cleanup thread" in caplog.text
+        assert "skipping bounded cleanup stage" in caplog.text
+    finally:
+        monkeypatch.setattr(
+            "meshtastic.interfaces.ble.lifecycle_shutdown_runtime.threading.Thread",
+            original_thread,
+        )
+        iface.close()
+
+
+def test_shutdown_mesh_close_skips_stage_when_start_fails_with_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """_close_mesh_interface should skip bounded stage when thread start fails."""
+    iface = _make_iface(monkeypatch)
+    coordinator = BLEShutdownLifecycleCoordinator(iface)
+    close_calls: list[str] = []
+
+    def _track_mesh_close(_iface: object) -> None:
+        close_calls.append("mesh-close")
+
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.lifecycle_shutdown_runtime.MeshInterface.close",
+        _track_mesh_close,
+    )
+
+    original_thread = threading.Thread
+
+    class _FailingThread:
+        def __init__(self, *, target: object, name: str, daemon: bool) -> None:
+            self.target = target
+            self.name = name
+            self.daemon = daemon
+
+        def start(self) -> None:
+            raise RuntimeError("thread start failure")
+
+        def join(self, timeout: float | None = None) -> None:
+            pass
+
+        def is_alive(self) -> bool:
+            return False
+
+    monkeypatch.setattr(
+        "meshtastic.interfaces.ble.lifecycle_shutdown_runtime.threading.Thread",
+        _FailingThread,
+    )
+
+    try:
+        with caplog.at_level(logging.WARNING):
+            coordinator._close_mesh_interface(timeout=0.5)
+        assert close_calls == []
+        assert "Failed to start MeshInterface.close thread" in caplog.text
+        assert "skipping bounded close stage" in caplog.text
+    finally:
+        monkeypatch.setattr(
+            "meshtastic.interfaces.ble.lifecycle_shutdown_runtime.threading.Thread",
+            original_thread,
+        )
+        iface.close()

--- a/tests/test_ble_lifecycle_receive_targets.py
+++ b/tests/test_ble_lifecycle_receive_targets.py
@@ -24,10 +24,10 @@ from meshtastic.interfaces.ble.lifecycle_primitives import (
     _DisconnectPlan,
     _OwnershipSnapshot,
 )
+from meshtastic.interfaces.ble.lifecycle_service import BLELifecycleService
 from meshtastic.interfaces.ble.lifecycle_shutdown_runtime import (
     BLEShutdownLifecycleCoordinator,
 )
-from meshtastic.interfaces.ble.lifecycle_service import BLELifecycleService
 from meshtastic.interfaces.ble.receive_service import BLEReceiveRecoveryService
 from meshtastic.interfaces.ble.state import ConnectionState
 from tests.test_ble_interface_fixtures import DummyClient, _build_interface
@@ -976,8 +976,8 @@ def test_shutdown_close_timeout_budget_rolls_forward_to_later_stages(
     coordinator._close_mesh_interface = _close_mesh_interface
     coordinator._unregister_exit_handler = lambda: None
     coordinator._shutdown_client = _shutdown_client
-    coordinator._cleanup_thread_coordinator = lambda *, timeout=None: captured.setdefault(
-        "cleanup_timeout", timeout
+    coordinator._cleanup_thread_coordinator = (
+        lambda *, timeout=None: captured.setdefault("cleanup_timeout", timeout)
     )
     coordinator._finalize_close_state = lambda: None
 

--- a/tests/test_ble_lifecycle_receive_targets.py
+++ b/tests/test_ble_lifecycle_receive_targets.py
@@ -265,7 +265,9 @@ def test_lifecycle_start_receive_and_schedule_auto_reconnect_branches(
         with iface._state_lock:
             iface._receiveThread = None
 
-        new_thread = SimpleNamespace(name="new-thread", ident=None, is_alive=lambda: False)
+        new_thread = SimpleNamespace(
+            name="new-thread", ident=None, is_alive=lambda: False
+        )
         monkeypatch.setattr(
             BLELifecycleService,
             "_thread_create_thread",
@@ -2954,7 +2956,9 @@ def test_shutdown_disconnect_client_fallback_on_unsupported_timeout(
     coordinator = BLEShutdownLifecycleCoordinator(iface)
     calls: list[tuple[object, dict[str, object]]] = []
 
-    def _disconnect_and_close_client(client: object, *, timeout: float | None = None) -> None:
+    def _disconnect_and_close_client(
+        client: object, *, timeout: float | None = None
+    ) -> None:
         if timeout is not None:
             raise TypeError(
                 "_disconnect_and_close_client() got an unexpected keyword argument 'timeout'"
@@ -3152,7 +3156,8 @@ def test_shutdown_cleanup_thread_not_duplicated_when_previous_alive(
         with caplog.at_level(logging.WARNING):
             coordinator._cleanup_thread_coordinator(timeout=0.01)
 
-        assert len(created_threads) == 1
+        assert len(created_threads) == 2
+        assert sum(1 for t in created_threads if t.started) == 1
         assert "previous bounded cleanup thread is still running" in caplog.text
     finally:
         iface.close()
@@ -3194,7 +3199,8 @@ def test_shutdown_mesh_close_thread_not_duplicated_when_previous_alive(
         with caplog.at_level(logging.WARNING):
             coordinator._close_mesh_interface(timeout=0.01)
 
-        assert len(created_threads) == 1
+        assert len(created_threads) == 2
+        assert sum(1 for t in created_threads if t.started) == 1
         assert "previous bounded close thread is still running" in caplog.text
     finally:
         iface.close()

--- a/tests/test_ble_lifecycle_receive_targets.py
+++ b/tests/test_ble_lifecycle_receive_targets.py
@@ -978,24 +978,26 @@ def test_shutdown_close_timeout_budget_rolls_forward_to_later_stages(
     coordinator._unregister_exit_handler = lambda: None
     coordinator._shutdown_client = _shutdown_client
     coordinator._cleanup_thread_coordinator = (
-        lambda *, timeout=None: captured.setdefault("cleanup_timeout", timeout)
+        lambda *, timeout=None: captured.__setitem__("cleanup_timeout", timeout)
     )
     coordinator._finalize_close_state = lambda: None
 
-    coordinator.close(
-        management_shutdown_wait_timeout=0.2,
-        management_wait_poll_seconds=0.01,
-        timeout=0.05,
-    )
+    try:
+        coordinator.close(
+            management_shutdown_wait_timeout=0.2,
+            management_wait_poll_seconds=0.01,
+            timeout=0.05,
+        )
 
-    assert captured["management_timeout"] == pytest.approx(0.05)
-    assert captured["join_timeout"] == pytest.approx(0.005)
-    assert captured["mesh_close_timeout"] == pytest.approx(0.002)
-    assert captured["client_disconnect_timeout"] == pytest.approx(0.001)
-    assert captured["disconnect_notification_wait_timeout"] == pytest.approx(0.001)
-    assert captured["unsubscribe_timeout"] == pytest.approx(0.001)
-    assert captured["cleanup_timeout"] == pytest.approx(0.001)
-    iface.close()
+        assert captured["management_timeout"] == pytest.approx(0.05)
+        assert captured["join_timeout"] == pytest.approx(0.005)
+        assert captured["mesh_close_timeout"] == pytest.approx(0.002)
+        assert captured["client_disconnect_timeout"] == pytest.approx(0.001)
+        assert captured["disconnect_notification_wait_timeout"] == pytest.approx(0.001)
+        assert captured["unsubscribe_timeout"] == pytest.approx(0.001)
+        assert captured["cleanup_timeout"] == pytest.approx(0.001)
+    finally:
+        iface.close()
 
 
 def test_close_mesh_interface_timeout_limits_blocking_wait(
@@ -1016,16 +1018,18 @@ def test_close_mesh_interface_timeout_limits_blocking_wait(
         _blocking_mesh_close,
     )
 
-    started = time.monotonic()
     try:
-        coordinator._close_mesh_interface(timeout=0.01)
-    finally:
-        release_close.set()
-    elapsed = time.monotonic() - started
+        started = time.monotonic()
+        try:
+            coordinator._close_mesh_interface(timeout=0.01)
+        finally:
+            release_close.set()
+        elapsed = time.monotonic() - started
 
-    assert close_called.is_set()
-    assert elapsed < 0.1
-    iface.close()
+        assert close_called.is_set()
+        assert elapsed < 0.1
+    finally:
+        iface.close()
 
 
 def test_lifecycle_shutdown_receive_thread_skips_self_join_by_ident(

--- a/tests/test_ble_naming_compatibility.py
+++ b/tests/test_ble_naming_compatibility.py
@@ -139,7 +139,7 @@ def test_ble_find_device_shim_is_silent_and_delegates() -> None:
     assert not any(issubclass(w.category, DeprecationWarning) for w in caught)
 
 
-def test_ble_interface_ble_address_shim_delegates_to_ble_address() -> None:
+def test_ble_interface_ble_address_shim_delegates_to_bleAddress() -> None:
     """ble_address should delegate to bleAddress and remain silent."""
     iface = object.__new__(BLEInterface)
     iface.address = "AA:BB:CC:DD:EE:FF"
@@ -155,7 +155,7 @@ def test_ble_interface_ble_address_shim_delegates_to_ble_address() -> None:
     assert not any(issubclass(w.category, DeprecationWarning) for w in caught)
 
 
-def test_ble_client_ble_address_shim_delegates_to_ble_address() -> None:
+def test_ble_client_ble_address_shim_delegates_to_bleAddress() -> None:
     """ble_address should delegate to bleAddress on BLEClient and remain silent."""
     client = object.__new__(BLEClient)
     client.address = "11:22:33:44:55:66"

--- a/tests/test_ble_naming_compatibility.py
+++ b/tests/test_ble_naming_compatibility.py
@@ -137,3 +137,34 @@ def test_ble_find_device_shim_is_silent_and_delegates() -> None:
     delegate.assert_called_once_with("abc")
     assert result is delegate.return_value
     assert not any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+def test_ble_interface_ble_address_shim_delegates_to_ble_address() -> None:
+    """ble_address should delegate to bleAddress and remain silent."""
+    iface = object.__new__(BLEInterface)
+    iface.address = "AA:BB:CC:DD:EE:FF"
+    iface.client = None
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        camel = iface.bleAddress
+        snake = iface.ble_address
+
+    assert camel == "AA:BB:CC:DD:EE:FF"
+    assert snake is camel
+    assert not any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+def test_ble_client_ble_address_shim_delegates_to_ble_address() -> None:
+    """ble_address should delegate to bleAddress on BLEClient and remain silent."""
+    client = object.__new__(BLEClient)
+    client.address = "11:22:33:44:55:66"
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        camel = client.bleAddress
+        snake = client.ble_address
+
+    assert camel == "11:22:33:44:55:66"
+    assert snake is camel
+    assert not any(issubclass(w.category, DeprecationWarning) for w in caught)

--- a/tests/test_ble_naming_compatibility.py
+++ b/tests/test_ble_naming_compatibility.py
@@ -139,7 +139,7 @@ def test_ble_find_device_shim_is_silent_and_delegates() -> None:
     assert not any(issubclass(w.category, DeprecationWarning) for w in caught)
 
 
-def test_ble_interface_ble_address_shim_delegates_to_bleAddress() -> None:
+def test_ble_interface_ble_address_shim_delegates_to_ble_address() -> None:
     """ble_address should delegate to bleAddress and remain silent."""
     iface = object.__new__(BLEInterface)
     iface.address = "AA:BB:CC:DD:EE:FF"
@@ -155,7 +155,7 @@ def test_ble_interface_ble_address_shim_delegates_to_bleAddress() -> None:
     assert not any(issubclass(w.category, DeprecationWarning) for w in caught)
 
 
-def test_ble_client_ble_address_shim_delegates_to_bleAddress() -> None:
+def test_ble_client_ble_address_shim_delegates_to_ble_address() -> None:
     """ble_address should delegate to bleAddress on BLEClient and remain silent."""
     client = object.__new__(BLEClient)
     client.address = "11:22:33:44:55:66"

--- a/tests/test_ble_runner.py
+++ b/tests/test_ble_runner.py
@@ -15,6 +15,7 @@ from meshtastic.interfaces.ble.runner import (
     BLECoroutineRunner,
     get_zombie_runner_count,
 )
+from meshtastic.interfaces.ble import runner as _runner_module
 
 pytestmark = pytest.mark.unit
 
@@ -55,10 +56,14 @@ def ensure_runner_running() -> Generator[None, None, None]:
     Start the BLECoroutineRunner before the test and re-validate or restart it
     after the test to prevent singleton state leakage between tests.
     """
+    with _runner_module._zombie_lock:
+        saved_zombie_count = _runner_module._zombie_runner_count
+        _runner_module._zombie_runner_count = 0
     runner = BLECoroutineRunner()
     runner._ensure_running()
     yield
-    # Ensure runner is still running after test for subsequent tests
+    with _runner_module._zombie_lock:
+        _runner_module._zombie_runner_count = saved_zombie_count
     runner._ensure_running()
 
 

--- a/tests/test_ble_utils.py
+++ b/tests/test_ble_utils.py
@@ -9,6 +9,8 @@ import pytest
 
 pytest.importorskip("bleak")
 import meshtastic.interfaces.ble.utils as ble_utils
+from meshtastic.ble_interface import sanitize_address as compat_sanitize_address
+from meshtastic.interfaces.ble import sanitize_address as public_sanitize_address
 from meshtastic.interfaces.ble.utils import (
     resolve_ble_module,
     with_timeout,
@@ -61,3 +63,15 @@ def test_resolve_ble_module_returns_module(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr(ble_utils.importlib, "import_module", lambda _name: sentinel)
 
     assert resolve_ble_module() is sentinel
+
+
+@pytest.mark.unit
+def test_sanitize_address_exported_from_ble_public_api() -> None:
+    """sanitize_address should be publicly exported from meshtastic.interfaces.ble."""
+    assert public_sanitize_address("AA-BB:CC_DD EE FF") == "aabbccddeeff"
+
+
+@pytest.mark.unit
+def test_sanitize_address_exported_from_ble_compat_surface() -> None:
+    """sanitize_address should be available through meshtastic.ble_interface."""
+    assert compat_sanitize_address("AA:BB:CC:DD:EE:FF") == "aabbccddeeff"

--- a/tests/test_ble_utils.py
+++ b/tests/test_ble_utils.py
@@ -11,24 +11,40 @@ pytest.importorskip("bleak")
 import meshtastic.interfaces.ble.utils as ble_utils
 from meshtastic.ble_interface import (
     BLEAddressMismatchError as CompatBLEAddressMismatchError,
-    BLEConnectionSuppressedError as CompatBLEConnectionSuppressedError,
-    BLEConnectionTimeoutError as CompatBLEConnectionTimeoutError,
-    BLEDBusTransportError as CompatBLEDBusTransportError,
-    BLEDeviceNotFoundError as CompatBLEDeviceNotFoundError,
-    BLEDiscoveryError as CompatBLEDiscoveryError,
-    MeshtasticBLEError as CompatMeshtasticBLEError,
-    sanitize_address as compat_sanitize_address,
 )
+from meshtastic.ble_interface import (
+    BLEConnectionSuppressedError as CompatBLEConnectionSuppressedError,
+)
+from meshtastic.ble_interface import (
+    BLEConnectionTimeoutError as CompatBLEConnectionTimeoutError,
+)
+from meshtastic.ble_interface import (
+    BLEDBusTransportError as CompatBLEDBusTransportError,
+)
+from meshtastic.ble_interface import (
+    BLEDeviceNotFoundError as CompatBLEDeviceNotFoundError,
+)
+from meshtastic.ble_interface import BLEDiscoveryError as CompatBLEDiscoveryError
+from meshtastic.ble_interface import MeshtasticBLEError as CompatMeshtasticBLEError
+from meshtastic.ble_interface import sanitize_address as compat_sanitize_address
 from meshtastic.interfaces.ble import (
     BLEAddressMismatchError as PublicBLEAddressMismatchError,
-    BLEConnectionSuppressedError as PublicBLEConnectionSuppressedError,
-    BLEConnectionTimeoutError as PublicBLEConnectionTimeoutError,
-    BLEDBusTransportError as PublicBLEDBusTransportError,
-    BLEDeviceNotFoundError as PublicBLEDeviceNotFoundError,
-    BLEDiscoveryError as PublicBLEDiscoveryError,
-    MeshtasticBLEError as PublicMeshtasticBLEError,
-    sanitize_address as public_sanitize_address,
 )
+from meshtastic.interfaces.ble import (
+    BLEConnectionSuppressedError as PublicBLEConnectionSuppressedError,
+)
+from meshtastic.interfaces.ble import (
+    BLEConnectionTimeoutError as PublicBLEConnectionTimeoutError,
+)
+from meshtastic.interfaces.ble import (
+    BLEDBusTransportError as PublicBLEDBusTransportError,
+)
+from meshtastic.interfaces.ble import (
+    BLEDeviceNotFoundError as PublicBLEDeviceNotFoundError,
+)
+from meshtastic.interfaces.ble import BLEDiscoveryError as PublicBLEDiscoveryError
+from meshtastic.interfaces.ble import MeshtasticBLEError as PublicMeshtasticBLEError
+from meshtastic.interfaces.ble import sanitize_address as public_sanitize_address
 from meshtastic.interfaces.ble.utils import (
     resolve_ble_module,
     with_timeout,

--- a/tests/test_ble_utils.py
+++ b/tests/test_ble_utils.py
@@ -121,3 +121,43 @@ def test_typed_ble_exceptions_exported_from_public_and_compat_surfaces() -> None
     assert PublicBLEConnectionTimeoutError is CompatBLEConnectionTimeoutError
     assert PublicBLEAddressMismatchError is CompatBLEAddressMismatchError
     assert PublicBLEDBusTransportError is CompatBLEDBusTransportError
+
+
+@pytest.mark.unit
+def test_ble_device_not_found_error_identifier_property() -> None:
+    """BLEDeviceNotFoundError should expose .identifier for BleakDeviceNotFoundError compat."""
+    err = PublicBLEDeviceNotFoundError(
+        "not found",
+        requested_identifier="AA:BB:CC:DD:EE:FF",
+    )
+    assert err.identifier == "AA:BB:CC:DD:EE:FF"
+    assert err.requested_identifier == "AA:BB:CC:DD:EE:FF"
+
+
+@pytest.mark.unit
+def test_ble_device_not_found_error_catchable_as_bleak_device_not_found() -> None:
+    """BLEDeviceNotFoundError should be catchable as BleakDeviceNotFoundError."""
+    from bleak.exc import BleakDeviceNotFoundError
+
+    err = PublicBLEDeviceNotFoundError("not found")
+    assert isinstance(err, BleakDeviceNotFoundError)
+
+
+@pytest.mark.unit
+def test_ble_connection_timeout_error_is_instance_of_timeout_error() -> None:
+    """BLEConnectionTimeoutError should be catchable as TimeoutError."""
+    err = PublicBLEConnectionTimeoutError("timed out")
+    assert isinstance(err, TimeoutError)
+
+
+@pytest.mark.unit
+def test_ble_errors_are_instance_of_ble_interface_ble_error() -> None:
+    """All new BLE exceptions should be catchable as BLEInterface.BLEError."""
+    from meshtastic.interfaces.ble import BLEInterface
+
+    assert isinstance(PublicBLEDeviceNotFoundError("x"), BLEInterface.BLEError)
+    assert isinstance(PublicBLEConnectionTimeoutError("x"), BLEInterface.BLEError)
+    assert isinstance(PublicBLEConnectionSuppressedError("x"), BLEInterface.BLEError)
+    assert isinstance(PublicBLEAddressMismatchError("x"), BLEInterface.BLEError)
+    assert isinstance(PublicBLEDBusTransportError("x"), BLEInterface.BLEError)
+    assert isinstance(PublicBLEDiscoveryError("x"), BLEInterface.BLEError)

--- a/tests/test_ble_utils.py
+++ b/tests/test_ble_utils.py
@@ -161,3 +161,16 @@ def test_ble_errors_are_instance_of_ble_interface_ble_error() -> None:
     assert isinstance(PublicBLEAddressMismatchError("x"), BLEInterface.BLEError)
     assert isinstance(PublicBLEDBusTransportError("x"), BLEInterface.BLEError)
     assert isinstance(PublicBLEDiscoveryError("x"), BLEInterface.BLEError)
+
+
+@pytest.mark.unit
+def test_ble_dbus_transport_error_str_returns_normalized_message() -> None:
+    """BLEDBusTransportError.__str__ should return the normalized Meshtastic message."""
+    err = PublicBLEDBusTransportError(
+        "normalized transport failure",
+        dbus_error="org.bluez.Error.Failed",
+        dbus_error_details=["raw detail"],
+    )
+    assert str(err) == "normalized transport failure"
+    assert err.dbus_error_name == "org.bluez.Error.Failed"
+    assert err.dbus_error_body == (["raw detail"],)

--- a/tests/test_ble_utils.py
+++ b/tests/test_ble_utils.py
@@ -9,8 +9,26 @@ import pytest
 
 pytest.importorskip("bleak")
 import meshtastic.interfaces.ble.utils as ble_utils
-from meshtastic.ble_interface import sanitize_address as compat_sanitize_address
-from meshtastic.interfaces.ble import sanitize_address as public_sanitize_address
+from meshtastic.ble_interface import (
+    BLEAddressMismatchError as CompatBLEAddressMismatchError,
+    BLEConnectionSuppressedError as CompatBLEConnectionSuppressedError,
+    BLEConnectionTimeoutError as CompatBLEConnectionTimeoutError,
+    BLEDBusTransportError as CompatBLEDBusTransportError,
+    BLEDeviceNotFoundError as CompatBLEDeviceNotFoundError,
+    BLEDiscoveryError as CompatBLEDiscoveryError,
+    MeshtasticBLEError as CompatMeshtasticBLEError,
+    sanitize_address as compat_sanitize_address,
+)
+from meshtastic.interfaces.ble import (
+    BLEAddressMismatchError as PublicBLEAddressMismatchError,
+    BLEConnectionSuppressedError as PublicBLEConnectionSuppressedError,
+    BLEConnectionTimeoutError as PublicBLEConnectionTimeoutError,
+    BLEDBusTransportError as PublicBLEDBusTransportError,
+    BLEDeviceNotFoundError as PublicBLEDeviceNotFoundError,
+    BLEDiscoveryError as PublicBLEDiscoveryError,
+    MeshtasticBLEError as PublicMeshtasticBLEError,
+    sanitize_address as public_sanitize_address,
+)
 from meshtastic.interfaces.ble.utils import (
     resolve_ble_module,
     with_timeout,
@@ -75,3 +93,15 @@ def test_sanitize_address_exported_from_ble_public_api() -> None:
 def test_sanitize_address_exported_from_ble_compat_surface() -> None:
     """sanitize_address should be available through meshtastic.ble_interface."""
     assert compat_sanitize_address("AA:BB:CC:DD:EE:FF") == "aabbccddeeff"
+
+
+@pytest.mark.unit
+def test_typed_ble_exceptions_exported_from_public_and_compat_surfaces() -> None:
+    """Typed BLE exceptions should be importable from public and compat BLE modules."""
+    assert PublicMeshtasticBLEError is CompatMeshtasticBLEError
+    assert PublicBLEDiscoveryError is CompatBLEDiscoveryError
+    assert PublicBLEDeviceNotFoundError is CompatBLEDeviceNotFoundError
+    assert PublicBLEConnectionSuppressedError is CompatBLEConnectionSuppressedError
+    assert PublicBLEConnectionTimeoutError is CompatBLEConnectionTimeoutError
+    assert PublicBLEAddressMismatchError is CompatBLEAddressMismatchError
+    assert PublicBLEDBusTransportError is CompatBLEDBusTransportError


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR ports BLE reliability improvements into mtjk. It introduces a typed BLE exception hierarchy and DBus-aware transport errors, stable BLE address accessors with compatibility shims, explicit post-connect address verification, conservative Linux/BlueZ stale-connection cleanup with a single retry, and end-to-end timeout budgeting for disconnect/close and lifecycle shutdown stages — while preserving backwards compatibility for common callers.

## Key changes

Features:
- Typed BLE exceptions and public exports
  - New base and concrete exceptions: MeshtasticBLEError, BLEDiscoveryError, BLEDeviceNotFoundError, BLEConnectionSuppressedError, BLEConnectionTimeoutError, BLEAddressMismatchError, BLEDBusTransportError.
  - Exceptions carry structured metadata (address, requested_identifier, timeout, connected_address, cause). BLEDeviceNotFoundError exposes an identifier compatibility property.
  - Re-exported from meshtastic.interfaces.ble and meshtastic.ble_interface; sanitize_address also exported.
- Stable BLE address accessors
  - BLEClient: bleAddress and ble_address (snake_case alias).
  - BLEInterface: bleAddress and ble_address (compat shim) with defined resolution precedence (active client address → interface address if valid BLE MAC → None).
- Explicit post-connect address verification
  - Connects that used an explicit target verify the connected peer address and raise BLEAddressMismatchError on mismatch; if the client cannot supply an address, a permissive fallback is used.
- DBus/BlueZ transport normalization
  - BLEDBusTransportError normalizes Bleak DBus errors, preserves dbus_error_name/dbus_error_body/details and original cause, and provides from_exception helpers for consistent diagnostics.
- Timeout-bounded shutdown and disconnect API
  - BLEInterface.disconnect(timeout: float | None = None) and BLEInterface.close(timeout: float | None = None).
  - A monotonic total timeout budget is threaded through lifecycle shutdown phases and forwarded to collaborators when supported (with compatibility fallback on unexpected keyword errors).
- BlueZ stale-connection recovery
  - Detects qualifying BlueZ stale/overlap connect failures, performs best-effort cleanup, and retries the direct connect once while preserving timeout budgets.

Fixes:
- Duplicate-connect suppression now raises BLEConnectionSuppressedError with contextual fields instead of a generic error.
- Discovery/device-not-found and connect-timeout paths raise typed exceptions (BLEDeviceNotFoundError, BLEConnectionTimeoutError) that preserve request context.
- Reconnect loop treats BLEDBusTransportError specially to preserve DBus-specific reconnect-delay behavior.
- Client safe-close forwards disconnect timeouts where supported and falls back compatibly when the underlying API rejects the keyword.

Refactors and tests:
- Comprehensive orchestration/lifecycle changes to compute and consume per-stage remaining timeouts and to support optional timeout forwarding with compatibility fallbacks.
- Minor typing/compatibility cleanups in ppk2, riden, slog, and stream resolution code.
- Extensive test additions/updates covering typed exception propagation, address verification, BlueZ stale-cleanup + retry, ble_address properties and exports, sanitize_address compatibility, and timeout forwarding. Test run reported: 754 passed, 3 skipped.

## Backward compatibility / migration notes

- BLEInterface.BLEError is aliased to MeshtasticBLEError; existing callers catching BLEInterface.BLEError remain functional.
- disconnect(timeout) and close(timeout) are optional (default None). Callers need not change call sites but may supply a finite timeout to bound shutdown budgets.
- Explicit-address verification may now raise BLEAddressMismatchError where previously permissive; callers that must allow mismatches should avoid passing explicit addresses or catch BLEAddressMismatchError.
- If lifecycle collaborators or client close/disconnect implementations do not accept a timeout kwarg, the code detects the TypeError and retries the call without the kwarg; projects are encouraged to accept the timeout kwarg where practical to enable budget propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->