### PR TITLE
Port upstream 2.7.10 CLI and bitfield improvements

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -234,6 +234,7 @@ considered stable API and may change without deprecation warnings.
 | `meshtastic.util`      | `message_to_json()`       | `messageToJson()`      |
 | `meshtastic.util`      | `to_node_num()`           | `toNodeNum()`          |
 | `meshtastic.util`      | `flags_to_list()`         | `flagsToList()`        |
+| `meshtastic.util`      | `flags_from_list()`       | `flagsFromList()`      |
 
 ### Node and Tunnel
 

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -110,6 +110,15 @@ except (ImportError, AttributeError) as exc:
 
 logger = logging.getLogger(__name__)
 
+# Map dotted preference paths to the protobuf enum that defines their flags.
+# These fields are stored as uint32 bitmasks in the protobuf but have an
+# associated enum that names the individual flags. Add new bitfield-enum
+# fields here as protobufs grow.
+BITFIELD_ENUMS = {
+    "network.enabled_protocols": config_pb2.Config.NetworkConfig.ProtocolFlags,
+    "position.position_flags": config_pb2.Config.PositionConfig.PositionFlags,
+}
+
 # ==============================================================================
 # CLI Timing Constants
 # ==============================================================================
@@ -1195,12 +1204,27 @@ def setPref(config: Any, comp_name: str, raw_val: Any) -> bool:
         print("Warning: network.wifi_psk must be 8 or more characters.")
         return False
 
+    # Handle uint32 bitfields that have an associated enum of flag names.
+    bitfield_enum = None
+    if config_type.message_type is not None:
+        bitfield_path = f"{config_type.name}.{pref.name}"
+        bitfield_enum = BITFIELD_ENUMS.get(bitfield_path)
+    if bitfield_enum and isinstance(val, str):
+        # At this point fromStr() could not parse val as int/float/bool/bytes,
+        # so treat it as a comma-separated list of bitfield flag names.
+        flag_names = [n.strip() for n in val.split(",") if n.strip()]
+        try:
+            val = meshtastic.util.flagsFromList(bitfield_enum, flag_names)
+        except ValueError as e:
+            print(f"ERROR: {e}")
+            return False
+
     enumType = pref.enum_type
     if enumType and isinstance(val, str):
         # We've failed so far to convert this string into an enum, try to find it by reflection
-        e = enumType.values_by_name.get(val)
-        if e:
-            val = e.number
+        ev = enumType.values_by_name.get(val)
+        if ev:
+            val = ev.number
         else:
             print(
                 f"{name[0]}.{uni_name} does not have an enum called {val}, so you can not set it."
@@ -3049,6 +3073,10 @@ def common() -> None:
                     "ERROR: Ham radio callsign cannot be empty or contain only whitespace characters"
                 )
 
+        # Fail fast before connecting if the OTA firmware file does not exist.
+        if args.ota_update is not None and not os.path.isfile(args.ota_update):
+            _cli_exit(f"Error: OTA firmware file not found: {args.ota_update}")
+
         if _power_meter_requested(args):
             _create_power_meter()
 
@@ -3278,10 +3306,11 @@ def addConnectionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParse
         "--host",
         "--tcp",
         "-t",
-        help="Connect to a device using TCP, optionally passing hostname/IP or host:port. (defaults to '%(const)s')",
+        help="Connect to a device using TCP, optionally passing hostname/IP or host:port (default port 4403). (defaults to '%(const)s')",
         nargs="?",
         default=None,
         const="localhost",
+        metavar="HOST[:PORT]",
     )
 
     group.add_argument(
@@ -4034,7 +4063,7 @@ def _poll_serial_reconnect(client: MeshInterface) -> None:
         elif isinstance(exc, MeshInterface.MeshInterfaceError):
             retryable = bool(
                 hasattr(client, "_is_retryable_connect_error")
-                and client._is_retryable_connect_error(exc)  # type: ignore[union-attr]
+                and client._is_retryable_connect_error(exc)
             )
         else:
             retryable = False

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -119,6 +119,52 @@ BITFIELD_ENUMS = {
     "position.position_flags": config_pb2.Config.PositionConfig.PositionFlags,
 }
 
+
+def _looks_like_integer_literal(value: str) -> bool:
+    stripped = value.strip()
+    if not stripped:
+        return False
+    if stripped[0] in "+-":
+        stripped = stripped[1:]
+    return bool(stripped) and stripped[0].isdigit()
+
+
+def _parse_integer_literal(value: str) -> int:
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError("empty integer literal")
+    unsigned = stripped[1:] if stripped[0] in "+-" else stripped
+    if unsigned.lower().startswith(("0x", "0b", "0o")):
+        return int(stripped, 0)
+    return int(stripped, 10)
+
+
+def _parse_bitfield_value(flag_type: Any, raw_val: Any) -> int:
+    if isinstance(raw_val, int):
+        val = raw_val
+    elif isinstance(raw_val, str):
+        stripped = raw_val.strip()
+        if _looks_like_integer_literal(stripped):
+            try:
+                val = _parse_integer_literal(stripped)
+            except ValueError as e:
+                raise ValueError(
+                    f"Invalid numeric bitfield value {raw_val!r}. Expected decimal, "
+                    "hex with 0x prefix, binary with 0b prefix, or comma-separated flag names."
+                ) from e
+        else:
+            flag_names = [n.strip() for n in stripped.split(",") if n.strip()]
+            val = meshtastic.util.flagsFromList(flag_type, flag_names)
+    else:
+        raise ValueError(
+            f"Invalid bitfield value {raw_val!r}. Expected integer, numeric string, or flag names."
+        )
+
+    if val < 0:
+        raise ValueError(f"Invalid bitfield value {raw_val!r}. Expected a non-negative integer.")
+    return val
+
+
 # ==============================================================================
 # CLI Timing Constants
 # ==============================================================================
@@ -1194,7 +1240,19 @@ def setPref(config: Any, comp_name: str, raw_val: Any) -> bool:
     if (not pref) or (not config_type):
         return False
 
-    if isinstance(raw_val, str):
+    # Handle uint32 bitfields that have an associated enum of flag names.
+    bitfield_enum = None
+    if config_type.message_type is not None:
+        bitfield_path = f"{config_type.name}.{pref.name}"
+        bitfield_enum = BITFIELD_ENUMS.get(bitfield_path)
+
+    if bitfield_enum:
+        try:
+            val = _parse_bitfield_value(bitfield_enum, raw_val)
+        except ValueError as e:
+            print(f"ERROR: {e}")
+            return False
+    elif isinstance(raw_val, str):
         val = meshtastic.util.fromStr(raw_val)
     else:
         val = raw_val
@@ -1203,21 +1261,6 @@ def setPref(config: Any, comp_name: str, raw_val: Any) -> bool:
     if snake_name == "wifi_psk" and len(str(raw_val)) < 8:
         print("Warning: network.wifi_psk must be 8 or more characters.")
         return False
-
-    # Handle uint32 bitfields that have an associated enum of flag names.
-    bitfield_enum = None
-    if config_type.message_type is not None:
-        bitfield_path = f"{config_type.name}.{pref.name}"
-        bitfield_enum = BITFIELD_ENUMS.get(bitfield_path)
-    if bitfield_enum and isinstance(val, str):
-        # At this point fromStr() could not parse val as int/float/bool/bytes,
-        # so treat it as a comma-separated list of bitfield flag names.
-        flag_names = [n.strip() for n in val.split(",") if n.strip()]
-        try:
-            val = meshtastic.util.flagsFromList(bitfield_enum, flag_names)
-        except ValueError as e:
-            print(f"ERROR: {e}")
-            return False
 
     enumType = pref.enum_type
     if enumType and isinstance(val, str):

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -134,7 +134,7 @@ def _parse_integer_literal(value: str) -> int:
     if not stripped:
         raise ValueError("empty integer literal")
     unsigned = stripped[1:] if stripped[0] in "+-" else stripped
-    if unsigned.lower().startswith(("0x", "0b", "0o")):
+    if unsigned.lower().startswith(("0x", "0b")):
         return int(stripped, 0)
     return int(stripped, 10)
 

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -6171,9 +6171,17 @@ def test_flatten_leaf_paths_empty_nested_dict() -> None:
 @pytest.mark.parametrize(
     "field,value,expected,expected_output_substring",
     [
+        ("position.position_flags", 513, 513, "513"),
+        ("position.position_flags", "513", 513, "513"),
+        ("position.position_flags", "0x201", 513, "0x201"),
+        ("position.position_flags", "0b1000000001", 513, "0b1000000001"),
         ("network.enabled_protocols", "UDP_BROADCAST", 1, "UDP_BROADCAST"),
+        ("network.enabled_protocols", "0x1", 1, "0x1"),
         ("position.position_flags", "ALTITUDE,SPEED", 513, "ALTITUDE,SPEED"),
+        ("position.position_flags", "ALTITUDE, SPEED", 513, "ALTITUDE, SPEED"),
         ("network.enabled_protocols", "0", 0, "0"),
+        ("network.enabled_protocols", "0x0", 0, "0x0"),
+        ("network.enabled_protocols", "0b0", 0, "0b0"),
         ("position.position_flags", "ALTITUDE, , SPEED", 513, "ALTITUDE, , SPEED"),
         (
             "network.enabled_protocols",
@@ -6183,21 +6191,29 @@ def test_flatten_leaf_paths_empty_nested_dict() -> None:
         ),
     ],
     ids=[
-        "single_flag",
-        "comma_separated_flags",
         "raw_integer",
+        "decimal_string",
+        "hex_string",
+        "binary_string",
+        "single_flag",
+        "network_hex_string",
+        "comma_separated_flags",
+        "comma_separated_flags_with_spaces",
+        "zero_decimal_string",
+        "zero_hex_string",
+        "zero_binary_string",
         "whitespace_and_empty_entries",
         "zero_valued_member_is_noop",
     ],
 )
 def test_main_setPref_bitfield(
     field: str,
-    value: str,
+    value: Any,
     expected: int,
     expected_output_substring: str,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """setPref() accepts bitfield flag names, comma-separated lists, and raw integers."""
+    """setPref() accepts bitfield flag names and numeric masks."""
     config = config_pb2.Config()
     assert setPref(config, field, value) is True
     assert _get_config_field(config, field) == expected
@@ -6217,6 +6233,22 @@ def test_main_setPref_bitfield_invalid_name(
     assert "Unknown flag 'TCP'" in out
     assert "NO_BROADCAST" in out
     assert "UDP_BROADCAST" in out
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_main_setPref_bitfield_invalid_numeric_string(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """setPref() rejects malformed numeric-looking bitfield values cleanly."""
+    config = config_pb2.Config()
+    assert setPref(config, "position.position_flags", "0xZZ") is False
+    assert config.position.position_flags == 0
+    out, _ = capsys.readouterr()
+    assert "Invalid numeric bitfield value '0xZZ'" in out
+    assert "decimal" in out
+    assert "0x" in out
+    assert "0b" in out
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -6237,15 +6237,17 @@ def test_main_setPref_bitfield_invalid_name(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+@pytest.mark.parametrize("value", ["0xZZ", "0o10"], ids=["invalid_hex", "octal"])
 def test_main_setPref_bitfield_invalid_numeric_string(
+    value: str,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """setPref() rejects malformed numeric-looking bitfield values cleanly."""
     config = config_pb2.Config()
-    assert setPref(config, "position.position_flags", "0xZZ") is False
+    assert setPref(config, "position.position_flags", value) is False
     assert config.position.position_flags == 0
     out, _ = capsys.readouterr()
-    assert "Invalid numeric bitfield value '0xZZ'" in out
+    assert f"Invalid numeric bitfield value '{value}'" in out
     assert "decimal" in out
     assert "0x" in out
     assert "0b" in out

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -32,6 +32,7 @@ from meshtastic.__main__ import (
     onNode,
     onReceive,
     printConfig,
+    setPref,
     support_info,
     traverseConfig,
     tunnelMain,
@@ -53,6 +54,14 @@ from ..tcp_interface import TCPInterface
 
 SDS_DISABLED_SENTINEL: int = 4_294_967_295
 MAIN_LOCAL_ADDR: str = cast(str, main_module.__dict__["LOCAL_ADDR"])
+
+
+def _get_config_field(config: Any, dotted_path: str) -> Any:
+    """Walk a dotted `section.field` path on a protobuf Config message."""
+    obj = config
+    for part in dotted_path.split("."):
+        obj = getattr(obj, part)
+    return obj
 
 
 def _mock_sendText_helper(
@@ -5101,6 +5110,7 @@ def test_main_ota_update_requires_tcp_interface(
 
     with (
         patch("meshtastic.serial_interface.SerialInterface", return_value=iface),
+        patch("os.path.isfile", return_value=True),
         pytest.raises(SystemExit) as excinfo,
     ):
         main()
@@ -5159,6 +5169,7 @@ def test_main_ota_update_retries_then_exits(
             _make_fake_tcp_interface(get_node=get_node),
         ),
         patch("meshtastic.ota.ESP32WiFiOTA", return_value=ota),
+        patch("os.path.isfile", return_value=True),
         patch("meshtastic.__main__.time.sleep") as sleep_mock,
         pytest.raises(SystemExit) as excinfo,
     ):
@@ -5206,6 +5217,7 @@ def test_main_ota_update_fails_fast_on_non_transport_error(
             _make_fake_tcp_interface(get_node=get_node),
         ),
         patch("meshtastic.ota.ESP32WiFiOTA", return_value=ota),
+        patch("os.path.isfile", return_value=True),
         patch("meshtastic.__main__.time.sleep") as sleep_mock,
         pytest.raises(SystemExit) as excinfo,
     ):
@@ -5254,6 +5266,7 @@ def test_main_ota_update_constructor_error_exits_gracefully(
                 "Invalid OTA destination 'bad:port': malformed address"
             ),
         ) as ota_ctor_mock,
+        patch("os.path.isfile", return_value=True),
         patch("meshtastic.__main__.time.sleep") as sleep_mock,
         pytest.raises(SystemExit) as excinfo,
     ):
@@ -5295,6 +5308,7 @@ def test_main_ota_update_succeeds_and_prints_completion(
             _make_fake_tcp_interface(get_node=get_node),
         ),
         patch("meshtastic.ota.ESP32WiFiOTA", return_value=ota),
+        patch("os.path.isfile", return_value=True),
         patch("meshtastic.__main__.time.sleep") as sleep_mock,
     ):
         main()
@@ -5339,6 +5353,7 @@ def test_main_ota_update_rejects_remote_dest(
     with (
         patch("meshtastic.tcp_interface.TCPInterface", _make_fake_tcp_interface()),
         patch("meshtastic.ota.ESP32WiFiOTA") as ota_cls,
+        patch("os.path.isfile", return_value=True),
         pytest.raises(SystemExit) as excinfo,
     ):
         main()
@@ -5394,6 +5409,7 @@ def test_main_ota_update_allows_explicit_local_dest(
             _make_fake_tcp_interface(get_node=get_node),
         ),
         patch("meshtastic.ota.ESP32WiFiOTA", return_value=ota),
+        patch("os.path.isfile", return_value=True),
         patch("meshtastic.__main__.time.sleep"),
     ):
         main()
@@ -6148,3 +6164,86 @@ def test_flatten_leaf_paths_empty_nested_dict() -> None:
     """_flatten_leaf_paths treats an empty nested dict as a leaf."""
     result = main_module._flatten_leaf_paths("lora", {"hop_limit": 3, "empty": {}})
     assert sorted(result) == ["lora.empty", "lora.hop_limit"]
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+@pytest.mark.parametrize(
+    "field,value,expected,expected_output_substring",
+    [
+        ("network.enabled_protocols", "UDP_BROADCAST", 1, "UDP_BROADCAST"),
+        ("position.position_flags", "ALTITUDE,SPEED", 513, "ALTITUDE,SPEED"),
+        ("network.enabled_protocols", "0", 0, "0"),
+        ("position.position_flags", "ALTITUDE, , SPEED", 513, "ALTITUDE, , SPEED"),
+        (
+            "network.enabled_protocols",
+            "NO_BROADCAST,UDP_BROADCAST",
+            1,
+            "NO_BROADCAST,UDP_BROADCAST",
+        ),
+    ],
+    ids=[
+        "single_flag",
+        "comma_separated_flags",
+        "raw_integer",
+        "whitespace_and_empty_entries",
+        "zero_valued_member_is_noop",
+    ],
+)
+def test_main_setPref_bitfield(
+    field: str,
+    value: str,
+    expected: int,
+    expected_output_substring: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """setPref() accepts bitfield flag names, comma-separated lists, and raw integers."""
+    config = config_pb2.Config()
+    assert setPref(config, field, value) is True
+    assert _get_config_field(config, field) == expected
+    out, _ = capsys.readouterr()
+    assert f"Set {field} to {expected_output_substring}" in out
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_main_setPref_bitfield_invalid_name(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """setPref() rejects unknown bitfield flag names."""
+    config = config_pb2.Config()
+    assert setPref(config, "network.enabled_protocols", "TCP") is False
+    out, _ = capsys.readouterr()
+    assert "Unknown flag 'TCP'" in out
+    assert "NO_BROADCAST" in out
+    assert "UDP_BROADCAST" in out
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_main_ota_update_file_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--ota-update with a missing firmware file exits early before connecting."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["", "--host", "localhost", "--ota-update", "/nonexistent/firmware.bin"],
+    )
+    mt_config.args = sys.argv  # type: ignore[assignment]
+
+    with (
+        patch("meshtastic.tcp_interface.TCPInterface") as tcp_cls,
+        patch("meshtastic.serial_interface.SerialInterface") as serial_cls,
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        main()
+
+    assert excinfo.value.code == 1
+    _, err = capsys.readouterr()
+    assert "OTA firmware file not found" in err
+    assert "/nonexistent/firmware.bin" in err
+    # Verify no transport was constructed before the file check fired
+    tcp_cls.assert_not_called()
+    serial_cls.assert_not_called()

--- a/meshtastic/tests/test_showNodes_favorite.py
+++ b/meshtastic/tests/test_showNodes_favorite.py
@@ -162,25 +162,6 @@ def test_showNodes_favorite_asterisk_display(
 
 
 @pytest.mark.unit
-def test_showNodes_favorite_field_formatting() -> None:
-    """Test the formatting logic for isFavorite field."""
-    # Test favorite node
-    raw_value: bool | None = True
-    formatted_value = "*" if raw_value else ""
-    assert formatted_value == "*"
-
-    # Test non-favorite node
-    raw_value = False
-    formatted_value = "*" if raw_value else ""
-    assert formatted_value == ""
-
-    # Test None/missing value
-    raw_value = None
-    formatted_value = "*" if raw_value else ""
-    assert formatted_value == ""
-
-
-@pytest.mark.unit
 def test_showNodes_with_custom_fields_including_favorite(
     capsys: pytest.CaptureFixture[str], favorite_nodes_iface: MeshInterface
 ) -> None:

--- a/meshtastic/tests/test_util.py
+++ b/meshtastic/tests/test_util.py
@@ -49,6 +49,7 @@ from meshtastic.util import (
     fixme,
     flags_to_list,
     flagsToList,
+    flagsFromList,
     fromPSK,
     fromStr,
     generate_channel_hash,
@@ -2022,3 +2023,80 @@ def test_flags_to_list_conservation(flags: int) -> None:
 
         assert accounted == (flags & known_union)
         assert (accounted | leftover) == flags
+
+
+# ---------------------------------------------------------------------------
+# flagsFromList tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_flagsFromList_single_flag() -> None:
+    """Test flagsFromList with a single flag name."""
+
+    assert flagsFromList(_POSITION_FLAGS, ["ALTITUDE"]) == 1
+
+
+@pytest.mark.unit
+def test_flagsFromList_multiple_flags() -> None:
+    """Test flagsFromList with multiple flag names."""
+
+    assert flagsFromList(_POSITION_FLAGS, ["ALTITUDE", "DOP"]) == 1 | 8
+
+
+@pytest.mark.unit
+def test_flagsFromList_empty_list() -> None:
+    """Test flagsFromList with empty list returns 0."""
+
+    assert flagsFromList(_POSITION_FLAGS, []) == 0
+
+
+@pytest.mark.unit
+def test_flagsFromList_strips_whitespace() -> None:
+    """Test flagsFromList strips whitespace from flag names."""
+
+    assert flagsFromList(_POSITION_FLAGS, ["  ALTITUDE  ", "DOP"]) == 1 | 8
+
+
+@pytest.mark.unit
+def test_flagsFromList_skips_empty_entries() -> None:
+    """Test flagsFromList skips empty entries in the list."""
+
+    assert flagsFromList(_POSITION_FLAGS, ["ALTITUDE", "", "  ", "DOP"]) == 1 | 8
+
+
+@pytest.mark.unit
+def test_flagsFromList_zero_valued_member_is_noop() -> None:
+    """Test that including a zero-valued member doesn't change the bitmask."""
+
+    result_with_zero = flagsFromList(_POSITION_FLAGS, ["UNSET", "ALTITUDE"])
+    result_without = flagsFromList(_POSITION_FLAGS, ["ALTITUDE"])
+    assert result_with_zero == result_without == 1
+
+
+@pytest.mark.unit
+def test_flagsFromList_raises_for_unknown_flag() -> None:
+    """Test flagsFromList raises ValueError for unknown flag names."""
+
+    with pytest.raises(ValueError, match="Unknown flag 'NOT_A_REAL_FLAG'"):
+        flagsFromList(_POSITION_FLAGS, ["NOT_A_REAL_FLAG"])
+
+
+@pytest.mark.unitslow
+@given(st.integers(min_value=0, max_value=0xFFFFF))
+def test_flagsFromList_roundtrip(flags: int) -> None:
+    """Property: flagsToList and flagsFromList roundtrip for known bits."""
+
+    for flag_type in (_EXCLUDED_MODULES, _POSITION_FLAGS):
+        names = [
+            n for n in flags_to_list(flag_type, flags)  # pyright: ignore[reportArgumentType]
+            if not n.startswith("UNKNOWN_ADDITIONAL_FLAGS(")
+        ]
+        if names:
+            reconstructed = flagsFromList(flag_type, names)
+            known_union = 0
+            for key in flag_type.keys():
+                value = flag_type.Value(key)
+                if value:
+                    known_union |= value
+            assert reconstructed == (flags & known_union)

--- a/meshtastic/tests/test_util.py
+++ b/meshtastic/tests/test_util.py
@@ -47,9 +47,10 @@ from meshtastic.util import (
     eliminate_duplicate_port,
     findPorts,
     fixme,
+    flags_from_list,
     flags_to_list,
-    flagsToList,
     flagsFromList,
+    flagsToList,
     fromPSK,
     fromStr,
     generate_channel_hash,
@@ -2042,6 +2043,13 @@ def test_flagsFromList_multiple_flags() -> None:
     """Test flagsFromList with multiple flag names."""
 
     assert flagsFromList(_POSITION_FLAGS, ["ALTITUDE", "DOP"]) == 1 | 8
+
+
+@pytest.mark.unit
+def test_flags_from_list_wrapper() -> None:
+    """Test snake_case flags_from_list compatibility wrapper."""
+
+    assert flags_from_list(_POSITION_FLAGS, ["ALTITUDE", "SPEED"]) == 513
 
 
 @pytest.mark.unit

--- a/meshtastic/util.py
+++ b/meshtastic/util.py
@@ -1292,9 +1292,10 @@ def _flags_to_list(flag_type: Any, flags: int) -> list[str]:
     """
     ret = []
     for key in flag_type.keys():
-        if flags & flag_type.Value(key):
+        value = flag_type.Value(key)
+        if flags & value:
             ret.append(key)
-            flags &= ~flag_type.Value(key)
+            flags &= ~value
     if flags > 0:
         ret.append(f"UNKNOWN_ADDITIONAL_FLAGS({flags})")
     return ret
@@ -1327,7 +1328,7 @@ def _flags_from_list(flag_type: Any, flags: list[str]) -> int:
         If any entry is not a member of `flag_type`. The error message lists the valid choices.
     """
     result = 0
-    valid_names = list(flag_type.keys())
+    valid_names = set(flag_type.keys())
     for flag_name in flags:
         flag_name = flag_name.strip()
         if not flag_name:

--- a/meshtastic/util.py
+++ b/meshtastic/util.py
@@ -1271,6 +1271,12 @@ def to_node_num(node_id: int | str) -> int:
 def _flags_to_list(flag_type: Any, flags: int) -> list[str]:
     """Convert a protobuf enum bitfield into a list of active flag names.
 
+    Zero-valued members (e.g. EXCLUDED_NONE, UNSET, NO_BROADCAST) never appear
+    in the result: they hold no bit, so `flags & value` is always False for
+    them, and a flags value of 0 therefore decodes to an empty list rather
+    than a named "no flags" entry. Any leftover bits not corresponding to a
+    known member are reported via `UNKNOWN_ADDITIONAL_FLAGS(<leftover>)`.
+
     Parameters
     ----------
     flag_type : Any
@@ -1286,14 +1292,52 @@ def _flags_to_list(flag_type: Any, flags: int) -> list[str]:
     """
     ret = []
     for key in flag_type.keys():
-        if key == "EXCLUDED_NONE":
-            continue
         if flags & flag_type.Value(key):
             ret.append(key)
             flags &= ~flag_type.Value(key)
     if flags > 0:
         ret.append(f"UNKNOWN_ADDITIONAL_FLAGS({flags})")
     return ret
+
+
+def _flags_from_list(flag_type: Any, flags: list[str]) -> int:
+    """Combine a list of protobuf enum flag names into a bitmask.
+
+    Zero-valued members (e.g. EXCLUDED_NONE, UNSET, NO_BROADCAST) are accepted
+    but are no-ops: they OR in 0 and thus set nothing. A list consisting
+    solely of such a member (or an empty list) yields 0, which round-trips
+    back through `_flags_to_list` as an empty list rather than the original
+    member name -- see `_flags_to_list`'s docstring.
+
+    Parameters
+    ----------
+    flag_type : Any
+        Protobuf EnumTypeWrapper providing `.keys()` and `.Value(name)` for enum members.
+    flags : list[str]
+        Flag member names to combine. Whitespace is trimmed; blank entries are skipped.
+
+    Returns
+    -------
+    int
+        Bitmask formed by OR-ing the values of the named flags.
+
+    Raises
+    ------
+    ValueError
+        If any entry is not a member of `flag_type`. The error message lists the valid choices.
+    """
+    result = 0
+    valid_names = list(flag_type.keys())
+    for flag_name in flags:
+        flag_name = flag_name.strip()
+        if not flag_name:
+            continue
+        if flag_name not in valid_names:
+            raise ValueError(
+                f"Unknown flag '{flag_name}'. Valid choices: {', '.join(sorted(valid_names))}"
+            )
+        result |= flag_type.Value(flag_name)
+    return result
 
 
 def flagsToList(flag_type: Any, flags: int) -> list[str]:
@@ -1319,3 +1363,32 @@ def flagsToList(flag_type: Any, flags: int) -> list[str]:
 def flags_to_list(flag_type: Any, flags: int) -> list[str]:
     """Backward-compatible wrapper for :func:`flagsToList`."""
     return flagsToList(flag_type, flags)
+
+
+def flagsFromList(flag_type: Any, flags: list[str]) -> int:
+    """Combine a list of protobuf enum flag names into a bitmask.
+
+    Parameters
+    ----------
+    flag_type : Any
+        Protobuf EnumTypeWrapper providing `.keys()` and `.Value(name)` for enum members.
+    flags : list[str]
+        Flag member names to combine. Whitespace is trimmed; blank entries are skipped.
+
+    Returns
+    -------
+    int
+        Bitmask formed by OR-ing the values of the named flags.
+
+    Raises
+    ------
+    ValueError
+        If any entry is not a member of `flag_type`. The error message lists the valid choices.
+    """
+    return _flags_from_list(flag_type, flags)
+
+
+# COMPAT_STABLE_SHIM: snake_case mirror of flagsFromList for naming consistency with flags_to_list.
+def flags_from_list(flag_type: Any, flags: list[str]) -> int:
+    """Backward-compatible wrapper for :func:`flagsFromList`."""
+    return flagsFromList(flag_type, flags)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Includes PEP 561 py.typed marker for type checker support
 [tool.poetry]
 name = "mtjk"
-version = "2.7.9.post2"
+version = "2.7.10.post1"
 description = "Python API & client shell for talking to Meshtastic devices"
 authors = ["Meshtastic Developers (upstream project authors)"]
 maintainers = ["Jeremiah K. <jeremiahk@gmx.com>"]


### PR DESCRIPTION
## Overview

This branch ports selected upstream 2.7.10 CLI and utility improvements into the current `mtjk` develop model.

## Key Changes

- Added support for setting selected protobuf bitfield fields by flag name or numeric mask:
  - `network.enabled_protocols`
  - `position.position_flags`
- Bitfield fields support flag names, decimal integers, hex integers with `0x` prefix, and binary integers with `0b` prefix.
- Added `flagsFromList()` and `flags_from_list()` helpers to convert protobuf enum flag names into bitmasks.
- Clarified zero-valued flag handling in `flagsToList()`.
- Added an early file-existence check for `--ota-update` before opening any transport.
- Clarified `--host` help text with `HOST[:PORT]` and the default TCP port.
- Removed an obsolete favorite-node formatting-only test.
- Added focused unit coverage for bitfield parsing, flag reconstruction, compatibility wrappers, and OTA missing-file behavior.
- Updated `COMPATIBILITY.md` for the new snake_case compatibility shim.
- Bumped the package version to `2.7.10.post1`.

## Validation

- `git diff --check` passed.
- Changed Python files compile with `py_compile`.
- Targeted ruff checks passed.
- Focused bitfield and util flag pytest selections passed.
- CI is green.

## Notes

- Global `fromStr()` behavior is unchanged; `0x...` still remains bytes-compatible outside bitfield fields.
- Bitfield parsing is intentionally limited to decimal, `0x` hex, `0b` binary, and comma-separated flag names.