### PR TITLE
Expand CLI support for firmware modem presets

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -2427,13 +2427,13 @@ def onConnected(interface: MeshInterface) -> None:
             node.localConfig.lora.modem_preset = modem_preset
             node.writeConfig("lora")
 
-        # Handle historical/common shorthands in their established order, then
-        # the schema-driven generic form. ``getattr`` keeps programmatic callers
-        # that provide a partial argparse-like namespace compatible.
+        # Resolve the final modem preset across historical shorthands (later
+        # wins) and the schema-driven --ch-preset, then write exactly once.
+        preset_val = None
         for _, destination, preset_name, _ in _MODEM_PRESET_SHORTHANDS:
             if getattr(args, destination, False):
-                _set_simple_config(
-                    config_pb2.Config.LoRaConfig.ModemPreset.Value(preset_name)
+                preset_val = config_pb2.Config.LoRaConfig.ModemPreset.Value(
+                    preset_name
                 )
 
         generic_preset_name = getattr(args, "ch_preset", None)
@@ -2451,6 +2451,8 @@ def onConnected(interface: MeshInterface) -> None:
                 preset_val = config_pb2.Config.LoRaConfig.ModemPreset.Value(
                     generic_preset_name
                 )
+
+        if preset_val is not None:
             _set_simple_config(preset_val)  # type: ignore[arg-type]
 
         if args.ch_set or args.ch_enable or args.ch_disable:

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -2438,9 +2438,20 @@ def onConnected(interface: MeshInterface) -> None:
 
         generic_preset_name = getattr(args, "ch_preset", None)
         if generic_preset_name is not None:
-            _set_simple_config(
-                config_pb2.Config.LoRaConfig.ModemPreset.Value(generic_preset_name)
-            )
+            # Accept integer enum values from programmatic callers; CLI always
+            # produces a string via _parse_modem_preset_name.
+            if isinstance(generic_preset_name, int):
+                # Validate by round-tripping through the name so bad integers
+                # fail with a clear error instead of silently corrupting config.
+                config_pb2.Config.LoRaConfig.ModemPreset.Name(
+                    generic_preset_name  # type: ignore[arg-type]
+                )
+                preset_val = generic_preset_name  # type: ignore[assignment]
+            else:
+                preset_val = config_pb2.Config.LoRaConfig.ModemPreset.Value(
+                    generic_preset_name
+                )
+            _set_simple_config(preset_val)  # type: ignore[arg-type]
 
         if args.ch_set or args.ch_enable or args.ch_disable:
             closeNow = True

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -119,6 +119,88 @@ BITFIELD_ENUMS = {
     "position.position_flags": config_pb2.Config.PositionConfig.PositionFlags,
 }
 
+# Public CLI shorthands for common modem presets. Keep this ordered to preserve
+# the historical behavior when callers supply more than one shorthand: later
+# options win. ``--ch-preset`` below is the scalable path for every enum value
+# present in the active protobuf schema, including future additions.
+_MODEM_PRESET_SHORTHANDS: tuple[
+    tuple[tuple[str, ...], str, str, str], ...
+] = (
+    (
+        ("--ch-vlongslow",),
+        "ch_vlongslow",
+        "VERY_LONG_SLOW",
+        "Change to the VERY_LONG_SLOW modem preset. Deprecated since 2.5 firmware.",
+    ),
+    (
+        ("--ch-longslow",),
+        "ch_longslow",
+        "LONG_SLOW",
+        "Change to the LONG_SLOW modem preset. Deprecated since 2.7 firmware.",
+    ),
+    (
+        ("--ch-longmod", "--ch-longmoderate"),
+        "ch_longmod",
+        "LONG_MODERATE",
+        "Change to the LONG_MODERATE modem preset",
+    ),
+    (
+        ("--ch-longfast",),
+        "ch_longfast",
+        "LONG_FAST",
+        "Change to the LONG_FAST modem preset",
+    ),
+    (
+        ("--ch-longturbo",),
+        "ch_longturbo",
+        "LONG_TURBO",
+        "Change to the LONG_TURBO modem preset",
+    ),
+    (
+        ("--ch-medslow",),
+        "ch_medslow",
+        "MEDIUM_SLOW",
+        "Change to the MEDIUM_SLOW modem preset",
+    ),
+    (
+        ("--ch-medfast",),
+        "ch_medfast",
+        "MEDIUM_FAST",
+        "Change to the MEDIUM_FAST modem preset",
+    ),
+    (
+        ("--ch-shortslow",),
+        "ch_shortslow",
+        "SHORT_SLOW",
+        "Change to the SHORT_SLOW modem preset",
+    ),
+    (
+        ("--ch-shortfast",),
+        "ch_shortfast",
+        "SHORT_FAST",
+        "Change to the SHORT_FAST modem preset",
+    ),
+    (
+        ("--ch-shortturbo",),
+        "ch_shortturbo",
+        "SHORT_TURBO",
+        "Change to the SHORT_TURBO modem preset",
+    ),
+)
+
+
+def _parse_modem_preset_name(value: str) -> str:
+    """Normalize and validate a modem preset against the active schema."""
+    normalized = value.strip().replace("-", "_").upper()
+    try:
+        config_pb2.Config.LoRaConfig.ModemPreset.Value(normalized)
+    except ValueError as exc:
+        choices = ", ".join(config_pb2.Config.LoRaConfig.ModemPreset.keys())
+        raise argparse.ArgumentTypeError(
+            f"Unknown modem preset {value!r}. Available presets: {choices}"
+        ) from exc
+    return normalized
+
 
 def _looks_like_integer_literal(value: str) -> bool:
     stripped = value.strip()
@@ -2345,27 +2427,20 @@ def onConnected(interface: MeshInterface) -> None:
             node.localConfig.lora.modem_preset = modem_preset
             node.writeConfig("lora")
 
-        # handle the simple radio set commands
-        if args.ch_vlongslow:
-            _set_simple_config(config_pb2.Config.LoRaConfig.ModemPreset.VERY_LONG_SLOW)
+        # Handle historical/common shorthands in their established order, then
+        # the schema-driven generic form. ``getattr`` keeps programmatic callers
+        # that provide a partial argparse-like namespace compatible.
+        for _, destination, preset_name, _ in _MODEM_PRESET_SHORTHANDS:
+            if getattr(args, destination, False):
+                _set_simple_config(
+                    config_pb2.Config.LoRaConfig.ModemPreset.Value(preset_name)
+                )
 
-        if args.ch_longslow:
-            _set_simple_config(config_pb2.Config.LoRaConfig.ModemPreset.LONG_SLOW)
-
-        if args.ch_longfast:
-            _set_simple_config(config_pb2.Config.LoRaConfig.ModemPreset.LONG_FAST)
-
-        if args.ch_medslow:
-            _set_simple_config(config_pb2.Config.LoRaConfig.ModemPreset.MEDIUM_SLOW)
-
-        if args.ch_medfast:
-            _set_simple_config(config_pb2.Config.LoRaConfig.ModemPreset.MEDIUM_FAST)
-
-        if args.ch_shortslow:
-            _set_simple_config(config_pb2.Config.LoRaConfig.ModemPreset.SHORT_SLOW)
-
-        if args.ch_shortfast:
-            _set_simple_config(config_pb2.Config.LoRaConfig.ModemPreset.SHORT_FAST)
+        generic_preset_name = getattr(args, "ch_preset", None)
+        if generic_preset_name is not None:
+            _set_simple_config(
+                config_pb2.Config.LoRaConfig.ModemPreset.Value(generic_preset_name)
+            )
 
         if args.ch_set or args.ch_enable or args.ch_disable:
             closeNow = True
@@ -3545,46 +3620,22 @@ def addConfigArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         metavar="RINGTONE",
     )
 
-    group.add_argument(
-        "--ch-vlongslow",
-        help="Change to the very long-range and slow modem preset",
-        action="store_true",
-    )
+    for flags, destination, _, help_text in _MODEM_PRESET_SHORTHANDS:
+        group.add_argument(
+            *flags,
+            dest=destination,
+            help=help_text,
+            action="store_true",
+        )
 
     group.add_argument(
-        "--ch-longslow",
-        help="Change to the long-range and slow modem preset",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--ch-longfast",
-        help="Change to the long-range and fast modem preset",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--ch-medslow",
-        help="Change to the med-range and slow modem preset",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--ch-medfast",
-        help="Change to the med-range and fast modem preset",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--ch-shortslow",
-        help="Change to the short-range and slow modem preset",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--ch-shortfast",
-        help="Change to the short-range and fast modem preset",
-        action="store_true",
+        "--ch-preset",
+        type=_parse_modem_preset_name,
+        metavar="PRESET",
+        help=(
+            "Change to any modem preset defined by the active protobuf schema. "
+            "Names are case-insensitive and may use '-' or '_' separators."
+        ),
     )
 
     group.add_argument("--set-owner", help="Set device owner name", action="store")

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=C0302,W0613,R0917
 
+import argparse
 import base64
 import importlib.util
 import logging
@@ -152,6 +153,57 @@ def test_main_init_parser_help_mentions_list_fields(
     assert "--list-fields" in out
     assert "protobuf schemas" in out
     assert err == ""
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+@pytest.mark.parametrize(
+    ("flag", "destination"),
+    (
+        pytest.param("--ch-longmod", "ch_longmod", id="long-moderate-short"),
+        pytest.param(
+            "--ch-longmoderate", "ch_longmod", id="long-moderate-long"
+        ),
+        pytest.param("--ch-longturbo", "ch_longturbo", id="long-turbo"),
+        pytest.param("--ch-shortturbo", "ch_shortturbo", id="short-turbo"),
+    ),
+)
+def test_main_init_parser_accepts_firmware_2_8_preset_shorthands(
+    monkeypatch: pytest.MonkeyPatch,
+    flag: str,
+    destination: str,
+) -> None:
+    """Firmware 2.8 preset shorthands should retain stable argparse destinations."""
+    monkeypatch.setattr(sys, "argv", ["meshtastic", flag])
+
+    initParser()
+
+    assert mt_config.args is not None
+    assert getattr(mt_config.args, destination) is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("raw_value", "expected"),
+    (
+        pytest.param("medium_turbo", "MEDIUM_TURBO", id="lower-snake"),
+        pytest.param("long-moderate", "LONG_MODERATE", id="lower-kebab"),
+        pytest.param(" TINY_FAST ", "TINY_FAST", id="whitespace"),
+    ),
+)
+def test_parse_modem_preset_name_uses_active_protobuf_schema(
+    raw_value: str,
+    expected: str,
+) -> None:
+    """The generic preset parser should normalize every active enum value."""
+    assert main_module._parse_modem_preset_name(raw_value) == expected
+
+
+@pytest.mark.unit
+def test_parse_modem_preset_name_rejects_unknown_value() -> None:
+    """Unknown generic presets should fail with schema-derived choices."""
+    with pytest.raises(argparse.ArgumentTypeError, match="Unknown modem preset"):
+        main_module._parse_modem_preset_name("future-but-not-yet-in-schema")
 
 
 @pytest.mark.unit
@@ -2817,6 +2869,55 @@ def test_main_ch_longfast_on_non_primary_channel(
             re.MULTILINE,
         )
         mo.assert_called()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+@pytest.mark.parametrize(
+    ("cli_args", "expected_preset"),
+    (
+        pytest.param(
+            ("--ch-longmod",),
+            config_pb2.Config.LoRaConfig.ModemPreset.LONG_MODERATE,
+            id="long-moderate",
+        ),
+        pytest.param(
+            ("--ch-longturbo",),
+            config_pb2.Config.LoRaConfig.ModemPreset.LONG_TURBO,
+            id="long-turbo",
+        ),
+        pytest.param(
+            ("--ch-shortturbo",),
+            config_pb2.Config.LoRaConfig.ModemPreset.SHORT_TURBO,
+            id="short-turbo",
+        ),
+        pytest.param(
+            ("--ch-preset", "medium-turbo"),
+            config_pb2.Config.LoRaConfig.ModemPreset.MEDIUM_TURBO,
+            id="generic-active-schema-value",
+        ),
+    ),
+)
+def test_main_modem_preset_options_write_expected_lora_config(
+    monkeypatch: pytest.MonkeyPatch,
+    cli_args: tuple[str, ...],
+    expected_preset: config_pb2.Config.LoRaConfig.ModemPreset.ValueType,
+) -> None:
+    """New shorthand and generic options should share the existing write path."""
+    monkeypatch.setattr(sys, "argv", ["meshtastic", *cli_args])
+    mocked_node = MagicMock(autospec=Node)
+    mocked_node.localConfig = localonly_pb2.LocalConfig()
+    iface = MagicMock(autospec=SerialInterface)
+    iface.__enter__ = MagicMock(return_value=iface)
+    iface.__exit__ = MagicMock(return_value=None)
+    iface.getNode.return_value = mocked_node
+
+    with patch("meshtastic.serial_interface.SerialInterface", return_value=iface):
+        main()
+
+    assert mocked_node.localConfig.lora.modem_preset == expected_preset
+    mocked_node.writeConfig.assert_called_once_with("lora")
+    mocked_node.requestConfig.assert_called_once()
 
 
 # PositionFlags:

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -2920,6 +2920,73 @@ def test_main_modem_preset_options_write_expected_lora_config(
     mocked_node.requestConfig.assert_called_once()
 
 
+@pytest.mark.unit
+def test_main_ch_preset_accepts_integer_enum_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Programmatic callers can pass integer ModemPreset values in ch_preset."""
+    monkeypatch.setattr(sys, "argv", ["meshtastic", "--ch-longmod"])
+
+    mocked_node = MagicMock(autospec=Node)
+    mocked_node.localConfig = localonly_pb2.LocalConfig()
+
+    iface = MagicMock(autospec=SerialInterface)
+    iface.__enter__ = MagicMock(return_value=iface)
+    iface.__exit__ = MagicMock(return_value=None)
+    iface.getNode.return_value = mocked_node
+
+    with patch("meshtastic.serial_interface.SerialInterface", return_value=iface):
+        # After initParser, patch ch_preset to an integer before common() runs
+        original_init = main_module.initParser
+
+        def _patched_init() -> None:
+            original_init()
+            assert mt_config.args is not None
+            mt_config.args.ch_preset = config_pb2.Config.LoRaConfig.ModemPreset.Value(
+                "SHORT_TURBO"
+            )
+
+        monkeypatch.setattr(main_module, "initParser", _patched_init)
+        main()
+
+    assert (
+        mocked_node.localConfig.lora.modem_preset
+        == config_pb2.Config.LoRaConfig.ModemPreset.SHORT_TURBO
+    )
+    mocked_node.writeConfig.assert_called_with("lora")
+
+
+@pytest.mark.unit
+def test_main_ch_preset_rejects_invalid_integer_enum_value(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Invalid integer enum values in ch_preset should cause a clean CLI exit."""
+    monkeypatch.setattr(sys, "argv", ["meshtastic", "--ch-longmod"])
+
+    mocked_node = MagicMock(autospec=Node)
+    mocked_node.localConfig = localonly_pb2.LocalConfig()
+    iface = MagicMock(autospec=SerialInterface)
+    iface.__enter__ = MagicMock(return_value=iface)
+    iface.__exit__ = MagicMock(return_value=None)
+    iface.getNode.return_value = mocked_node
+
+    with patch("meshtastic.serial_interface.SerialInterface", return_value=iface):
+        original_init = main_module.initParser
+
+        def _patched_init() -> None:
+            original_init()
+            assert mt_config.args is not None
+            mt_config.args.ch_preset = 99999
+
+        monkeypatch.setattr(main_module, "initParser", _patched_init)
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 1
+        _out, err = capsys.readouterr()
+        assert "has no name defined for value 99999" in err
+
+
 # PositionFlags:
 # Misc info that might be helpful (this info will grow stale, just
 # a snapshot of the values.) The radioconfig_pb2.PositionFlags.Name and bit values are:


### PR DESCRIPTION
## Summary by Sourcery

Expand and generalize CLI modem preset handling while preserving compatibility with historical shorthand flags.

New Features:
- Add new shorthand flags for additional modem presets, including long moderate and turbo variants, aligned with newer firmware presets.
- Introduce a generic --ch-preset CLI option that accepts any modem preset defined in the active protobuf schema with flexible name normalization.

Enhancements:
- Centralize modem preset shorthand definitions in a single table and drive both argparse setup and runtime handling from it to maintain stable destinations and ordering.
- Validate modem preset names against the active protobuf schema via a dedicated parser that provides clear, schema-derived error messages.

Tests:
- Add unit tests to verify argparse destinations for new preset shorthand flags remain stable.
- Add unit tests for modem preset name parsing, including normalization rules and rejection of unknown values.
- Add integration-style tests to confirm shorthand and generic preset options write the expected LoRa modem configuration.