### PR TITLE
fix(tests): adapt traffic_management tests to removed toggles

### DIFF
--- a/meshtastic/tests/test_mesh_interface_traffic_management.py
+++ b/meshtastic/tests/test_mesh_interface_traffic_management.py
@@ -9,18 +9,25 @@ from ..protobuf import mesh_pb2
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_handle_from_radio_with_traffic_management_module_config() -> None:
-    """Test _handle_from_radio with moduleConfig.traffic_management."""
+    """Test _handle_from_radio with moduleConfig.traffic_management.
+
+    The bool toggles (``enabled``, ``rate_limit_enabled``, ...) were removed
+    from the protobuf in favour of the "non-zero implies enabled" convention
+    on their companion uint32 fields, so we exercise that convention here.
+    """
     iface = MeshInterface(noProto=True)
     try:
         from_radio = mesh_pb2.FromRadio()
-        from_radio.moduleConfig.traffic_management.enabled = True
-        from_radio.moduleConfig.traffic_management.rate_limit_enabled = True
+        tm = from_radio.moduleConfig.traffic_management
+        tm.position_min_interval_secs = 30
+        tm.rate_limit_window_secs = 60
+        tm.rate_limit_max_packets = 100
 
         iface._handle_from_radio(from_radio.SerializeToString())
 
-        assert iface.localNode.moduleConfig.traffic_management.enabled is True
-        assert (
-            iface.localNode.moduleConfig.traffic_management.rate_limit_enabled is True
-        )
+        result = iface.localNode.moduleConfig.traffic_management
+        assert result.position_min_interval_secs == 30
+        assert result.rate_limit_window_secs == 60
+        assert result.rate_limit_max_packets == 100
     finally:
         iface.close()

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -744,11 +744,18 @@ def test_writeChannel_forwards_admin_index_to_session_key_bootstrap(
 def test_writeConfig_traffic_management(
     autospec_local_node_iface: Callable[[type[Any]], MagicMock],
 ) -> None:
-    """Test writeConfig writes traffic_management module config through set_module_config."""
+    """Test writeConfig writes traffic_management module config through set_module_config.
+
+    The bool toggles (``enabled``, ``rate_limit_enabled``, ...) were removed
+    from the protobuf in favour of the "non-zero implies enabled" convention
+    on their companion uint32 fields, so we exercise that convention here.
+    """
     iface = autospec_local_node_iface(MeshInterface)
     anode = Node(iface, "!12345678", noProto=True)
-    anode.moduleConfig.traffic_management.enabled = True
-    anode.moduleConfig.traffic_management.rate_limit_enabled = True
+    tm = anode.moduleConfig.traffic_management
+    tm.position_min_interval_secs = 30
+    tm.rate_limit_window_secs = 60
+    tm.rate_limit_max_packets = 100
 
     sent_messages: list[admin_pb2.AdminMessage] = []
     anode._send_admin = _make_fake_send_admin(  # type: ignore[method-assign,assignment]
@@ -761,8 +768,10 @@ def test_writeConfig_traffic_management(
     sent_message = sent_messages[0]
     assert sent_message.HasField("set_module_config")
     assert sent_message.set_module_config.HasField("traffic_management")
-    assert sent_message.set_module_config.traffic_management.enabled is True
-    assert sent_message.set_module_config.traffic_management.rate_limit_enabled is True
+    result = sent_message.set_module_config.traffic_management
+    assert result.position_min_interval_secs == 30
+    assert result.rate_limit_window_secs == 60
+    assert result.rate_limit_max_packets == 100
 
 
 @pytest.mark.unit


### PR DESCRIPTION
The bundled protobuf bump (a0bd24a) removed 9 fields from TrafficManagementConfig via a reserved declaration: 8 bool toggle fields (enabled, rate_limit_enabled, position_dedup_enabled, nodeinfo_direct_response, drop_unknown_enabled, exhaust_hop_telemetry, exhaust_hop_position, router_preserve_hops) and 1 uint32 field (position_precision_bits, removed because precision is now derived from the channel's own position_precision ceiling). The bools were replaced by a 'non-zero implies enabled' convention on their companion uint32 fields.

Production code only references traffic_management as a string config name or passes the whole submessage, so it was unaffected. Update the two tests that still referenced the removed fields to exercise the new convention by setting non-zero values on position_min_interval_secs, rate_limit_window_secs, and rate_limit_max_packets.