### PR TITLE
Refactor CI workflow and optimize Containerfile build

### DIFF
--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -31,14 +31,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          VERSION="$(
-            python3 -c "
-              import tomllib
-              from pathlib import Path
-              data = tomllib.loads(Path('pyproject.toml').read_text(encoding='utf-8'))
-              print(data['tool']['poetry']['version'])
-            "
-          )"
+          VERSION="$(python3 -c "import tomllib; from pathlib import Path; print(tomllib.loads(Path('pyproject.toml').read_text(encoding='utf-8'))['tool']['poetry']['version'])")"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
           BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')

--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up QEMU for multi-platform builds
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
         with:
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
@@ -92,7 +92,7 @@ jobs:
         with:
           context: .
           file: ./Containerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -21,9 +21,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          # Manual dispatch builds from develop; releases build from the release tag.
-          ref: ${{ github.event_name == 'workflow_dispatch' && 'develop' || github.ref }}
 
       - name: Extract version and build info
         id: get_version

--- a/Containerfile
+++ b/Containerfile
@@ -7,7 +7,10 @@
 FROM docker.io/library/python:3.14-slim-bookworm AS builder
 
 # git is required for pip VCS installs (e.g. riden) and poetry build metadata.
-RUN apt-get update && apt-get install -y --no-install-recommends git && \
+# build-essential provides gcc for compiling native extensions (cffi, msgpack, etc.)
+# on platforms where pre-built wheels are not available (e.g. arm/v7 on Python 3.14).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git build-essential && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build

--- a/Containerfile
+++ b/Containerfile
@@ -20,11 +20,13 @@ WORKDIR /build
 COPY pyproject.toml poetry.lock README.md ./
 COPY meshtastic/ meshtastic/
 
-# Build the wheel with Poetry, then install to a relocatable prefix.
-# --find-links prefers the locally built wheel; deps are fetched from PyPI.
-# The container is immutable once built, providing reproducible deployments.
-RUN pip install --no-cache-dir poetry==2.4.1 && \
-    poetry build --format wheel --no-interaction && \
+# Install poetry in an isolated venv so its dependencies (packaging, requests,
+# etc.) do not pollute the system Python.  Without isolation, pip's
+# --prefix=/install skips shared deps it considers "already installed",
+# causing missing modules in the runtime image.
+RUN python -m venv /opt/poetry && \
+    /opt/poetry/bin/pip install --no-cache-dir poetry==2.4.1 && \
+    /opt/poetry/bin/poetry build --format wheel --no-interaction && \
     pip install --no-cache-dir --prefix=/install \
     --find-links=./dist "mtjk[cli,tunnel,analysis]" && \
     pip install --no-cache-dir --prefix=/install \

--- a/Containerfile
+++ b/Containerfile
@@ -10,7 +10,7 @@ FROM docker.io/library/python:3.14-slim-bookworm AS builder
 # build-essential provides gcc for compiling native extensions (cffi, msgpack, etc.)
 # on platforms where pre-built wheels are not available (e.g. arm/v7 on Python 3.14).
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git build-essential && \
+    git build-essential libffi-dev && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build

--- a/Containerfile
+++ b/Containerfile
@@ -6,6 +6,10 @@
 # Build stage
 FROM docker.io/library/python:3.14-slim-bookworm AS builder
 
+# git is required for pip VCS installs (e.g. riden) and poetry build metadata.
+RUN apt-get update && apt-get install -y --no-install-recommends git && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /build
 
 # Copy dependency files first to leverage Docker layer caching.

--- a/Containerfile
+++ b/Containerfile
@@ -11,20 +11,19 @@ WORKDIR /build
 # Copy dependency files first to leverage Docker layer caching.
 # README.md is required by pyproject.toml for the build.
 COPY pyproject.toml poetry.lock README.md ./
-
-# Export locked requirements from poetry.lock and install to prefix.
-# This ensures reproducible builds with exact dependency versions.
-RUN pip install --no-cache-dir poetry==2.4.1 && \
-    poetry export --format requirements.txt --extras cli --extras tunnel \
-    --without dev --output requirements.txt && \
-    pip install --no-cache-dir --prefix=/install -r requirements.txt
-
-# Copy source code, build the wheel, install it to prefix.
-# --no-index ensures only the locally built wheel is used.
 COPY meshtastic/ meshtastic/
-RUN poetry build --format wheel --no-interaction && \
-    pip install --no-cache-dir --no-index --no-deps --prefix=/install \
-    --find-links=./dist "mtjk"
+
+# Build the wheel with Poetry, then install to a relocatable prefix.
+# --find-links prefers the locally built wheel; deps are fetched from PyPI.
+# The container is immutable once built, providing reproducible deployments.
+RUN pip install --no-cache-dir poetry==2.4.1 && \
+    poetry build --format wheel --no-interaction && \
+    pip install --no-cache-dir --prefix=/install \
+    --find-links=./dist "mtjk[cli,tunnel,analysis]" && \
+    pip install --no-cache-dir --prefix=/install \
+    riden@git+https://github.com/geeksville/riden.git@1.2.1 \
+    ppk2-api parse pyarrow platformdirs \
+    jupyterlab matplotlib ipympl ipywidgets jupyterlab-widgets
 
 # Runtime stage
 FROM docker.io/library/python:3.14-slim-bookworm

--- a/Containerfile
+++ b/Containerfile
@@ -7,31 +7,45 @@
 FROM docker.io/library/python:3.14-slim-bookworm AS builder
 
 # git is required for pip VCS installs (e.g. riden) and poetry build metadata.
-# build-essential provides gcc for compiling native extensions (cffi, msgpack, etc.)
-# on platforms where pre-built wheels are not available (e.g. arm/v7 on Python 3.14).
+# build-essential and libffi-dev provide gcc and ffi.h for compiling native
+# extensions (cffi, msgpack, rapidfuzz) from source when needed.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git build-essential libffi-dev && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
 
-# Copy dependency files first to leverage Docker layer caching.
-# README.md is required by pyproject.toml for the build.
+# Install poetry and the export plugin in an isolated venv so their
+# dependencies (packaging, requests, etc.) do not pollute the system Python.
+# Without isolation, pip's --prefix=/install skips shared deps it considers
+# "already installed", causing missing modules in the runtime image.
+RUN python -m venv /opt/poetry && \
+    /opt/poetry/bin/pip install --no-cache-dir poetry==2.4.1 poetry-plugin-export
+
+# --- Layer 1: Dependency resolution and install (cached unless lock changes) ---
 COPY pyproject.toml poetry.lock README.md ./
+
+# Export all pinned deps (extras + powermon group) to requirements.txt, then
+# install them to the relocatable prefix.  This layer is only rebuilt when
+# pyproject.toml or poetry.lock changes — source edits do NOT invalidate it.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    /opt/poetry/bin/poetry export \
+    --format requirements.txt \
+    --extras cli --extras tunnel --extras analysis \
+    --with powermon \
+    --without dev \
+    --without-hashes \
+    --output requirements.txt && \
+    pip install --no-cache-dir --prefix=/install -r requirements.txt
+
+# --- Layer 2: Source + wheel build (rebuilt on every source change) ---
 COPY meshtastic/ meshtastic/
 
-# Install poetry in an isolated venv so its dependencies (packaging, requests,
-# etc.) do not pollute the system Python.  Without isolation, pip's
-# --prefix=/install skips shared deps it considers "already installed",
-# causing missing modules in the runtime image.
-RUN python -m venv /opt/poetry && \
-    /opt/poetry/bin/pip install --no-cache-dir poetry==2.4.1 && \
-    /opt/poetry/bin/poetry build --format wheel --no-interaction && \
-    pip install --no-cache-dir --prefix=/install \
-    --find-links=./dist "mtjk[cli,tunnel,analysis]" && \
-    pip install --no-cache-dir --prefix=/install \
-    riden@git+https://github.com/geeksville/riden.git@1.2.1 \
-    ppk2-api parse pyarrow platformdirs
+# Build the wheel and install it on top of the already-installed deps.
+# --no-deps avoids re-resolving; all transitive deps are in Layer 1.
+RUN /opt/poetry/bin/poetry build --format wheel --no-interaction && \
+    pip install --no-cache-dir --no-deps --prefix=/install \
+    --find-links=./dist mtjk
 
 # Runtime stage
 FROM docker.io/library/python:3.14-slim-bookworm

--- a/Containerfile
+++ b/Containerfile
@@ -45,7 +45,7 @@ COPY meshtastic/ meshtastic/
 # --no-deps avoids re-resolving; all transitive deps are in Layer 1.
 RUN /opt/poetry/bin/poetry build --format wheel --no-interaction && \
     pip install --no-cache-dir --no-deps --prefix=/install \
-    --find-links=./dist mtjk
+    ./dist/*.whl
 
 # Runtime stage
 FROM docker.io/library/python:3.14-slim-bookworm

--- a/Containerfile
+++ b/Containerfile
@@ -26,8 +26,7 @@ RUN pip install --no-cache-dir poetry==2.4.1 && \
     --find-links=./dist "mtjk[cli,tunnel,analysis]" && \
     pip install --no-cache-dir --prefix=/install \
     riden@git+https://github.com/geeksville/riden.git@1.2.1 \
-    ppk2-api parse pyarrow platformdirs \
-    jupyterlab matplotlib ipympl ipywidgets jupyterlab-widgets
+    ppk2-api parse pyarrow platformdirs
 
 # Runtime stage
 FROM docker.io/library/python:3.14-slim-bookworm


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This pull request streamlines the container build workflow and narrows the supported target platforms. The changes simplify version extraction in CI, reorganize the Containerfile builder stage to use an isolated Poetry environment, and limit multi-architecture builds to `linux/amd64` and `linux/arm64` only (removing `linux/arm/v7` support).

## Key Changes

**Workflow Simplification**
- Refactored version/build info extraction in the container-build workflow from a multi-line Python script to a single-line command using `tomllib` to read `pyproject.toml`
- Removed manual ref parameter from checkout step in the workflow

**Platform Changes**
- Removed `linux/arm/v7` from the QEMU setup in the workflow
- Restricted Docker multi-platform builds to `linux/amd64` and `linux/arm64` only

**Containerfile Builder Stage Refactoring**
- Added system build dependencies (`git`, `build-essential`, `libffi-dev`) to the builder stage
- Set up an isolated Python virtual environment at `/opt/poetry` for Poetry and `poetry-plugin-export`
- Reorganized dependency resolution layer to use Docker BuildKit cache for pip downloads
- Modified Poetry dependency export to include `analysis` extras and `powermon` group with hashes disabled
- Adjusted wheel build and installation to use the isolated Poetry environment and `--find-links` with the dependency prefix

## Platform Support Impact

The removal of `linux/arm/v7` support means container images will no longer be built for 32-bit ARM architectures. Users running on 32-bit ARM systems will need to build the image locally or use an alternative distribution method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->