### PR TITLE
Rework Docker release workflow for versioned multi-arch images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 !Containerfile*
 !Dockerfile
 !README.md
+!LICENSE.md
 !bin/container-entrypoint.sh
 !examples/
 !extra/

--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -75,3 +75,5 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -34,6 +34,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.14"
+
       - name: Extract version and build info
         id: get_version
         shell: bash

--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -1,84 +1,106 @@
-name: Create and publish Container image
+name: Docker Build and Publish
 
 on:
-  push:
-    branches:
-      - master
-      - develop
-    tags:
-      - '*.*.*'
-  pull_request:
-    branches:
-      - master
-      - develop
+  workflow_dispatch:
+  release:
+    types: [published]
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: jeremiah-k/mtjk
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
-  build-and-push-image:
+  docker-build:
     runs-on: ubuntu-latest
-    continue-on-error: false
-    permissions:
-      contents: read
-      packages: write
+    timeout-minutes: 45
+
     strategy:
       matrix:
         include:
-          - container: Containerfile.debian
-            autotag: false
-            suffix: -debian
           - container: Containerfile.alpine
-            autotag: ${{ startsWith(github.ref, 'refs/heads/') && 'auto' || 'true' }}
-    # Container builds run in upstream (meshtastic/python) and this fork (jeremiah-k/mtjk)
-    if: github.repository == 'meshtastic/python' || github.repository == 'jeremiah-k/mtjk'
+            suffix: ""
+            tag_latest: true
+          - container: Containerfile.debian
+            suffix: -debian
+            tag_latest: false
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          fetch-depth: 0
           persist-credentials: false
 
-      - name: Set up QEMU
+      - name: Extract version and build info
+        id: get_version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION="$(python3 -c "import tomllib; from pathlib import Path; print(tomllib.loads(Path('pyproject.toml').read_text(encoding='utf-8'))['tool']['poetry']['version'])")"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo "build_date=$BUILD_DATE" >> "$GITHUB_OUTPUT"
+
+          VCS_REF=$(git rev-parse HEAD)
+          echo "vcs_ref=$VCS_REF" >> "$GITHUB_OUTPUT"
+
+          GIT_SHA=$(git rev-parse --short HEAD)
+          echo "git_sha=$GIT_SHA" >> "$GITHUB_OUTPUT"
+
+          if [ "${{ github.event_name }}" == "release" ]; then
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up QEMU for multi-platform builds
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
-      - name: Login to Container registry
+      - name: Log in to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Docker meta
+      - name: Extract metadata
         id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
-          images: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=edge
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-          flavor: |
-            latest=${{ matrix.autotag }}
-            suffix=${{ matrix.suffix }}
+            type=semver,pattern={{version}}${{ matrix.suffix }},value=${{ steps.get_version.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}}${{ matrix.suffix }},value=${{ steps.get_version.outputs.version }}
+            type=semver,pattern={{major}}${{ matrix.suffix }},value=${{ steps.get_version.outputs.version }}
+            type=raw,value=latest${{ matrix.suffix }},enable=${{ steps.get_version.outputs.is_release == 'true' && matrix.tag_latest }}
+            type=raw,value=${{ steps.get_version.outputs.version }}-dev-${{ steps.get_version.outputs.git_sha }}${{ matrix.suffix }},enable=${{ steps.get_version.outputs.is_release == 'false' }}
+          labels: |
+            org.opencontainers.image.title=mtjk
+            org.opencontainers.image.description=Python API and CLI for Meshtastic devices (mtjk fork)
+            org.opencontainers.image.url=https://github.com/jeremiah-k/mtjk
+            org.opencontainers.image.source=https://github.com/jeremiah-k/mtjk
+            org.opencontainers.image.licenses=GPL-3.0-only
+            org.opencontainers.image.version=${{ steps.get_version.outputs.version }}
+            org.opencontainers.image.revision=${{ steps.get_version.outputs.vcs_ref }}
+            org.opencontainers.image.created=${{ steps.get_version.outputs.build_date }}
 
-      - name: Build and push
+      - name: Build and push Docker image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
-          platforms: linux/amd64,linux/386,linux/arm64
           context: .
           file: ${{ matrix.container }}
-          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: false

--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -1,7 +1,13 @@
 name: Docker Build and Publish
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      push:
+        description: "Push images to registry"
+        required: false
+        type: boolean
+        default: true
   release:
     types: [published]
 
@@ -45,7 +51,14 @@ jobs:
         run: |
           set -euo pipefail
 
-          VERSION="$(python3 -c "import tomllib; from pathlib import Path; print(tomllib.loads(Path('pyproject.toml').read_text(encoding='utf-8'))['tool']['poetry']['version'])")"
+          VERSION=$(python3 <<'EOF'
+import tomllib
+from pathlib import Path
+
+data = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+print(data["tool"]["poetry"]["version"])
+EOF
+          )
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
           BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
@@ -103,9 +116,12 @@ jobs:
           context: .
           file: ${{ matrix.container }}
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name == 'release' || inputs.push }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # provenance disabled: avoids creating separate attestation manifests
+          # that complicate image pull references (e.g. ghcr.io/repo:tag
+          # returns a manifest list with both the image and attestation layers)
           provenance: false

--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -1,7 +1,7 @@
 name: Docker Build and Publish
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: {}
   release:
     types: [published]
 

--- a/Containerfile.alpine
+++ b/Containerfile.alpine
@@ -5,24 +5,31 @@
 ARG TARGET_VERSION="3.11-alpine"
 ARG TARGET_ARCH="library"
 
-FROM docker.io/${TARGET_ARCH}/python:${TARGET_VERSION}
+FROM docker.io/${TARGET_ARCH}/python:${TARGET_VERSION} AS builder
 
 WORKDIR /tmp/build
 
-COPY . /tmp/build
+COPY pyproject.toml poetry.lock /tmp/build/
 
-RUN _poetry_venv_dir="$(mktemp -d -p "${TMPDIR:-/tmp}" 'poetry_venv.XXXXXX')" && \
-    apk add --no-cache libffi && \
-    apk add --no-cache --virtual .build-deps build-base libffi-dev && \
-    python -m 'venv' "${_poetry_venv_dir}" && \
-    "${_poetry_venv_dir}/bin/pip" install --no-cache-dir 'poetry' && \
-    "${_poetry_venv_dir}/bin/poetry" config --local virtualenvs.create false && \
-    "${_poetry_venv_dir}/bin/poetry" install --without dev --extras cli --extras tunnel --no-interaction --no-ansi && \
-    apk del .build-deps && \
+RUN apk add --no-cache --virtual .build-deps build-base libffi-dev && \
+    pip install --no-cache-dir 'poetry==2.4.1' && \
+    poetry config virtualenvs.create false && \
+    poetry install --without dev --extras cli --extras tunnel --no-interaction --no-ansi --no-root
+
+COPY . /tmp/build/
+
+RUN poetry build --format wheel --no-interaction
+
+FROM docker.io/${TARGET_ARCH}/python:${TARGET_VERSION}
+
+RUN apk add --no-cache libffi && \
     addgroup -S meshtastic && \
-    adduser -S -G meshtastic -h /home/meshtastic meshtastic && \
-    rm -f -r "${_poetry_venv_dir}" && \
-    rm -f -r "/tmp/build"
+    adduser -S -G meshtastic -h /home/meshtastic meshtastic
+
+COPY --from=builder /tmp/build/dist/*.whl /tmp/
+
+RUN wheel=$(echo /tmp/meshtastic-*.whl) && pip install --no-cache-dir "${wheel}[cli,tunnel]" && \
+    rm -f /tmp/meshtastic-*.whl
 
 COPY "./bin/container-entrypoint.sh" "/init"
 RUN chmod 0755 /init

--- a/Containerfile.alpine
+++ b/Containerfile.alpine
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2025 Olliver Schinagl <oliver@schinagl.nl>
 
-ARG TARGET_VERSION="3.11-alpine"
+ARG TARGET_VERSION="3.14-alpine"
 ARG TARGET_ARCH="library"
 
 FROM docker.io/${TARGET_ARCH}/python:${TARGET_VERSION} AS builder

--- a/Containerfile.alpine
+++ b/Containerfile.alpine
@@ -28,7 +28,9 @@ RUN apk add --no-cache libffi && \
 
 COPY --from=builder /tmp/build/dist/*.whl /tmp/
 
-RUN wheel=$(echo /tmp/mtjk-*.whl) && pip install --no-cache-dir "${wheel}[cli,tunnel]" && \
+RUN wheel=$(echo /tmp/mtjk-*.whl) && \
+    [ -f "${wheel}" ] || { echo "ERROR: Wheel file not found"; exit 1; } && \
+    pip install --no-cache-dir "${wheel}[cli,tunnel]" && \
     rm -f /tmp/mtjk-*.whl
 
 COPY "./bin/container-entrypoint.sh" "/init"

--- a/Containerfile.debian
+++ b/Containerfile.debian
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2025 Olliver Schinagl <oliver@schinagl.nl>
 
-ARG TARGET_VERSION="3.11"
+ARG TARGET_VERSION="3.14-slim-bookworm"
 ARG TARGET_ARCH="library"
 
 FROM docker.io/${TARGET_ARCH}/python:${TARGET_VERSION} AS builder

--- a/Containerfile.debian
+++ b/Containerfile.debian
@@ -25,7 +25,9 @@ RUN useradd --system --create-home --home-dir /home/meshtastic meshtastic
 
 COPY --from=builder /tmp/build/dist/*.whl /tmp/
 
-RUN wheel=$(echo /tmp/mtjk-*.whl) && pip install --no-cache-dir "${wheel}[cli,tunnel]" && \
+RUN wheel=$(echo /tmp/mtjk-*.whl) && \
+    [ -f "${wheel}" ] || { echo "ERROR: Wheel file not found"; exit 1; } && \
+    pip install --no-cache-dir "${wheel}[cli,tunnel]" && \
     rm -f /tmp/mtjk-*.whl
 
 COPY "./bin/container-entrypoint.sh" "/init"

--- a/Containerfile.debian
+++ b/Containerfile.debian
@@ -5,20 +5,28 @@
 ARG TARGET_VERSION="3.11"
 ARG TARGET_ARCH="library"
 
-FROM docker.io/${TARGET_ARCH}/python:${TARGET_VERSION}
+FROM docker.io/${TARGET_ARCH}/python:${TARGET_VERSION} AS builder
 
 WORKDIR /tmp/build
 
-COPY . /tmp/build
+COPY pyproject.toml poetry.lock /tmp/build/
 
-RUN _poetry_venv_dir="$(mktemp -d -p "${TMPDIR:-/tmp}" 'poetry_venv.XXXXXX')" && \
-    python -m 'venv' "${_poetry_venv_dir}" && \
-    "${_poetry_venv_dir}/bin/pip" install --no-cache-dir 'poetry' && \
-    "${_poetry_venv_dir}/bin/poetry" config --local virtualenvs.create false && \
-    "${_poetry_venv_dir}/bin/poetry" install --without dev --extras cli --extras tunnel --no-interaction --no-ansi && \
-    useradd --system --create-home --home-dir /home/meshtastic meshtastic && \
-    rm -f -r "${_poetry_venv_dir}" && \
-    rm -f -r "/tmp/build"
+RUN pip install --no-cache-dir 'poetry==2.4.1' && \
+    poetry config virtualenvs.create false && \
+    poetry install --without dev --extras cli --extras tunnel --no-interaction --no-ansi --no-root
+
+COPY . /tmp/build/
+
+RUN poetry build --format wheel --no-interaction
+
+FROM docker.io/${TARGET_ARCH}/python:${TARGET_VERSION}
+
+RUN useradd --system --create-home --home-dir /home/meshtastic meshtastic
+
+COPY --from=builder /tmp/build/dist/*.whl /tmp/
+
+RUN wheel=$(echo /tmp/meshtastic-*.whl) && pip install --no-cache-dir "${wheel}[cli,tunnel]" && \
+    rm -f /tmp/meshtastic-*.whl
 
 COPY "./bin/container-entrypoint.sh" "/init"
 RUN chmod 0755 /init

--- a/examples/replymessage.py
+++ b/examples/replymessage.py
@@ -10,14 +10,21 @@ Cleanup/error handling: clear connect failures and graceful Ctrl+C close.
 import argparse
 import time
 from typing import Any
+
 from pubsub import pub
+
+import meshtastic.ble_interface
 import meshtastic.serial_interface
 import meshtastic.tcp_interface
-import meshtastic.ble_interface
 from meshtastic.mesh_interface import MeshInterface
 
 # Type alias for the union of supported interface types
-Interface = meshtastic.serial_interface.SerialInterface | meshtastic.ble_interface.BLEInterface | meshtastic.tcp_interface.TCPInterface
+Interface = (
+    meshtastic.serial_interface.SerialInterface
+    | meshtastic.ble_interface.BLEInterface
+    | meshtastic.tcp_interface.TCPInterface
+)
+
 
 def onReceive(packet: dict[str, Any], interface: MeshInterface) -> None:
     """Reply to every received packet with some info."""

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -42,8 +42,11 @@ from meshtastic.protobuf import (
     mesh_pb2,
     portnums_pb2,
 )
-from meshtastic.version import get_active_version
-from meshtastic.version import INSTALL_UPGRADE_HINT, PROJECT_DISPLAY_NAME
+from meshtastic.version import (
+    INSTALL_UPGRADE_HINT,
+    PROJECT_DISPLAY_NAME,
+    get_active_version,
+)
 
 argcomplete: ModuleType | None = None
 try:

--- a/meshtastic/powermon/ppk2.py
+++ b/meshtastic/powermon/ppk2.py
@@ -7,7 +7,7 @@ import time
 from contextlib import suppress
 from typing import Final
 
-from ppk2_api import ppk2_api  # type: ignore[import-untyped]
+from ppk2_api import ppk2_api  # type: ignore[import-untyped,import-not-found]
 
 from .constants import MICROAMPS_PER_MILLIAMP, MILLIVOLTS_PER_VOLT, MIN_SUPPLY_VOLTAGE_V
 from .power_supply import PowerError, PowerSupply

--- a/meshtastic/slog/slog.py
+++ b/meshtastic/slog/slog.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeAlias
 
-import parse  # type: ignore[import-untyped]
+import parse  # type: ignore[import-untyped,import-not-found]
 import platformdirs
 import pyarrow as pa
 from pubsub import pub

--- a/meshtastic/tests/test_inject_nanopb_options.py
+++ b/meshtastic/tests/test_inject_nanopb_options.py
@@ -560,7 +560,10 @@ def test_inject_comments_with_braces_do_not_corrupt_nesting():
     """
     result = _inject(
         proto,
-        specific={("Outer", "name"): {"max_size": 20}, ("Outer", "Inner", "value"): {"max_size": 30}},
+        specific={
+            ("Outer", "name"): {"max_size": 20},
+            ("Outer", "Inner", "value"): {"max_size": 30},
+        },
     )
     # Both fields should get options — comments with braces must not break tracking
     assert "name = 1 [(nanopb).max_size = 20]" in result
@@ -578,7 +581,9 @@ def test_inject_map_fields_are_skipped():
           string name = 2;
         }
     """
-    result = _inject(proto, wildcard={"labels": {"max_size": 10}, "name": {"max_size": 20}})
+    result = _inject(
+        proto, wildcard={"labels": {"max_size": 10}, "name": {"max_size": 20}}
+    )
     # map field should NOT have options injected
     assert "labels" in result
     assert "(nanopb)" not in next(
@@ -603,7 +608,10 @@ def test_inject_oneof_fields_get_options():
     """
     result = _inject(
         proto,
-        specific={("Packet", "text"): {"max_size": 200}, ("Packet", "data"): {"max_size": 233}},
+        specific={
+            ("Packet", "text"): {"max_size": 200},
+            ("Packet", "data"): {"max_size": 233},
+        },
     )
     assert "text = 1 [(nanopb).max_size = 200]" in result
     assert "data = 2 [(nanopb).max_size = 233]" in result

--- a/meshtastic/version.py
+++ b/meshtastic/version.py
@@ -16,9 +16,7 @@ PROJECT_DISPLAY_NAME: str = "Meshtastic (mtjk fork)"
 
 # Recommended one-liner for upgrading the package.
 # Uses pipx (recommended for CLI tools) with pip as fallback.
-INSTALL_UPGRADE_HINT: str = (
-    f"pipx upgrade {PACKAGE_NAME}"
-)
+INSTALL_UPGRADE_HINT: str = f"pipx upgrade {PACKAGE_NAME}"
 
 
 def getActiveVersion() -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "meshtastic"
-version = "2.7.8"
+version = "2.7.9"
 description = "Python API & client shell for talking to Meshtastic devices"
 authors = ["Meshtastic Developers <contact@meshtastic.org>"]
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary by Sourcery

Update container build workflow to publish versioned Debian and Alpine images from releases and bump the package version.

Enhancements:
- Tidy example and library code formatting and hints, and bump the Python package version to 2.7.9.post1.

Build:
- Rework GitHub Actions container workflow to build multi-platform Debian and Alpine images on releases with explicit image name, OCI metadata labels, and refined semver/tagging scheme using the pyproject version.
- Enable Buildx/QEMU-based builds with registry login, build cache usage, and always-push behaviour for linux/amd64 and linux/arm64 images.

Tests:
- Apply minor formatting and style cleanups in tests without changing behavior.