### PR TITLE
Extract port discovery module and refactor send queue runtime

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -9,7 +9,7 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.7.6
+      ref: v1.8.0
       uri: https://github.com/trunk-io/plugins
 lint:
   disabled:
@@ -81,14 +81,14 @@ lint:
   enabled:
     - actionlint@1.7.12
     - black@26.3.1
-    - checkov@3.2.524
+    - checkov@3.2.526
     - git-diff-check
     - gitleaks@8.30.1
     - isort@8.0.1
     - markdownlint@0.48.0
     - osv-scanner@2.3.5
     - prettier@3.8.3
-    - ruff@0.15.11
+    - ruff@0.15.12
     - shellcheck@0.11.0
     - shfmt@3.6.0
     - taplo@0.10.0
@@ -101,7 +101,7 @@ runtimes:
   enabled:
     - go@1.21.0
     - node@22.16.0
-    - python@3.10.8
+    - python@3.14.4
 actions:
   disabled:
     - trunk-announce

--- a/meshtastic/_port_discovery.py
+++ b/meshtastic/_port_discovery.py
@@ -152,10 +152,7 @@ def _detect_supported_devices() -> set[SupportedDevice]:
             normalized_vid = _normalize_usb_hex_id(vid, field_name="vendor_id")
             if normalized_vid is None:
                 continue
-            if (
-                f"VID_{normalized_vid}" in sp_output_upper
-                or f"{normalized_vid}&PID_" in sp_output_upper
-            ):
+            if f"VID_{normalized_vid}" in sp_output_upper:
                 possible_devices.update(_get_devices_with_vendor_id(vid))
     elif system == "Darwin":
         _, sp_output = subprocess.getstatusoutput("system_profiler SPUSBDataType")
@@ -179,6 +176,10 @@ def _detect_windows_needs_driver(
     )
     if vendor_id is None:
         return False
+    product_id = _normalize_usb_hex_id(
+        sd.usb_product_id_in_hex,
+        field_name="product_id",
+    )
 
     matching_blocks = [
         block
@@ -186,6 +187,10 @@ def _detect_windows_needs_driver(
             _windows_pnp_device_output(present_only=False)
         )
         if f"VID_{vendor_id}" in block.upper()
+        and (
+            product_id is None
+            or f"PID_{product_id}" in block.upper()
+        )
     ]
     needs_driver = any("CM_PROB_FAILED_INSTALL" in block for block in matching_blocks)
     if needs_driver and log_reason:

--- a/meshtastic/_port_discovery.py
+++ b/meshtastic/_port_discovery.py
@@ -185,7 +185,7 @@ def _detect_windows_needs_driver(
         for block in _iter_pnp_device_blocks(
             _windows_pnp_device_output(present_only=False)
         )
-        if vendor_id in block.upper()
+        if f"VID_{vendor_id}" in block.upper()
     ]
     needs_driver = any("CM_PROB_FAILED_INSTALL" in block for block in matching_blocks)
     if needs_driver and log_reason:
@@ -364,13 +364,15 @@ def _detect_windows_port_from_output(
             product_id,
             field_name="product_id",
         )
+        if product_id is not None and normalized_product_id is None:
+            continue
         for device_block in device_blocks:
             device_block_upper = device_block.upper()
-            if normalized_vendor_id not in device_block_upper:
+            if f"VID_{normalized_vendor_id}" not in device_block_upper:
                 continue
             if (
                 normalized_product_id is not None
-                and normalized_product_id not in device_block_upper
+                and f"PID_{normalized_product_id}" not in device_block_upper
             ):
                 continue
             for com_suffix in _COM_PORT_RE.findall(device_block):

--- a/meshtastic/_port_discovery.py
+++ b/meshtastic/_port_discovery.py
@@ -170,28 +170,41 @@ def _detect_windows_needs_driver(
     """Return whether Windows reports a failed driver install for a supported device."""
     if not sd or platform.system() != "Windows":
         return False
-    vendor_id = _normalize_usb_hex_id(
-        sd.usb_vendor_id_in_hex,
-        field_name="vendor_id",
-    )
-    if vendor_id is None:
+    usb_ids = getattr(sd, "usb_ids", None)
+    if (
+        not usb_ids
+        and getattr(sd, "usb_vendor_id_in_hex", None) is not None
+        and getattr(sd, "usb_product_id_in_hex", None) is not None
+    ):
+        usb_ids = (
+            (sd.usb_vendor_id_in_hex, sd.usb_product_id_in_hex),  # type: ignore[union-attr]
+        )
+    if not usb_ids:
         return False
-    product_id = _normalize_usb_hex_id(
-        sd.usb_product_id_in_hex,
-        field_name="product_id",
-    )
 
-    matching_blocks = [
-        block
-        for block in _iter_pnp_device_blocks(
-            _windows_pnp_device_output(present_only=False)
+    device_blocks = tuple(_iter_pnp_device_blocks(
+        _windows_pnp_device_output(present_only=False),
+    ))
+    matching_blocks: list[str] = []
+    for vendor_id, product_id in usb_ids or ():
+        normalized_vendor_id = _normalize_usb_hex_id(
+            vendor_id,
+            field_name="vendor_id",
         )
-        if f"VID_{vendor_id}" in block.upper()
-        and (
-            product_id is None
-            or f"PID_{product_id}" in block.upper()
+        normalized_product_id = _normalize_usb_hex_id(
+            product_id,
+            field_name="product_id",
         )
-    ]
+        if normalized_vendor_id is None or normalized_product_id is None:
+            continue
+        for block in device_blocks:
+            block_upper = block.upper()
+            if (
+                f"VID_{normalized_vendor_id}" in block_upper
+                and f"PID_{normalized_product_id}" in block_upper
+            ):
+                matching_blocks.append(block)
+
     needs_driver = any("CM_PROB_FAILED_INSTALL" in block for block in matching_blocks)
     if needs_driver and log_reason:
         logger.debug("\n\n".join(matching_blocks))

--- a/meshtastic/_port_discovery.py
+++ b/meshtastic/_port_discovery.py
@@ -1,0 +1,255 @@
+"""Private serial and USB port discovery helpers."""
+
+from __future__ import annotations
+
+import glob
+import logging
+import os
+import platform
+import re
+import subprocess
+from collections.abc import Callable, Iterable
+from typing import Any
+
+import serial.tools.list_ports  # type: ignore[import-untyped]
+
+from meshtastic.supported_device import SupportedDevice, supported_devices
+
+logger = logging.getLogger(__name__)
+
+_LINUX_SERIAL_BY_ID_DIR = "/dev/serial/by-id"
+
+
+def _linux_by_id_aliases() -> dict[str, str]:
+    """Map Linux tty realpaths to stable /dev/serial/by-id aliases."""
+    if platform.system() != "Linux":
+        return {}
+    if not os.path.isdir(_LINUX_SERIAL_BY_ID_DIR):
+        return {}
+    aliases: dict[str, str] = {}
+    for alias in glob.glob(f"{_LINUX_SERIAL_BY_ID_DIR}/*"):
+        try:
+            resolved = os.path.realpath(alias)
+        except OSError:
+            continue
+        if resolved:
+            aliases[resolved] = alias
+    return aliases
+
+
+def _find_ports(
+    *,
+    eliminate_duplicates: bool,
+    blacklist_vids: set[int],
+    whitelist_vids: set[int],
+    eliminate_duplicate_port_fn: Callable[[list[str]], list[str]],
+) -> list[str]:
+    """Return sorted serial device paths likely to be Meshtastic radios."""
+    all_ports = serial.tools.list_ports.comports()
+
+    ports: list[str] = [
+        port.device
+        for port in all_ports
+        if port.vid is not None and port.vid in whitelist_vids
+    ]
+
+    if not ports:
+        ports = [
+            port.device
+            for port in all_ports
+            if port.vid is not None and port.vid not in blacklist_vids
+        ]
+
+    alias_by_realpath = _linux_by_id_aliases()
+    if alias_by_realpath:
+        mapped_ports: list[str] = []
+        for device in ports:
+            try:
+                resolved_device = os.path.realpath(device)
+            except OSError:
+                resolved_device = device
+            mapped_ports.append(alias_by_realpath.get(resolved_device, device))
+        ports = list(dict.fromkeys(mapped_ports))
+
+    ports.sort()
+    if eliminate_duplicates:
+        ports = eliminate_duplicate_port_fn(ports)
+    return ports
+
+
+def _detect_supported_devices() -> set[SupportedDevice]:
+    """Detect supported USB devices attached to the host."""
+    system = platform.system()
+    possible_devices: set[SupportedDevice] = set()
+    if system == "Linux":
+        _, lsusb_output = subprocess.getstatusoutput("lsusb")
+        for vid in _get_unique_vendor_ids():
+            if re.search(f" {vid}:", lsusb_output, re.MULTILINE):
+                possible_devices.update(_get_devices_with_vendor_id(vid))
+    elif system == "Windows":
+        _, sp_output = subprocess.getstatusoutput(
+            'powershell.exe "[Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8;'
+            'Get-PnpDevice -PresentOnly | Format-List"'
+        )
+        for vid in _get_unique_vendor_ids():
+            if re.search(f"DeviceID.*{vid.upper()}&", sp_output, re.MULTILINE):
+                possible_devices.update(_get_devices_with_vendor_id(vid))
+    elif system == "Darwin":
+        _, sp_output = subprocess.getstatusoutput("system_profiler SPUSBDataType")
+        for vid in _get_unique_vendor_ids():
+            if re.search(f"Vendor ID: 0x{vid}", sp_output, re.MULTILINE):
+                possible_devices.update(_get_devices_with_vendor_id(vid))
+    return possible_devices
+
+
+def _detect_windows_needs_driver(sd: Any, print_reason: bool = False) -> bool:
+    """Return whether Windows reports a failed driver install for a supported device."""
+    if not sd or platform.system() != "Windows":
+        return False
+
+    command = (
+        'powershell.exe "[Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8; '
+        "Get-PnpDevice | Where-Object{ ($_.DeviceId -like "
+        f"'*{sd.usb_vendor_id_in_hex.upper()}*'"
+        ')} | Format-List"'
+    )
+    _, sp_output = subprocess.getstatusoutput(command)
+    needs_driver = bool(re.search("CM_PROB_FAILED_INSTALL", sp_output, re.MULTILINE))
+    if needs_driver and print_reason:
+        logger.debug(sp_output)
+    return needs_driver
+
+
+def _eliminate_duplicate_port(ports: list[str]) -> list[str]:
+    """Collapse likely duplicate serial device paths to one representative."""
+    if len(ports) != 2:
+        return ports
+
+    sorted_ports = sorted(ports)
+    first_port, second_port = sorted_ports
+    if "usbserial" in first_port and "wchusbserial" in second_port:
+        first = first_port.replace("usbserial-", "")
+        second = second_port.replace("wchusbserial", "")
+        if first == second:
+            return [second_port]
+    elif "usbmodem" in first_port and "wchusbserial" in second_port:
+        first = first_port.replace("usbmodem", "")
+        second = second_port.replace("wchusbserial", "")
+        if first == second:
+            return [second_port]
+    elif "SLAB_USBtoUART" in first_port and "usbserial" in second_port:
+        return [second_port]
+    return ports
+
+
+def _is_windows11() -> bool:
+    """Return whether the host appears to be Windows 11."""
+    if platform.system() != "Windows":
+        return False
+    try:
+        if float(platform.release()) < 10.0:
+            return False
+        patch = platform.version().split(".")[2][:5]
+        return int(patch) >= 22000
+    except Exception:
+        logger.exception("Problem detecting Windows 11")
+    return False
+
+
+def _get_unique_vendor_ids() -> set[str]:
+    """Collect normalized USB vendor IDs from supported-device metadata."""
+    vids: set[str] = set()
+    for device in supported_devices:
+        usb_ids = device.usb_ids
+        if usb_ids:
+            vids.update(vendor_id for vendor_id, _ in usb_ids)
+        elif device.usb_vendor_id_in_hex:
+            vids.add(device.usb_vendor_id_in_hex)
+    return vids
+
+
+def _get_devices_with_vendor_id(vid: str) -> set[SupportedDevice]:
+    """Return supported devices that match a USB vendor ID."""
+    normalized_vid = vid.strip().lower().removeprefix("0x")
+    matching_devices: set[SupportedDevice] = set()
+    for device in supported_devices:
+        if any(
+            isinstance(vendor_id, str)
+            and vendor_id.lower().removeprefix("0x") == normalized_vid
+            for vendor_id, _ in device.usb_ids or ()
+        ):
+            matching_devices.add(device)
+            continue
+        if (
+            isinstance(device.usb_vendor_id_in_hex, str)
+            and device.usb_vendor_id_in_hex.lower().removeprefix("0x")
+            == normalized_vid
+        ):
+            matching_devices.add(device)
+    return matching_devices
+
+
+def _discover_unix_ports(base_port: str) -> set[str]:
+    """Discover Unix serial-device paths matching one base-port prefix."""
+    return set(glob.glob(f"/dev/{base_port}*"))
+
+
+def _active_ports_on_supported_devices(
+    sds: Iterable[SupportedDevice],
+    *,
+    eliminate_duplicates: bool,
+    detect_windows_port_fn: Callable[[SupportedDevice | None], set[str]],
+    eliminate_duplicate_port_fn: Callable[[list[str]], list[str]],
+) -> set[str]:
+    """Collect active serial ports for supported devices on the current platform."""
+    ports: set[str] = set()
+    baseports: set[str] = set()
+    system = platform.system()
+
+    for device in sds:
+        if system == "Linux" and device.baseport_on_linux is not None:
+            baseports.add(device.baseport_on_linux)
+        elif system == "Darwin" and device.baseport_on_mac is not None:
+            baseports.add(device.baseport_on_mac)
+
+    if system in ("Linux", "Darwin"):
+        for base_port in baseports:
+            ports |= _discover_unix_ports(base_port)
+    elif system == "Windows":
+        for device in sds:
+            ports.update(detect_windows_port_fn(device))
+
+    if eliminate_duplicates:
+        port_list = eliminate_duplicate_port_fn(list(ports))
+        port_list.sort()
+        ports = set(port_list)
+    return ports
+
+
+def _detect_windows_port(sd: SupportedDevice | None) -> set[str]:
+    """Detect Windows COM ports associated with a supported USB device."""
+    ports: set[str] = set()
+    if not sd or platform.system() != "Windows":
+        return ports
+
+    usb_ids = sd.usb_ids
+    if (
+        not usb_ids
+        and sd.usb_vendor_id_in_hex is not None
+        and sd.usb_product_id_in_hex is not None
+    ):
+        usb_ids = ((sd.usb_vendor_id_in_hex, sd.usb_product_id_in_hex),)
+    for vendor_id, product_id in usb_ids or ():
+        filters = [f"($_.DeviceId -like '*{vendor_id.upper()}*')"]
+        if product_id:
+            filters.append(f"($_.DeviceId -like '*{product_id.upper()}*')")
+        where_clause = " -and ".join(filters)
+        command = (
+            'powershell.exe "[Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8;'
+            f"Get-PnpDevice -PresentOnly | Where-Object{{ {where_clause} }} | "
+            'Format-List"'
+        )
+        _, sp_output = subprocess.getstatusoutput(command)
+        for com_suffix in re.compile(r"\(COM(.*)\)").findall(sp_output):
+            ports.add(f"COM{com_suffix}")
+    return ports

--- a/meshtastic/_port_discovery.py
+++ b/meshtastic/_port_discovery.py
@@ -21,6 +21,7 @@ from meshtastic.supported_device import (
 logger = logging.getLogger(__name__)
 
 _LINUX_SERIAL_BY_ID_DIR = "/dev/serial/by-id"
+_POWERSHELL_TIMEOUT_SECONDS = 10
 _COM_PORT_RE = re.compile(r"\(COM(\d+)\)")
 _PNP_DEVICE_BLOCK_RE = re.compile(r"(?:\r?\n){2,}")
 
@@ -49,7 +50,14 @@ def _run_powershell(command: str) -> str:
             capture_output=True,
             check=False,
             text=True,
+            timeout=_POWERSHELL_TIMEOUT_SECONDS,
         )
+    except subprocess.TimeoutExpired:
+        logger.debug(
+            "PowerShell command timed out after %s seconds",
+            _POWERSHELL_TIMEOUT_SECONDS,
+        )
+        return ""
     except OSError:
         logger.debug("Unable to run PowerShell command", exc_info=True)
         return ""
@@ -146,7 +154,7 @@ def _detect_supported_devices() -> set[SupportedDevice]:
                 continue
             if (
                 f"VID_{normalized_vid}" in sp_output_upper
-                or f"{normalized_vid}&" in sp_output_upper
+                or f"{normalized_vid}&PID_" in sp_output_upper
             ):
                 possible_devices.update(_get_devices_with_vendor_id(vid))
     elif system == "Darwin":

--- a/meshtastic/_port_discovery.py
+++ b/meshtastic/_port_discovery.py
@@ -9,15 +9,67 @@ import platform
 import re
 import subprocess
 from collections.abc import Callable, Iterable
-from typing import Any
 
 import serial.tools.list_ports  # type: ignore[import-untyped]
 
-from meshtastic.supported_device import SupportedDevice, supported_devices
+from meshtastic.supported_device import (
+    USB_ID_HEX_RE,
+    SupportedDevice,
+    supported_devices,
+)
 
 logger = logging.getLogger(__name__)
 
 _LINUX_SERIAL_BY_ID_DIR = "/dev/serial/by-id"
+_COM_PORT_RE = re.compile(r"\(COM(\d+)\)")
+_PNP_DEVICE_BLOCK_RE = re.compile(r"(?:\r?\n){2,}")
+
+
+def _normalize_usb_hex_id(raw_value: object, *, field_name: str) -> str | None:
+    """Return a validated uppercase USB VID/PID, or None for unusable values."""
+    if not isinstance(raw_value, str):
+        return None
+    normalized = raw_value.strip().lower().removeprefix("0x")
+    if not USB_ID_HEX_RE.fullmatch(normalized):
+        logger.debug("Ignoring invalid USB %s: %r", field_name, raw_value)
+        return None
+    return normalized.upper()
+
+
+def _run_powershell(command: str) -> str:
+    """Run a PowerShell command without a shell and return stdout."""
+    try:
+        completed = subprocess.run(
+            [
+                "powershell.exe",
+                "-NoProfile",
+                "-Command",
+                f"[Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8; {command}",
+            ],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+    except OSError:
+        logger.debug("Unable to run PowerShell command", exc_info=True)
+        return ""
+    if completed.returncode != 0:
+        logger.debug("PowerShell command failed: %s", completed.stderr.strip())
+    return completed.stdout
+
+
+def _windows_pnp_device_output(*, present_only: bool) -> str:
+    """Return formatted Windows PnP device output for Python-side filtering."""
+    present_only_arg = " -PresentOnly" if present_only else ""
+    return _run_powershell(f"Get-PnpDevice{present_only_arg} | Format-List")
+
+
+def _iter_pnp_device_blocks(output: str) -> Iterable[str]:
+    """Yield non-empty Format-List device blocks from PowerShell output."""
+    for block in _PNP_DEVICE_BLOCK_RE.split(output):
+        block = block.strip()
+        if block:
+            yield block
 
 
 def _linux_by_id_aliases() -> dict[str, str]:
@@ -87,12 +139,15 @@ def _detect_supported_devices() -> set[SupportedDevice]:
             if re.search(f" {vid}:", lsusb_output, re.MULTILINE):
                 possible_devices.update(_get_devices_with_vendor_id(vid))
     elif system == "Windows":
-        _, sp_output = subprocess.getstatusoutput(
-            'powershell.exe "[Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8;'
-            'Get-PnpDevice -PresentOnly | Format-List"'
-        )
+        sp_output_upper = _windows_pnp_device_output(present_only=True).upper()
         for vid in _get_unique_vendor_ids():
-            if re.search(f"DeviceID.*{vid.upper()}&", sp_output, re.MULTILINE):
+            normalized_vid = _normalize_usb_hex_id(vid, field_name="vendor_id")
+            if normalized_vid is None:
+                continue
+            if (
+                f"VID_{normalized_vid}" in sp_output_upper
+                or f"{normalized_vid}&" in sp_output_upper
+            ):
                 possible_devices.update(_get_devices_with_vendor_id(vid))
     elif system == "Darwin":
         _, sp_output = subprocess.getstatusoutput("system_profiler SPUSBDataType")
@@ -102,44 +157,66 @@ def _detect_supported_devices() -> set[SupportedDevice]:
     return possible_devices
 
 
-def _detect_windows_needs_driver(sd: Any, print_reason: bool = False) -> bool:
+def _detect_windows_needs_driver(
+    sd: SupportedDevice | None,
+    *,
+    log_reason: bool = False,
+) -> bool:
     """Return whether Windows reports a failed driver install for a supported device."""
     if not sd or platform.system() != "Windows":
         return False
-
-    command = (
-        'powershell.exe "[Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8; '
-        "Get-PnpDevice | Where-Object{ ($_.DeviceId -like "
-        f"'*{sd.usb_vendor_id_in_hex.upper()}*'"
-        ')} | Format-List"'
+    vendor_id = _normalize_usb_hex_id(
+        sd.usb_vendor_id_in_hex,
+        field_name="vendor_id",
     )
-    _, sp_output = subprocess.getstatusoutput(command)
-    needs_driver = bool(re.search("CM_PROB_FAILED_INSTALL", sp_output, re.MULTILINE))
-    if needs_driver and print_reason:
-        logger.debug(sp_output)
+    if vendor_id is None:
+        return False
+
+    matching_blocks = [
+        block
+        for block in _iter_pnp_device_blocks(
+            _windows_pnp_device_output(present_only=False)
+        )
+        if vendor_id in block.upper()
+    ]
+    needs_driver = any("CM_PROB_FAILED_INSTALL" in block for block in matching_blocks)
+    if needs_driver and log_reason:
+        logger.debug("\n\n".join(matching_blocks))
     return needs_driver
+
+
+def _preferred_duplicate_port(first_port: str, second_port: str) -> str | None:
+    """Return the preferred representative when two paths name one serial port."""
+    sorted_ports = sorted((first_port, second_port))
+    first_sorted, second_sorted = sorted_ports
+    if "usbserial" in first_sorted and "wchusbserial" in second_sorted:
+        first = first_sorted.replace("usbserial-", "")
+        second = second_sorted.replace("wchusbserial", "")
+        if first == second:
+            return second_sorted
+    elif "usbmodem" in first_sorted and "wchusbserial" in second_sorted:
+        first = first_sorted.replace("usbmodem", "")
+        second = second_sorted.replace("wchusbserial", "")
+        if first == second:
+            return second_sorted
+    elif "SLAB_USBtoUART" in first_sorted and "usbserial" in second_sorted:
+        return second_sorted
+    return None
 
 
 def _eliminate_duplicate_port(ports: list[str]) -> list[str]:
     """Collapse likely duplicate serial device paths to one representative."""
-    if len(ports) != 2:
-        return ports
-
-    sorted_ports = sorted(ports)
-    first_port, second_port = sorted_ports
-    if "usbserial" in first_port and "wchusbserial" in second_port:
-        first = first_port.replace("usbserial-", "")
-        second = second_port.replace("wchusbserial", "")
-        if first == second:
-            return [second_port]
-    elif "usbmodem" in first_port and "wchusbserial" in second_port:
-        first = first_port.replace("usbmodem", "")
-        second = second_port.replace("wchusbserial", "")
-        if first == second:
-            return [second_port]
-    elif "SLAB_USBtoUART" in first_port and "usbserial" in second_port:
-        return [second_port]
-    return ports
+    deduped: list[str] = []
+    for port in ports:
+        for index, existing_port in enumerate(deduped):
+            preferred_port = _preferred_duplicate_port(existing_port, port)
+            if preferred_port is None:
+                continue
+            deduped[index] = preferred_port
+            break
+        else:
+            deduped.append(port)
+    return deduped
 
 
 def _is_windows11() -> bool:
@@ -149,8 +226,13 @@ def _is_windows11() -> bool:
     try:
         if float(platform.release()) < 10.0:
             return False
-        patch = platform.version().split(".")[2][:5]
+        version_parts = platform.version().split(".")
+        if len(version_parts) < 3:
+            return False
+        patch = version_parts[2]
         return int(patch) >= 22000
+    except ValueError:
+        return False
     except Exception:
         logger.exception("Problem detecting Windows 11")
     return False
@@ -200,13 +282,19 @@ def _active_ports_on_supported_devices(
     eliminate_duplicates: bool,
     detect_windows_port_fn: Callable[[SupportedDevice | None], set[str]],
     eliminate_duplicate_port_fn: Callable[[list[str]], list[str]],
+    detect_windows_port_from_output_fn: Callable[
+        [SupportedDevice | None, str],
+        set[str],
+    ]
+    | None = None,
 ) -> set[str]:
     """Collect active serial ports for supported devices on the current platform."""
     ports: set[str] = set()
     baseports: set[str] = set()
     system = platform.system()
+    sds_list = list(sds)
 
-    for device in sds:
+    for device in sds_list:
         if system == "Linux" and device.baseport_on_linux is not None:
             baseports.add(device.baseport_on_linux)
         elif system == "Darwin" and device.baseport_on_mac is not None:
@@ -216,20 +304,37 @@ def _active_ports_on_supported_devices(
         for base_port in baseports:
             ports |= _discover_unix_ports(base_port)
     elif system == "Windows":
-        for device in sds:
-            ports.update(detect_windows_port_fn(device))
+        if detect_windows_port_from_output_fn is None:
+            for device in sds_list:
+                ports.update(detect_windows_port_fn(device))
+        else:
+            sp_output = _windows_pnp_device_output(present_only=True)
+            for device in sds_list:
+                ports.update(detect_windows_port_from_output_fn(device, sp_output))
 
     if eliminate_duplicates:
         port_list = eliminate_duplicate_port_fn(list(ports))
-        port_list.sort()
         ports = set(port_list)
     return ports
 
 
 def _detect_windows_port(sd: SupportedDevice | None) -> set[str]:
     """Detect Windows COM ports associated with a supported USB device."""
-    ports: set[str] = set()
     if not sd or platform.system() != "Windows":
+        return set()
+    return _detect_windows_port_from_output(
+        sd,
+        _windows_pnp_device_output(present_only=True),
+    )
+
+
+def _detect_windows_port_from_output(
+    sd: SupportedDevice | None,
+    sp_output: str,
+) -> set[str]:
+    """Extract COM ports for one supported device from PnP Format-List output."""
+    ports: set[str] = set()
+    if not sd:
         return ports
 
     usb_ids = sd.usb_ids
@@ -239,17 +344,27 @@ def _detect_windows_port(sd: SupportedDevice | None) -> set[str]:
         and sd.usb_product_id_in_hex is not None
     ):
         usb_ids = ((sd.usb_vendor_id_in_hex, sd.usb_product_id_in_hex),)
+    device_blocks = tuple(_iter_pnp_device_blocks(sp_output))
     for vendor_id, product_id in usb_ids or ():
-        filters = [f"($_.DeviceId -like '*{vendor_id.upper()}*')"]
-        if product_id:
-            filters.append(f"($_.DeviceId -like '*{product_id.upper()}*')")
-        where_clause = " -and ".join(filters)
-        command = (
-            'powershell.exe "[Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8;'
-            f"Get-PnpDevice -PresentOnly | Where-Object{{ {where_clause} }} | "
-            'Format-List"'
+        normalized_vendor_id = _normalize_usb_hex_id(
+            vendor_id,
+            field_name="vendor_id",
         )
-        _, sp_output = subprocess.getstatusoutput(command)
-        for com_suffix in re.compile(r"\(COM(.*)\)").findall(sp_output):
-            ports.add(f"COM{com_suffix}")
+        if normalized_vendor_id is None:
+            continue
+        normalized_product_id = _normalize_usb_hex_id(
+            product_id,
+            field_name="product_id",
+        )
+        for device_block in device_blocks:
+            device_block_upper = device_block.upper()
+            if normalized_vendor_id not in device_block_upper:
+                continue
+            if (
+                normalized_product_id is not None
+                and normalized_product_id not in device_block_upper
+            ):
+                continue
+            for com_suffix in _COM_PORT_RE.findall(device_block):
+                ports.add(f"COM{com_suffix}")
     return ports

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -1653,7 +1653,6 @@ class MeshInterface:  # pylint: disable=R0902
         self._queue_send_runtime._send_to_radio(
             toRadio,
             send_impl=self._send_to_radio_impl,
-            pop_for_send=self._queue_pop_for_send,
             sleep_fn=time.sleep,
         )
 

--- a/meshtastic/mesh_interface_runtime/queue_send.py
+++ b/meshtastic/mesh_interface_runtime/queue_send.py
@@ -94,7 +94,6 @@ class _QueueSendRuntime:
         to_radio: mesh_pb2.ToRadio,
         *,
         send_impl: Callable[[mesh_pb2.ToRadio], None],
-        pop_for_send: Callable[[], tuple[int, mesh_pb2.ToRadio | bool] | None],
         sleep_fn: Callable[[float], None],
     ) -> None:
         """Run outbound send/resend loop using queue ownership semantics."""
@@ -109,7 +108,7 @@ class _QueueSendRuntime:
         sent_packet_ids: set[int] = set()
         try:
             while True:
-                to_resend = pop_for_send()
+                to_resend = self._pop_for_send()
                 if to_resend is None:
                     with self._lock:
                         queue_has_items = bool(self._get_queue())
@@ -140,14 +139,12 @@ class _QueueSendRuntime:
         to_radio: mesh_pb2.ToRadio,
         *,
         send_impl: Callable[[mesh_pb2.ToRadio], None],
-        pop_for_send: Callable[[], tuple[int, mesh_pb2.ToRadio | bool] | None],
         sleep_fn: Callable[[float], None],
     ) -> None:
         """Run outbound send/resend loop using queue ownership semantics."""
         self._send_to_radio(
             to_radio,
             send_impl=send_impl,
-            pop_for_send=pop_for_send,
             sleep_fn=sleep_fn,
         )
 

--- a/meshtastic/mesh_interface_runtime/send_pipeline.py
+++ b/meshtastic/mesh_interface_runtime/send_pipeline.py
@@ -864,7 +864,6 @@ class SendPipeline:
         self._queue_send_runtime._send_to_radio(
             toRadio,
             send_impl=self._send_to_radio_impl,
-            pop_for_send=self._interface._queue_pop_for_send,
             sleep_fn=time.sleep,
         )
 

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -3697,13 +3697,15 @@ def test_send_to_radio_waits_resends_and_tracks_requeue(
             "_pop_for_send",
             lambda: next(pops),
         )
-        iface._send_to_radio(incoming)
-        monkeypatch.setattr(
-            iface._queue_send_runtime,
-            "_pop_for_send",
-            original_pop,
-        )
-        assert 123 in iface.queue
+        try:
+            iface._send_to_radio(incoming)
+            assert 123 in iface.queue
+        finally:
+            monkeypatch.setattr(
+                iface._queue_send_runtime,
+                "_pop_for_send",
+                original_pop,
+            )
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -3691,10 +3691,18 @@ def test_send_to_radio_waits_resends_and_tracks_requeue(
         incoming.packet.id = 999
         monkeypatch.setattr(iface, "_send_to_radio_impl", lambda _msg: None)
         pops = iter([(123, packet), None])
-        original_pop = iface._queue_pop_for_send
-        monkeypatch.setattr(iface, "_queue_pop_for_send", lambda: next(pops))
+        original_pop = iface._queue_send_runtime._pop_for_send
+        monkeypatch.setattr(
+            iface._queue_send_runtime,
+            "_pop_for_send",
+            lambda: next(pops),
+        )
         iface._send_to_radio(incoming)
-        monkeypatch.setattr(iface, "_queue_pop_for_send", original_pop)
+        monkeypatch.setattr(
+            iface._queue_send_runtime,
+            "_pop_for_send",
+            original_pop,
+        )
         assert 123 in iface.queue
 
 
@@ -3722,14 +3730,22 @@ def test_send_to_radio_successful_missing_entry_is_not_immediately_requeued(
 
         monkeypatch.setattr(iface, "_send_to_radio_impl", _send_impl)
         pops = iter([(123, packet), None])
-        original_pop = iface._queue_pop_for_send
-        monkeypatch.setattr(iface, "_queue_pop_for_send", lambda: next(pops))
+        original_pop = iface._queue_send_runtime._pop_for_send
+        monkeypatch.setattr(
+            iface._queue_send_runtime,
+            "_pop_for_send",
+            lambda: next(pops),
+        )
         try:
             iface._send_to_radio(incoming)
             assert 123 in sent_ids
             assert 123 not in iface.queue
         finally:
-            monkeypatch.setattr(iface, "_queue_pop_for_send", original_pop)
+            monkeypatch.setattr(
+                iface._queue_send_runtime,
+                "_pop_for_send",
+                original_pop,
+            )
 
 
 @pytest.mark.unit
@@ -3756,14 +3772,22 @@ def test_send_to_radio_requeues_packet_when_send_impl_raises(
 
         monkeypatch.setattr(iface, "_send_to_radio_impl", _failing_send)
         pops = iter([(123, packet), None])
-        original_pop = iface._queue_pop_for_send
-        monkeypatch.setattr(iface, "_queue_pop_for_send", lambda: next(pops))
+        original_pop = iface._queue_send_runtime._pop_for_send
+        monkeypatch.setattr(
+            iface._queue_send_runtime,
+            "_pop_for_send",
+            lambda: next(pops),
+        )
         try:
             with pytest.raises(_SendImplFailure, match="send failed"):
                 iface._send_to_radio(incoming)
             assert 123 in iface.queue
         finally:
-            monkeypatch.setattr(iface, "_queue_pop_for_send", original_pop)
+            monkeypatch.setattr(
+                iface._queue_send_runtime,
+                "_pop_for_send",
+                original_pop,
+            )
             # Keep context-manager shutdown path from triggering the intentional send failure.
             monkeypatch.setattr(iface, "_send_to_radio_impl", lambda _msg: None)
 

--- a/meshtastic/tests/test_mesh_interface_queue_send_runtime.py
+++ b/meshtastic/tests/test_mesh_interface_queue_send_runtime.py
@@ -237,7 +237,6 @@ def test_non_packet_send_does_not_drain_existing_queue() -> None:
     runtime._send_to_radio(
         control_frame,
         send_impl=sent.append,
-        pop_for_send=runtime._pop_for_send,
         sleep_fn=lambda _: None,
     )
 
@@ -261,7 +260,6 @@ def test_sent_packet_without_queue_status_does_not_track_awaiting_correlation() 
     runtime._send_to_radio(
         packet,
         send_impl=lambda _: None,
-        pop_for_send=runtime._pop_for_send,
         sleep_fn=lambda _: None,
     )
 
@@ -288,7 +286,6 @@ def test_sent_packet_after_queue_status_tracks_awaiting_correlation() -> None:
     runtime._send_to_radio(
         packet,
         send_impl=lambda _: None,
-        pop_for_send=runtime._pop_for_send,
         sleep_fn=lambda _: None,
     )
 
@@ -330,7 +327,6 @@ def test_expired_awaiting_queue_status_id_is_treated_as_unexpected(
     runtime._send_to_radio(
         packet,
         send_impl=lambda _: None,
-        pop_for_send=runtime._pop_for_send,
         sleep_fn=lambda _: None,
     )
     queue_status_reply = mesh_pb2.QueueStatus()
@@ -379,6 +375,41 @@ def test_send_to_radio_propagates_transport_failure() -> None:
         runtime._send_to_radio(
             packet,
             send_impl=fail_send,
-            pop_for_send=runtime._pop_for_send,
             sleep_fn=lambda _: None,
         )
+
+
+@pytest.mark.unit
+def test_send_to_radio_uses_runtime_pop_method(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    harness = _QueueHarness()
+    runtime = _QueueSendRuntime(
+        lock=harness.lock,
+        get_queue=lambda: harness.queue,
+        get_queue_status=lambda: harness.queue_status,
+        set_queue_status=harness.set_queue_status,
+        queue_wait_delay_seconds=0.0,
+    )
+    existing = mesh_pb2.ToRadio()
+    existing.packet.id = 123
+    incoming = mesh_pb2.ToRadio()
+    incoming.packet.id = 456
+    pops = iter([(123, existing), (456, incoming), None])
+    sent: list[int] = []
+
+    def fake_pop_for_send() -> tuple[int, mesh_pb2.ToRadio | bool] | None:
+        popped = next(pops)
+        if popped is None:
+            harness.queue.clear()
+        return popped
+
+    monkeypatch.setattr(runtime, "_pop_for_send", fake_pop_for_send)
+
+    runtime._send_to_radio(
+        incoming,
+        send_impl=lambda msg: sent.append(msg.packet.id),
+        sleep_fn=lambda _: None,
+    )
+
+    assert sent == [123, 456]

--- a/meshtastic/tests/test_send_pipeline.py
+++ b/meshtastic/tests/test_send_pipeline.py
@@ -1335,6 +1335,20 @@ class TestSendToRadio:
         mock_interface._queue_send_runtime._send_to_radio.assert_called_once()
 
     @pytest.mark.unit
+    def test_send_to_radio_does_not_callback_through_interface_pop(
+        self, send_pipeline: SendPipeline, mock_interface: MagicMock
+    ) -> None:
+        """Queue send runtime should own pop orchestration without MeshInterface callbacks."""
+        to_radio = mesh_pb2.ToRadio()
+        to_radio.packet.id = 12345
+
+        send_pipeline._send_to_radio(to_radio)
+
+        call = mock_interface._queue_send_runtime._send_to_radio.call_args
+        assert call is not None
+        assert "pop_for_send" not in call.kwargs
+
+    @pytest.mark.unit
     def test_send_to_radio_no_proto_skips(
         self,
         send_pipeline: SendPipeline,

--- a/meshtastic/tests/test_util.py
+++ b/meshtastic/tests/test_util.py
@@ -2,19 +2,25 @@
 
 import base64
 import binascii
+import glob
 import json
 import logging
+import platform
 import re
+import subprocess
 import threading
 import warnings
 from collections import Counter
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
+import serial.tools.list_ports  # type: ignore[import-untyped]
 from hypothesis import given
 from hypothesis import strategies as st
 
+import meshtastic.util as util_module
 from meshtastic.protobuf import mesh_pb2
 from meshtastic.supported_device import (
     SupportedDevice,
@@ -35,6 +41,8 @@ from meshtastic.util import (
     catchAndIgnore,
     channel_hash,
     convert_mac_addr,
+    detect_supported_devices,
+    detect_windows_needs_driver,
     dotdict,
     eliminate_duplicate_port,
     findPorts,
@@ -85,6 +93,15 @@ class _TempPort:
         """
         self.device = device
         self.vid = vid
+
+
+@pytest.mark.unit
+def test_util_preserves_port_discovery_monkeypatch_modules() -> None:
+    """Legacy tests can still patch module objects through meshtastic.util."""
+    assert util_module.glob is glob
+    assert util_module.platform is platform
+    assert util_module.subprocess is subprocess
+    assert util_module.serial.tools.list_ports is serial.tools.list_ports
 
 
 @pytest.mark.unit
@@ -417,6 +434,82 @@ def test_findPorts_keeps_tty_path_when_no_by_id_alias_matches(
     assert findPorts() == [tty_device]
 
 
+@pytest.mark.unit
+@patch("subprocess.run")
+@patch("platform.system", return_value="Windows")
+def test_detect_supported_devices_windows_uses_safe_pnp_query(
+    patch_system: MagicMock,
+    patch_run: MagicMock,
+) -> None:
+    """Windows supported-device detection should query PnP once without VID interpolation."""
+    patch_run.return_value = subprocess.CompletedProcess(
+        args=["powershell.exe"],
+        returncode=0,
+        stdout="DeviceID : USB\\VID_303A&PID_1001\n",
+        stderr="",
+    )
+
+    devices = detect_supported_devices()
+
+    assert any(device.usb_vendor_id_in_hex == "303a" for device in devices)
+    command = patch_run.call_args.args[0]
+    assert command[:3] == ["powershell.exe", "-NoProfile", "-Command"]
+    assert "303A" not in " ".join(command)
+    patch_system.assert_called()
+
+
+@pytest.mark.unit
+@patch("subprocess.run")
+@patch("platform.system", return_value="Windows")
+def test_detect_windows_needs_driver_filters_pnp_output(
+    patch_system: MagicMock,
+    patch_run: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Driver detection should filter one static PnP query in Python."""
+    patch_run.return_value = subprocess.CompletedProcess(
+        args=["powershell.exe"],
+        returncode=0,
+        stdout=(
+            "DeviceID : USB\\VID_303A&PID_1001\n"
+            "Status   : CM_PROB_FAILED_INSTALL\n"
+        ),
+        stderr="",
+    )
+    device = SupportedDevice(
+        name="x",
+        for_firmware="heltec-v3",
+        usb_vendor_id_in_hex="303A",
+        usb_product_id_in_hex="1001",
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        assert detect_windows_needs_driver(device, print_reason=True) is True
+
+    assert "CM_PROB_FAILED_INSTALL" in caplog.text
+    command = patch_run.call_args.args[0]
+    assert "303A" not in " ".join(command)
+    patch_system.assert_called()
+
+
+@pytest.mark.unit
+@patch("subprocess.run")
+@patch("platform.system", return_value="Windows")
+def test_detect_windows_needs_driver_rejects_invalid_vendor_id(
+    patch_system: MagicMock,
+    patch_run: MagicMock,
+) -> None:
+    """Invalid VID metadata should not be interpolated into a command."""
+    device = cast(
+        Any,
+        SimpleNamespace(usb_vendor_id_in_hex="303A'; Remove-Item C:\\"),
+    )
+
+    assert detect_windows_needs_driver(device) is False
+    patch_run.assert_not_called()
+    patch_system.assert_called()
+
+
 @pytest.mark.unitslow
 def test_convert_mac_addr() -> None:
     """Test convert_mac_addr()."""
@@ -485,6 +578,20 @@ def test_eliminate_duplicate_port() -> None:
     assert eliminate_duplicate_port(
         ["/dev/cu.wchusbserial53230051441", "/dev/cu.usbmodem53230051441"]
     ) == ["/dev/cu.wchusbserial53230051441"]
+    assert eliminate_duplicate_port(
+        [
+            "/dev/fake",
+            "/dev/cu.usbserial-1430",
+            "/dev/cu.wchusbserial1430",
+        ]
+    ) == ["/dev/fake", "/dev/cu.wchusbserial1430"]
+    assert eliminate_duplicate_port(
+        [
+            "/dev/cu.usbmodem11301",
+            "/dev/fake",
+            "/dev/cu.wchusbserial11301",
+        ]
+    ) == ["/dev/cu.wchusbserial11301", "/dev/fake"]
 
 
 @pytest.mark.unit
@@ -497,6 +604,22 @@ def test_is_windows11_true(
     patched_version: MagicMock,
 ) -> None:
     """Test is_windows11()."""
+    assert is_windows11() is True
+    patched_platform.assert_called()
+    patched_release.assert_called()
+    patched_version.assert_called()
+
+
+@pytest.mark.unit
+@patch("platform.version", return_value="10.0.123456.1")
+@patch("platform.release", return_value="10")
+@patch("platform.system", return_value="Windows")
+def test_is_windows11_allows_six_digit_build_numbers(
+    patched_platform: MagicMock,
+    patched_release: MagicMock,
+    patched_version: MagicMock,
+) -> None:
+    """Windows build parsing should not truncate future six-digit builds."""
     assert is_windows11() is True
     patched_platform.assert_called()
     patched_release.assert_called()
@@ -554,9 +677,12 @@ def test_is_windows11_false_win8_1(
 def test_is_windows11_false_winserver(
     patched_platform: MagicMock,
     patched_release: MagicMock,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test is_windows11()."""
-    assert is_windows11() is False
+    with caplog.at_level(logging.ERROR):
+        assert is_windows11() is False
+    assert "Problem detecting Windows 11" not in caplog.text
     patched_platform.assert_called()
     patched_release.assert_called()
 
@@ -623,6 +749,69 @@ def test_active_ports_on_supported_devices_win(
     assert active_ports_on_supported_devices(fake_supported_devices) == {"COM2"}
     mock_platform.assert_called()
     mock_dwp.assert_called()
+
+
+@pytest.mark.unit
+@patch("meshtastic.util.detectWindowsPort", side_effect=[{"COM2"}, {"COM3"}])
+@patch("platform.system", return_value="Windows")
+def test_active_ports_on_supported_devices_win_accepts_generators(
+    mock_platform: MagicMock,
+    mock_dwp: MagicMock,
+) -> None:
+    """Windows active-port discovery should not exhaust one-shot iterables."""
+    fake_supported_devices = (
+        SupportedDevice(name=f"device-{index}", for_firmware="heltec-v2.1")
+        for index in range(2)
+    )
+
+    assert active_ports_on_supported_devices(fake_supported_devices) == {
+        "COM2",
+        "COM3",
+    }
+    assert mock_dwp.call_count == 2
+    mock_platform.assert_called()
+
+
+@pytest.mark.unit
+@patch("subprocess.run")
+@patch("platform.system", return_value="Windows")
+def test_active_ports_on_supported_devices_win_default_path_queries_once(
+    mock_platform: MagicMock,
+    mock_run: MagicMock,
+) -> None:
+    """The default Windows path should query PnP once for all devices."""
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=["powershell.exe"],
+        returncode=0,
+        stdout=(
+            "Name     : Meshtastic Serial (COM2)\n"
+            "DeviceID : USB\\VID_303A&PID_1001\n\n"
+            "Name     : Meshtastic Serial (COM3)\n"
+            "DeviceID : USB\\VID_303A&PID_1002\n"
+        ),
+        stderr="",
+    )
+    fake_supported_devices = [
+        SupportedDevice(
+            name="device-1",
+            for_firmware="heltec-v3",
+            usb_vendor_id_in_hex="303A",
+            usb_product_id_in_hex="1001",
+        ),
+        SupportedDevice(
+            name="device-2",
+            for_firmware="heltec-v3",
+            usb_vendor_id_in_hex="303A",
+            usb_product_id_in_hex="1002",
+        ),
+    ]
+
+    assert active_ports_on_supported_devices(fake_supported_devices) == {
+        "COM2",
+        "COM3",
+    }
+    mock_run.assert_called_once()
+    mock_platform.assert_called()
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_util.py
+++ b/meshtastic/tests/test_util.py
@@ -571,7 +571,7 @@ def test_active_ports_on_supported_devices_empty(mock_platform: MagicMock) -> No
 
 
 @pytest.mark.unit
-@patch("meshtastic.util.glob.glob")
+@patch("meshtastic._port_discovery.glob.glob")
 @patch("platform.system", return_value="Linux")
 def test_active_ports_on_supported_devices_linux(
     mock_platform: MagicMock,
@@ -591,7 +591,7 @@ def test_active_ports_on_supported_devices_linux(
 
 
 @pytest.mark.unit
-@patch("meshtastic.util.glob.glob")
+@patch("meshtastic._port_discovery.glob.glob")
 @patch("platform.system", return_value="Darwin")
 def test_active_ports_on_supported_devices_mac(
     mock_platform: MagicMock,
@@ -626,7 +626,7 @@ def test_active_ports_on_supported_devices_win(
 
 
 @pytest.mark.unit
-@patch("meshtastic.util.glob.glob")
+@patch("meshtastic._port_discovery.glob.glob")
 @patch("platform.system", return_value="Darwin")
 def test_active_ports_on_supported_devices_mac_no_duplicates_check(
     mock_platform: MagicMock,
@@ -650,7 +650,7 @@ def test_active_ports_on_supported_devices_mac_no_duplicates_check(
 
 
 @pytest.mark.unit
-@patch("meshtastic.util.glob.glob")
+@patch("meshtastic._port_discovery.glob.glob")
 @patch("platform.system", return_value="Darwin")
 def test_active_ports_on_supported_devices_mac_duplicates_check(
     mock_platform: MagicMock,

--- a/meshtastic/tests/test_util_windows_port.py
+++ b/meshtastic/tests/test_util_windows_port.py
@@ -1,5 +1,6 @@
 """Targeted tests for Windows COM-port detection helpers in util.py."""
 
+import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,15 +11,23 @@ from meshtastic.util import detect_windows_port, detectWindowsPort
 
 @pytest.mark.unit
 @patch("platform.system", return_value="Windows")
-@patch(
-    "subprocess.getstatusoutput",
-    return_value=(0, "DeviceId : USB\\\\VID_303A&PID_1001 (COM12)"),
-)
+@patch("subprocess.run")
 def test_detectWindowsPort_parses_com_port_from_powershell_output(
-    _mock_subprocess: MagicMock,
+    mock_run: MagicMock,
     _mock_system: MagicMock,
 ) -> None:
     """DetectWindowsPort should parse COM ports from PowerShell output on Windows."""
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=["powershell.exe"],
+        returncode=0,
+        stdout=(
+            "Name     : Meshtastic Serial (COM12) Extra (ignored)\n"
+            "DeviceID : USB\\\\VID_303A&PID_1001\n\n"
+            "Name     : Other Serial (COM7)\n"
+            "DeviceID : USB\\\\VID_303A&PID_9999\n"
+        ),
+        stderr="",
+    )
     device = SupportedDevice(
         name="x",
         for_firmware="heltec-v3",
@@ -27,6 +36,9 @@ def test_detectWindowsPort_parses_com_port_from_powershell_output(
     )
 
     assert detectWindowsPort(device) == {"COM12"}
+    command = mock_run.call_args.args[0]
+    assert command[:3] == ["powershell.exe", "-NoProfile", "-Command"]
+    assert "303A" not in " ".join(command)
 
 
 @pytest.mark.unit

--- a/meshtastic/util.py
+++ b/meshtastic/util.py
@@ -942,10 +942,10 @@ def detect_windows_needs_driver(sd: Any, print_reason: bool = False) -> bool:
 def eliminate_duplicate_port(ports: list[str]) -> list[str]:
     """Reduce paired serial port paths to a single representative when they likely refer to the same physical device.
 
-    This function examines a list of serial port path strings and, when the list contains exactly two entries
-    that match known duplicate naming patterns (e.g., usbserial vs wchusbserial, usbmodem vs wchusbserial,
-    SLAB_USBtoUART vs usbserial), returns a list containing a single preferred port.
-    If no duplicate pattern is detected or the list length is not two, the original list is returned unchanged.
+    This function examines a list of serial port path strings and collapses duplicate pairs
+    matching known naming patterns (e.g., usbserial vs wchusbserial, usbmodem vs wchusbserial,
+    SLAB_USBtoUART vs usbserial) into a single preferred port. Duplicate pairs are collapsed
+    even inside larger port lists, not only when exactly two ports are provided.
 
     Parameters
     ----------
@@ -955,7 +955,7 @@ def eliminate_duplicate_port(ports: list[str]) -> list[str]:
     Returns
     -------
     list
-        Either the original list of ports or a list containing one representative port when a duplicate pair is recognized.
+        The deduplicated port list with duplicate pairs collapsed to one representative each.
     """
     return _port_discovery._eliminate_duplicate_port(ports)
 

--- a/meshtastic/util.py
+++ b/meshtastic/util.py
@@ -1,12 +1,9 @@
 """Utility functions."""
 
 import base64
-import glob
 import logging
 import os
-import platform
 import re
-import subprocess
 import sys
 import threading
 import time
@@ -21,12 +18,11 @@ from typing import (
 
 import packaging.version as pkg_version
 import requests
-import serial  # type: ignore[import-untyped]
-import serial.tools.list_ports  # type: ignore[import-untyped]
 from google.protobuf.json_format import MessageToJson
 from google.protobuf.message import Message
 
-from meshtastic.supported_device import SupportedDevice, supported_devices
+from meshtastic import _port_discovery
+from meshtastic.supported_device import SupportedDevice
 from meshtastic.version import get_active_version
 
 """Some devices such as a seger jlink or st-link we never want to accidentally open
@@ -50,7 +46,6 @@ whitelistVids: set[int] = WHITELIST_VIDS
 
 # Interval for polling the deferred execution queue in seconds
 _DEFERRED_QUEUE_POLL_TIMEOUT_SECONDS = 0.1
-_LINUX_SERIAL_BY_ID_DIR = "/dev/serial/by-id"
 
 logger = logging.getLogger(__name__)
 
@@ -345,65 +340,12 @@ def findPorts(eliminate_duplicates: bool = False) -> list[str]:
     list[str]
         Sorted list of serial device path strings.
     """
-
-    def _linux_by_id_aliases() -> dict[str, str]:
-        """Map Linux tty realpaths to stable /dev/serial/by-id aliases."""
-        if platform.system() != "Linux":
-            return {}
-        if not os.path.isdir(_LINUX_SERIAL_BY_ID_DIR):
-            return {}
-        aliases: dict[str, str] = {}
-        for alias in glob.glob(f"{_LINUX_SERIAL_BY_ID_DIR}/*"):
-            try:
-                resolved = os.path.realpath(alias)
-            except OSError:
-                continue
-            if resolved:
-                aliases[resolved] = alias
-        return aliases
-
-    all_ports = serial.tools.list_ports.comports()
-
-    # look for 'likely' meshtastic devices
-    ports: list[str] = list(
-        map(
-            lambda port: port.device,
-            filter(
-                lambda port: port.vid is not None and port.vid in WHITELIST_VIDS,
-                all_ports,
-            ),
-        )
+    return _port_discovery._find_ports(
+        eliminate_duplicates=eliminate_duplicates,
+        blacklist_vids=BLACKLIST_VIDS,
+        whitelist_vids=WHITELIST_VIDS,
+        eliminate_duplicate_port_fn=eliminate_duplicate_port,
     )
-
-    # if no likely devices, just list everything not blacklisted
-    if len(ports) == 0:
-        ports = list(
-            map(
-                lambda port: port.device,
-                filter(
-                    lambda port: port.vid is not None
-                    and port.vid not in BLACKLIST_VIDS,
-                    all_ports,
-                ),
-            )
-        )
-
-    alias_by_realpath = _linux_by_id_aliases()
-    if alias_by_realpath:
-        mapped_ports: list[str] = []
-        for device in ports:
-            try:
-                resolved_device = os.path.realpath(device)
-            except OSError:
-                resolved_device = device
-            mapped_ports.append(alias_by_realpath.get(resolved_device, device))
-        # Keep deterministic ordering while preventing alias/raw duplicate pairs.
-        ports = list(dict.fromkeys(mapped_ports))
-
-    ports.sort()
-    if eliminate_duplicates:
-        ports = eliminate_duplicate_port(ports)
-    return ports
 
 
 class DotDict(dict[str, Any]):
@@ -959,62 +901,7 @@ def detect_supported_devices() -> set[SupportedDevice]:
     set[SupportedDevice]
         A set of supported device descriptors for matching devices; empty set if none are found.
     """
-    system: str = platform.system()
-    # print(f'system:{system}')
-
-    possible_devices = set()
-    if system == "Linux":
-        # if linux, run lsusb and list ports
-
-        # linux: use lsusb
-        # Bus 001 Device 091: ID 10c4:ea60 Silicon Labs CP210x UART Bridge
-        _, lsusb_output = subprocess.getstatusoutput("lsusb")
-        vids = get_unique_vendor_ids()
-        for vid in vids:
-            # print(f'looking for {vid}...')
-            search = f" {vid}:"
-            # print(f'search:"{search}"')
-            if re.search(search, lsusb_output, re.MULTILINE):
-                # print(f'Found vendor id that matches')
-                devices = get_devices_with_vendor_id(vid)
-                for device in devices:
-                    possible_devices.add(device)
-
-    elif system == "Windows":
-        # if windows, run Get-PnpDevice
-        _, sp_output = subprocess.getstatusoutput(
-            'powershell.exe "[Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8;'
-            'Get-PnpDevice -PresentOnly | Format-List"'
-        )
-        # print(f'sp_output:{sp_output}')
-        vids = get_unique_vendor_ids()
-        for vid in vids:
-            # print(f'looking for {vid.upper()}...')
-            search = f"DeviceID.*{vid.upper()}&"
-            # search = f'{vid.upper()}'
-            # print(f'search:"{search}"')
-            if re.search(search, sp_output, re.MULTILINE):
-                # print(f'Found vendor id that matches')
-                devices = get_devices_with_vendor_id(vid)
-                for device in devices:
-                    possible_devices.add(device)
-
-    elif system == "Darwin":
-        # run: system_profiler SPUSBDataType
-        # Note: If in boot mode, the 19003 reports same product ID as 5005.
-
-        _, sp_output = subprocess.getstatusoutput("system_profiler SPUSBDataType")
-        vids = get_unique_vendor_ids()
-        for vid in vids:
-            # print(f'looking for {vid}...')
-            search = f"Vendor ID: 0x{vid}"
-            # print(f'search:"{search}"')
-            if re.search(search, sp_output, re.MULTILINE):
-                # print(f'Found vendor id that matches')
-                devices = get_devices_with_vendor_id(vid)
-                for device in devices:
-                    possible_devices.add(device)
-    return possible_devices
+    return _port_discovery._detect_supported_devices()
 
 
 def detect_windows_needs_driver(sd: Any, print_reason: bool = False) -> bool:
@@ -1032,30 +919,7 @@ def detect_windows_needs_driver(sd: Any, print_reason: bool = False) -> bool:
     bool
         `True` if Windows indicates the device has a failed installation (a driver likely needs installation), `False` otherwise.
     """
-    need_to_install_driver: bool = False
-
-    if sd:
-        system = platform.system()
-        # print(f'in detect_windows_needs_driver system:{system}')
-
-        if system == "Windows":
-            # if windows, see if we can find a DeviceId with the vendor id
-            # Get-PnpDevice  | Where-Object{ ($_.DeviceId -like '*10C4*')} | Format-List
-            command = 'powershell.exe "[Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8; Get-PnpDevice | Where-Object{ ($_.DeviceId -like '
-            command += f"'*{sd.usb_vendor_id_in_hex.upper()}*'"
-            command += ')} | Format-List"'
-
-            # print(f'command:{command}')
-            _, sp_output = subprocess.getstatusoutput(command)
-            # print(f'sp_output:{sp_output}')
-            search = "CM_PROB_FAILED_INSTALL"
-            # print(f'search:"{search}"')
-            if re.search(search, sp_output, re.MULTILINE):
-                need_to_install_driver = True
-                # if the want to see the reason
-                if print_reason:
-                    logger.debug(sp_output)
-    return need_to_install_driver
+    return _port_discovery._detect_windows_needs_driver(sd, print_reason=print_reason)
 
 
 def eliminate_duplicate_port(ports: list[str]) -> list[str]:
@@ -1076,30 +940,7 @@ def eliminate_duplicate_port(ports: list[str]) -> list[str]:
     list
         Either the original list of ports or a list containing one representative port when a duplicate pair is recognized.
     """
-    new_ports = []
-    if len(ports) != 2:
-        new_ports = ports
-    else:
-        sorted_ports = sorted(ports)
-        if "usbserial" in sorted_ports[0] and "wchusbserial" in sorted_ports[1]:
-            first = sorted_ports[0].replace("usbserial-", "")
-            second = sorted_ports[1].replace("wchusbserial", "")
-            if first == second:
-                new_ports.append(sorted_ports[1])
-            else:
-                new_ports = ports
-        elif "usbmodem" in sorted_ports[0] and "wchusbserial" in sorted_ports[1]:
-            first = sorted_ports[0].replace("usbmodem", "")
-            second = sorted_ports[1].replace("wchusbserial", "")
-            if first == second:
-                new_ports.append(sorted_ports[1])
-            else:
-                new_ports = ports
-        elif "SLAB_USBtoUART" in sorted_ports[0] and "usbserial" in sorted_ports[1]:
-            new_ports.append(sorted_ports[1])
-        else:
-            new_ports = ports
-    return new_ports
+    return _port_discovery._eliminate_duplicate_port(ports)
 
 
 def is_windows11() -> bool:
@@ -1110,18 +951,7 @@ def is_windows11() -> bool:
     bool
         `True` if the OS is Windows and the OS build (version patch) is 22000 or greater, `False` otherwise.
     """
-    is_win11: bool = False
-    if platform.system() == "Windows":
-        try:
-            if float(platform.release()) >= 10.0:
-                patch = platform.version().split(".")[2]
-                # in case they add some number suffix later, just get first 5 chars of patch
-                patch = patch[:5]
-                if int(patch) >= 22000:
-                    is_win11 = True
-        except Exception:
-            logger.exception("Problem detecting Windows 11")
-    return is_win11
+    return _port_discovery._is_windows11()
 
 
 def get_unique_vendor_ids() -> set[str]:
@@ -1133,14 +963,7 @@ def get_unique_vendor_ids() -> set[str]:
         A set of normalized lowercase USB vendor IDs from all known VID/PID
         tuples (primary IDs and aliases).
     """
-    vids: set[str] = set()
-    for d in supported_devices:
-        usb_ids = d.usb_ids
-        if usb_ids:
-            vids.update(vendor_id for vendor_id, _ in usb_ids)
-        elif d.usb_vendor_id_in_hex:
-            vids.add(d.usb_vendor_id_in_hex)
-    return vids
+    return _port_discovery._get_unique_vendor_ids()
 
 
 def get_devices_with_vendor_id(vid: str) -> set[SupportedDevice]:
@@ -1157,22 +980,7 @@ def get_devices_with_vendor_id(vid: str) -> set[SupportedDevice]:
         Set of SupportedDevice entries whose primary or aliased VID/PID tuples
         include the provided vendor id.
     """
-    normalized_vid = vid.strip().lower().removeprefix("0x")
-    sd: set[SupportedDevice] = set()
-    for d in supported_devices:
-        if any(
-            isinstance(vendor_id, str)
-            and vendor_id.lower().removeprefix("0x") == normalized_vid
-            for vendor_id, _ in d.usb_ids or ()
-        ):
-            sd.add(d)
-            continue
-        if (
-            isinstance(d.usb_vendor_id_in_hex, str)
-            and d.usb_vendor_id_in_hex.lower().removeprefix("0x") == normalized_vid
-        ):
-            sd.add(d)
-    return sd
+    return _port_discovery._get_devices_with_vendor_id(vid)
 
 
 def _discover_unix_ports(bp: str) -> set[str]:
@@ -1188,7 +996,7 @@ def _discover_unix_ports(bp: str) -> set[str]:
     set[str]
         Matching absolute device paths, or an empty set.
     """
-    return set(glob.glob(f"/dev/{bp}*"))
+    return _port_discovery._discover_unix_ports(bp)
 
 
 def active_ports_on_supported_devices(
@@ -1210,34 +1018,12 @@ def active_ports_on_supported_devices(
     set[str]
         A set of active port path strings (for example, "/dev/ttyUSB0" on Unix or "COM3" on Windows).
     """
-    ports: set[str] = set()
-    baseports: set[str] = set()
-    system: str = platform.system()
-
-    # figure out what possible base ports there are
-    for d in sds:
-        if system == "Linux" and d.baseport_on_linux is not None:
-            baseports.add(d.baseport_on_linux)
-        elif system == "Darwin" and d.baseport_on_mac is not None:
-            baseports.add(d.baseport_on_mac)
-
-    if system in ("Linux", "Darwin"):
-        for bp in baseports:
-            ports |= _discover_unix_ports(bp)
-    elif system == "Windows":
-        # for each device in supported devices found
-        for d in sds:
-            # find the port(s)
-            com_ports = detectWindowsPort(d)
-            # print(f'com_ports:{com_ports}')
-            # add all ports
-            for com_port in com_ports:
-                ports.add(com_port)
-    if eliminate_duplicates:
-        portlist: list[str] = eliminate_duplicate_port(list(ports))
-        portlist.sort()
-        ports = set(portlist)
-    return ports
+    return _port_discovery._active_ports_on_supported_devices(
+        sds,
+        eliminate_duplicates=eliminate_duplicates,
+        detect_windows_port_fn=detectWindowsPort,
+        eliminate_duplicate_port_fn=eliminate_duplicate_port,
+    )
 
 
 def detectWindowsPort(sd: SupportedDevice | None) -> set[str]:
@@ -1260,32 +1046,7 @@ def detectWindowsPort(sd: SupportedDevice | None) -> set[str]:
         A set of COM port names (e.g., "COM3", "COM4") discovered for the
         device; empty if none found.
     """
-    ports = set()
-
-    if sd:
-        system = platform.system()
-        if system == "Windows":
-            usb_ids = sd.usb_ids
-            if (
-                not usb_ids
-                and sd.usb_vendor_id_in_hex is not None
-                and sd.usb_product_id_in_hex is not None
-            ):
-                usb_ids = ((sd.usb_vendor_id_in_hex, sd.usb_product_id_in_hex),)
-            for vendor_id, product_id in usb_ids or ():
-                filters = [f"($_.DeviceId -like '*{vendor_id.upper()}*')"]
-                if product_id:
-                    filters.append(f"($_.DeviceId -like '*{product_id.upper()}*')")
-                where_clause = " -and ".join(filters)
-                command = (
-                    'powershell.exe "[Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8;'
-                    f'Get-PnpDevice -PresentOnly | Where-Object{{ {where_clause} }} | Format-List"'
-                )
-                _, sp_output = subprocess.getstatusoutput(command)
-                p = re.compile(r"\(COM(.*)\)")
-                for x in p.findall(sp_output):
-                    ports.add(f"COM{x}")
-    return ports
+    return _port_discovery._detect_windows_port(sd)
 
 
 # COMPAT_STABLE_SHIM: historical snake_case alias for detectWindowsPort().

--- a/meshtastic/util.py
+++ b/meshtastic/util.py
@@ -1,9 +1,12 @@
 """Utility functions."""
 
 import base64
+import glob  # noqa: F401
 import logging
 import os
+import platform  # noqa: F401
 import re
+import subprocess  # noqa: F401
 import sys
 import threading
 import time
@@ -14,16 +17,27 @@ from typing import (
     Any,
     Callable,
     NoReturn,
+    cast,
 )
 
 import packaging.version as pkg_version
 import requests
+import serial.tools.list_ports  # type: ignore[import-untyped] # noqa: F401
 from google.protobuf.json_format import MessageToJson
 from google.protobuf.message import Message
 
-from meshtastic import _port_discovery
+import meshtastic._port_discovery as _port_discovery  # pylint: disable=consider-using-from-import
 from meshtastic.supported_device import SupportedDevice
 from meshtastic.version import get_active_version
+
+# Keep these module imports available for downstream tests and integrations that
+# historically monkeypatch meshtastic.util.<module> during port discovery.
+_PORT_DISCOVERY_MONKEYPATCH_MODULES = (
+    glob,
+    platform,
+    subprocess,
+    serial.tools.list_ports,
+)
 
 """Some devices such as a seger jlink or st-link we never want to accidentally open
      0483 STMicroelectronics ST-LINK/V2
@@ -919,7 +933,10 @@ def detect_windows_needs_driver(sd: Any, print_reason: bool = False) -> bool:
     bool
         `True` if Windows indicates the device has a failed installation (a driver likely needs installation), `False` otherwise.
     """
-    return _port_discovery._detect_windows_needs_driver(sd, print_reason=print_reason)
+    return _port_discovery._detect_windows_needs_driver(
+        cast(SupportedDevice | None, sd),
+        log_reason=print_reason,
+    )
 
 
 def eliminate_duplicate_port(ports: list[str]) -> list[str]:
@@ -1023,6 +1040,11 @@ def active_ports_on_supported_devices(
         eliminate_duplicates=eliminate_duplicates,
         detect_windows_port_fn=detectWindowsPort,
         eliminate_duplicate_port_fn=eliminate_duplicate_port,
+        detect_windows_port_from_output_fn=(
+            _port_discovery._detect_windows_port_from_output
+            if detectWindowsPort is _DEFAULT_DETECT_WINDOWS_PORT
+            else None
+        ),
     )
 
 
@@ -1053,6 +1075,9 @@ def detectWindowsPort(sd: SupportedDevice | None) -> set[str]:
 def detect_windows_port(sd: SupportedDevice | None) -> set[str]:
     """Compatibility alias for detectWindowsPort()."""
     return detectWindowsPort(sd)
+
+
+_DEFAULT_DETECT_WINDOWS_PORT = detectWindowsPort
 
 
 def check_if_newer_version() -> str | None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This pull request refactors port discovery into a dedicated private module and changes the send-queue runtime so it manages its own dequeue logic. Platform-specific USB/serial probing and parsing were moved out of util.py into meshtastic/_port_discovery.py to centralize discovery and make util.py a thin delegating layer. The queued send runtime now uses an internal _pop_for_send implementation instead of accepting a pop_for_send callback, and MeshInterface/SendPipeline now pass an explicit send_impl hook and sleep_fn to the queue runtime.

## Key changes

- Refactors
  - Added meshtastic/_port_discovery.py: platform-aware helpers for USB/serial discovery and parsing (Windows PowerShell PnP parsing with UTF-8/timeout/OS error handling and driver-failure detection, macOS system_profiler parsing, Linux lsusb + /dev/serial/by-id alias resolution, VID/PID normalization, duplicate-port elimination heuristics, Windows 11 detection helper, and ancillary vendor-id helpers).
  - meshtastic/util.py now delegates discovery functions (findPorts, detect_supported_devices, detect_windows_needs_driver, eliminate_duplicate_port, is_windows11, get_unique_vendor_ids, get_devices_with_vendor_id, _discover_unix_ports, active_ports_on_supported_devices, detectWindowsPort) to meshtastic._port_discovery and exposes a small set of modules for monkeypatching via _PORT_DISCOVERY_MONKEYPATCH_MODULES.
  - Removed inline platform probing/subprocess/regex/globbing implementations from util.py.

- Runtime / behavior
  - _QueueSendRuntime now provides its own _pop_for_send method and calls it internally; send_to_radio no longer accepts a pop_for_send argument.
  - MeshInterface._send_to_radio and SendPipeline._send_to_radio updated to call the queue runtime with send_impl=self._send_to_radio_impl and sleep_fn=time.sleep (no pop_for_send passed).

- Tests
  - Unit tests updated to reflect the new module structure and runtime behavior across tests/test_mesh_interface.py, tests/test_mesh_interface_queue_send_runtime.py, tests/test_send_pipeline.py, tests/test_util.py, and tests/test_util_windows_port.py.
  - Tests now monkeypatch the runtime's _pop_for_send when needed (instead of injecting pop_for_send), patch meshtastic._port_discovery or util._PORT_DISCOVERY_MONKEYPATCH_MODULES for discovery behavior, and include expanded Windows-focused coverage (PowerShell command safety, driver-needed detection), by-id aliasing, duplicate-elimination ordering, and Windows build/version parsing.

## Breaking changes / migration notes

- No public API changes are intended for end users.
- Internal callers and tests: _QueueSendRuntime.send_to_radio removed the pop_for_send parameter. Callers or test harnesses that previously injected pop_for_send must instead patch/override _QueueSendRuntime._pop_for_send on the runtime instance.
- Tests or integrations that monkeypatch discovery helpers should either patch the modules listed in util._PORT_DISCOVERY_MONKEYPATCH_MODULES (glob, platform, subprocess, serial.tools.list_ports) or patch meshtastic._port_discovery directly as appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->