### PR TITLE
Minimize channel deletion rewrite logic

### DIFF
--- a/meshtastic/node_runtime/transport_runtime/channel.py
+++ b/meshtastic/node_runtime/transport_runtime/channel.py
@@ -219,8 +219,20 @@ class _NodeDeleteChannelRuntime:
         staged_channels.pop(channel_index)
         self._normalize_staged_channels(staged_channels)
 
+        # Only rewrite slots whose complete serialized protobuf changes. A
+        # normal channel cache contains all MAX_CHANNELS entries, so deleting
+        # the final active secondary usually changes just the deleted slot
+        # instead of rewriting every trailing DISABLED slot. If the cache is
+        # incomplete, remain conservative and write slots whose previous
+        # firmware state is unknown.
         channels_to_rewrite: list[channel_pb2.Channel] = []
         for rewrite_index in range(channel_index, MAX_CHANNELS):
+            if (
+                rewrite_index < len(channels)
+                and staged_channels[rewrite_index].SerializeToString()
+                == channels[rewrite_index].SerializeToString()
+            ):
+                continue
             channel_snapshot = channel_pb2.Channel()
             channel_snapshot.CopyFrom(staged_channels[rewrite_index])
             channels_to_rewrite.append(channel_snapshot)
@@ -242,7 +254,11 @@ class _NodeDeleteChannelRuntime:
             original_channels_fingerprint=_channels_fingerprint(channels),
             pre_delete_admin_index=pre_delete_admin_index,
             post_delete_admin_index=post_delete_admin_index,
-            switch_after_admin_slot_rewrite=(pre_delete_admin_index >= channel_index),
+            switch_after_admin_slot_rewrite=(
+                is_local_node
+                and pre_delete_admin_index != post_delete_admin_index
+                and pre_delete_admin_index >= channel_index
+            ),
             channels_to_rewrite=channels_to_rewrite,
             staged_channels=staged_channels,
         )

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -1256,7 +1256,12 @@ def test_deleteChannel_rewrites_following_channels_and_updates_admin_index(
 
     assert anode.channels is not None
     assert len(anode.channels) == CHANNEL_LIMIT
-    assert anode._send_admin.call_count == CHANNEL_LIMIT - 1
+    written_indexes = [
+        call.args[0].set_channel.index for call in anode._send_admin.call_args_list
+    ]
+    # Slot 2 was present in the incomplete cache and is already the same
+    # normalized DISABLED protobuf. Unknown slots 3..7 remain conservative.
+    assert written_indexes == [1, *range(3, CHANNEL_LIMIT)]
     admin_indexes = [
         _get_mock_call_arg(call, name="adminIndex", positional_index=3)
         for call in anode._send_admin.call_args_list
@@ -1294,6 +1299,107 @@ def test_deleteChannel_switches_admin_index_after_rewriting_former_admin_slot(
     # Keep old admin index (2) through rewrite of old slot 2, then switch to 1.
     assert admin_indexes[:2] == [2, 2]
     assert all(index == 1 for index in admin_indexes[2:])
+
+
+def _build_full_channel_table(
+    highest_secondary_index: int,
+) -> list[Channel]:
+    """Build a complete channel table with a contiguous active prefix."""
+    channels: list[Channel] = []
+    for index in range(CHANNEL_LIMIT):
+        channel = Channel(index=index)
+        if index == 0:
+            channel.role = Channel.Role.PRIMARY
+            channel.settings.name = "primary"
+        elif index <= highest_secondary_index:
+            channel.role = Channel.Role.SECONDARY
+            channel.settings.name = f"channel-{index}"
+        else:
+            channel.role = Channel.Role.DISABLED
+        channels.append(channel)
+    return channels
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("highest_secondary_index", "delete_index", "expected_writes"),
+    (
+        pytest.param(1, 1, [1], id="delete-only-secondary"),
+        pytest.param(2, 1, [1, 2], id="shift-one-secondary"),
+        pytest.param(3, 1, [1, 2, 3], id="shift-two-secondaries"),
+        pytest.param(3, 2, [2, 3], id="delete-middle-secondary"),
+    ),
+)
+def test_deleteChannel_writes_only_changed_complete_cache_slots(
+    autospec_local_node_iface: Callable[[type[Any]], MagicMock],
+    highest_secondary_index: int,
+    delete_index: int,
+    expected_writes: list[int],
+) -> None:
+    """A complete cache should not rewrite identical trailing disabled slots."""
+    iface = autospec_local_node_iface(MeshInterface)
+    anode = Node(iface, "!12345678", noProto=True)
+    iface.localNode = anode
+    anode.channels = _build_full_channel_table(highest_secondary_index)
+    anode.ensureSessionKey = MagicMock()  # type: ignore[method-assign]
+    anode._send_admin = MagicMock()  # type: ignore[method-assign]
+
+    anode.deleteChannel(delete_index)
+
+    written_indexes = [
+        call.args[0].set_channel.index for call in anode._send_admin.call_args_list
+    ]
+    assert written_indexes == expected_writes
+    assert all(
+        _get_mock_call_arg(call, name="adminIndex", positional_index=3) == 0
+        for call in anode._send_admin.call_args_list
+    )
+    assert anode.channels is not None
+    assert [channel.index for channel in anode.channels] == list(
+        range(CHANNEL_LIMIT)
+    )
+
+
+@pytest.mark.unit
+def test_deleteChannel_identical_trailing_disabled_slot_requires_no_write(
+    autospec_local_node_iface: Callable[[type[Any]], MagicMock],
+) -> None:
+    """Deleting the final empty disabled slot should be an on-device no-op."""
+    iface = autospec_local_node_iface(MeshInterface)
+    anode = Node(iface, "!12345678", noProto=True)
+    iface.localNode = anode
+    anode.channels = _build_full_channel_table(1)
+    anode.ensureSessionKey = MagicMock()  # type: ignore[method-assign]
+    anode._send_admin = MagicMock()  # type: ignore[method-assign]
+
+    anode.deleteChannel(CHANNEL_LIMIT - 1)
+
+    anode.ensureSessionKey.assert_not_called()
+    anode._send_admin.assert_not_called()
+    assert anode.channels is not None
+    assert len(anode.channels) == CHANNEL_LIMIT
+    assert anode.channels[-1].role == Channel.Role.DISABLED
+
+
+@pytest.mark.unit
+def test_deleteChannel_compares_complete_payload_not_only_channel_role(
+    autospec_local_node_iface: Callable[[type[Any]], MagicMock],
+) -> None:
+    """Settings changes in disabled slots must still be rewritten after a shift."""
+    iface = autospec_local_node_iface(MeshInterface)
+    anode = Node(iface, "!12345678", noProto=True)
+    iface.localNode = anode
+    anode.channels = _build_full_channel_table(1)
+    anode.channels[2].settings.name = "stale-disabled-payload"
+    anode.ensureSessionKey = MagicMock()  # type: ignore[method-assign]
+    anode._send_admin = MagicMock()  # type: ignore[method-assign]
+
+    anode.deleteChannel(1)
+
+    written_indexes = [
+        call.args[0].set_channel.index for call in anode._send_admin.call_args_list
+    ]
+    assert written_indexes == [1, 2]
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_node_runtime_transport.py
+++ b/meshtastic/tests/test_node_runtime_transport.py
@@ -674,6 +674,9 @@ class TestNodeDeleteChannelRuntime:
             else:
                 ch.role = channel_pb2.Channel.Role.DISABLED
             channels.append(ch)
+        # Mark one trailing slot with stale data so it is rewritten
+        # after the admin-index switch, making the switch observable.
+        channels[3].settings.name = "stale-disabled"
 
         mock_local_node.channels = channels
 


### PR DESCRIPTION
## Summary by Sourcery

Optimize channel deletion to avoid unnecessary rewrites of unchanged disabled slots while preserving correct admin index switching behavior.

Bug Fixes:
- Ensure admin index switching after channel deletion only occurs for local nodes when the admin index actually changes.
- Prevent unnecessary session key establishment and admin writes when deleting an already-disabled trailing channel slot.

Enhancements:
- Only rewrite channel slots whose full serialized payload changes during deletion, allowing more efficient updates for complete channel caches.

Tests:
- Add parametrized tests to verify that channel deletion only rewrites changed slots in a complete cache.
- Add tests to confirm that deleting the final disabled channel slot is a no-op on the device.
- Add tests to ensure disabled slots are compared by full payload, not just role, when deciding whether to rewrite after a shift.
- Refine existing channel deletion tests to assert the exact set of rewritten channel indexes rather than just call counts.