### PR TITLE
Support raw base64 PSK values without prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ junit.xml
 .codex
 meshtastic/tests/api_baselines/*_test.json
 .worktrees/
-
+.sisyphus/
 
 #Ignore vscode AI rules
 .github/instructions/codacy.instructions.md

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -81,7 +81,7 @@ lint:
   enabled:
     - actionlint@1.7.12
     - black@26.3.1
-    - checkov@3.2.526
+    - checkov@3.2.528
     - git-diff-check
     - gitleaks@8.30.1
     - isort@8.0.1

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -3527,7 +3527,8 @@ def addChannelConfigArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPa
             "Can set the 'psk' using this command. To disable encryption on primary channel:'--ch-set psk none --ch-index 0'. "
             "To set encryption with a new random key on second channel:'--ch-set psk random --ch-index 1'. "
             "To set encryption back to the default:'--ch-set psk default --ch-index 0'. To set encryption with your "
-            "own key: '--ch-set psk 0x1a1a1a1a2b2b2b2b1a1a1a1a2b2b2b2b1a1a1a1a2b2b2b2b1a1a1a1a2b2b2b2b --ch-index 0'."
+            "own key: '--ch-set psk 0x1a1a1a1a2b2b2b2b1a1a1a1a2b2b2b2b1a1a1a1a2b2b2b2b1a1a1a1a2b2b2b2b --ch-index 0'. "
+            "Base64-encoded keys are also accepted: '--ch-set psk HR8D2KziD3IfvpHlwHAfCAh4JP/I7dsHwKdVllfKoD0= --ch-index 1'."
         ),
         nargs=2,
         action="append",

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -4492,7 +4492,7 @@ def test_main_ch_set_psk_with_ch_index(capsys: pytest.CaptureFixture[str]) -> No
         "",
         "--ch-set",
         "psk",
-        "foo",
+        "none",
         "--host",
         "meshtastic.local",
         "--ch-index",

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -4512,6 +4512,96 @@ def test_main_ch_set_psk_with_ch_index(capsys: pytest.CaptureFixture[str]) -> No
     mo.assert_called()
 
 
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_main_ch_set_psk_with_base64_raw(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test --ch-set psk with a raw base64 string."""
+    sys.argv = [
+        "",
+        "--ch-set",
+        "psk",
+        "HR8D2KziD3IfvpHlwHAfCAh4JP/I7dsHwKdVllfKoD0=",
+        "--host",
+        "meshtastic.local",
+        "--ch-index",
+        "1",
+    ]
+    mt_config.args = sys.argv  # type: ignore[assignment]
+
+    iface = MagicMock(autospec=TCPInterface)
+    iface.__enter__ = MagicMock(return_value=iface)
+    iface.__exit__ = MagicMock(return_value=None)
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=iface) as mo:
+        main()
+    out, err = capsys.readouterr()
+    assert re.search(r"Connected to radio", out, re.MULTILINE)
+    assert re.search(r"Writing modified channels to device", out, re.MULTILINE)
+    assert err == ""
+    mo.assert_called()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_main_ch_set_psk_with_base64_prefix(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test --ch-set psk with base64: prefix."""
+    sys.argv = [
+        "",
+        "--ch-set",
+        "psk",
+        "base64:HR8D2KziD3IfvpHlwHAfCAh4JP/I7dsHwKdVllfKoD0=",
+        "--host",
+        "meshtastic.local",
+        "--ch-index",
+        "1",
+    ]
+    mt_config.args = sys.argv  # type: ignore[assignment]
+
+    iface = MagicMock(autospec=TCPInterface)
+    iface.__enter__ = MagicMock(return_value=iface)
+    iface.__exit__ = MagicMock(return_value=None)
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=iface) as mo:
+        main()
+    out, err = capsys.readouterr()
+    assert re.search(r"Connected to radio", out, re.MULTILINE)
+    assert re.search(r"Writing modified channels to device", out, re.MULTILINE)
+    assert err == ""
+    mo.assert_called()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_main_ch_set_psk_with_hex(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test --ch-set psk with hex value."""
+    sys.argv = [
+        "",
+        "--ch-set",
+        "psk",
+        "0x1a1a",
+        "--host",
+        "meshtastic.local",
+        "--ch-index",
+        "1",
+    ]
+    mt_config.args = sys.argv  # type: ignore[assignment]
+
+    iface = MagicMock(autospec=TCPInterface)
+    iface.__enter__ = MagicMock(return_value=iface)
+    iface.__exit__ = MagicMock(return_value=None)
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=iface) as mo:
+        main()
+    out, err = capsys.readouterr()
+    assert re.search(r"Connected to radio", out, re.MULTILINE)
+    assert re.search(r"Writing modified channels to device", out, re.MULTILINE)
+    assert err == ""
+    mo.assert_called()
+
+
 # TODO
 # doesn't work properly with nested/module config stuff
 # @pytest.mark.unit

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -4514,75 +4514,33 @@ def test_main_ch_set_psk_with_ch_index(capsys: pytest.CaptureFixture[str]) -> No
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-def test_main_ch_set_psk_with_base64_raw(
+@pytest.mark.parametrize(
+    "psk_value",
+    [
+        pytest.param(
+            "HR8D2KziD3IfvpHlwHAfCAh4JP/I7dsHwKdVllfKoD0=",
+            id="base64_raw",
+        ),
+        pytest.param(
+            "base64:HR8D2KziD3IfvpHlwHAfCAh4JP/I7dsHwKdVllfKoD0=",
+            id="base64_prefix",
+        ),
+        pytest.param(
+            "0x1a1a",
+            id="hex",
+        ),
+    ],
+)
+def test_main_ch_set_psk_with_supported_encodings(
+    psk_value: str,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Test --ch-set psk with a raw base64 string."""
+    """Test --ch-set psk with raw base64, base64: prefix, and hex encodings."""
     sys.argv = [
         "",
         "--ch-set",
         "psk",
-        "HR8D2KziD3IfvpHlwHAfCAh4JP/I7dsHwKdVllfKoD0=",
-        "--host",
-        "meshtastic.local",
-        "--ch-index",
-        "1",
-    ]
-    mt_config.args = sys.argv  # type: ignore[assignment]
-
-    iface = MagicMock(autospec=TCPInterface)
-    iface.__enter__ = MagicMock(return_value=iface)
-    iface.__exit__ = MagicMock(return_value=None)
-    with patch("meshtastic.tcp_interface.TCPInterface", return_value=iface) as mo:
-        main()
-    out, err = capsys.readouterr()
-    assert re.search(r"Connected to radio", out, re.MULTILINE)
-    assert re.search(r"Writing modified channels to device", out, re.MULTILINE)
-    assert err == ""
-    mo.assert_called()
-
-
-@pytest.mark.unit
-@pytest.mark.usefixtures("reset_mt_config")
-def test_main_ch_set_psk_with_base64_prefix(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """Test --ch-set psk with base64: prefix."""
-    sys.argv = [
-        "",
-        "--ch-set",
-        "psk",
-        "base64:HR8D2KziD3IfvpHlwHAfCAh4JP/I7dsHwKdVllfKoD0=",
-        "--host",
-        "meshtastic.local",
-        "--ch-index",
-        "1",
-    ]
-    mt_config.args = sys.argv  # type: ignore[assignment]
-
-    iface = MagicMock(autospec=TCPInterface)
-    iface.__enter__ = MagicMock(return_value=iface)
-    iface.__exit__ = MagicMock(return_value=None)
-    with patch("meshtastic.tcp_interface.TCPInterface", return_value=iface) as mo:
-        main()
-    out, err = capsys.readouterr()
-    assert re.search(r"Connected to radio", out, re.MULTILINE)
-    assert re.search(r"Writing modified channels to device", out, re.MULTILINE)
-    assert err == ""
-    mo.assert_called()
-
-
-@pytest.mark.unit
-@pytest.mark.usefixtures("reset_mt_config")
-def test_main_ch_set_psk_with_hex(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """Test --ch-set psk with hex value."""
-    sys.argv = [
-        "",
-        "--ch-set",
-        "psk",
-        "0x1a1a",
+        psk_value,
         "--host",
         "meshtastic.local",
         "--ch-index",

--- a/meshtastic/tests/test_psk_security.py
+++ b/meshtastic/tests/test_psk_security.py
@@ -46,7 +46,9 @@ def test_psk_rejects_invalid_base64_lengths() -> None:
 @pytest.mark.unit
 def test_psk_accepts_valid_formats() -> None:
     """Ensure valid formats are still accepted."""
-    assert fromPSK("random")
+    random_key = fromPSK("random")
+    assert isinstance(random_key, bytes)
+    assert len(random_key) == 32
     assert fromPSK("none") == b"\x00"
     assert fromPSK("default") == b"\x01"
     assert fromPSK("simple1") == b"\x02"

--- a/meshtastic/tests/test_psk_security.py
+++ b/meshtastic/tests/test_psk_security.py
@@ -1,0 +1,55 @@
+"""Security regression tests for PSK parsing."""
+
+import pytest
+from meshtastic.util import fromPSK
+
+@pytest.mark.unit
+def test_psk_rejects_plaintext_passwords() -> None:
+    """Ensure that common password-like strings are rejected by fromPSK."""
+    invalid_psks = [
+        "mypassword",
+        "hunter2",
+        "password123",
+        "correct horse battery staple",
+        " admin ",
+        "!@#$%^&*",
+    ]
+    for psk in invalid_psks:
+        with pytest.raises(ValueError, match="Invalid PSK format"):
+            fromPSK(psk)
+
+@pytest.mark.unit
+def test_psk_rejects_non_byte_types() -> None:
+    """Ensure that fromPSK does not return non-byte types."""
+    # Although fromPSK takes a str, we want to ensure it doesn't accidentally
+    # return something that would be parsed as another type by fromStr if we were still using it.
+    invalid_inputs = [
+        "123",    # Would be int
+        "123.45", # Would be float
+        "True",   # Would be bool
+        "no",     # Would be bool
+    ]
+    for val in invalid_inputs:
+        with pytest.raises(ValueError, match="Invalid PSK format"):
+            fromPSK(val)
+
+@pytest.mark.unit
+def test_psk_rejects_invalid_base64_lengths() -> None:
+    """Ensure that raw base64 is only accepted for standard AES key lengths."""
+    # "AQ==" is 1 byte, should be rejected if raw
+    with pytest.raises(ValueError, match="Invalid PSK format"):
+        fromPSK("AQ==")
+
+    # "AAECAwQFBgcICQoLDA0ODw==" is 16 bytes, should be accepted
+    assert len(fromPSK("AAECAwQFBgcICQoLDA0ODw==")) == 16
+
+@pytest.mark.unit
+def test_psk_accepts_valid_formats() -> None:
+    """Ensure valid formats are still accepted."""
+    assert fromPSK("random")
+    assert fromPSK("none") == b"\x00"
+    assert fromPSK("default") == b"\x01"
+    assert fromPSK("simple1") == b"\x02"
+    assert fromPSK("0x1234") == b"\x124"
+    assert fromPSK("base64:AQ==") == b"\x01"
+    assert fromPSK("") == b""

--- a/meshtastic/tests/test_util.py
+++ b/meshtastic/tests/test_util.py
@@ -156,7 +156,20 @@ def test_fromPSK() -> None:
     assert fromPSK("none") == b"\x00"
     assert fromPSK("default") == b"\x01"
     assert fromPSK("simple22") == b"\x17"
+    # "trash" is NOT valid base64 (bad padding length), falls back to string
     assert fromPSK("trash") == "trash"
+    # Raw base64 auto-detection: 32-byte PSK
+    raw_b64_key = "HR8D2KziD3IfvpHlwHAfCAh4JP/I7dsHwKdVllfKoD0="
+    expected_bytes = base64.b64decode(raw_b64_key)
+    assert fromPSK(raw_b64_key) == expected_bytes
+    # Raw base64: short key same as default
+    assert fromPSK("AQ==") == b"\x01"
+    # base64: prefix still works
+    assert fromPSK(f"base64:{raw_b64_key}") == expected_bytes
+    # Hex still works
+    assert fromPSK("0x1a") == b"\x1a"
+    # Invalid base64 (spaces/special chars) falls back to string
+    assert fromPSK("not valid base64!") == "not valid base64!"
     with pytest.raises(ValueError, match=r"simpleN"):
         fromPSK("simple")
     with pytest.raises(ValueError, match=r"simpleN"):

--- a/meshtastic/tests/test_util.py
+++ b/meshtastic/tests/test_util.py
@@ -156,22 +156,25 @@ def test_fromPSK() -> None:
     assert fromPSK("none") == b"\x00"
     assert fromPSK("default") == b"\x01"
     assert fromPSK("simple22") == b"\x17"
-    # "trash" is NOT valid base64 (bad padding length), falls back to string
-    assert fromPSK("trash") == "trash"
+    # "trash" is NOT valid base64, now raises ValueError
+    with pytest.raises(ValueError, match="Invalid PSK format"):
+        fromPSK("trash")
     # Raw base64 auto-detection: deterministic standard AES key lengths
     for key_length in (16, 24, 32):
         expected_bytes = bytes(range(key_length))
         raw_b64_key = base64.b64encode(expected_bytes).decode("ascii")
         assert fromPSK(raw_b64_key) == expected_bytes
-    # Raw base64: short (1-byte) key is NOT an allowed PSK length, stays string
-    assert fromPSK("AQ==") == "AQ=="
+    # Raw base64: short (1-byte) key is NOT an allowed PSK length, now raises ValueError
+    with pytest.raises(ValueError, match="Invalid PSK format"):
+        fromPSK("AQ==")
     # Explicit base64: prefix still works for any length (including 1-byte default)
     assert fromPSK("base64:AQ==") == b"\x01"
     assert fromPSK(f"base64:{raw_b64_key}") == expected_bytes
     # Hex still works
     assert fromPSK("0x1a") == b"\x1a"
-    # Invalid base64 (spaces/special chars) falls back to string
-    assert fromPSK("not valid base64!") == "not valid base64!"
+    # Invalid base64 (spaces/special chars) now raises ValueError
+    with pytest.raises(ValueError, match="Invalid PSK format"):
+        fromPSK("not valid base64!")
     with pytest.raises(ValueError, match=r"simpleN"):
         fromPSK("simple")
     with pytest.raises(ValueError, match=r"simpleN"):

--- a/meshtastic/tests/test_util.py
+++ b/meshtastic/tests/test_util.py
@@ -158,13 +158,15 @@ def test_fromPSK() -> None:
     assert fromPSK("simple22") == b"\x17"
     # "trash" is NOT valid base64 (bad padding length), falls back to string
     assert fromPSK("trash") == "trash"
-    # Raw base64 auto-detection: 32-byte PSK
-    raw_b64_key = "HR8D2KziD3IfvpHlwHAfCAh4JP/I7dsHwKdVllfKoD0="
-    expected_bytes = base64.b64decode(raw_b64_key)
-    assert fromPSK(raw_b64_key) == expected_bytes
-    # Raw base64: short key same as default
-    assert fromPSK("AQ==") == b"\x01"
-    # base64: prefix still works
+    # Raw base64 auto-detection: deterministic standard AES key lengths
+    for key_length in (16, 24, 32):
+        expected_bytes = bytes(range(key_length))
+        raw_b64_key = base64.b64encode(expected_bytes).decode("ascii")
+        assert fromPSK(raw_b64_key) == expected_bytes
+    # Raw base64: short (1-byte) key is NOT an allowed PSK length, stays string
+    assert fromPSK("AQ==") == "AQ=="
+    # Explicit base64: prefix still works for any length (including 1-byte default)
+    assert fromPSK("base64:AQ==") == b"\x01"
     assert fromPSK(f"base64:{raw_b64_key}") == expected_bytes
     # Hex still works
     assert fromPSK("0x1a") == b"\x1a"

--- a/meshtastic/util.py
+++ b/meshtastic/util.py
@@ -111,7 +111,7 @@ def genPSK256() -> bytes:
     return os.urandom(32)
 
 
-def fromPSK(valstr: str) -> Any:
+def fromPSK(valstr: str) -> bytes:
     """Parse a user-provided PSK specification into the internal PSK byte representation.
 
     Recognizes these special forms:
@@ -120,9 +120,7 @@ def fromPSK(valstr: str) -> Any:
     - "default": return a single byte with value 1 to indicate the default channel PSK.
     - "simpleN": where N is an integer in 0..254; return a single byte with value (N + 1).
 
-    For any other input, parse using general string-to-value rules (e.g., hex, base64:,
-    numeric, boolean, or plain string). If the result is still a plain string (not
-    recognized as any of the above), strict base64 decoding is attempted as a fallback.
+    For any other input, parse using strict byte-oriented rules (hex, base64:, or raw base64).
     Raw base64-encoded PSK values (without the ``base64:`` prefix) are accepted only
     when they decode to a standard AES key length (16, 24, or 32 bytes).
 
@@ -133,17 +131,21 @@ def fromPSK(valstr: str) -> Any:
 
     Returns
     -------
-    Any
-        The PSK as bytes for recognized PSK forms; otherwise the parsed value
-        according to general string parsing rules (hex/base64/numeric/boolean/string).
+    bytes
+        The PSK as bytes.
+
+    Raises
+    ------
+    ValueError
+        If the input is not a recognized PSK format or cannot be decoded as bytes.
     """
     if valstr == "random":
         return genPSK256()
-    elif valstr == "none":
+    if valstr == "none":
         return bytes([0])  # Use the 'no encryption' PSK
-    elif valstr == "default":
+    if valstr == "default":
         return bytes([1])  # Use default channel psk
-    elif valstr.startswith("simple"):
+    if valstr.startswith("simple"):
         digits = valstr[6:]
         if not digits or not digits.isdigit():
             raise ValueError(_PSK_SIMPLE_MSG)
@@ -152,16 +154,44 @@ def fromPSK(valstr: str) -> Any:
             raise ValueError(f"{_PSK_SIMPLE_MSG}, got {n}")
         # Use one of the single byte encodings
         return bytes([n + 1])
-    else:
-        val = fromStr(valstr)
-        if isinstance(val, str):
-            try:
-                decoded = base64.b64decode(valstr, validate=True)
-                if len(decoded) in _ALLOWED_RAW_BASE64_PSK_BYTE_LENGTHS:
-                    val = decoded
-            except (binascii.Error, ValueError):
-                pass
-        return val
+
+    # For everything else, it MUST result in bytes.
+    # We no longer fall back to fromStr() because it returns non-byte types (int/float/bool/str)
+    # which are not valid for a PSK and could lead to accidental plaintext password use.
+
+    if len(valstr) == 0:
+        return bytes()
+
+    if valstr.startswith("0x"):
+        # Parse hex and preserve compatibility with "0x"/single-nibble forms.
+        hex_value = valstr[2:]
+        if len(hex_value) == 0:
+            hex_value = "00"
+        elif len(hex_value) % 2 == 1:
+            hex_value = "0" + hex_value
+        try:
+            return bytes.fromhex(hex_value)
+        except ValueError as e:
+            raise ValueError(f"Invalid hex PSK: {valstr!r}") from e
+
+    if valstr.startswith("base64:"):
+        try:
+            return base64.b64decode(valstr[7:], validate=True)
+        except (binascii.Error, ValueError) as e:
+            raise ValueError(f"Invalid base64 PSK: {valstr!r}") from e
+
+    # Auto-detection of raw base64 (only for standard AES key lengths)
+    try:
+        decoded = base64.b64decode(valstr, validate=True)
+        if len(decoded) in _ALLOWED_RAW_BASE64_PSK_BYTE_LENGTHS:
+            return decoded
+    except (binascii.Error, ValueError):
+        pass
+
+    raise ValueError(
+        f"Invalid PSK format: {valstr!r}. Expected a keyword (none, default, random, simpleN), "
+        "hex (0x...), explicit base64 (base64:...), or raw base64 (16, 24, or 32 bytes)."
+    )
 
 
 def fromStr(valstr: str) -> Any:

--- a/meshtastic/util.py
+++ b/meshtastic/util.py
@@ -118,8 +118,10 @@ def fromPSK(valstr: str) -> Any:
     - "default": return a single byte with value 1 to indicate the default channel PSK.
     - "simpleN": where N is an integer in 0..254; return a single byte with value (N + 1).
 
-    For any other input, parse using general string-to-value rules (e.g., hex, base64,
-    numeric, boolean, or plain string) and return the corresponding value.
+    For any other input, parse using general string-to-value rules (e.g., hex, base64:,
+    numeric, boolean, or plain string).  If the result is still a plain string (not
+    recognized as any of the above), base64 decoding is attempted as a fallback so that
+    raw base64-encoded PSK values (without the ``base64:`` prefix) are accepted.
 
     Parameters
     ----------
@@ -148,7 +150,13 @@ def fromPSK(valstr: str) -> Any:
         # Use one of the single byte encodings
         return bytes([n + 1])
     else:
-        return fromStr(valstr)
+        val = fromStr(valstr)
+        if isinstance(val, str):
+            try:
+                val = base64.b64decode(valstr)
+            except Exception:
+                pass
+        return val
 
 
 def fromStr(valstr: str) -> Any:

--- a/meshtastic/util.py
+++ b/meshtastic/util.py
@@ -75,7 +75,7 @@ DISTRIBUTION_NAME_CANDIDATES: tuple[str, ...] = ("mtjk", "meshtastic")
 
 
 _PSK_SIMPLE_MSG = 'Invalid PSK format: expected "simpleN" with N in 0..254'
-_ALLOWED_RAW_BASE64_PSK_BYTE_LENGTHS = (16, 24, 32)
+_ALLOWED_RAW_BASE64_PSK_BYTE_LENGTHS: tuple[int, ...] = (16, 24, 32)
 
 
 def quoteBooleans(a_string: str) -> str:

--- a/meshtastic/util.py
+++ b/meshtastic/util.py
@@ -139,13 +139,15 @@ def fromPSK(valstr: str) -> bytes:
     ValueError
         If the input is not a recognized PSK format or cannot be decoded as bytes.
     """
+    result: bytes | None = None
+
     if valstr == "random":
-        return genPSK256()
-    if valstr == "none":
-        return bytes([0])  # Use the 'no encryption' PSK
-    if valstr == "default":
-        return bytes([1])  # Use default channel psk
-    if valstr.startswith("simple"):
+        result = genPSK256()
+    elif valstr == "none":
+        result = bytes([0])  # Use the 'no encryption' PSK
+    elif valstr == "default":
+        result = bytes([1])  # Use default channel psk
+    elif valstr.startswith("simple"):
         digits = valstr[6:]
         if not digits or not digits.isdigit():
             raise ValueError(_PSK_SIMPLE_MSG)
@@ -153,16 +155,10 @@ def fromPSK(valstr: str) -> bytes:
         if not 0 <= n <= 254:
             raise ValueError(f"{_PSK_SIMPLE_MSG}, got {n}")
         # Use one of the single byte encodings
-        return bytes([n + 1])
-
-    # For everything else, it MUST result in bytes.
-    # We no longer fall back to fromStr() because it returns non-byte types (int/float/bool/str)
-    # which are not valid for a PSK and could lead to accidental plaintext password use.
-
-    if len(valstr) == 0:
-        return bytes()
-
-    if valstr.startswith("0x"):
+        result = bytes([n + 1])
+    elif len(valstr) == 0:
+        result = bytes()
+    elif valstr.startswith("0x"):
         # Parse hex and preserve compatibility with "0x"/single-nibble forms.
         hex_value = valstr[2:]
         if len(hex_value) == 0:
@@ -170,28 +166,29 @@ def fromPSK(valstr: str) -> bytes:
         elif len(hex_value) % 2 == 1:
             hex_value = "0" + hex_value
         try:
-            return bytes.fromhex(hex_value)
+            result = bytes.fromhex(hex_value)
         except ValueError as e:
             raise ValueError(f"Invalid hex PSK: {valstr!r}") from e
-
-    if valstr.startswith("base64:"):
+    elif valstr.startswith("base64:"):
         try:
-            return base64.b64decode(valstr[7:], validate=True)
+            result = base64.b64decode(valstr[7:], validate=True)
         except (binascii.Error, ValueError) as e:
             raise ValueError(f"Invalid base64 PSK: {valstr!r}") from e
+    else:
+        # Auto-detection of raw base64 (only for standard AES key lengths)
+        try:
+            decoded = base64.b64decode(valstr, validate=True)
+            if len(decoded) in _ALLOWED_RAW_BASE64_PSK_BYTE_LENGTHS:
+                result = decoded
+        except (binascii.Error, ValueError):
+            pass
 
-    # Auto-detection of raw base64 (only for standard AES key lengths)
-    try:
-        decoded = base64.b64decode(valstr, validate=True)
-        if len(decoded) in _ALLOWED_RAW_BASE64_PSK_BYTE_LENGTHS:
-            return decoded
-    except (binascii.Error, ValueError):
-        pass
-
-    raise ValueError(
-        f"Invalid PSK format: {valstr!r}. Expected a keyword (none, default, random, simpleN), "
-        "hex (0x...), explicit base64 (base64:...), or raw base64 (16, 24, or 32 bytes)."
-    )
+    if result is None:
+        raise ValueError(
+            f"Invalid PSK format: {valstr!r}. Expected a keyword (none, default, random, simpleN), "
+            "hex (0x...), explicit base64 (base64:...), or raw base64 (16, 24, or 32 bytes)."
+        )
+    return result
 
 
 def fromStr(valstr: str) -> Any:

--- a/meshtastic/util.py
+++ b/meshtastic/util.py
@@ -1,6 +1,7 @@
 """Utility functions."""
 
 import base64
+import binascii
 import glob  # noqa: F401
 import logging
 import os
@@ -74,6 +75,7 @@ DISTRIBUTION_NAME_CANDIDATES: tuple[str, ...] = ("mtjk", "meshtastic")
 
 
 _PSK_SIMPLE_MSG = 'Invalid PSK format: expected "simpleN" with N in 0..254'
+_ALLOWED_RAW_BASE64_PSK_BYTE_LENGTHS = (16, 24, 32)
 
 
 def quoteBooleans(a_string: str) -> str:
@@ -119,9 +121,10 @@ def fromPSK(valstr: str) -> Any:
     - "simpleN": where N is an integer in 0..254; return a single byte with value (N + 1).
 
     For any other input, parse using general string-to-value rules (e.g., hex, base64:,
-    numeric, boolean, or plain string).  If the result is still a plain string (not
-    recognized as any of the above), base64 decoding is attempted as a fallback so that
-    raw base64-encoded PSK values (without the ``base64:`` prefix) are accepted.
+    numeric, boolean, or plain string). If the result is still a plain string (not
+    recognized as any of the above), strict base64 decoding is attempted as a fallback.
+    Raw base64-encoded PSK values (without the ``base64:`` prefix) are accepted only
+    when they decode to a standard AES key length (16, 24, or 32 bytes).
 
     Parameters
     ----------
@@ -153,8 +156,10 @@ def fromPSK(valstr: str) -> Any:
         val = fromStr(valstr)
         if isinstance(val, str):
             try:
-                val = base64.b64decode(valstr)
-            except Exception:
+                decoded = base64.b64decode(valstr, validate=True)
+                if len(decoded) in _ALLOWED_RAW_BASE64_PSK_BYTE_LENGTHS:
+                    val = decoded
+            except (binascii.Error, ValueError):
                 pass
         return val
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR tightens PSK parsing to require deterministic byte outputs, adds support for accepting raw base64-encoded PSKs (without a base64: prefix) when the decoded length matches an AES key size, updates CLI help text to document base64 PSKs, adds focused unit and security tests, and includes small repository maintenance updates.

## Key changes

Features
- util.fromPSK(valstr: str) -> bytes
  - Now returns bytes and no longer falls back to non-bytes parsing.
  - If an unprefixed string fails initial parsing, the function will attempt strict base64 decoding and accept the result only if the decoded length is exactly one of the allowed AES key sizes (16, 24, 32 bytes).
  - Continues to support:
    - Explicit base64 with the base64: prefix (strict decoding).
    - Hex strings with 0x prefix (single-nibble supported).
    - Empty string → empty bytes.
    - Keyword-like values (random, none, default, simpleN).
  - Docstring updated to document parsing rules and allowed lengths.
- CLI help
  - meshtastic/__main__.py: help text for --ch-set updated to explicitly mention base64-encoded PSKs.

Tests
- meshtastic/tests/test_util.py
  - Tests updated to expect ValueError for invalid or non-byte PSK inputs.
  - Verifies raw base64 auto-detection and decoding into valid AES key sizes, explicit base64:, and hex parsing.
- meshtastic/tests/test_main.py
  - New parametrized CLI test covering raw base64, base64-prefixed, and hex PSK inputs.
- meshtastic/tests/test_psk_security.py
  - New regression tests ensuring rejection of plaintext-like inputs, non-byte outputs, invalid base64 lengths, and continued acceptance of valid formats.

Maintenance / tooling
- .gitignore: added .sisyphus/ to ignore list.
- .trunk/trunk.yaml: bumped checkov action from checkov@3.2.526 to checkov@3.2.528.

## Breaking changes / migration notes

- Behavioral change: fromPSK now guarantees a bytes return and raises ValueError for inputs that do not deterministically parse into bytes. Callers that previously relied on falling back to non-bytes values or the original string must:
  - Provide inputs in an accepted format (hex with 0x..., explicit base64:, raw base64 that decodes to 16/24/32 bytes, or recognized keyword values), or
  - Catch ValueError and handle parsing failures explicitly.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jeremiah-k/mtjk/pull/162)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->