### PR TITLE
Add Meshtasticd SimRadio harness and firmware smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,7 @@ jobs:
       PYTHON_VERSION: "3.13"
       POETRY_INSTALL_ARGS: --all-extras --with dev,powermon
       MESHTASTICD_SIM_LOG_DIR: ${{ github.workspace }}/.meshtasticd-logs/simradio/${{ matrix.channel }}
+      SIMRADIO_RESULT_DIR: ${{ github.workspace }}/.test-results/simradio/${{ matrix.channel }}
       MESHTASTICD_CHANNEL: "${{ matrix.channel }}"
     steps:
       - *checkout_step
@@ -282,14 +283,31 @@ jobs:
             fi
             sleep "$((attempt * 10))"
           done
+      - name: Record installed meshtasticd package
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${SIMRADIO_RESULT_DIR}"
+          dpkg-query -W -f='${Package}\t${Version}\n' meshtasticd \
+            | tee "${SIMRADIO_RESULT_DIR}/firmware-package.txt"
+          timeout 5s meshtasticd --version 2>&1 \
+            | tee "${SIMRADIO_RESULT_DIR}/firmware-version.txt" || true
       - name: Run process-managed simradio smoke tests
-        run: poetry run pytest -m simradio -v --durations=20
-      - name: Upload simradio firmware logs
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${SIMRADIO_RESULT_DIR}"
+          poetry run pytest -m simradio -vv --tb=long --durations=20 \
+            --junitxml="${SIMRADIO_RESULT_DIR}/junit.xml" 2>&1 \
+            | tee "${SIMRADIO_RESULT_DIR}/pytest.log"
+      - name: Upload simradio firmware logs and test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: simradio-${{ matrix.channel }}-logs
-          path: ${{ env.MESHTASTICD_SIM_LOG_DIR }}
+          path: |
+            ${{ env.MESHTASTICD_SIM_LOG_DIR }}
+            ${{ env.SIMRADIO_RESULT_DIR }}
           if-no-files-found: warn
   # Fast install sanity check across Python versions.
   # Full tests run in the tests job above.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,42 @@ jobs:
           name: meshtasticd-multinode-logs
           path: ${{ env.MESHTASTICD_LOG_DIR }}
           if-no-files-found: warn
+  simradio-firmware:
+    name: SimRadio Firmware (${{ matrix.channel }}, py3.13)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    continue-on-error: ${{ matrix.channel == 'daily' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        channel:
+          - beta
+          - alpha
+          - daily
+    env:
+      PYTHON_VERSION: "3.13"
+      POETRY_INSTALL_ARGS: --all-extras --with dev,powermon
+      MESHTASTICD_SIM_LOG_DIR: ${{ github.workspace }}/.meshtasticd-logs/simradio/${{ matrix.channel }}
+    steps:
+      - *checkout_step
+      - *setup_python_step
+      - *cache_poetry_step
+      - *install_dependencies_step
+      - *install_local_step
+      - name: Install meshtasticd (${{ matrix.channel }}) from PPA
+        run: |
+          sudo add-apt-repository -y ppa:meshtastic/${{ matrix.channel }}
+          sudo apt-get update
+          sudo apt-get install -y meshtasticd
+      - name: Run process-managed simradio smoke tests
+        run: poetry run pytest -m simradio -v
+      - name: Upload simradio firmware logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: simradio-${{ matrix.channel }}-logs
+          path: ${{ env.MESHTASTICD_SIM_LOG_DIR }}
+          if-no-files-found: warn
   # Fast install sanity check across Python versions.
   # Full tests run in the tests job above.
   # Lint/type checks run in dedicated jobs for earlier independent failures.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - &checkout_step
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - &setup_python_step
         name: Install Python 3
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -259,6 +261,7 @@ jobs:
       PYTHON_VERSION: "3.13"
       POETRY_INSTALL_ARGS: --all-extras --with dev,powermon
       MESHTASTICD_SIM_LOG_DIR: ${{ github.workspace }}/.meshtasticd-logs/simradio/${{ matrix.channel }}
+      MESHTASTICD_CHANNEL: "${{ matrix.channel }}"
     steps:
       - *checkout_step
       - *setup_python_step
@@ -267,11 +270,20 @@ jobs:
       - *install_local_step
       - name: Install meshtasticd (${{ matrix.channel }}) from PPA
         run: |
-          sudo add-apt-repository -y ppa:meshtastic/${{ matrix.channel }}
-          sudo apt-get update
-          sudo apt-get install -y meshtasticd
+          for attempt in 1 2 3; do
+            if sudo add-apt-repository -y "ppa:meshtastic/${MESHTASTICD_CHANNEL}" \
+              && sudo apt-get update \
+              && sudo apt-get install -y meshtasticd; then
+              exit 0
+            fi
+            if [ "${attempt}" -eq 3 ]; then
+              echo "meshtasticd PPA installation failed after ${attempt} attempts" >&2
+              exit 1
+            fi
+            sleep "$((attempt * 10))"
+          done
       - name: Run process-managed simradio smoke tests
-        run: poetry run pytest -m simradio -v
+        run: poetry run pytest -m simradio -v --durations=20
       - name: Upload simradio firmware logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,7 @@ jobs:
     name: SimRadio Firmware (${{ matrix.channel }}, py3.13)
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    continue-on-error: ${{ matrix.channel == 'daily' }}
+    continue-on-error: ${{ matrix.channel != 'beta' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,7 @@ jobs:
       MESHTASTICD_SIM_LOG_DIR: ${{ github.workspace }}/.meshtasticd-logs/simradio/${{ matrix.channel }}
       SIMRADIO_RESULT_DIR: ${{ github.workspace }}/.test-results/simradio/${{ matrix.channel }}
       MESHTASTICD_CHANNEL: "${{ matrix.channel }}"
+      SIMRADIO_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - *checkout_step
       - *setup_python_step
@@ -288,6 +289,19 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "${SIMRADIO_RESULT_DIR}"
+          {
+            printf 'repository=%s\n' "${GITHUB_REPOSITORY}"
+            printf 'github_sha=%s\n' "${GITHUB_SHA}"
+            printf 'source_sha=%s\n' "${SIMRADIO_SOURCE_SHA}"
+            printf 'checkout_sha=%s\n' "$(git rev-parse HEAD)"
+            printf 'ref=%s\n' "${GITHUB_REF}"
+            printf 'head_ref=%s\n' "${GITHUB_HEAD_REF:-}"
+            printf 'base_ref=%s\n' "${GITHUB_BASE_REF:-}"
+            printf 'workflow=%s\n' "${GITHUB_WORKFLOW}"
+            printf 'run_id=%s\n' "${GITHUB_RUN_ID}"
+            printf 'run_attempt=%s\n' "${GITHUB_RUN_ATTEMPT}"
+            printf 'channel=%s\n' "${MESHTASTICD_CHANNEL}"
+          } | tee "${SIMRADIO_RESULT_DIR}/source-context.txt"
           dpkg-query -W -f='${Package}\t${Version}\n' meshtasticd \
             | tee "${SIMRADIO_RESULT_DIR}/firmware-package.txt"
           timeout 5s meshtasticd --version 2>&1 \

--- a/.github/workflows/daily_simradio.yml
+++ b/.github/workflows/daily_simradio.yml
@@ -1,0 +1,64 @@
+name: Daily SimRadio Firmware
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  PYTHON_VERSION: "3.13"
+  POETRY_INSTALL_ARGS: --all-extras --with dev,powermon
+  MESHTASTICD_SIM_LOG_DIR: ${{ github.workspace }}/.meshtasticd-logs/simradio/daily
+
+concurrency:
+  group: daily-simradio-firmware
+  cancel-in-progress: false
+
+jobs:
+  simradio-firmware:
+    name: Daily firmware smoke (py3.13)
+    if: github.repository == 'jeremiah-k/mtjk'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Install Python 3
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Cache Poetry artifacts
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/pypoetry
+            ~/.cache/pip
+          key: ${{ runner.os }}-${{ env.PYTHON_VERSION }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.PYTHON_VERSION }}-poetry-
+            ${{ runner.os }}-poetry-
+      - name: Install project dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "poetry==2.3.2"
+          poetry install ${{ env.POETRY_INSTALL_ARGS }}
+          poetry run meshtastic --version
+      - name: Install daily meshtasticd from PPA
+        run: |
+          sudo add-apt-repository -y ppa:meshtastic/daily
+          sudo apt-get update
+          sudo apt-get install -y meshtasticd
+      - name: Run process-managed simradio smoke tests
+        run: poetry run pytest -m simradio -v
+      - name: Upload daily simradio firmware logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: daily-simradio-firmware-logs
+          path: ${{ env.MESHTASTICD_SIM_LOG_DIR }}
+          if-no-files-found: warn

--- a/.github/workflows/daily_simradio.yml
+++ b/.github/workflows/daily_simradio.yml
@@ -13,6 +13,7 @@ env:
   PYTHON_VERSION: "3.13"
   POETRY_INSTALL_ARGS: --all-extras --with dev,powermon
   MESHTASTICD_SIM_LOG_DIR: ${{ github.workspace }}/.meshtasticd-logs/simradio/daily
+  SIMRADIO_RESULT_DIR: ${{ github.workspace }}/.test-results/simradio/daily
   MESHTASTICD_CHANNEL: "daily"
 
 concurrency:
@@ -63,12 +64,29 @@ jobs:
             fi
             sleep "$((attempt * 10))"
           done
+      - name: Record installed meshtasticd package
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${SIMRADIO_RESULT_DIR}"
+          dpkg-query -W -f='${Package}\t${Version}\n' meshtasticd \
+            | tee "${SIMRADIO_RESULT_DIR}/firmware-package.txt"
+          timeout 5s meshtasticd --version 2>&1 \
+            | tee "${SIMRADIO_RESULT_DIR}/firmware-version.txt" || true
       - name: Run process-managed simradio smoke tests
-        run: poetry run pytest -m simradio -v --durations=20
-      - name: Upload daily simradio firmware logs
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${SIMRADIO_RESULT_DIR}"
+          poetry run pytest -m simradio -vv --tb=long --durations=20 \
+            --junitxml="${SIMRADIO_RESULT_DIR}/junit.xml" 2>&1 \
+            | tee "${SIMRADIO_RESULT_DIR}/pytest.log"
+      - name: Upload daily simradio firmware logs and test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: daily-simradio-firmware-logs
-          path: ${{ env.MESHTASTICD_SIM_LOG_DIR }}
+          path: |
+            ${{ env.MESHTASTICD_SIM_LOG_DIR }}
+            ${{ env.SIMRADIO_RESULT_DIR }}
           if-no-files-found: warn

--- a/.github/workflows/daily_simradio.yml
+++ b/.github/workflows/daily_simradio.yml
@@ -13,6 +13,7 @@ env:
   PYTHON_VERSION: "3.13"
   POETRY_INSTALL_ARGS: --all-extras --with dev,powermon
   MESHTASTICD_SIM_LOG_DIR: ${{ github.workspace }}/.meshtasticd-logs/simradio/daily
+  MESHTASTICD_CHANNEL: "daily"
 
 concurrency:
   group: daily-simradio-firmware
@@ -50,11 +51,20 @@ jobs:
           poetry run meshtastic --version
       - name: Install daily meshtasticd from PPA
         run: |
-          sudo add-apt-repository -y ppa:meshtastic/daily
-          sudo apt-get update
-          sudo apt-get install -y meshtasticd
+          for attempt in 1 2 3; do
+            if sudo add-apt-repository -y "ppa:meshtastic/${MESHTASTICD_CHANNEL}" \
+              && sudo apt-get update \
+              && sudo apt-get install -y meshtasticd; then
+              exit 0
+            fi
+            if [ "${attempt}" -eq 3 ]; then
+              echo "meshtasticd PPA installation failed after ${attempt} attempts" >&2
+              exit 1
+            fi
+            sleep "$((attempt * 10))"
+          done
       - name: Run process-managed simradio smoke tests
-        run: poetry run pytest -m simradio -v
+        run: poetry run pytest -m simradio -v --durations=20
       - name: Upload daily simradio firmware logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/daily_simradio.yml
+++ b/.github/workflows/daily_simradio.yml
@@ -15,6 +15,7 @@ env:
   MESHTASTICD_SIM_LOG_DIR: ${{ github.workspace }}/.meshtasticd-logs/simradio/daily
   SIMRADIO_RESULT_DIR: ${{ github.workspace }}/.test-results/simradio/daily
   MESHTASTICD_CHANNEL: "daily"
+  SIMRADIO_SOURCE_SHA: ${{ github.sha }}
 
 concurrency:
   group: daily-simradio-firmware
@@ -69,6 +70,19 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "${SIMRADIO_RESULT_DIR}"
+          {
+            printf 'repository=%s\n' "${GITHUB_REPOSITORY}"
+            printf 'github_sha=%s\n' "${GITHUB_SHA}"
+            printf 'source_sha=%s\n' "${SIMRADIO_SOURCE_SHA}"
+            printf 'checkout_sha=%s\n' "$(git rev-parse HEAD)"
+            printf 'ref=%s\n' "${GITHUB_REF}"
+            printf 'head_ref=%s\n' "${GITHUB_HEAD_REF:-}"
+            printf 'base_ref=%s\n' "${GITHUB_BASE_REF:-}"
+            printf 'workflow=%s\n' "${GITHUB_WORKFLOW}"
+            printf 'run_id=%s\n' "${GITHUB_RUN_ID}"
+            printf 'run_attempt=%s\n' "${GITHUB_RUN_ATTEMPT}"
+            printf 'channel=%s\n' "${MESHTASTICD_CHANNEL}"
+          } | tee "${SIMRADIO_RESULT_DIR}/source-context.txt"
           dpkg-query -W -f='${Package}\t${Version}\n' meshtasticd \
             | tee "${SIMRADIO_RESULT_DIR}/firmware-package.txt"
           timeout 5s meshtasticd --version 2>&1 \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean test ci ci-strict ci-base lint lint-tests docs cov open-coverage virt virt-meshtasticd virt-smokevirt-meshtasticd virt-multinode-meshtasticd smoke1 smoke1-destructive slow install examples protobufs protobufs-update api-baseline api-baseline-master FORCE
+.PHONY: all clean test ci ci-strict ci-base lint lint-tests docs cov open-coverage virt virt-meshtasticd virt-smokevirt-meshtasticd virt-multinode-meshtasticd simradio smoke1 smoke1-destructive slow install examples protobufs protobufs-update api-baseline api-baseline-master FORCE
 
 POETRY_RUN := poetry run
 API_BASELINE_FILE := meshtastic/tests/api_baselines/api_baseline.json
@@ -56,6 +56,10 @@ virt-smokevirt-meshtasticd:
 # run dual-daemon meshtasticd integration tests against host-network simulators
 virt-multinode-meshtasticd:
 	./bin/run-multinode-with-meshtasticd.sh
+
+# run process-managed native meshtasticd single/multi-node smoke tests
+simradio:
+	$(POETRY_RUN) pytest -m simradio -v
 
 # run stable non-destructive smoke1 hardware checks
 smoke1:

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ virt-multinode-meshtasticd:
 
 # run process-managed native meshtasticd single/multi-node smoke tests
 simradio:
-	$(POETRY_RUN) pytest -m simradio -v
+	$(POETRY_RUN) pytest -m simradio -v --durations=20
 
 # run stable non-destructive smoke1 hardware checks
 smoke1:

--- a/meshtastic/tests/SIMRADIO.md
+++ b/meshtastic/tests/SIMRADIO.md
@@ -46,7 +46,18 @@ The single-node fixture releases its interface before yielding. CLI processes
 therefore have exclusive ownership of the firmware API port, and state checks
 open and close one temporary interface only after the CLI process exits. The
 multi-node fixture retains one interface per distinct firmware port so its
-packet bridge remains connected without client contention.
+packet bridge remains connected without client contention. Because that fixture
+is module-scoped, text sends go through `SimMesh.send_text()`, which enforces a
+small per-sender interval. Current alpha and daily firmware reject a second
+`TEXT_MESSAGE_APP` packet sent too soon after the first instead of queueing it;
+the harness-level pacing prevents test order and propagation speed from deciding
+whether a message is accepted.
+
+CLI subprocess timeouts and firmware request timeouts are separate. `run_cli()`
+therefore supplies a bounded `--timeout` value by default so optional admin reads
+that a firmware build does not implement cannot outlive the subprocess budget.
+Tests may override that request timeout explicitly, or pass `None` when they need
+the CLI's production default.
 
 ## CI policy
 

--- a/meshtastic/tests/SIMRADIO.md
+++ b/meshtastic/tests/SIMRADIO.md
@@ -75,7 +75,10 @@ pre-reboot window. Arbitrary daemon exits remain failures. The only process-exit
 recovery is the observed firmware 2.7 Portduino factory-reset crash: it must be
 `SIGSEGV`, come from a firmware 2.7 boot banner, occur after the current test's
 reset-complete and reboot-scheduled markers, and successfully boot again from
-the same VFS. The recovery is emitted
+the same VFS. Relaunch preflight checks for an active TCP listener rather than
+requiring a raw bind to succeed, because the exited daemon can leave accepted
+connections in kernel teardown state after the crash even though no process owns
+the listening port. The recovery is emitted
 as a pytest warning and archived in `simradio-reboot-recovery.txt`; the reset
 configuration is then verified normally. The bridge also preserves optional decoded packet metadata
 such as `bitfield`; firmware 2.8 requires that presence marker to accept modern

--- a/meshtastic/tests/SIMRADIO.md
+++ b/meshtastic/tests/SIMRADIO.md
@@ -43,7 +43,11 @@ Every fixture:
    drain, and verifies the persisted value through bounded fresh-connection
    polling without replaying the mutation;
 3. waits for an actual Portduino boot marker after commands that really schedule
-   a reboot, rather than treating TCP availability as reboot completion;
+   a reboot, rather than treating TCP availability as reboot completion. For the
+   documented firmware 2.7 factory-reset-only Portduino `SIGSEGV`, the harness
+   accepts recovery only after exact reset-complete and delayed-reboot log evidence,
+   relaunches the same VFS, records the crash in the artifact, and still requires
+   the next boot marker and post-reset state assertions;
 4. tears down subscriptions, interfaces, process groups, and files even after
    partial startup failure.
 
@@ -67,7 +71,13 @@ an ACK
 that arrived before the wait began. Commands that really reboot, such as factory
 reset, still wait for Portduino's next stable `Using config file <port>` startup
 marker. A successful TCP reconnect by itself is insufficient during a delayed
-pre-reboot window. The bridge also preserves optional decoded packet metadata
+pre-reboot window. Arbitrary daemon exits remain failures. The only process-exit
+recovery is the observed firmware 2.7 Portduino factory-reset crash: it must be
+`SIGSEGV`, come from a firmware 2.7 boot banner, occur after the current test's
+reset-complete and reboot-scheduled markers, and successfully boot again from
+the same VFS. The recovery is emitted
+as a pytest warning and archived in `simradio-reboot-recovery.txt`; the reset
+configuration is then verified normally. The bridge also preserves optional decoded packet metadata
 such as `bitfield`; firmware 2.8 requires that presence marker to accept modern
 zero-hop packets.
 
@@ -85,7 +95,10 @@ package version, a bounded `meshtasticd --version` probe, and a
 `source-context.txt` file containing the exact repository SHA, workflow run ID,
 run attempt, ref, and firmware channel. Every archived daemon directory also
 contains `simradio-context.txt` with its node ID, TCP port, process ID, checked-out
-and pull-request source SHAs, channel, and fixture setup identity. This keeps a failed beta, alpha, or
+and pull-request source SHAs, channel, and fixture setup identity. A narrowly
+recovered 2.7 factory-reset reboot crash also adds
+`simradio-reboot-recovery.txt` with both process IDs, exit status, signal, and
+checkpoint metadata. This keeps a failed beta, alpha, or
 daily run diagnosable without relying on the Actions log retention UI and makes
 stale job links immediately distinguishable from the current branch head.
 

--- a/meshtastic/tests/SIMRADIO.md
+++ b/meshtastic/tests/SIMRADIO.md
@@ -37,9 +37,16 @@ Every fixture:
 
 1. starts owned process groups and temporary VFS directories;
 2. sets the LoRa region to `US` for firmware 2.8 preset validation;
-3. reconnects after the reboot-capable region write;
+3. retries a real `TCPInterface` after reboot-capable writes instead of opening
+   disposable readiness probes;
 4. tears down subscriptions, interfaces, process groups, and files even after
    partial startup failure.
+
+The single-node fixture releases its interface before yielding. CLI processes
+therefore have exclusive ownership of the firmware API port, and state checks
+open and close one temporary interface only after the CLI process exits. The
+multi-node fixture retains one interface per distinct firmware port so its
+packet bridge remains connected without client contention.
 
 ## CI policy
 
@@ -53,6 +60,8 @@ Markers:
 
 - `simradio`: all process-managed native firmware tests.
 - `simradio_mesh`: the multi-node topology subset.
+- `smokevirt`: both native live-test modules, because they exercise virtual
+  firmware devices.
 
 The ordinary pytest selection excludes `simradio`; these tests run only when
 explicitly selected or by their dedicated workflows.

--- a/meshtastic/tests/SIMRADIO.md
+++ b/meshtastic/tests/SIMRADIO.md
@@ -49,11 +49,17 @@ therefore have exclusive ownership of the firmware API port, and state checks
 open and close one temporary interface only after the CLI process exits. The
 multi-node fixture retains one interface per distinct firmware port so its
 packet bridge remains connected without client contention. Because that fixture
-is module-scoped, text sends go through `SimMesh.send_text()`, which enforces a
-small per-sender interval. Current alpha and daily firmware reject a second
-`TEXT_MESSAGE_APP` packet sent too soon after the first instead of queueing it;
-the harness-level pacing prevents test order and propagation speed from deciding
-whether a message is accepted.
+is module-scoped, text sends go through `SimMesh.send_text()`. Firmware 2.8
+enforces a two-second `TEXT_MESSAGE_APP` PhoneAPI limit, so the helper applies a
+small per-sender scheduling margin. This prevents test order and propagation
+speed from deciding whether the next message is accepted.
+
+Reboot-capable setup and reset tests wait for Portduino's next stable
+`Using config file <port>` startup marker. A successful TCP reconnect by itself
+is insufficient because the simulator can still accept clients during the
+delayed pre-reboot window. The bridge also preserves optional decoded packet
+metadata such as `bitfield`; firmware 2.8 requires that presence marker to
+accept modern zero-hop packets.
 
 CLI subprocess timeouts and firmware request timeouts are separate. `run_cli()`
 therefore supplies a bounded `--timeout` value by default so optional admin reads

--- a/meshtastic/tests/SIMRADIO.md
+++ b/meshtastic/tests/SIMRADIO.md
@@ -1,0 +1,57 @@
+# Native SimRadio firmware testing
+
+The native SimRadio suite complements the pinned Docker integration tests. It
+launches installed `meshtasticd` binaries as disposable processes and bridges
+their `SIMULATOR_APP` packets in Python. This lets daily, alpha, and beta
+firmware packages exercise the current library without replacing the stable
+2.7 container baseline.
+
+## Running locally
+
+Native tests currently require Linux and an executable `meshtasticd` binary.
+The harness checks `MESHTASTICD_BIN` first and then `PATH`.
+
+```bash
+make simradio
+```
+
+The following environment variables are supported:
+
+- `MESHTASTICD_BIN`: explicit executable path.
+- `MESHTASTICD_SIM_BASE_PORT`: first TCP port for the three-node mesh; defaults
+  to `4404`. Single-node fixtures use this value plus 100.
+- `MESHTASTICD_SIM_LOG_DIR`: persistent artifact directory for per-process
+  stdout and stderr. Without it, temporary logs are removed during teardown.
+
+Do not run this marker concurrently in multiple pytest workers unless each
+worker receives a distinct base port.
+
+## Test isolation
+
+Single-node CLI tests use a function-scoped, freshly erased simulator. The
+three-node A-B-C chain is module-scoped because its tests do not mutate shared
+configuration and all packet assertions use unique payloads and
+interface-filtered subscriptions.
+
+Every fixture:
+
+1. starts owned process groups and temporary VFS directories;
+2. sets the LoRa region to `US` for firmware 2.8 preset validation;
+3. reconnects after the reboot-capable region write;
+4. tears down subscriptions, interfaces, process groups, and files even after
+   partial startup failure.
+
+## CI policy
+
+Pull-request CI runs beta, alpha, and daily PPA packages. Daily firmware is
+allowed to fail so an upstream breakage is visible without blocking unrelated
+changes. Beta and alpha failures are blocking. A scheduled workflow also runs
+the daily package once per day and uploads all simulator logs.
+
+Markers:
+
+- `simradio`: all process-managed native firmware tests.
+- `simradio_mesh`: the multi-node topology subset.
+
+The ordinary pytest selection excludes `simradio`; these tests run only when
+explicitly selected or by their dedicated workflows.

--- a/meshtastic/tests/SIMRADIO.md
+++ b/meshtastic/tests/SIMRADIO.md
@@ -43,10 +43,11 @@ Every fixture:
 
 ## CI policy
 
-Pull-request CI runs beta, alpha, and daily PPA packages. Daily firmware is
-allowed to fail so an upstream breakage is visible without blocking unrelated
-changes. Beta and alpha failures are blocking. A scheduled workflow also runs
-the daily package once per day and uploads all simulator logs.
+Pull-request CI runs beta, alpha, and daily PPA packages. Beta failures are
+blocking (the PR cannot merge until they pass). Alpha and daily failures are
+non-blocking so upstream regressions in pre-release channels are visible
+without blocking unrelated changes. A scheduled workflow also runs the daily
+package once per day and uploads all simulator logs regardless of outcome.
 
 Markers:
 

--- a/meshtastic/tests/SIMRADIO.md
+++ b/meshtastic/tests/SIMRADIO.md
@@ -38,9 +38,11 @@ interface-filtered subscriptions.
 Every fixture:
 
 1. starts owned process groups and temporary VFS directories;
-2. sets the LoRa region to `US` for firmware 2.8 preset validation;
-3. retries a real `TCPInterface` after reboot-capable writes instead of opening
-   disposable readiness probes;
+2. sets the LoRa region to `US` for firmware 2.8 preset validation, keeps
+   the CLI connection open long enough for the asynchronous local write to
+   drain, and verifies the persisted value through a fresh connection;
+3. waits for an actual Portduino boot marker after commands that really schedule
+   a reboot, rather than treating TCP availability as reboot completion;
 4. tears down subscriptions, interfaces, process groups, and files even after
    partial startup failure.
 
@@ -54,12 +56,16 @@ enforces a two-second `TEXT_MESSAGE_APP` PhoneAPI limit, so the helper applies a
 small per-sender scheduling margin. This prevents test order and propagation
 speed from deciding whether the next message is accepted.
 
-Reboot-capable setup and reset tests wait for Portduino's next stable
-`Using config file <port>` startup marker. A successful TCP reconnect by itself
-is insufficient because the simulator can still accept clients during the
-delayed pre-reboot window. The bridge also preserves optional decoded packet
-metadata such as `bitfield`; firmware 2.8 requires that presence marker to
-accept modern zero-hop packets.
+LoRa region changes are live-applied by current firmware and do not schedule a
+Portduino reboot. The setup helper therefore uses the CLI's explicit
+`--wait-to-disconnect` drain window and verifies the value independently; it
+does not force `--dest ^local`, whose legacy unscoped ACK wait can miss an ACK
+that arrived before the wait began. Commands that really reboot, such as factory
+reset, still wait for Portduino's next stable `Using config file <port>` startup
+marker. A successful TCP reconnect by itself is insufficient during a delayed
+pre-reboot window. The bridge also preserves optional decoded packet metadata
+such as `bitfield`; firmware 2.8 requires that presence marker to accept modern
+zero-hop packets.
 
 CLI subprocess timeouts and firmware request timeouts are separate. `run_cli()`
 therefore supplies a bounded `--timeout` value by default so optional admin reads

--- a/meshtastic/tests/SIMRADIO.md
+++ b/meshtastic/tests/SIMRADIO.md
@@ -19,7 +19,9 @@ The following environment variables are supported:
 
 - `MESHTASTICD_BIN`: explicit executable path.
 - `MESHTASTICD_SIM_BASE_PORT`: first TCP port for the three-node mesh; defaults
-  to `4404`. Single-node fixtures use this value plus 100.
+  to `4404`. Function-scoped single-node fixtures start at this value plus 100
+  and consume a fresh sequential port for each test, avoiding immediate listener
+  rebinding after reboot-heavy cases.
 - `MESHTASTICD_SIM_LOG_DIR`: persistent artifact directory for per-process
   stdout and stderr. Without it, temporary logs are removed during teardown.
 
@@ -58,6 +60,14 @@ therefore supplies a bounded `--timeout` value by default so optional admin read
 that a firmware build does not implement cannot outlive the subprocess budget.
 Tests may override that request timeout explicitly, or pass `None` when they need
 the CLI's production default.
+
+## Failure artifacts
+
+Firmware jobs archive both daemon logs and test-run diagnostics. Each channel
+artifact includes the verbose pytest transcript, JUnit XML, installed Debian
+package version, and a bounded `meshtasticd --version` probe. This keeps a
+failed beta, alpha, or daily run diagnosable without relying on the Actions log
+retention UI.
 
 ## CI policy
 

--- a/meshtastic/tests/SIMRADIO.md
+++ b/meshtastic/tests/SIMRADIO.md
@@ -40,7 +40,8 @@ Every fixture:
 1. starts owned process groups and temporary VFS directories;
 2. sets the LoRa region to `US` for firmware 2.8 preset validation, keeps
    the CLI connection open long enough for the asynchronous local write to
-   drain, and verifies the persisted value through a fresh connection;
+   drain, and verifies the persisted value through bounded fresh-connection
+   polling without replaying the mutation;
 3. waits for an actual Portduino boot marker after commands that really schedule
    a reboot, rather than treating TCP availability as reboot completion;
 4. tears down subscriptions, interfaces, process groups, and files even after
@@ -58,8 +59,11 @@ speed from deciding whether the next message is accepted.
 
 LoRa region changes are live-applied by current firmware and do not schedule a
 Portduino reboot. The setup helper therefore uses the CLI's explicit
-`--wait-to-disconnect` drain window and verifies the value independently; it
-does not force `--dest ^local`, whose legacy unscoped ACK wait can miss an ACK
+`--wait-to-disconnect` drain window and verifies the value independently. If
+the first fresh configuration snapshot still reflects the pre-write state, the
+harness reconnects and polls for a bounded interval; it never sends the region
+write a second time. It does not force `--dest ^local`, whose legacy unscoped ACK wait can miss
+an ACK
 that arrived before the wait began. Commands that really reboot, such as factory
 reset, still wait for Portduino's next stable `Using config file <port>` startup
 marker. A successful TCP reconnect by itself is insufficient during a delayed
@@ -77,9 +81,13 @@ the CLI's production default.
 
 Firmware jobs archive both daemon logs and test-run diagnostics. Each channel
 artifact includes the verbose pytest transcript, JUnit XML, installed Debian
-package version, and a bounded `meshtasticd --version` probe. This keeps a
-failed beta, alpha, or daily run diagnosable without relying on the Actions log
-retention UI.
+package version, a bounded `meshtasticd --version` probe, and a
+`source-context.txt` file containing the exact repository SHA, workflow run ID,
+run attempt, ref, and firmware channel. Every archived daemon directory also
+contains `simradio-context.txt` with its node ID, TCP port, process ID, checked-out
+and pull-request source SHAs, channel, and fixture setup identity. This keeps a failed beta, alpha, or
+daily run diagnosable without relying on the Actions log retention UI and makes
+stale job links immediately distinguishable from the current branch head.
 
 ## CI policy
 

--- a/meshtastic/tests/conftest.py
+++ b/meshtastic/tests/conftest.py
@@ -5,6 +5,7 @@
 
 import argparse
 import copy
+import itertools
 import importlib
 import math
 import os
@@ -42,6 +43,7 @@ if TYPE_CHECKING:
 
 
 SINGLE_NODE_PORT_OFFSET = 100
+_SINGLE_NODE_PORT_SEQUENCE = itertools.count()
 
 
 def _skip_simradio_if_unavailable() -> None:
@@ -73,13 +75,29 @@ def _simradio_log_root() -> Path | None:
     return Path(raw_value).expanduser() if raw_value else None
 
 
+def _next_simradio_single_node_port() -> int:
+    """Return the next deterministic function-scoped simulator port."""
+    return (
+        _simradio_base_port()
+        + SINGLE_NODE_PORT_OFFSET
+        + next(_SINGLE_NODE_PORT_SEQUENCE)
+    )
+
+
 @pytest.fixture(scope="function")
 def firmware_node() -> Generator[SimNode, None, None]:
     """Yield one freshly erased, US-region native meshtasticd simulator."""
     _skip_simradio_if_unavailable()
+    # Function-scoped simulators use a fresh port instead of immediately
+    # rebinding the same listener after every test.  Recent firmware opens
+    # several short-lived TCP clients during reboot/config flows, and the
+    # kernel can retain the previous port in a non-bindable state briefly
+    # after teardown.  A deterministic sequence preserves debuggable ports
+    # while eliminating that cross-test lifecycle race.
+    single_node_port = _next_simradio_single_node_port()
     mesh = SimMesh(
         node_count=1,
-        base_port=_simradio_base_port() + SINGLE_NODE_PORT_OFFSET,
+        base_port=single_node_port,
         log_root=_simradio_log_root(),
     )
     try:

--- a/meshtastic/tests/conftest.py
+++ b/meshtastic/tests/conftest.py
@@ -104,9 +104,11 @@ def firmware_node() -> Generator[SimNode, None, None]:
         mesh.start()
         node = mesh.get_node(0)
         node.disconnect()
+        previous_boot_count = node.boot_count()
         set_region(node.port, "US")
-        # Confirm the reboot through the real interface, then release ownership
-        # before yielding so every CLI subprocess is the port's only client.
+        node.wait_for_reboot(previous_boot_count)
+        # Confirm the completed reboot through the real interface, then release
+        # ownership before yielding so every CLI subprocess is the port's only client.
         node.connect()
         node.disconnect()
         yield node
@@ -126,9 +128,12 @@ def firmware_mesh() -> Generator[SimMesh, None, None]:
     )
     try:
         mesh.start()
+        previous_boot_counts = {node.node_id: node.boot_count() for node in mesh.nodes}
         for node in mesh.nodes:
             node.disconnect()
             set_region(node.port, "US")
+        for node in mesh.nodes:
+            node.wait_for_reboot(previous_boot_counts[node.node_id])
         mesh.reconnect_all()
         if not mesh.wait_for_convergence(timeout=30.0):
             raise AssertionError(

--- a/meshtastic/tests/conftest.py
+++ b/meshtastic/tests/conftest.py
@@ -104,13 +104,10 @@ def firmware_node() -> Generator[SimNode, None, None]:
         mesh.start()
         node = mesh.get_node(0)
         node.disconnect()
-        previous_boot_count = node.boot_count()
+        # LoRa changes apply live.  set_region() drains the CLI write and then
+        # verifies the persisted value through an independent connection, which
+        # it closes before returning.
         set_region(node.port, "US")
-        node.wait_for_reboot(previous_boot_count)
-        # Confirm the completed reboot through the real interface, then release
-        # ownership before yielding so every CLI subprocess is the port's only client.
-        node.connect()
-        node.disconnect()
         yield node
     finally:
         mesh.stop()
@@ -128,12 +125,9 @@ def firmware_mesh() -> Generator[SimMesh, None, None]:
     )
     try:
         mesh.start()
-        previous_boot_counts = {node.node_id: node.boot_count() for node in mesh.nodes}
         for node in mesh.nodes:
             node.disconnect()
             set_region(node.port, "US")
-        for node in mesh.nodes:
-            node.wait_for_reboot(previous_boot_counts[node.node_id])
         mesh.reconnect_all()
         if not mesh.wait_for_convergence(timeout=30.0):
             raise AssertionError(

--- a/meshtastic/tests/conftest.py
+++ b/meshtastic/tests/conftest.py
@@ -87,7 +87,10 @@ def firmware_node() -> Generator[SimNode, None, None]:
         node = mesh.get_node(0)
         node.disconnect()
         set_region(node.port, "US")
+        # Confirm the reboot through the real interface, then release ownership
+        # before yielding so every CLI subprocess is the port's only client.
         node.connect()
+        node.disconnect()
         yield node
     finally:
         mesh.stop()

--- a/meshtastic/tests/conftest.py
+++ b/meshtastic/tests/conftest.py
@@ -7,10 +7,12 @@ import argparse
 import copy
 import importlib
 import math
+import os
 import shutil
 import threading
 import time
 from collections.abc import Callable, Generator
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, NoReturn, cast
 from unittest.mock import MagicMock, create_autospec, patch
 
@@ -22,12 +24,99 @@ from meshtastic.util import DeferredExecution
 
 from ..mesh_interface import MeshInterface
 from ..serial_interface import SerialInterface
+from .simradio_harness import (
+    CHAIN_TOPOLOGY,
+    DEFAULT_BASE_PORT,
+    SimMesh,
+    SimNode,
+    find_meshtasticd,
+    is_compatible_host,
+)
+from .simradio_helpers import set_region
 
 if TYPE_CHECKING:
     from meshtastic.powermon.power_supply import PowerSupply
     from meshtastic.powermon.ppk2 import PPK2PowerSupply
     from meshtastic.powermon.riden import RidenPowerSupply
     from meshtastic.powermon.stress import PowerStressClient
+
+
+SINGLE_NODE_PORT_OFFSET = 100
+
+
+def _skip_simradio_if_unavailable() -> None:
+    """Skip native firmware tests when meshtasticd cannot run on this host."""
+    if not is_compatible_host():
+        pytest.skip("native meshtasticd simulator tests require Linux")
+    if find_meshtasticd() is None:
+        pytest.skip(
+            "meshtasticd not found; set MESHTASTICD_BIN or install it on PATH"
+        )
+
+
+def _simradio_base_port() -> int:
+    """Return the optionally configured native simulator base port."""
+    raw_value = os.environ.get("MESHTASTICD_SIM_BASE_PORT")
+    if raw_value is None:
+        return DEFAULT_BASE_PORT
+    try:
+        return int(raw_value)
+    except ValueError as exc:
+        raise pytest.UsageError(
+            f"MESHTASTICD_SIM_BASE_PORT must be an integer, got {raw_value!r}"
+        ) from exc
+
+
+def _simradio_log_root() -> Path | None:
+    """Return the optional persistent simulator log artifact directory."""
+    raw_value = os.environ.get("MESHTASTICD_SIM_LOG_DIR")
+    return Path(raw_value).expanduser() if raw_value else None
+
+
+@pytest.fixture(scope="function")
+def firmware_node() -> Generator[SimNode, None, None]:
+    """Yield one freshly erased, US-region native meshtasticd simulator."""
+    _skip_simradio_if_unavailable()
+    mesh = SimMesh(
+        node_count=1,
+        base_port=_simradio_base_port() + SINGLE_NODE_PORT_OFFSET,
+        log_root=_simradio_log_root(),
+    )
+    try:
+        mesh.start()
+        node = mesh.get_node(0)
+        node.disconnect()
+        set_region(node.port, "US")
+        node.connect()
+        yield node
+    finally:
+        mesh.stop()
+
+
+@pytest.fixture(scope="module")
+def firmware_mesh() -> Generator[SimMesh, None, None]:
+    """Yield a converged three-node A-B-C native simradio chain."""
+    _skip_simradio_if_unavailable()
+    mesh = SimMesh(
+        node_count=3,
+        topology=CHAIN_TOPOLOGY,
+        base_port=_simradio_base_port(),
+        log_root=_simradio_log_root(),
+    )
+    try:
+        mesh.start()
+        for node in mesh.nodes:
+            node.disconnect()
+            set_region(node.port, "US")
+        mesh.reconnect_all()
+        if not mesh.wait_for_convergence(timeout=30.0):
+            raise AssertionError(
+                "simradio mesh failed to converge; "
+                f"node DB counts={mesh.node_db_counts()}"
+            )
+        yield mesh
+    finally:
+        mesh.stop()
 
 
 def pytest_addoption(  # pylint: disable=unused-argument

--- a/meshtastic/tests/simradio_harness.py
+++ b/meshtastic/tests/simradio_harness.py
@@ -1,0 +1,556 @@
+"""Process-managed meshtasticd simulator harness for firmware smoke tests.
+
+The harness launches native ``meshtasticd`` processes in simulator mode and
+bridges their ``SIMULATOR_APP`` packets according to an explicit topology. It
+is additive to the container-backed integration harnesses in ``bin/``: native
+simradio jobs exercise daily/alpha/beta firmware packages, while the existing
+Docker jobs retain a pinned regression baseline.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import platform
+import shutil
+import signal
+import socket
+import subprocess
+import tempfile
+import threading
+import time
+from collections.abc import Collection, Mapping
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, BinaryIO
+
+from pubsub import pub
+
+from meshtastic import BROADCAST_NUM
+from meshtastic.mesh_interface import MeshInterface
+from meshtastic.protobuf import mesh_pb2, portnums_pb2
+from meshtastic.tcp_interface import TCPInterface
+
+logger = logging.getLogger(__name__)
+
+HW_ID_OFFSET = 16
+DEFAULT_BASE_PORT = 4404
+DEFAULT_RSSI = -50
+DEFAULT_SNR = 10.0
+BOOT_TIMEOUT_SECONDS = 30.0
+PROCESS_EXIT_TIMEOUT_SECONDS = 5.0
+NODE_INFO_SETTLE_SECONDS = 5.0
+PORT_RELEASE_SETTLE_SECONDS = 0.25
+MAX_LOG_TAIL_BYTES = 16_384
+
+CHAIN_TOPOLOGY: Mapping[int, frozenset[int]] = MappingProxyType(
+    {
+        0: frozenset({1}),
+        1: frozenset({0, 2}),
+        2: frozenset({1}),
+    }
+)
+
+
+def find_meshtasticd() -> str | None:
+    """Return an executable meshtasticd path from the environment or PATH."""
+    configured = os.environ.get("MESHTASTICD_BIN")
+    if configured:
+        candidate = Path(configured).expanduser()
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate.resolve())
+    return shutil.which("meshtasticd")
+
+
+def is_compatible_host() -> bool:
+    """Return whether native meshtasticd simulator tests support this host."""
+    return platform.system() == "Linux"
+
+
+def _wait_for_port(port: int, timeout: float = BOOT_TIMEOUT_SECONDS) -> None:
+    """Wait until localhost accepts a TCP connection on ``port``."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("localhost", port), timeout=0.5):
+                return
+        except OSError:
+            time.sleep(0.2)
+    raise TimeoutError(f"localhost:{port} did not listen within {timeout:.1f}s")
+
+
+def _ensure_port_available(port: int) -> None:
+    """Fail before launch when another process already owns ``port``."""
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+            raise RuntimeError(f"localhost:{port} is already in use")
+    except OSError:
+        pass
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            probe.bind(("127.0.0.1", port))
+    except OSError as exc:
+        raise RuntimeError(f"localhost:{port} is already in use") from exc
+
+
+def _copy_channel_topology(
+    topology: Mapping[int, Collection[int]] | None,
+    node_count: int,
+) -> dict[int, frozenset[int]] | None:
+    """Validate and defensively copy an optional directed receiver topology."""
+    if topology is None:
+        return None
+    copied: dict[int, frozenset[int]] = {}
+    for transmitter, receivers in topology.items():
+        if transmitter < 0 or transmitter >= node_count:
+            raise ValueError(f"Topology transmitter index out of range: {transmitter}")
+        normalized_receivers = frozenset(receivers)
+        if transmitter in normalized_receivers:
+            raise ValueError(f"Topology node {transmitter} cannot receive its own packet")
+        invalid = sorted(
+            receiver
+            for receiver in normalized_receivers
+            if receiver < 0 or receiver >= node_count
+        )
+        if invalid:
+            raise ValueError(
+                f"Topology receiver indices out of range for node {transmitter}: {invalid}"
+            )
+        copied[transmitter] = normalized_receivers
+    return copied
+
+
+def _inject_simulator_packet(
+    iface: TCPInterface,
+    to_radio: mesh_pb2.ToRadio,
+) -> None:
+    """Inject a simulator packet across fork and current-upstream internals."""
+    sender = getattr(iface, "_send_to_radio", None)
+    if not callable(sender):
+        # Upstream's first simradio harness still uses this pre-refactor
+        # internal spelling. Keeping the fallback here isolates that divergence
+        # without expanding either library's public compatibility surface.
+        sender = getattr(iface, "_sendToRadio", None)
+    if not callable(sender):
+        raise RuntimeError("TCPInterface has no simulator injection method")
+    sender(to_radio)
+
+
+class SimNode:
+    """Own one meshtasticd process, filesystem, logs, and TCP interface."""
+
+    def __init__(
+        self,
+        node_id: int,
+        *,
+        base_port: int = DEFAULT_BASE_PORT,
+        log_root: Path | None = None,
+    ) -> None:
+        if node_id < 0:
+            raise ValueError("node_id must not be negative")
+        if base_port <= 0 or base_port + node_id > 65_535:
+            raise ValueError("simradio node port must stay within 1..65535")
+        self.node_id = node_id
+        self.hw_id = node_id + HW_ID_OFFSET
+        self.port = base_port + node_id
+        self.log_root = log_root
+        self.process: subprocess.Popen[bytes] | None = None
+        self.workdir: Path | None = None
+        self.iface: TCPInterface | None = None
+        self._temporary_directory: tempfile.TemporaryDirectory[str] | None = None
+        self._log_files: list[BinaryIO] = []
+
+    @property
+    def node_num(self) -> int:
+        """Return the firmware node number, falling back to the configured HW ID."""
+        iface = self.iface
+        if iface is not None and iface.myInfo is not None:
+            return iface.myInfo.my_node_num
+        return self.hw_id
+
+    def start(self, binary: str) -> None:
+        """Launch a freshly erased meshtasticd simulator process."""
+        if self.process is not None or self._temporary_directory is not None:
+            raise RuntimeError(f"simradio node {self.node_id} is already started")
+        _ensure_port_available(self.port)
+        try:
+            self._temporary_directory = tempfile.TemporaryDirectory(
+                prefix=f"meshtasticd-simradio-{self.node_id}-"
+            )
+            self.workdir = Path(self._temporary_directory.name)
+            vfs_directory = self.workdir / "vfs"
+            vfs_directory.mkdir()
+            stdout_path = self.workdir / "meshtasticd.log"
+            stderr_path = self.workdir / "meshtasticd.err"
+            stdout_file = stdout_path.open("wb", buffering=0)
+            self._log_files.append(stdout_file)
+            stderr_file = stderr_path.open("wb", buffering=0)
+            self._log_files.append(stderr_file)
+            self.process = subprocess.Popen(  # pylint: disable=consider-using-with
+                [
+                    binary,
+                    "-s",
+                    "-h",
+                    str(self.hw_id),
+                    "-p",
+                    str(self.port),
+                    "-d",
+                    str(vfs_directory),
+                    "-e",
+                ],
+                stdout=stdout_file,
+                stderr=stderr_file,
+                start_new_session=True,
+            )
+            _wait_for_port(self.port)
+            if self.process.poll() is not None:
+                raise RuntimeError(
+                    f"meshtasticd node {self.node_id} exited with "
+                    f"status {self.process.returncode} during startup"
+                )
+        except Exception as exc:
+            diagnostics = self.diagnostics()
+            self.close(send_exit=False)
+            raise RuntimeError(
+                f"meshtasticd node {self.node_id} failed to start on port "
+                f"{self.port}: {exc}\n{diagnostics}"
+            ) from exc
+
+    def connect(self) -> TCPInterface:
+        """Open a fresh TCPInterface connection to this simulator."""
+        self.disconnect()
+        _wait_for_port(self.port)
+        self.iface = TCPInterface(
+            hostname="localhost",
+            portNumber=self.port,
+            connectNow=True,
+            connectTimeout=10.0,
+        )
+        return self.iface
+
+    def disconnect(self) -> None:
+        """Close only the Python interface while leaving firmware running."""
+        iface = self.iface
+        self.iface = None
+        if iface is not None:
+            with contextlib.suppress(Exception):
+                iface.close()
+
+    def diagnostics(self) -> str:
+        """Return bounded stdout/stderr tails for startup and CI failures."""
+        workdir = self.workdir
+        if workdir is None:
+            return "simradio diagnostics unavailable: no work directory"
+        sections: list[str] = []
+        for filename in ("meshtasticd.log", "meshtasticd.err"):
+            path = workdir / filename
+            try:
+                raw = path.read_bytes()[-MAX_LOG_TAIL_BYTES:]
+            except OSError as exc:
+                sections.append(f"[{filename}] unavailable: {exc}")
+                continue
+            sections.append(
+                f"[{filename} tail]\n{raw.decode('utf-8', errors='replace')}"
+            )
+        return "\n".join(sections)
+
+    def close(self, *, send_exit: bool = True) -> None:
+        """Close the interface, terminate the process group, and archive logs."""
+        iface = self.iface
+        self.iface = None
+        if iface is not None:
+            if send_exit:
+                with contextlib.suppress(Exception):
+                    iface.localNode.exitSimulator()
+            with contextlib.suppress(Exception):
+                iface.close()
+
+        process = self.process
+        self.process = None
+        if process is not None and process.poll() is None:
+            with contextlib.suppress(ProcessLookupError, OSError):
+                os.killpg(os.getpgid(process.pid), signal.SIGTERM)
+            try:
+                process.wait(timeout=PROCESS_EXIT_TIMEOUT_SECONDS)
+            except subprocess.TimeoutExpired:
+                with contextlib.suppress(ProcessLookupError, OSError):
+                    os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+                with contextlib.suppress(subprocess.TimeoutExpired):
+                    process.wait(timeout=PROCESS_EXIT_TIMEOUT_SECONDS)
+
+        for log_file in self._log_files:
+            with contextlib.suppress(Exception):
+                log_file.close()
+        self._log_files.clear()
+        self._archive_logs()
+        temporary_directory = self._temporary_directory
+        self._temporary_directory = None
+        self.workdir = None
+        if temporary_directory is not None:
+            try:
+                temporary_directory.cleanup()
+            except OSError:
+                logger.exception(
+                    "Failed to remove simradio work directory for node %d",
+                    self.node_id,
+                )
+        if process is not None:
+            time.sleep(PORT_RELEASE_SETTLE_SECONDS)
+
+    def _archive_logs(self) -> None:
+        """Copy process logs to the configured persistent CI artifact directory."""
+        if self.log_root is None or self.workdir is None:
+            return
+        destination = self.log_root / f"node-{self.node_id}" / self.workdir.name
+        try:
+            destination.mkdir(parents=True, exist_ok=True)
+            for filename in ("meshtasticd.log", "meshtasticd.err"):
+                source = self.workdir / filename
+                if source.exists():
+                    shutil.copy2(source, destination / filename)
+        except OSError:
+            logger.exception(
+                "Failed to archive simradio logs for node %d to %s",
+                self.node_id,
+                destination,
+            )
+
+
+class SimMesh:
+    """Manage simulator nodes and bridge packets through a directed topology."""
+
+    def __init__(
+        self,
+        node_count: int = 1,
+        *,
+        topology: Mapping[int, Collection[int]] | None = None,
+        base_port: int = DEFAULT_BASE_PORT,
+        log_root: Path | None = None,
+    ) -> None:
+        if node_count <= 0:
+            raise ValueError("node_count must be positive")
+        if base_port <= 0 or base_port + node_count - 1 > 65_535:
+            raise ValueError("simradio port range must stay within 1..65535")
+        self.node_count = node_count
+        self.topology = _copy_channel_topology(topology, node_count)
+        self.base_port = base_port
+        self.nodes = [
+            SimNode(index, base_port=base_port, log_root=log_root)
+            for index in range(node_count)
+        ]
+        self._port_to_index: dict[int, int] = {}
+        self._bridge_lock = threading.Lock()
+        self._subscribed = False
+        self._started = False
+
+    def start(self) -> None:
+        """Start and connect all nodes, cleaning up atomically on failure."""
+        if self._started:
+            raise RuntimeError("simradio mesh is already started")
+        binary = find_meshtasticd()
+        if binary is None:
+            raise RuntimeError(
+                "meshtasticd not found; set MESHTASTICD_BIN or install it on PATH"
+            )
+        try:
+            for node in self.nodes:
+                node.start(binary)
+            for node in self.nodes:
+                node.connect()
+                self._port_to_index[node.port] = node.node_id
+            pub.subscribe(self._on_sim_packet, "meshtastic.receive.simulator")
+            self._subscribed = True
+            self._started = True
+            if self.node_count > 1:
+                self.trigger_node_info_exchange()
+        except Exception:
+            self.stop()
+            raise
+
+    def stop(self) -> None:
+        """Unsubscribe and close every node, including partially started meshes."""
+        if self._subscribed:
+            with contextlib.suppress(Exception):
+                pub.unsubscribe(self._on_sim_packet, "meshtastic.receive.simulator")
+            self._subscribed = False
+        self._started = False
+        with self._bridge_lock:
+            self._port_to_index.clear()
+        for node in reversed(self.nodes):
+            try:
+                node.close()
+            except Exception:  # pylint: disable=broad-except
+                logger.exception("Failed to close simradio node %d", node.node_id)
+
+    def reconnect_all(self) -> None:
+        """Reconnect every harness interface after reboot-capable config changes."""
+        for node in self.nodes:
+            node.connect()
+        if self.node_count > 1:
+            self.trigger_node_info_exchange()
+
+    def get_node(self, index: int) -> SimNode:
+        """Return one simulator node by zero-based index."""
+        return self.nodes[index]
+
+    def get_iface(self, index: int) -> TCPInterface:
+        """Return a connected interface for one simulator node."""
+        iface = self.nodes[index].iface
+        if iface is None:
+            raise RuntimeError(f"simradio node {index} is not connected")
+        return iface
+
+    def trigger_node_info_exchange(self) -> None:
+        """Request broadcast NodeInfo responses to accelerate DB convergence."""
+        for node in self.nodes:
+            iface = node.iface
+            if iface is None:
+                continue
+            user = mesh_pb2.User(
+                id=f"!{node.node_num:08x}",
+                long_name=f"Simradio Node {node.node_id}",
+                short_name=f"S{node.node_id:03d}"[-4:],
+                hw_model=mesh_pb2.HardwareModel.PORTDUINO,
+            )
+            try:
+                iface.sendData(
+                    user,
+                    destinationId=BROADCAST_NUM,
+                    portNum=portnums_pb2.PortNum.NODEINFO_APP,
+                    wantAck=False,
+                    wantResponse=True,
+                )
+            except Exception as exc:  # pylint: disable=broad-except
+                logger.debug(
+                    "NodeInfo trigger for simradio node %d failed: %s",
+                    node.node_id,
+                    exc,
+                )
+        time.sleep(NODE_INFO_SETTLE_SECONDS)
+
+    def node_db_counts(self) -> list[int]:
+        """Return current node-database sizes for diagnostics."""
+        return [
+            len(node.iface.nodes)
+            if node.iface is not None and node.iface.nodes is not None
+            else 0
+            for node in self.nodes
+        ]
+
+    def wait_for_convergence(self, timeout: float = 30.0) -> bool:
+        """Wait until every node database contains the complete simulated mesh."""
+        if self.node_count <= 1:
+            return True
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if all(count >= self.node_count for count in self.node_db_counts()):
+                return True
+            time.sleep(0.5)
+        logger.warning(
+            "Simradio mesh did not converge in %.1fs; node DB counts=%s",
+            timeout,
+            self.node_db_counts(),
+        )
+        return False
+
+    def _receiver_indices(self, transmitter_index: int) -> tuple[int, ...]:
+        """Return deterministic receivers for a transmitter node."""
+        if self.topology is not None:
+            return tuple(sorted(self.topology.get(transmitter_index, frozenset())))
+        return tuple(
+            index for index in range(self.node_count) if index != transmitter_index
+        )
+
+    def _on_sim_packet(
+        self,
+        packet: dict[str, Any],
+        interface: MeshInterface,
+    ) -> None:
+        """Forward one SIMULATOR_APP packet to topology-selected receivers."""
+        transmitter_port = getattr(interface, "portNumber", None)
+        if not isinstance(transmitter_port, int):
+            return
+        transmitter_index = self._port_to_index.get(transmitter_port)
+        if transmitter_index is None:
+            return
+        receiver_indices = self._receiver_indices(transmitter_index)
+        if not receiver_indices:
+            return
+        decoded = packet.get("decoded")
+        if not isinstance(decoded, dict):
+            logger.warning("Dropping simulator packet without decoded mapping")
+            return
+        payload = decoded.get("payload", b"")
+        if hasattr(payload, "SerializeToString"):
+            payload = payload.SerializeToString()
+        if not isinstance(payload, bytes):
+            try:
+                payload = bytes(payload)
+            except (TypeError, ValueError):
+                logger.warning("Dropping simulator packet with non-bytes payload")
+                return
+        if len(payload) > mesh_pb2.Constants.DATA_PAYLOAD_LEN:
+            logger.warning("Dropping oversized simulator payload: %d bytes", len(payload))
+            return
+        try:
+            base_packet = _build_mesh_packet(packet, payload)
+        except (TypeError, ValueError) as exc:
+            logger.warning("Dropping malformed simulator packet: %s", exc)
+            return
+        with self._bridge_lock:
+            if not self._started:
+                return
+            for receiver_index in receiver_indices:
+                receiver_iface = self.nodes[receiver_index].iface
+                if receiver_iface is None:
+                    continue
+                received_packet = mesh_pb2.MeshPacket()
+                received_packet.CopyFrom(base_packet)
+                received_packet.rx_rssi = DEFAULT_RSSI
+                received_packet.rx_snr = DEFAULT_SNR
+                to_radio = mesh_pb2.ToRadio()
+                to_radio.packet.CopyFrom(received_packet)
+                try:
+                    _inject_simulator_packet(receiver_iface, to_radio)
+                except Exception as exc:  # pylint: disable=broad-except
+                    logger.error(
+                        "Failed forwarding simulator packet from node %d to node %d: %s",
+                        transmitter_index,
+                        receiver_index,
+                        exc,
+                    )
+
+    def __enter__(self) -> SimMesh:
+        self.start()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.stop()
+
+
+def _build_mesh_packet(
+    packet: Mapping[str, Any], payload: bytes
+) -> mesh_pb2.MeshPacket:
+    """Reconstruct the firmware-facing packet used for simulator injection."""
+    mesh_packet = mesh_pb2.MeshPacket()
+    mesh_packet.decoded.payload = payload
+    mesh_packet.decoded.portnum = portnums_pb2.PortNum.SIMULATOR_APP
+    mesh_packet.to = int(packet.get("to", BROADCAST_NUM))
+    setattr(mesh_packet, "from", int(packet.get("from", 0)))
+    mesh_packet.id = int(packet.get("id", 0))
+    mesh_packet.want_ack = bool(packet.get("wantAck", False))
+    mesh_packet.hop_limit = int(packet.get("hopLimit", 0))
+    mesh_packet.hop_start = int(packet.get("hopStart", 0))
+    mesh_packet.via_mqtt = bool(packet.get("viaMQTT", False))
+    mesh_packet.relay_node = int(packet.get("relayNode", 0))
+    mesh_packet.next_hop = int(packet.get("nextHop", 0))
+    mesh_packet.channel = int(packet.get("channel", 0))
+    decoded = packet.get("decoded")
+    if isinstance(decoded, Mapping):
+        if "requestId" in decoded:
+            mesh_packet.decoded.request_id = int(decoded["requestId"])
+        if "wantResponse" in decoded:
+            mesh_packet.decoded.want_response = bool(decoded["wantResponse"])
+    return mesh_packet

--- a/meshtastic/tests/simradio_harness.py
+++ b/meshtastic/tests/simradio_harness.py
@@ -32,6 +32,8 @@ from meshtastic.mesh_interface import MeshInterface
 from meshtastic.protobuf import mesh_pb2, portnums_pb2
 from meshtastic.tcp_interface import TCPInterface
 
+from .simradio_helpers import connect_iface
+
 logger = logging.getLogger(__name__)
 
 HW_ID_OFFSET = 16
@@ -40,7 +42,6 @@ DEFAULT_RSSI = -50
 DEFAULT_SNR = 10.0
 BOOT_TIMEOUT_SECONDS = 30.0
 PROCESS_EXIT_TIMEOUT_SECONDS = 5.0
-NODE_INFO_SETTLE_SECONDS = 5.0
 PORT_RELEASE_SETTLE_SECONDS = 0.25
 MAX_LOG_TAIL_BYTES = 16_384
 
@@ -68,28 +69,10 @@ def is_compatible_host() -> bool:
     return platform.system() == "Linux"
 
 
-def _wait_for_port(port: int, timeout: float = BOOT_TIMEOUT_SECONDS) -> None:
-    """Wait until localhost accepts a TCP connection on ``port``."""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            with socket.create_connection(("localhost", port), timeout=0.5):
-                return
-        except OSError:
-            time.sleep(0.2)
-    raise TimeoutError(f"localhost:{port} did not listen within {timeout:.1f}s")
-
-
 def _ensure_port_available(port: int) -> None:
     """Fail before launch when another process already owns ``port``."""
     try:
-        with socket.create_connection(("127.0.0.1", port), timeout=0.2):
-            raise RuntimeError(f"localhost:{port} is already in use")
-    except OSError:
-        pass
-    try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
-            probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             probe.bind(("127.0.0.1", port))
     except OSError as exc:
         raise RuntimeError(f"localhost:{port} is already in use") from exc
@@ -204,7 +187,6 @@ class SimNode:
                 stderr=stderr_file,
                 start_new_session=True,
             )
-            _wait_for_port(self.port)
             if self.process.poll() is not None:
                 raise RuntimeError(
                     f"meshtasticd node {self.node_id} exited with "
@@ -218,17 +200,26 @@ class SimNode:
                 f"{self.port}: {exc}\n{diagnostics}"
             ) from exc
 
-    def connect(self) -> TCPInterface:
-        """Open a fresh TCPInterface connection to this simulator."""
+    def connect(self, timeout: float = BOOT_TIMEOUT_SECONDS) -> TCPInterface:
+        """Retry and retain the sole TCPInterface connection to this simulator."""
         self.disconnect()
-        _wait_for_port(self.port)
-        self.iface = TCPInterface(
-            hostname="localhost",
-            portNumber=self.port,
-            connectNow=True,
-            connectTimeout=10.0,
-        )
-        return self.iface
+        process = self.process
+        if process is None:
+            raise RuntimeError(f"simradio node {self.node_id} is not started")
+        if process.poll() is not None:
+            raise RuntimeError(
+                f"meshtasticd node {self.node_id} exited with status "
+                f"{process.returncode}\n{self.diagnostics()}"
+            )
+        try:
+            iface = connect_iface(self.port, wait_timeout=timeout)
+        except Exception as exc:
+            raise RuntimeError(
+                f"meshtasticd node {self.node_id} did not become ready on port "
+                f"{self.port}: {exc}\n{self.diagnostics()}"
+            ) from exc
+        self.iface = iface
+        return iface
 
     def disconnect(self) -> None:
         """Close only the Python interface while leaving firmware running."""
@@ -428,7 +419,6 @@ class SimMesh:
                     node.node_id,
                     exc,
                 )
-        time.sleep(NODE_INFO_SETTLE_SECONDS)
 
     def node_db_counts(self) -> list[int]:
         """Return current node-database sizes for diagnostics."""
@@ -502,25 +492,29 @@ class SimMesh:
         with self._bridge_lock:
             if not self._started:
                 return
-            for receiver_index in receiver_indices:
-                receiver_iface = self.nodes[receiver_index].iface
-                if receiver_iface is None:
-                    continue
-                received_packet = mesh_pb2.MeshPacket()
-                received_packet.CopyFrom(base_packet)
-                received_packet.rx_rssi = DEFAULT_RSSI
-                received_packet.rx_snr = DEFAULT_SNR
-                to_radio = mesh_pb2.ToRadio()
-                to_radio.packet.CopyFrom(received_packet)
-                try:
-                    _inject_simulator_packet(receiver_iface, to_radio)
-                except Exception as exc:  # pylint: disable=broad-except
-                    logger.error(
-                        "Failed forwarding simulator packet from node %d to node %d: %s",
-                        transmitter_index,
-                        receiver_index,
-                        exc,
-                    )
+            receivers = tuple(
+                (receiver_index, self.nodes[receiver_index].iface)
+                for receiver_index in receiver_indices
+            )
+
+        for receiver_index, receiver_iface in receivers:
+            if receiver_iface is None:
+                continue
+            received_packet = mesh_pb2.MeshPacket()
+            received_packet.CopyFrom(base_packet)
+            received_packet.rx_rssi = DEFAULT_RSSI
+            received_packet.rx_snr = DEFAULT_SNR
+            to_radio = mesh_pb2.ToRadio()
+            to_radio.packet.CopyFrom(received_packet)
+            try:
+                _inject_simulator_packet(receiver_iface, to_radio)
+            except Exception as exc:  # pylint: disable=broad-except
+                logger.error(
+                    "Failed forwarding simulator packet from node %d to node %d: %s",
+                    transmitter_index,
+                    receiver_index,
+                    exc,
+                )
 
     def __enter__(self) -> SimMesh:
         self.start()

--- a/meshtastic/tests/simradio_harness.py
+++ b/meshtastic/tests/simradio_harness.py
@@ -43,6 +43,7 @@ DEFAULT_SNR = 10.0
 BOOT_TIMEOUT_SECONDS = 30.0
 PROCESS_EXIT_TIMEOUT_SECONDS = 5.0
 PORT_RELEASE_SETTLE_SECONDS = 0.25
+TEXT_MESSAGE_MIN_INTERVAL_SECONDS = 1.1
 MAX_LOG_TAIL_BYTES = 16_384
 
 CHAIN_TOPOLOGY: Mapping[int, frozenset[int]] = MappingProxyType(
@@ -333,6 +334,8 @@ class SimMesh:
         ]
         self._port_to_index: dict[int, int] = {}
         self._bridge_lock = threading.Lock()
+        self._text_send_lock = threading.Lock()
+        self._last_text_send_at: dict[int, float] = {}
         self._subscribed = False
         self._started = False
 
@@ -345,6 +348,8 @@ class SimMesh:
             raise RuntimeError(
                 "meshtasticd not found; set MESHTASTICD_BIN or install it on PATH"
             )
+        with self._text_send_lock:
+            self._last_text_send_at.clear()
         try:
             for node in self.nodes:
                 node.start(binary)
@@ -392,6 +397,33 @@ class SimMesh:
         if iface is None:
             raise RuntimeError(f"simradio node {index} is not connected")
         return iface
+
+    def send_text(
+        self,
+        sender_index: int,
+        text: str,
+        **kwargs: Any,
+    ) -> mesh_pb2.MeshPacket:
+        """Send text while respecting firmware's PhoneAPI text throttle.
+
+        The mesh fixture is module-scoped, so a test may begin immediately
+        after the previous test's text send.  Some firmware channels reject a
+        second ``TEXT_MESSAGE_APP`` packet during that short interval instead
+        of queueing it.  Pace sends per originating node so test ordering and
+        packet propagation speed cannot decide whether the next packet is
+        accepted.
+        """
+        iface = self.get_iface(sender_index)
+        with self._text_send_lock:
+            now = time.monotonic()
+            last_send = self._last_text_send_at.get(sender_index)
+            if last_send is not None:
+                remaining = TEXT_MESSAGE_MIN_INTERVAL_SECONDS - (now - last_send)
+                if remaining > 0:
+                    time.sleep(remaining)
+            result = iface.sendText(text, **kwargs)
+            self._last_text_send_at[sender_index] = time.monotonic()
+        return result
 
     def trigger_node_info_exchange(self) -> None:
         """Request broadcast NodeInfo responses to accelerate DB convergence."""

--- a/meshtastic/tests/simradio_harness.py
+++ b/meshtastic/tests/simradio_harness.py
@@ -10,6 +10,7 @@ Docker jobs retain a pinned regression baseline.
 from __future__ import annotations
 
 import contextlib
+import errno
 import logging
 import os
 import platform
@@ -25,7 +26,7 @@ from dataclasses import dataclass
 from collections.abc import Collection, Mapping
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any, BinaryIO
+from typing import Any, BinaryIO, Literal
 
 from pubsub import pub
 
@@ -47,6 +48,7 @@ PROCESS_EXIT_TIMEOUT_SECONDS = 5.0
 PORT_RELEASE_SETTLE_SECONDS = 0.25
 TEXT_MESSAGE_MIN_INTERVAL_SECONDS = 2.25
 REBOOT_POLL_INTERVAL_SECONDS = 0.1
+PORT_LISTENER_PROBE_TIMEOUT_SECONDS = 0.1
 MAX_LOG_TAIL_BYTES = 16_384
 CONTEXT_FILENAME = "simradio-context.txt"
 REBOOT_RECOVERY_FILENAME = "simradio-reboot-recovery.txt"
@@ -84,12 +86,26 @@ def is_compatible_host() -> bool:
 
 
 def _ensure_port_available(port: int) -> None:
-    """Fail before launch when another process already owns ``port``."""
+    """Fail when another process is actively listening on ``port``.
+
+    A bind probe is too strict for restart validation because an exited TCP
+    server can leave accepted connections in kernel teardown states even though
+    no process owns the listening socket.  The harness only needs to prevent
+    attaching to an unrelated live service, so probe for a listener instead and
+    let ``meshtasticd`` perform the authoritative bind.
+    """
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
-            probe.bind(("127.0.0.1", port))
+            probe.settimeout(PORT_LISTENER_PROBE_TIMEOUT_SECONDS)
+            result = probe.connect_ex(("127.0.0.1", port))
     except OSError as exc:
-        raise RuntimeError(f"localhost:{port} is already in use") from exc
+        raise RuntimeError(f"cannot inspect localhost:{port}: {exc}") from exc
+    if result == 0:
+        raise RuntimeError(f"localhost:{port} is already in use")
+    if result != errno.ECONNREFUSED:
+        raise RuntimeError(
+            f"cannot confirm localhost:{port} is available: connect_ex returned {result}"
+        )
 
 
 def _copy_channel_topology(
@@ -209,7 +225,7 @@ class SimNode:
         if self.process is not None:
             raise RuntimeError(f"simradio node {self.node_id} already owns a process")
         _ensure_port_available(self.port)
-        mode = "ab" if append_logs else "wb"
+        mode: Literal["ab", "wb"] = "ab" if append_logs else "wb"
         stdout_file = (workdir / "meshtasticd.log").open(mode, buffering=0)
         stderr_file = (workdir / "meshtasticd.err").open(mode, buffering=0)
         try:

--- a/meshtastic/tests/simradio_harness.py
+++ b/meshtastic/tests/simradio_harness.py
@@ -13,6 +13,7 @@ import contextlib
 import logging
 import os
 import platform
+import re
 import shutil
 import signal
 import socket
@@ -20,6 +21,7 @@ import subprocess
 import tempfile
 import threading
 import time
+from dataclasses import dataclass
 from collections.abc import Collection, Mapping
 from pathlib import Path
 from types import MappingProxyType
@@ -47,6 +49,15 @@ TEXT_MESSAGE_MIN_INTERVAL_SECONDS = 2.25
 REBOOT_POLL_INTERVAL_SECONDS = 0.1
 MAX_LOG_TAIL_BYTES = 16_384
 CONTEXT_FILENAME = "simradio-context.txt"
+REBOOT_RECOVERY_FILENAME = "simradio-reboot-recovery.txt"
+FACTORY_RESET_REBOOT_MARKERS = (
+    "Factory config reset finished, rebooting soon",
+    "Reboot in ",
+)
+KNOWN_FACTORY_RESET_REBOOT_EXIT_CODES: frozenset[int] = frozenset(
+    {-signal.SIGSEGV}
+)
+KNOWN_FACTORY_RESET_REBOOT_VERSION_RE = re.compile(r"\bS:B:\d+,2\.7\.\d+,")
 
 CHAIN_TOPOLOGY: Mapping[int, frozenset[int]] = MappingProxyType(
     {
@@ -124,6 +135,15 @@ def _inject_simulator_packet(
     sender(to_radio)
 
 
+@dataclass(frozen=True)
+class RebootCheckpoint:
+    """Identify one running process and the log position before a reboot command."""
+
+    boot_count: int
+    log_size: int
+    process_pid: int
+
+
 class SimNode:
     """Own one meshtasticd process, filesystem, logs, and TCP interface."""
 
@@ -147,6 +167,9 @@ class SimNode:
         self.iface: TCPInterface | None = None
         self._temporary_directory: tempfile.TemporaryDirectory[str] | None = None
         self._log_files: list[BinaryIO] = []
+        self._binary: str | None = None
+        self._restart_count = 0
+        self._last_reboot_exit_status: int | None = None
 
     @property
     def node_num(self) -> int:
@@ -160,21 +183,37 @@ class SimNode:
         """Launch a freshly erased meshtasticd simulator process."""
         if self.process is not None or self._temporary_directory is not None:
             raise RuntimeError(f"simradio node {self.node_id} is already started")
-        _ensure_port_available(self.port)
         try:
             self._temporary_directory = tempfile.TemporaryDirectory(
                 prefix=f"meshtasticd-simradio-{self.node_id}-"
             )
             self.workdir = Path(self._temporary_directory.name)
-            vfs_directory = self.workdir / "vfs"
-            vfs_directory.mkdir()
-            stdout_path = self.workdir / "meshtasticd.log"
-            stderr_path = self.workdir / "meshtasticd.err"
-            stdout_file = stdout_path.open("wb", buffering=0)
-            self._log_files.append(stdout_file)
-            stderr_file = stderr_path.open("wb", buffering=0)
-            self._log_files.append(stderr_file)
-            self.process = subprocess.Popen(  # pylint: disable=consider-using-with
+            (self.workdir / "vfs").mkdir()
+            self._binary = binary
+            self._restart_count = 0
+            self._last_reboot_exit_status = None
+            self._launch_process(binary, append_logs=False)
+        except Exception as exc:
+            diagnostics = self.diagnostics()
+            self.close(send_exit=False)
+            raise RuntimeError(
+                f"meshtasticd node {self.node_id} failed to start on port "
+                f"{self.port}: {exc}\n{diagnostics}"
+            ) from exc
+
+    def _launch_process(self, binary: str, *, append_logs: bool) -> None:
+        """Launch against the current VFS, optionally appending to existing logs."""
+        workdir = self.workdir
+        if workdir is None:
+            raise RuntimeError(f"simradio node {self.node_id} has no work directory")
+        if self.process is not None:
+            raise RuntimeError(f"simradio node {self.node_id} already owns a process")
+        _ensure_port_available(self.port)
+        mode = "ab" if append_logs else "wb"
+        stdout_file = (workdir / "meshtasticd.log").open(mode, buffering=0)
+        stderr_file = (workdir / "meshtasticd.err").open(mode, buffering=0)
+        try:
+            process = subprocess.Popen(  # pylint: disable=consider-using-with
                 [
                     binary,
                     "-s",
@@ -183,26 +222,25 @@ class SimNode:
                     "-p",
                     str(self.port),
                     "-d",
-                    str(vfs_directory),
+                    str(workdir / "vfs"),
                     "-e",
                 ],
                 stdout=stdout_file,
                 stderr=stderr_file,
                 start_new_session=True,
             )
-            if self.process.poll() is not None:
-                raise RuntimeError(
-                    f"meshtasticd node {self.node_id} exited with "
-                    f"status {self.process.returncode} during startup"
-                )
-            self._write_context(binary)
-        except Exception as exc:
-            diagnostics = self.diagnostics()
-            self.close(send_exit=False)
+        except Exception:
+            stdout_file.close()
+            stderr_file.close()
+            raise
+        self._log_files.extend((stdout_file, stderr_file))
+        self.process = process
+        if process.poll() is not None:
             raise RuntimeError(
-                f"meshtasticd node {self.node_id} failed to start on port "
-                f"{self.port}: {exc}\n{diagnostics}"
-            ) from exc
+                f"meshtasticd node {self.node_id} exited with "
+                f"status {process.returncode} during startup"
+            )
+        self._write_context(binary)
 
     def _write_context(self, binary: str) -> None:
         """Persist source, workflow, and fixture identity beside daemon logs."""
@@ -225,6 +263,13 @@ class SimNode:
             ("github_run_id", os.environ.get("GITHUB_RUN_ID", "")),
             ("github_run_attempt", os.environ.get("GITHUB_RUN_ATTEMPT", "")),
             ("meshtasticd_channel", os.environ.get("MESHTASTICD_CHANNEL", "")),
+            ("restart_count", str(self._restart_count)),
+            (
+                "last_reboot_exit_status",
+                ""
+                if self._last_reboot_exit_status is None
+                else str(self._last_reboot_exit_status),
+            ),
         )
         content = "".join(f"{key}={value}\n" for key, value in values)
         try:
@@ -276,6 +321,169 @@ class SimNode:
             return 0
         return output.count(f"Using config file {self.port}")
 
+    def reboot_checkpoint(self) -> RebootCheckpoint:
+        """Capture the owned process and log position before a rebooting command."""
+        process = self.process
+        workdir = self.workdir
+        if process is None or workdir is None:
+            raise RuntimeError(f"simradio node {self.node_id} is not started")
+        if process.poll() is not None:
+            raise RuntimeError(
+                f"meshtasticd node {self.node_id} already exited with status "
+                f"{process.returncode}"
+            )
+        try:
+            log_size = (workdir / "meshtasticd.log").stat().st_size
+        except OSError as exc:
+            raise RuntimeError(
+                f"cannot capture reboot log checkpoint for node {self.node_id}: {exc}"
+            ) from exc
+        return RebootCheckpoint(
+            boot_count=self.boot_count(),
+            log_size=log_size,
+            process_pid=process.pid,
+        )
+
+    def _log_since(self, offset: int) -> str:
+        """Read daemon output appended after a previously captured byte offset."""
+        workdir = self.workdir
+        if workdir is None:
+            return ""
+        try:
+            with (workdir / "meshtasticd.log").open("rb") as log_file:
+                log_file.seek(max(0, offset))
+                return log_file.read().decode("utf-8", errors="replace")
+        except OSError:
+            return ""
+
+    def wait_for_factory_reset_reboot(
+        self,
+        checkpoint: RebootCheckpoint,
+        *,
+        timeout: float = BOOT_TIMEOUT_SECONDS,
+    ) -> int | None:
+        """Wait for reset reboot, recovering only the known 2.7 Portduino crash.
+
+        Firmware 2.7 can persist a completed factory reset and then terminate with
+        ``SIGSEGV`` when its delayed Portduino reboot fires.  Recovery is allowed
+        only when the exact post-checkpoint reset and reboot markers are present.
+        The same VFS is relaunched and a new boot marker is still required.
+        """
+        if checkpoint.boot_count < 0 or checkpoint.log_size < 0:
+            raise ValueError("invalid reboot checkpoint")
+        if timeout <= 0:
+            raise ValueError("timeout must be positive")
+        process = self.process
+        if process is None:
+            raise RuntimeError(f"simradio node {self.node_id} is not started")
+        if process.pid != checkpoint.process_pid:
+            raise RuntimeError(
+                f"simradio node {self.node_id} process changed before reboot wait"
+            )
+
+        deadline = time.monotonic() + timeout
+        recovered_exit_status: int | None = None
+        while time.monotonic() < deadline:
+            status = process.poll()
+            if status is not None:
+                if recovered_exit_status is not None:
+                    raise RuntimeError(
+                        f"replacement meshtasticd node {self.node_id} exited with "
+                        f"status {status} while waiting for reboot\n{self.diagnostics()}"
+                    )
+                evidence = self._log_since(checkpoint.log_size)
+                full_log = self._log_since(0)
+                missing_markers = [
+                    marker
+                    for marker in FACTORY_RESET_REBOOT_MARKERS
+                    if marker not in evidence
+                ]
+                if not KNOWN_FACTORY_RESET_REBOOT_VERSION_RE.search(full_log):
+                    missing_markers.append("firmware 2.7 boot banner")
+                if (
+                    status not in KNOWN_FACTORY_RESET_REBOOT_EXIT_CODES
+                    or missing_markers
+                ):
+                    marker_detail = ", ".join(repr(marker) for marker in missing_markers)
+                    raise RuntimeError(
+                        f"meshtasticd node {self.node_id} exited with unexpected "
+                        f"status {status} while waiting for factory-reset reboot; "
+                        f"missing markers: {marker_detail or 'none'}\n"
+                        f"{self.diagnostics()}"
+                    )
+                recovered_exit_status = status
+                self._restart_after_expected_reboot_exit(
+                    checkpoint=checkpoint,
+                    exit_status=status,
+                    evidence=evidence,
+                )
+                process = self.process
+                if process is None:
+                    raise RuntimeError(
+                        f"simradio node {self.node_id} recovery did not launch a process"
+                    )
+                continue
+            if self.boot_count() > checkpoint.boot_count:
+                return recovered_exit_status
+            time.sleep(REBOOT_POLL_INTERVAL_SECONDS)
+        raise RuntimeError(
+            f"meshtasticd node {self.node_id} did not complete factory-reset reboot "
+            f"within {timeout:.1f}s; boot count remained {self.boot_count()}\n"
+            f"{self.diagnostics()}"
+        )
+
+    def _restart_after_expected_reboot_exit(
+        self,
+        *,
+        checkpoint: RebootCheckpoint,
+        exit_status: int,
+        evidence: str,
+    ) -> None:
+        """Relaunch the same VFS after a narrowly validated reboot-time exit."""
+        process = self.process
+        binary = self._binary
+        workdir = self.workdir
+        if process is None or binary is None or workdir is None:
+            raise RuntimeError(f"simradio node {self.node_id} cannot be recovered")
+        if process.pid != checkpoint.process_pid or process.poll() != exit_status:
+            raise RuntimeError(
+                f"simradio node {self.node_id} recovery process no longer matches "
+                "the reboot checkpoint"
+            )
+        old_pid = process.pid
+        self.disconnect()
+        self.process = None
+        self._close_log_files()
+        time.sleep(PORT_RELEASE_SETTLE_SECONDS)
+        self._restart_count += 1
+        self._last_reboot_exit_status = exit_status
+        self._launch_process(binary, append_logs=True)
+        replacement = self.process
+        if replacement is None:
+            raise RuntimeError(f"simradio node {self.node_id} recovery launch failed")
+        signal_name = ""
+        if exit_status < 0:
+            with contextlib.suppress(ValueError):
+                signal_name = signal.Signals(-exit_status).name
+        recovery_record = (
+            "event=factory-reset-reboot-process-recovery\n"
+            f"old_pid={old_pid}\n"
+            f"new_pid={replacement.pid}\n"
+            f"exit_status={exit_status}\n"
+            f"exit_signal={signal_name}\n"
+            f"checkpoint_boot_count={checkpoint.boot_count}\n"
+            f"evidence_bytes={len(evidence.encode('utf-8'))}\n"
+        )
+        try:
+            with (workdir / REBOOT_RECOVERY_FILENAME).open(
+                "a", encoding="utf-8"
+            ) as recovery_file:
+                recovery_file.write(recovery_record)
+        except OSError:
+            logger.exception(
+                "Failed to write reboot recovery record for node %d", self.node_id
+            )
+
     def wait_for_reboot(
         self,
         previous_boot_count: int,
@@ -317,7 +525,10 @@ class SimNode:
         if workdir is None:
             return "simradio diagnostics unavailable: no work directory"
         sections: list[str] = []
-        for filename in ("meshtasticd.log", "meshtasticd.err", CONTEXT_FILENAME):
+        filenames = ["meshtasticd.log", "meshtasticd.err", CONTEXT_FILENAME]
+        if (workdir / REBOOT_RECOVERY_FILENAME).exists():
+            filenames.append(REBOOT_RECOVERY_FILENAME)
+        for filename in filenames:
             path = workdir / filename
             try:
                 raw = path.read_bytes()[-MAX_LOG_TAIL_BYTES:]
@@ -328,6 +539,13 @@ class SimNode:
                 f"[{filename} tail]\n{raw.decode('utf-8', errors='replace')}"
             )
         return "\n".join(sections)
+
+    def _close_log_files(self) -> None:
+        """Close every parent-owned daemon log handle."""
+        for log_file in self._log_files:
+            with contextlib.suppress(Exception):
+                log_file.close()
+        self._log_files.clear()
 
     def close(self, *, send_exit: bool = True) -> None:
         """Close the interface, terminate the process group, and archive logs."""
@@ -353,14 +571,14 @@ class SimNode:
                 with contextlib.suppress(subprocess.TimeoutExpired):
                     process.wait(timeout=PROCESS_EXIT_TIMEOUT_SECONDS)
 
-        for log_file in self._log_files:
-            with contextlib.suppress(Exception):
-                log_file.close()
-        self._log_files.clear()
+        self._close_log_files()
         self._archive_logs()
         temporary_directory = self._temporary_directory
         self._temporary_directory = None
         self.workdir = None
+        self._binary = None
+        self._restart_count = 0
+        self._last_reboot_exit_status = None
         if temporary_directory is not None:
             try:
                 temporary_directory.cleanup()
@@ -379,7 +597,12 @@ class SimNode:
         destination = self.log_root / f"node-{self.node_id}" / self.workdir.name
         try:
             destination.mkdir(parents=True, exist_ok=True)
-            for filename in ("meshtasticd.log", "meshtasticd.err", CONTEXT_FILENAME):
+            for filename in (
+                "meshtasticd.log",
+                "meshtasticd.err",
+                CONTEXT_FILENAME,
+                REBOOT_RECOVERY_FILENAME,
+            ):
                 source = self.workdir / filename
                 if source.exists():
                     shutil.copy2(source, destination / filename)

--- a/meshtastic/tests/simradio_harness.py
+++ b/meshtastic/tests/simradio_harness.py
@@ -579,4 +579,9 @@ def _build_mesh_packet(
             mesh_packet.decoded.request_id = int(decoded["requestId"])
         if "wantResponse" in decoded:
             mesh_packet.decoded.want_response = bool(decoded["wantResponse"])
+        if "bitfield" in decoded:
+            # Data.bitfield is proto3-optional.  Assign even zero so presence is
+            # retained: firmware 2.8 uses it to distinguish a valid modern
+            # hop_start=0 packet from legacy packets that omitted hop_start.
+            mesh_packet.decoded.bitfield = int(decoded["bitfield"])
     return mesh_packet

--- a/meshtastic/tests/simradio_harness.py
+++ b/meshtastic/tests/simradio_harness.py
@@ -46,6 +46,7 @@ PORT_RELEASE_SETTLE_SECONDS = 0.25
 TEXT_MESSAGE_MIN_INTERVAL_SECONDS = 2.25
 REBOOT_POLL_INTERVAL_SECONDS = 0.1
 MAX_LOG_TAIL_BYTES = 16_384
+CONTEXT_FILENAME = "simradio-context.txt"
 
 CHAIN_TOPOLOGY: Mapping[int, frozenset[int]] = MappingProxyType(
     {
@@ -194,6 +195,7 @@ class SimNode:
                     f"meshtasticd node {self.node_id} exited with "
                     f"status {self.process.returncode} during startup"
                 )
+            self._write_context(binary)
         except Exception as exc:
             diagnostics = self.diagnostics()
             self.close(send_exit=False)
@@ -201,6 +203,36 @@ class SimNode:
                 f"meshtasticd node {self.node_id} failed to start on port "
                 f"{self.port}: {exc}\n{diagnostics}"
             ) from exc
+
+    def _write_context(self, binary: str) -> None:
+        """Persist source, workflow, and fixture identity beside daemon logs."""
+        workdir = self.workdir
+        process = self.process
+        if workdir is None or process is None:
+            return
+        values = (
+            ("node_id", str(self.node_id)),
+            ("hw_id", str(self.hw_id)),
+            ("port", str(self.port)),
+            ("pid", str(process.pid)),
+            ("binary", binary),
+            ("pytest_current_test", os.environ.get("PYTEST_CURRENT_TEST", "")),
+            ("github_repository", os.environ.get("GITHUB_REPOSITORY", "")),
+            ("github_sha", os.environ.get("GITHUB_SHA", "")),
+            ("source_sha", os.environ.get("SIMRADIO_SOURCE_SHA", "")),
+            ("github_ref", os.environ.get("GITHUB_REF", "")),
+            ("github_head_ref", os.environ.get("GITHUB_HEAD_REF", "")),
+            ("github_run_id", os.environ.get("GITHUB_RUN_ID", "")),
+            ("github_run_attempt", os.environ.get("GITHUB_RUN_ATTEMPT", "")),
+            ("meshtasticd_channel", os.environ.get("MESHTASTICD_CHANNEL", "")),
+        )
+        content = "".join(f"{key}={value}\n" for key, value in values)
+        try:
+            (workdir / CONTEXT_FILENAME).write_text(content, encoding="utf-8")
+        except OSError:
+            logger.exception(
+                "Failed to write simradio context for node %d", self.node_id
+            )
 
     def connect(self, timeout: float = BOOT_TIMEOUT_SECONDS) -> TCPInterface:
         """Retry and retain the sole TCPInterface connection to this simulator."""
@@ -285,7 +317,7 @@ class SimNode:
         if workdir is None:
             return "simradio diagnostics unavailable: no work directory"
         sections: list[str] = []
-        for filename in ("meshtasticd.log", "meshtasticd.err"):
+        for filename in ("meshtasticd.log", "meshtasticd.err", CONTEXT_FILENAME):
             path = workdir / filename
             try:
                 raw = path.read_bytes()[-MAX_LOG_TAIL_BYTES:]
@@ -347,7 +379,7 @@ class SimNode:
         destination = self.log_root / f"node-{self.node_id}" / self.workdir.name
         try:
             destination.mkdir(parents=True, exist_ok=True)
-            for filename in ("meshtasticd.log", "meshtasticd.err"):
+            for filename in ("meshtasticd.log", "meshtasticd.err", CONTEXT_FILENAME):
                 source = self.workdir / filename
                 if source.exists():
                     shutil.copy2(source, destination / filename)

--- a/meshtastic/tests/simradio_harness.py
+++ b/meshtastic/tests/simradio_harness.py
@@ -43,7 +43,8 @@ DEFAULT_SNR = 10.0
 BOOT_TIMEOUT_SECONDS = 30.0
 PROCESS_EXIT_TIMEOUT_SECONDS = 5.0
 PORT_RELEASE_SETTLE_SECONDS = 0.25
-TEXT_MESSAGE_MIN_INTERVAL_SECONDS = 1.1
+TEXT_MESSAGE_MIN_INTERVAL_SECONDS = 2.25
+REBOOT_POLL_INTERVAL_SECONDS = 0.1
 MAX_LOG_TAIL_BYTES = 16_384
 
 CHAIN_TOPOLOGY: Mapping[int, frozenset[int]] = MappingProxyType(
@@ -230,6 +231,54 @@ class SimNode:
             with contextlib.suppress(Exception):
                 iface.close()
 
+    def boot_count(self) -> int:
+        """Return the number of simulator boots recorded in the process log."""
+        workdir = self.workdir
+        if workdir is None:
+            return 0
+        try:
+            output = (workdir / "meshtasticd.log").read_text(
+                encoding="utf-8", errors="replace"
+            )
+        except OSError:
+            return 0
+        return output.count(f"Using config file {self.port}")
+
+    def wait_for_reboot(
+        self,
+        previous_boot_count: int,
+        *,
+        timeout: float = BOOT_TIMEOUT_SECONDS,
+    ) -> None:
+        """Wait until the owned simulator records a boot after ``previous_boot_count``.
+
+        Portduino reboots in-process, so a successful TCP connection alone does
+        not prove that a delayed reboot has occurred.  Its stable
+        ``Using config file <port>`` startup marker does.
+        """
+        if previous_boot_count < 0:
+            raise ValueError("previous_boot_count must not be negative")
+        if timeout <= 0:
+            raise ValueError("timeout must be positive")
+        process = self.process
+        if process is None:
+            raise RuntimeError(f"simradio node {self.node_id} is not started")
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if process.poll() is not None:
+                raise RuntimeError(
+                    f"meshtasticd node {self.node_id} exited with status "
+                    f"{process.returncode} while waiting for reboot\n"
+                    f"{self.diagnostics()}"
+                )
+            if self.boot_count() > previous_boot_count:
+                return
+            time.sleep(REBOOT_POLL_INTERVAL_SECONDS)
+        raise RuntimeError(
+            f"meshtasticd node {self.node_id} did not reboot within {timeout:.1f}s; "
+            f"boot count remained {self.boot_count()}\n{self.diagnostics()}"
+        )
+
     def diagnostics(self) -> str:
         """Return bounded stdout/stderr tails for startup and CI failures."""
         workdir = self.workdir
@@ -408,8 +457,9 @@ class SimMesh:
 
         The mesh fixture is module-scoped, so a test may begin immediately
         after the previous test's text send.  Some firmware channels reject a
-        second ``TEXT_MESSAGE_APP`` packet during that short interval instead
-        of queueing it.  Pace sends per originating node so test ordering and
+        second ``TEXT_MESSAGE_APP`` packet inside its two-second window instead
+        of queueing it.  Pace sends per originating node with a small scheduling
+        margin so test ordering and
         packet propagation speed cannot decide whether the next packet is
         accepted.
         """

--- a/meshtastic/tests/simradio_helpers.py
+++ b/meshtastic/tests/simradio_helpers.py
@@ -14,13 +14,14 @@ from typing import Any
 
 from pubsub import pub
 
-from meshtastic import LOCAL_ADDR
+from meshtastic.protobuf import config_pb2
 from meshtastic.tcp_interface import TCPInterface
 from meshtastic.util import camel_to_snake
 
 logger = logging.getLogger(__name__)
 
 PAUSE_AFTER_CLI_SECONDS = 0.2
+REGION_WRITE_DRAIN_SECONDS = 2
 DEFAULT_CLI_TIMEOUT_SECONDS = 60.0
 DEFAULT_DEVICE_REQUEST_TIMEOUT_SECONDS = 20.0
 DEFAULT_CONNECT_WAIT_SECONDS = 30.0
@@ -418,19 +419,43 @@ def cli_then_verify(
 
 
 def set_region(port: int, region: str = "US") -> None:
-    """Set the simulator LoRa region and wait for the local admin ACK."""
+    """Apply and independently verify a live simulator LoRa-region write.
+
+    LoRa configuration is applied live by current firmware and does not reboot
+    Portduino.  Keep the CLI transport open briefly so its asynchronous local
+    admin packet can drain, then verify the persisted value through a separate
+    connection.  Do not force ``--dest ^local`` here: that selects the CLI's
+    remote-style legacy ACK wait, which can miss an ACK that arrives before the
+    unscoped wait begins.
+    """
+    try:
+        expected_region = config_pb2.Config.LoRaConfig.RegionCode.Value(region)
+    except ValueError as exc:
+        raise ValueError(f"Unknown LoRa region {region!r}") from exc
+
     result = run_cli(
         port,
         "--set",
         "lora.region",
         region,
-        "--dest",
-        LOCAL_ADDR,
+        "--wait-to-disconnect",
+        str(REGION_WRITE_DRAIN_SECONDS),
     )
     if result.returncode != 0:
         raise RuntimeError(
             f"Failed to set lora.region={region} on port {port}:\n{result.output}"
         )
+
+    def _assert_region(iface: TCPInterface) -> None:
+        actual_region = iface.localNode.localConfig.lora.region
+        if actual_region != expected_region:
+            actual_name = config_pb2.Config.LoRaConfig.RegionCode.Name(actual_region)
+            raise AssertionError(
+                f"lora.region did not persist on port {port}: "
+                f"expected {region}, got {actual_name}"
+            )
+
+    verify_state(port, _assert_region)
 
 
 class PacketCollector:

--- a/meshtastic/tests/simradio_helpers.py
+++ b/meshtastic/tests/simradio_helpers.py
@@ -25,6 +25,8 @@ REGION_WRITE_DRAIN_SECONDS = 2
 DEFAULT_CLI_TIMEOUT_SECONDS = 60.0
 DEFAULT_DEVICE_REQUEST_TIMEOUT_SECONDS = 20.0
 DEFAULT_CONNECT_WAIT_SECONDS = 30.0
+DEFAULT_STATE_VERIFY_TIMEOUT_SECONDS = 10.0
+STATE_VERIFY_RETRY_DELAY_SECONDS = 0.25
 CONNECT_ATTEMPT_TIMEOUT_SECONDS = 10.0
 CONNECT_RETRY_DELAY_SECONDS = 0.5
 DEFAULT_RECEIVE_TIMEOUT_SECONDS = 15.0
@@ -392,6 +394,60 @@ def verify_state(
         time.sleep(PAUSE_AFTER_CLI_SECONDS)
 
 
+def verify_state_eventually(
+    port: int,
+    verifier: Callable[[TCPInterface], None],
+    *,
+    no_nodes: bool = False,
+    timeout: float = DEFAULT_STATE_VERIFY_TIMEOUT_SECONDS,
+    retry_delay: float = STATE_VERIFY_RETRY_DELAY_SECONDS,
+) -> None:
+    """Poll fresh connections until an asynchronous firmware state converges.
+
+    The mutation is never replayed.  Only verifier ``AssertionError`` results are
+    retried, so programming errors and unexpected exceptions still fail
+    immediately.  Each attempt uses a fresh configuration snapshot and closes
+    its interface before the bounded retry delay.
+    """
+    if timeout <= 0:
+        raise ValueError("timeout must be positive")
+    if retry_delay < 0:
+        raise ValueError("retry_delay must not be negative")
+
+    deadline = time.monotonic() + timeout
+    attempts = 0
+    last_mismatch: AssertionError | None = None
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        attempts += 1
+        iface = connect_iface(
+            port,
+            no_nodes=no_nodes,
+            wait_timeout=min(DEFAULT_CONNECT_WAIT_SECONDS, remaining),
+        )
+        try:
+            verifier(iface)
+            return
+        except AssertionError as exc:
+            last_mismatch = exc
+        finally:
+            with contextlib.suppress(Exception):
+                iface.close()
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        time.sleep(min(retry_delay, remaining))
+
+    detail = str(last_mismatch) if last_mismatch is not None else "unknown mismatch"
+    raise AssertionError(
+        f"firmware state on localhost:{port} did not converge within "
+        f"{timeout:.1f}s after {attempts} fresh connection(s): {detail}"
+    ) from last_mismatch
+
+
 def cli_then_verify(
     port: int,
     arguments: Sequence[str],
@@ -455,7 +511,7 @@ def set_region(port: int, region: str = "US") -> None:
                 f"expected {region}, got {actual_name}"
             )
 
-    verify_state(port, _assert_region)
+    verify_state_eventually(port, _assert_region)
 
 
 class PacketCollector:

--- a/meshtastic/tests/simradio_helpers.py
+++ b/meshtastic/tests/simradio_helpers.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 
 PAUSE_AFTER_CLI_SECONDS = 0.2
 DEFAULT_CLI_TIMEOUT_SECONDS = 60.0
+DEFAULT_DEVICE_REQUEST_TIMEOUT_SECONDS = 20.0
 DEFAULT_CONNECT_WAIT_SECONDS = 30.0
 CONNECT_ATTEMPT_TIMEOUT_SECONDS = 10.0
 CONNECT_RETRY_DELAY_SECONDS = 0.5
@@ -239,6 +240,7 @@ def run_cli(
     port: int,
     *arguments: str,
     timeout: float = DEFAULT_CLI_TIMEOUT_SECONDS,
+    request_timeout: float | None = DEFAULT_DEVICE_REQUEST_TIMEOUT_SECONDS,
     retries: int | None = None,
     retry_delay: float = 1.0,
 ) -> CLIResult:
@@ -247,6 +249,13 @@ def run_cli(
     ``retries`` controls the maximum retry count after the first attempt.
     When ``retries`` is ``None`` (the default), the value is selected from
     :data:`_DEFAULT_RETRIES` based on the detected operation kind.
+
+    ``request_timeout`` bounds protocol request/response waits inside the CLI.
+    This is intentionally shorter than the subprocess timeout so a firmware
+    feature that accepts an admin request but never answers it cannot strand
+    the test process until pytest's outer timeout fires.  An explicit
+    ``--timeout`` in ``arguments`` takes precedence; pass ``None`` to preserve
+    the CLI's own default.
     """
     if retries is None:
         retries = _DEFAULT_RETRIES[_classify_cli_operation(arguments)]
@@ -254,14 +263,23 @@ def run_cli(
         raise ValueError("retries must not be negative")
     if timeout <= 0:
         raise ValueError("timeout must be positive")
+    if request_timeout is not None and request_timeout <= 0:
+        raise ValueError("request_timeout must be positive or None")
     if retry_delay < 0:
         raise ValueError("retry_delay must not be negative")
+    has_explicit_request_timeout = "--timeout" in arguments
+    request_timeout_arguments = (
+        []
+        if request_timeout is None or has_explicit_request_timeout
+        else ["--timeout", str(min(request_timeout, timeout))]
+    )
     argv = [
         sys.executable,
         "-m",
         "meshtastic",
         "--host",
         f"localhost:{port}",
+        *request_timeout_arguments,
         *arguments,
     ]
     # Never log positional values: configuration commands may contain Wi-Fi

--- a/meshtastic/tests/simradio_helpers.py
+++ b/meshtastic/tests/simradio_helpers.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import contextlib
 import logging
-import socket
 import subprocess
 import sys
 import threading
@@ -16,13 +15,15 @@ from typing import Any
 from pubsub import pub
 
 from meshtastic.tcp_interface import TCPInterface
+from meshtastic.util import camel_to_snake
 
 logger = logging.getLogger(__name__)
 
 PAUSE_AFTER_CLI_SECONDS = 0.2
-PAUSE_AFTER_REGION_CHANGE_SECONDS = 2.0
 DEFAULT_CLI_TIMEOUT_SECONDS = 60.0
 DEFAULT_CONNECT_WAIT_SECONDS = 30.0
+CONNECT_ATTEMPT_TIMEOUT_SECONDS = 10.0
+CONNECT_RETRY_DELAY_SECONDS = 0.5
 DEFAULT_RECEIVE_TIMEOUT_SECONDS = 15.0
 DEFAULT_ABSENCE_TIMEOUT_SECONDS = 3.0
 CLI_TIMEOUT_RETURN_CODE = 124
@@ -32,14 +33,83 @@ _TRANSIENT_CLI_OUTPUT = (
     "connection reset by peer",
     "connection refused",
 )
+_SECRET_SET_FIELD_NAMES = frozenset(
+    {
+        "admin_key",
+        "api_key",
+        "auth_token",
+        "password",
+        "passphrase",
+        "private_key",
+        "psk",
+        "secret",
+        "session_passkey",
+        "token",
+        "wifi_psk",
+    }
+)
+_SECRET_CHANNEL_FIELD_NAMES = frozenset({"psk"})
+_SECRET_URL_OPTIONS = frozenset({"--seturl", "--ch-set-url", "--ch-add-url"})
+
+
+def _normalize_field_name(field: str) -> str:
+    """Normalize a CLI field path for secret classification."""
+    return ".".join(
+        camel_to_snake(component.strip().replace("-", "_"))
+        for component in field.split(".")
+    )
+
+
+def _is_secret_set_field(field: str) -> bool:
+    """Return whether a ``--set`` field carries credential material."""
+    components = [
+        component
+        for component in _normalize_field_name(field).split(".")
+        if component and not component.isdecimal()
+    ]
+    if not components:
+        return False
+    leaf = components[-1]
+    return leaf in _SECRET_SET_FIELD_NAMES or any(
+        leaf.endswith(f"_{suffix}") for suffix in _SECRET_SET_FIELD_NAMES
+    )
+
+
+def _secret_cli_values(arguments: Sequence[str]) -> tuple[str, ...]:
+    """Extract only credential-bearing values from structured CLI arguments."""
+    secrets: list[str] = []
+
+    def _append_url_secret(url: str) -> None:
+        secrets.append(url)
+        fragment = url.rpartition("#")[2]
+        if fragment:
+            secrets.append(fragment)
+
+    for index, argument in enumerate(arguments):
+        if argument == "--set" and index + 2 < len(arguments):
+            if _is_secret_set_field(arguments[index + 1]):
+                secrets.append(arguments[index + 2])
+        elif argument == "--ch-set" and index + 2 < len(arguments):
+            field = _normalize_field_name(arguments[index + 1])
+            if field in _SECRET_CHANNEL_FIELD_NAMES:
+                secrets.append(arguments[index + 2])
+        elif argument in _SECRET_URL_OPTIONS and index + 1 < len(arguments):
+            _append_url_secret(arguments[index + 1])
+        else:
+            for option in _SECRET_URL_OPTIONS:
+                prefix = f"{option}="
+                if argument.startswith(prefix):
+                    _append_url_secret(argument[len(prefix) :])
+                    break
+    return tuple(secrets)
 
 
 def _redact_cli_diagnostics(output: str, arguments: Sequence[str]) -> str:
-    """Remove positional CLI values before including output in exceptions."""
+    """Remove credential-bearing CLI values from exception diagnostics."""
     redacted = output
-    for argument in arguments:
-        if argument and not argument.startswith("--"):
-            redacted = redacted.replace(argument, "<redacted>")
+    for secret in sorted(_secret_cli_values(arguments), key=len, reverse=True):
+        if secret:
+            redacted = redacted.replace(secret, "<redacted>")
     return redacted
 
 
@@ -243,56 +313,47 @@ def run_cli(
     raise AssertionError("simradio CLI retry loop exhausted unexpectedly")
 
 
-def _wait_for_port(
-    port: int,
-    *,
-    timeout: float = DEFAULT_CONNECT_WAIT_SECONDS,
-) -> None:
-    """Wait for a simulator TCP listener after a reboot-capable write."""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            with socket.create_connection(("localhost", port), timeout=0.5):
-                return
-        except OSError:
-            time.sleep(0.2)
-    raise TimeoutError(f"localhost:{port} did not accept connections in {timeout:.1f}s")
-
-
 def connect_iface(
     port: int,
     *,
     no_nodes: bool = False,
-    retries: int = 4,
     wait_timeout: float = DEFAULT_CONNECT_WAIT_SECONDS,
 ) -> TCPInterface:
-    """Open a fresh configured TCPInterface with reboot-aware retries."""
-    if retries < 0:
-        raise ValueError("retries must not be negative")
+    """Retry the owned TCPInterface connection until firmware is configured."""
+    if wait_timeout <= 0:
+        raise ValueError("wait_timeout must be positive")
+    deadline = time.monotonic() + wait_timeout
     last_exception: Exception | None = None
-    for attempt in range(1, retries + 2):
+    attempt = 0
+    while True:
+        attempt += 1
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
         try:
-            _wait_for_port(port, timeout=wait_timeout)
             return TCPInterface(
                 hostname="localhost",
                 portNumber=port,
                 connectNow=True,
-                connectTimeout=10.0,
+                connectTimeout=min(CONNECT_ATTEMPT_TIMEOUT_SECONDS, remaining),
                 noNodes=no_nodes,
+                timeout=min(CONNECT_ATTEMPT_TIMEOUT_SECONDS, remaining),
             )
         except Exception as exc:  # pylint: disable=broad-except
             last_exception = exc
-            if attempt <= retries:
-                logger.debug(
-                    "Retrying simradio interface connection (%d/%d): %s",
-                    attempt,
-                    retries + 1,
-                    exc,
-                )
-                time.sleep(0.5)
-                continue
-            raise
-    raise AssertionError(f"unreachable connection loop: {last_exception}")
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            logger.debug(
+                "Retrying actual simradio interface connection (attempt %d): %s",
+                attempt,
+                exc,
+            )
+            time.sleep(min(CONNECT_RETRY_DELAY_SECONDS, remaining))
+    raise TimeoutError(
+        f"localhost:{port} did not complete a TCPInterface connection "
+        f"within {wait_timeout:.1f}s"
+    ) from last_exception
 
 
 def verify_state(
@@ -338,14 +399,12 @@ def cli_then_verify(
 
 
 def set_region(port: int, region: str = "US") -> None:
-    """Set the simulator LoRa region and wait for its listener to settle."""
+    """Set the simulator LoRa region through an unshared CLI connection."""
     result = run_cli(port, "--set", "lora.region", region)
     if result.returncode != 0:
         raise RuntimeError(
             f"Failed to set lora.region={region} on port {port}:\n{result.output}"
         )
-    time.sleep(PAUSE_AFTER_REGION_CHANGE_SECONDS)
-    _wait_for_port(port)
 
 
 class PacketCollector:

--- a/meshtastic/tests/simradio_helpers.py
+++ b/meshtastic/tests/simradio_helpers.py
@@ -65,31 +65,32 @@ def _timeout_output(exc: subprocess.TimeoutExpired) -> str:
 # Operation-aware retry policy
 # ---------------------------------------------------------------------------
 
-# CLI arguments that indicate a non-idempotent operation. Retrying these after
-# an ambiguous transport failure could duplicate side effects (delete the wrong
-# secondary, factory-reset a device the user intended to keep, etc.).
-_NON_IDEMPOTENT_ARGUMENTS: frozenset[str] = frozenset(
+# Destructive operations that must never be retried.
+_DESTRUCTIVE_ARGUMENTS: frozenset[str] = frozenset(
     {
         "--ch-add",
         "--ch-del",
-        "--ch-index",  # paired with --ch-add / --ch-del / --ch-enable / --ch-disable
         "--ch-enable",
         "--ch-disable",
         "--factory-reset",
+        "--factory-reset-config",
+        "--factory-reset-device",
         "--reboot",
+        "--reboot-ota",
+        "--enter-dfu",
         "--shutdown",
         "--ota-update",
         "--reset-nodedb",
+        "--test",  # sends stress-test traffic
     }
 )
 
-# CLI arguments that never mutate device state.
+# Operations that never mutate device state.
 _READ_ONLY_ARGUMENTS: frozenset[str] = frozenset(
     {
         "--info",
         "--nodes",
         "--qr",
-        "--test",
         "--get",
         "--export-config",
         "--list-fields",
@@ -98,9 +99,32 @@ _READ_ONLY_ARGUMENTS: frozenset[str] = frozenset(
     }
 )
 
-# Default retries per operation kind.  idempotent-mutations (--set, --set-owner,
-# --seturl, --set-ham, --set-position, etc.) and read-only commands are safe to
-# retry on transient transport errors.
+# Operations that are safe to retry because repeating them produces the
+# same result (set owner, configure a channel, etc.).
+_IDEMPOTENT_ARGUMENTS: frozenset[str] = frozenset(
+    {
+        "--set",
+        "--set-owner",
+        "--set-owner-short",
+        "--set-ham",
+        "--set-position",
+        "--seturl",
+    }
+)
+
+# Semantic --set values that trigger destructive device actions.
+_DESTRUCTIVE_SET_VALUES: frozenset[str] = frozenset(
+    {
+        "factory_reset",
+        "reboot",
+        "shutdown",
+        "ota_update",
+    }
+)
+
+# Default retries per operation kind.  Only read-only and explicitly safe
+# idempotent mutations are allowed to retry.  Everything else defaults to
+# zero so an ambiguous transport failure cannot duplicate side effects.
 _DEFAULT_RETRIES: dict[str, int] = {
     "read_only": 2,
     "idempotent_mutation": 2,
@@ -109,18 +133,36 @@ _DEFAULT_RETRIES: dict[str, int] = {
 
 
 def _classify_cli_operation(arguments: Sequence[str]) -> str:
-    """Map CLI arguments to an operation kind for the retry policy.
+    """Map CLI arguments to ``read_only``, ``idempotent_mutation``, or ``non_idempotent``.
 
-    The first recognized argument wins — callers that mix arguments are
-    classified conservatively as non_idempotent.
+    Destructive arguments take priority, then semantic ``--set destructive``
+    forms, then read-only allowlist, then idempotent-mutation allowlist.
+    Unknown operations default to ``non_idempotent``.
     """
+    # Phase 1: explicit destructive flags
     for argument in arguments:
-        if argument in _NON_IDEMPOTENT_ARGUMENTS:
+        if argument in _DESTRUCTIVE_ARGUMENTS:
             return "non_idempotent"
+
+    # Phase 2: semantic --set with destructive field values
+    for i, argument in enumerate(arguments):
+        if argument == "--set" and i + 1 < len(arguments):
+            field = arguments[i + 1].split(".")[0]
+            if field in _DESTRUCTIVE_SET_VALUES:
+                return "non_idempotent"
+
+    # Phase 3: explicit read-only flags
     for argument in arguments:
         if argument in _READ_ONLY_ARGUMENTS:
             return "read_only"
-    return "idempotent_mutation"
+
+    # Phase 4: explicit idempotent-mutation flags
+    for argument in arguments:
+        if argument in _IDEMPOTENT_ARGUMENTS:
+            return "idempotent_mutation"
+
+    # Phase 5: default conservative — assume non-idempotent
+    return "non_idempotent"
 
 
 def run_cli(

--- a/meshtastic/tests/simradio_helpers.py
+++ b/meshtastic/tests/simradio_helpers.py
@@ -61,14 +61,83 @@ def _timeout_output(exc: subprocess.TimeoutExpired) -> str:
     return output
 
 
+# ---------------------------------------------------------------------------
+# Operation-aware retry policy
+# ---------------------------------------------------------------------------
+
+# CLI arguments that indicate a non-idempotent operation. Retrying these after
+# an ambiguous transport failure could duplicate side effects (delete the wrong
+# secondary, factory-reset a device the user intended to keep, etc.).
+_NON_IDEMPOTENT_ARGUMENTS: frozenset[str] = frozenset(
+    {
+        "--ch-add",
+        "--ch-del",
+        "--ch-index",  # paired with --ch-add / --ch-del / --ch-enable / --ch-disable
+        "--ch-enable",
+        "--ch-disable",
+        "--factory-reset",
+        "--reboot",
+        "--shutdown",
+        "--ota-update",
+        "--reset-nodedb",
+    }
+)
+
+# CLI arguments that never mutate device state.
+_READ_ONLY_ARGUMENTS: frozenset[str] = frozenset(
+    {
+        "--info",
+        "--nodes",
+        "--qr",
+        "--test",
+        "--get",
+        "--export-config",
+        "--list-fields",
+        "--support",
+        "--device-metadata",
+    }
+)
+
+# Default retries per operation kind.  idempotent-mutations (--set, --set-owner,
+# --seturl, --set-ham, --set-position, etc.) and read-only commands are safe to
+# retry on transient transport errors.
+_DEFAULT_RETRIES: dict[str, int] = {
+    "read_only": 2,
+    "idempotent_mutation": 2,
+    "non_idempotent": 0,
+}
+
+
+def _classify_cli_operation(arguments: Sequence[str]) -> str:
+    """Map CLI arguments to an operation kind for the retry policy.
+
+    The first recognized argument wins — callers that mix arguments are
+    classified conservatively as non_idempotent.
+    """
+    for argument in arguments:
+        if argument in _NON_IDEMPOTENT_ARGUMENTS:
+            return "non_idempotent"
+    for argument in arguments:
+        if argument in _READ_ONLY_ARGUMENTS:
+            return "read_only"
+    return "idempotent_mutation"
+
+
 def run_cli(
     port: int,
     *arguments: str,
     timeout: float = DEFAULT_CLI_TIMEOUT_SECONDS,
-    retries: int = 2,
+    retries: int | None = None,
     retry_delay: float = 1.0,
 ) -> CLIResult:
-    """Run the in-tree CLI against one simulator with transient retries."""
+    """Run the in-tree CLI against one simulator with transient retries.
+
+    ``retries`` controls the maximum retry count after the first attempt.
+    When ``retries`` is ``None`` (the default), the value is selected from
+    :data:`_DEFAULT_RETRIES` based on the detected operation kind.
+    """
+    if retries is None:
+        retries = _DEFAULT_RETRIES[_classify_cli_operation(arguments)]
     if retries < 0:
         raise ValueError("retries must not be negative")
     if timeout <= 0:

--- a/meshtastic/tests/simradio_helpers.py
+++ b/meshtastic/tests/simradio_helpers.py
@@ -1,0 +1,404 @@
+"""CLI, connection, and packet helpers for native simradio smoke tests."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import socket
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from pubsub import pub
+
+from meshtastic.tcp_interface import TCPInterface
+
+logger = logging.getLogger(__name__)
+
+PAUSE_AFTER_CLI_SECONDS = 0.2
+PAUSE_AFTER_REGION_CHANGE_SECONDS = 2.0
+DEFAULT_CLI_TIMEOUT_SECONDS = 60.0
+DEFAULT_CONNECT_WAIT_SECONDS = 30.0
+DEFAULT_RECEIVE_TIMEOUT_SECONDS = 15.0
+DEFAULT_ABSENCE_TIMEOUT_SECONDS = 3.0
+CLI_TIMEOUT_RETURN_CODE = 124
+_TRANSIENT_CLI_OUTPUT = (
+    "error connecting",
+    "timed out waiting for connection",
+    "connection reset by peer",
+    "connection refused",
+)
+
+
+def _redact_cli_diagnostics(output: str, arguments: Sequence[str]) -> str:
+    """Remove positional CLI values before including output in exceptions."""
+    redacted = output
+    for argument in arguments:
+        if argument and not argument.startswith("--"):
+            redacted = redacted.replace(argument, "<redacted>")
+    return redacted
+
+
+@dataclass(frozen=True)
+class CLIResult:
+    """Result of one possibly retried in-tree CLI invocation."""
+
+    returncode: int
+    output: str
+    attempts: int
+    timed_out: bool = False
+
+
+def _timeout_output(exc: subprocess.TimeoutExpired) -> str:
+    """Normalize TimeoutExpired output across text and bytes subprocess modes."""
+    output = exc.stdout or exc.stderr or ""
+    if isinstance(output, bytes):
+        return output.decode("utf-8", errors="replace")
+    return output
+
+
+def run_cli(
+    port: int,
+    *arguments: str,
+    timeout: float = DEFAULT_CLI_TIMEOUT_SECONDS,
+    retries: int = 2,
+    retry_delay: float = 1.0,
+) -> CLIResult:
+    """Run the in-tree CLI against one simulator with transient retries."""
+    if retries < 0:
+        raise ValueError("retries must not be negative")
+    if timeout <= 0:
+        raise ValueError("timeout must be positive")
+    if retry_delay < 0:
+        raise ValueError("retry_delay must not be negative")
+    argv = [
+        sys.executable,
+        "-m",
+        "meshtastic",
+        "--host",
+        f"localhost:{port}",
+        *arguments,
+    ]
+    # Never log positional values: configuration commands may contain Wi-Fi
+    # credentials, private keys, or lockdown passphrases. Option names and the
+    # target port provide enough diagnostics without retaining secrets.
+    logger.debug(
+        "Running simradio CLI on port %d with options %s",
+        port,
+        [argument for argument in arguments if argument.startswith("--")],
+    )
+    last_output = ""
+    for attempt in range(1, retries + 2):
+        try:
+            completed = subprocess.run(  # noqa: S603
+                argv,
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired as exc:
+            last_output = _timeout_output(exc)
+            if attempt <= retries:
+                time.sleep(retry_delay)
+                continue
+            return CLIResult(
+                CLI_TIMEOUT_RETURN_CODE,
+                last_output,
+                attempt,
+                timed_out=True,
+            )
+
+        last_output = completed.stdout
+        transient_failure = completed.returncode != 0 and any(
+            marker in last_output.casefold() for marker in _TRANSIENT_CLI_OUTPUT
+        )
+        if transient_failure and attempt <= retries:
+            logger.debug(
+                "Retrying transient simradio CLI failure (%d/%d)",
+                attempt,
+                retries + 1,
+            )
+            time.sleep(retry_delay)
+            continue
+        return CLIResult(completed.returncode, last_output, attempt)
+    raise AssertionError("simradio CLI retry loop exhausted unexpectedly")
+
+
+def _wait_for_port(
+    port: int,
+    *,
+    timeout: float = DEFAULT_CONNECT_WAIT_SECONDS,
+) -> None:
+    """Wait for a simulator TCP listener after a reboot-capable write."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("localhost", port), timeout=0.5):
+                return
+        except OSError:
+            time.sleep(0.2)
+    raise TimeoutError(f"localhost:{port} did not accept connections in {timeout:.1f}s")
+
+
+def connect_iface(
+    port: int,
+    *,
+    no_nodes: bool = False,
+    retries: int = 4,
+    wait_timeout: float = DEFAULT_CONNECT_WAIT_SECONDS,
+) -> TCPInterface:
+    """Open a fresh configured TCPInterface with reboot-aware retries."""
+    if retries < 0:
+        raise ValueError("retries must not be negative")
+    last_exception: Exception | None = None
+    for attempt in range(1, retries + 2):
+        try:
+            _wait_for_port(port, timeout=wait_timeout)
+            return TCPInterface(
+                hostname="localhost",
+                portNumber=port,
+                connectNow=True,
+                connectTimeout=10.0,
+                noNodes=no_nodes,
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            last_exception = exc
+            if attempt <= retries:
+                logger.debug(
+                    "Retrying simradio interface connection (%d/%d): %s",
+                    attempt,
+                    retries + 1,
+                    exc,
+                )
+                time.sleep(0.5)
+                continue
+            raise
+    raise AssertionError(f"unreachable connection loop: {last_exception}")
+
+
+def verify_state(
+    port: int,
+    verifier: Callable[[TCPInterface], None],
+    *,
+    no_nodes: bool = False,
+) -> None:
+    """Verify firmware state through a fresh library connection."""
+    iface = connect_iface(port, no_nodes=no_nodes)
+    try:
+        verifier(iface)
+    finally:
+        with contextlib.suppress(Exception):
+            iface.close()
+        time.sleep(PAUSE_AFTER_CLI_SECONDS)
+
+
+def cli_then_verify(
+    port: int,
+    arguments: Sequence[str],
+    verifier: Callable[[TCPInterface], None] | None,
+    *,
+    expected_returncode: int | None = 0,
+    no_nodes: bool = False,
+    cli_timeout: float = DEFAULT_CLI_TIMEOUT_SECONDS,
+) -> CLIResult:
+    """Run a CLI action, assert its result, then verify state independently."""
+    result = run_cli(port, *arguments, timeout=cli_timeout)
+    if expected_returncode is not None and result.returncode != expected_returncode:
+        option_names = [
+            argument for argument in arguments if argument.startswith("--")
+        ]
+        raise AssertionError(
+            f"CLI returned {result.returncode}; expected {expected_returncode}.\n"
+            f"Command options: {option_names!r}\n"
+            f"{_redact_cli_diagnostics(result.output, arguments)}"
+        )
+    time.sleep(PAUSE_AFTER_CLI_SECONDS)
+    if verifier is not None:
+        verify_state(port, verifier, no_nodes=no_nodes)
+    return result
+
+
+def set_region(port: int, region: str = "US") -> None:
+    """Set the simulator LoRa region and wait for its listener to settle."""
+    result = run_cli(port, "--set", "lora.region", region)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Failed to set lora.region={region} on port {port}:\n{result.output}"
+        )
+    time.sleep(PAUSE_AFTER_REGION_CHANGE_SECONDS)
+    _wait_for_port(port)
+
+
+class PacketCollector:
+    """Thread-safe, interface-filtered pubsub packet subscription."""
+
+    def __init__(self, iface: TCPInterface, topic: str) -> None:
+        self.iface = iface
+        self.topic = topic
+        self._condition = threading.Condition()
+        self._packets: list[dict[str, Any]] = []
+        self._closed = False
+
+        def _handler(packet: dict[str, Any], interface: TCPInterface) -> None:
+            if interface is not self.iface:
+                return
+            with self._condition:
+                if self._closed:
+                    return
+                self._packets.append(packet)
+                self._condition.notify_all()
+
+        self._handler = _handler
+        pub.subscribe(self._handler, topic)
+
+    @property
+    def packets(self) -> list[dict[str, Any]]:
+        """Return a stable snapshot of collected packets."""
+        with self._condition:
+            return list(self._packets)
+
+    @property
+    def texts(self) -> list[str]:
+        """Return decoded text payloads from the current packet snapshot."""
+        return [
+            str(decoded.get("text", ""))
+            for packet in self.packets
+            if isinstance((decoded := packet.get("decoded")), dict)
+            and decoded.get("portnum") == "TEXT_MESSAGE_APP"
+        ]
+
+    @property
+    def traceroutes(self) -> list[dict[str, Any]]:
+        """Return decoded traceroute packets from the current snapshot."""
+        return [
+            packet
+            for packet in self.packets
+            if isinstance((decoded := packet.get("decoded")), dict)
+            and decoded.get("portnum") == "TRACEROUTE_APP"
+        ]
+
+    @property
+    def telemetries(self) -> list[dict[str, Any]]:
+        """Return decoded telemetry packets from the current snapshot."""
+        return [
+            packet
+            for packet in self.packets
+            if isinstance((decoded := packet.get("decoded")), dict)
+            and decoded.get("portnum") == "TELEMETRY_APP"
+        ]
+
+    @property
+    def positions(self) -> list[dict[str, Any]]:
+        """Return decoded position packets from the current snapshot."""
+        return [
+            packet
+            for packet in self.packets
+            if isinstance((decoded := packet.get("decoded")), dict)
+            and decoded.get("portnum") == "POSITION_APP"
+        ]
+
+    def wait_for_packet(
+        self,
+        predicate: Callable[[dict[str, Any]], bool],
+        *,
+        timeout: float = DEFAULT_RECEIVE_TIMEOUT_SECONDS,
+    ) -> dict[str, Any] | None:
+        """Wait until a packet matches ``predicate`` and return that packet."""
+        deadline = time.monotonic() + timeout
+        with self._condition:
+            while True:
+                for packet in self._packets:
+                    if predicate(packet):
+                        return packet
+                if self._closed:
+                    return None
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return None
+                self._condition.wait(timeout=remaining)
+
+    def wait_for_text(
+        self,
+        text: str,
+        *,
+        timeout: float = DEFAULT_RECEIVE_TIMEOUT_SECONDS,
+    ) -> bool:
+        """Wait for an exact decoded text message."""
+        return (
+            self.wait_for_packet(
+                lambda packet: (
+                    isinstance(packet.get("decoded"), dict)
+                    and packet["decoded"].get("portnum") == "TEXT_MESSAGE_APP"
+                    and packet["decoded"].get("text") == text
+                ),
+                timeout=timeout,
+            )
+            is not None
+        )
+
+    def assert_no_text(
+        self,
+        text: str,
+        *,
+        timeout: float = DEFAULT_ABSENCE_TIMEOUT_SECONDS,
+    ) -> None:
+        """Assert that an exact text does not arrive during a bounded window."""
+        packet = self.wait_for_packet(
+            lambda candidate: (
+                isinstance(candidate.get("decoded"), dict)
+                and candidate["decoded"].get("portnum") == "TEXT_MESSAGE_APP"
+                and candidate["decoded"].get("text") == text
+            ),
+            timeout=timeout,
+        )
+        if packet is not None:
+            raise AssertionError(f"Unexpected text {text!r} received: {packet!r}")
+
+    def clear(self) -> None:
+        """Discard collected packets while keeping the subscription active."""
+        with self._condition:
+            self._packets.clear()
+
+    def close(self) -> None:
+        """Unsubscribe only this collector without disturbing other listeners."""
+        with self._condition:
+            if self._closed:
+                return
+            self._closed = True
+            self._condition.notify_all()
+        with contextlib.suppress(Exception):
+            pub.unsubscribe(self._handler, self.topic)
+
+    def __enter__(self) -> PacketCollector:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+
+def subscribe_texts(iface: TCPInterface) -> PacketCollector:
+    """Collect text packets received by one interface."""
+    return PacketCollector(iface, "meshtastic.receive.text")
+
+
+def subscribe_traceroutes(iface: TCPInterface) -> PacketCollector:
+    """Collect traceroute packets received by one interface."""
+    return PacketCollector(iface, "meshtastic.receive.traceroute")
+
+
+def subscribe_telemetries(iface: TCPInterface) -> PacketCollector:
+    """Collect telemetry packets received by one interface."""
+    return PacketCollector(iface, "meshtastic.receive.telemetry")
+
+
+def subscribe_positions(iface: TCPInterface) -> PacketCollector:
+    """Collect position packets received by one interface."""
+    return PacketCollector(iface, "meshtastic.receive.position")

--- a/meshtastic/tests/simradio_helpers.py
+++ b/meshtastic/tests/simradio_helpers.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from pubsub import pub
 
+from meshtastic import LOCAL_ADDR
 from meshtastic.tcp_interface import TCPInterface
 from meshtastic.util import camel_to_snake
 
@@ -417,8 +418,15 @@ def cli_then_verify(
 
 
 def set_region(port: int, region: str = "US") -> None:
-    """Set the simulator LoRa region through an unshared CLI connection."""
-    result = run_cli(port, "--set", "lora.region", region)
+    """Set the simulator LoRa region and wait for the local admin ACK."""
+    result = run_cli(
+        port,
+        "--set",
+        "lora.region",
+        region,
+        "--dest",
+        LOCAL_ADDR,
+    )
     if result.returncode != 0:
         raise RuntimeError(
             f"Failed to set lora.region={region} on port {port}:\n{result.output}"

--- a/meshtastic/tests/test_simradio_cli.py
+++ b/meshtastic/tests/test_simradio_cli.py
@@ -22,7 +22,6 @@ from meshtastic.tcp_interface import TCPInterface
 from .simradio_harness import SimNode
 from .simradio_helpers import (
     cli_then_verify,
-    connect_iface,
     run_cli,
     verify_state,
 )
@@ -484,7 +483,10 @@ def test_simradio_cli_factory_reset_config_isolated(firmware_node: SimNode) -> N
         _assert_fixed_position,
     )
 
-    # Run the real factory reset with zero automatic retries.
+    # Run the real factory reset with zero automatic retries.  Record the
+    # current Portduino boot marker so verification cannot accidentally attach
+    # before the delayed reboot has happened.
+    previous_boot_count = firmware_node.boot_count()
     reset_result = run_cli(
         firmware_node.port,
         "--factory-reset",
@@ -495,9 +497,7 @@ def test_simradio_cli_factory_reset_config_isolated(firmware_node: SimNode) -> N
     # The output must not follow the unknown-setting "Choices" path.
     assert "Choices are" not in reset_result.output
 
-    # Wait for the node to come back after reboot.
-    iface = connect_iface(firmware_node.port)
-    iface.close()
+    firmware_node.wait_for_reboot(previous_boot_count)
 
     def _assert_default_config(iface: TCPInterface) -> None:
         assert iface.localNode.localConfig.position.fixed_position is False

--- a/meshtastic/tests/test_simradio_cli.py
+++ b/meshtastic/tests/test_simradio_cli.py
@@ -20,7 +20,7 @@ from meshtastic.protobuf import channel_pb2, config_pb2
 from meshtastic.tcp_interface import TCPInterface
 
 from .simradio_harness import SimNode
-from .simradio_helpers import cli_then_verify, run_cli
+from .simradio_helpers import _wait_for_port, cli_then_verify, run_cli, verify_state
 
 pytestmark = pytest.mark.simradio
 
@@ -464,16 +464,41 @@ def test_simradio_cli_schema_get_set_paths(firmware_node: SimNode) -> None:
 
 
 def test_simradio_cli_factory_reset_isolated(firmware_node: SimNode) -> None:
-    """Factory reset should return success on its disposable simulator."""
-    result = run_cli(
+    """--factory-reset should clear a previously set value on an isolated node."""
+    # Change a known setting first.
+    set_result = run_cli(
         firmware_node.port,
-        "--set",
-        "factory_reset",
-        "true",
+        "--set-owner",
+        "BeforeReset",
+        timeout=30.0,
+    )
+    assert set_result.returncode == 0, set_result.output
+
+    def _assert_before_reset(iface: TCPInterface) -> None:
+        assert iface.getLongName() == "BeforeReset"
+
+    verify_state(firmware_node.port, _assert_before_reset)
+
+    # Run the real factory reset with zero automatic retries.
+    reset_result = run_cli(
+        firmware_node.port,
+        "--factory-reset",
+        retries=0,
         timeout=90.0,
     )
-    assert result.returncode == 0, result.output
-    assert re.search(r"(?i)factory.?reset|writing", result.output)
+    assert reset_result.returncode == 0, reset_result.output
+    # The output must not follow the unknown-setting "Choices" path.
+    assert "Choices are" not in reset_result.output
+
+    # Wait for the node to come back and verify the owner reverted.
+    _wait_for_port(firmware_node.port)
+
+    def _assert_default_owner(iface: TCPInterface) -> None:
+        name = iface.getLongName()
+        assert name is not None
+        assert name != "BeforeReset", f"owner was not reset, got {name!r}"
+
+    verify_state(firmware_node.port, _assert_default_owner)
 
 
 def test_simradio_fixture_exposes_connected_node(firmware_node: SimNode) -> None:

--- a/meshtastic/tests/test_simradio_cli.py
+++ b/meshtastic/tests/test_simradio_cli.py
@@ -422,7 +422,10 @@ def test_simradio_cli_yaml_export_restore_round_trip(
     assert isinstance(exported_config, dict)
     exported_position = exported_config.get("position")
     assert isinstance(exported_position, dict)
-    assert exported_position.get("fixed_position") is True
+    # ``MessageToDict`` emits protobuf field names in lowerCamelCase.  The
+    # top-level config section follows mt_config naming mode, but nested
+    # protobuf fields retain their JSON spelling in exported YAML.
+    assert exported_position.get("fixedPosition") is True
 
     cli_then_verify(
         firmware_node.port,

--- a/meshtastic/tests/test_simradio_cli.py
+++ b/meshtastic/tests/test_simradio_cli.py
@@ -20,9 +20,11 @@ from meshtastic.protobuf import channel_pb2, config_pb2
 from meshtastic.tcp_interface import TCPInterface
 
 from .simradio_harness import SimNode
-from .simradio_helpers import _wait_for_port, cli_then_verify, run_cli, verify_state
+from .simradio_helpers import cli_then_verify, run_cli, verify_state
 
-pytestmark = pytest.mark.simradio
+pytestmark = [pytest.mark.simradio, pytest.mark.smokevirt]
+
+REBOOT_CLI_TIMEOUT_SECONDS = 90.0
 
 
 def _channel(iface: TCPInterface, index: int) -> channel_pb2.Channel | None:
@@ -353,7 +355,7 @@ def test_simradio_cli_channel_url_paths(firmware_node: SimNode) -> None:
         firmware_node.port,
         ("--seturl", expected_url),
         _assert_url,
-        cli_timeout=90.0,
+        cli_timeout=REBOOT_CLI_TIMEOUT_SECONDS,
     )
 
     invalid_url = (
@@ -396,7 +398,7 @@ def test_simradio_cli_yaml_export_restore_round_trip(
         firmware_node.port,
         ("--configure", str(initial_config)),
         _assert_profile,
-        cli_timeout=90.0,
+        cli_timeout=REBOOT_CLI_TIMEOUT_SECONDS,
     )
 
     exported = tmp_path / "exported.yaml"
@@ -404,7 +406,7 @@ def test_simradio_cli_yaml_export_restore_round_trip(
         firmware_node.port,
         "--export-config",
         str(exported),
-        timeout=90.0,
+        timeout=REBOOT_CLI_TIMEOUT_SECONDS,
     )
     assert export_result.returncode == 0, export_result.output
     parsed = yaml.safe_load(exported.read_text(encoding="utf-8"))
@@ -432,7 +434,7 @@ def test_simradio_cli_yaml_export_restore_round_trip(
         firmware_node.port,
         ("--configure", str(exported)),
         _assert_profile,
-        cli_timeout=90.0,
+        cli_timeout=REBOOT_CLI_TIMEOUT_SECONDS,
     )
 
 
@@ -484,14 +486,11 @@ def test_simradio_cli_factory_reset_isolated(firmware_node: SimNode) -> None:
         firmware_node.port,
         "--factory-reset",
         retries=0,
-        timeout=90.0,
+        timeout=REBOOT_CLI_TIMEOUT_SECONDS,
     )
     assert reset_result.returncode == 0, reset_result.output
     # The output must not follow the unknown-setting "Choices" path.
     assert "Choices are" not in reset_result.output
-
-    # Wait for the node to come back and verify the owner reverted.
-    _wait_for_port(firmware_node.port)
 
     def _assert_default_owner(iface: TCPInterface) -> None:
         name = iface.getLongName()
@@ -501,10 +500,14 @@ def test_simradio_cli_factory_reset_isolated(firmware_node: SimNode) -> None:
     verify_state(firmware_node.port, _assert_default_owner)
 
 
-def test_simradio_fixture_exposes_connected_node(firmware_node: SimNode) -> None:
-    """The fixture should remain usable directly by library-level smoke tests."""
-    assert firmware_node.iface is not None
-    assert firmware_node.iface.localNode is not None
-    assert firmware_node.node_num > 0
-    assert isinstance(firmware_node.iface.getMyNodeInfo(), dict)
-    firmware_node.iface.showNodes()
+def test_simradio_fixture_supports_explicit_connection(firmware_node: SimNode) -> None:
+    """Library smoke tests may explicitly claim and release the firmware client."""
+    assert firmware_node.iface is None
+    iface = firmware_node.connect()
+    try:
+        assert iface.localNode is not None
+        assert firmware_node.node_num > 0
+        assert isinstance(iface.getMyNodeInfo(), dict)
+        iface.showNodes()
+    finally:
+        firmware_node.disconnect()

--- a/meshtastic/tests/test_simradio_cli.py
+++ b/meshtastic/tests/test_simradio_cli.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import base64
 import re
+import warnings
 from functools import partial
 from pathlib import Path
 
@@ -486,7 +487,7 @@ def test_simradio_cli_factory_reset_config_isolated(firmware_node: SimNode) -> N
     # Run the real factory reset with zero automatic retries.  Record the
     # current Portduino boot marker so verification cannot accidentally attach
     # before the delayed reboot has happened.
-    previous_boot_count = firmware_node.boot_count()
+    reboot_checkpoint = firmware_node.reboot_checkpoint()
     reset_result = run_cli(
         firmware_node.port,
         "--factory-reset",
@@ -497,7 +498,17 @@ def test_simradio_cli_factory_reset_config_isolated(firmware_node: SimNode) -> N
     # The output must not follow the unknown-setting "Choices" path.
     assert "Choices are" not in reset_result.output
 
-    firmware_node.wait_for_reboot(previous_boot_count)
+    recovered_exit_status = firmware_node.wait_for_factory_reset_reboot(
+        reboot_checkpoint
+    )
+    if recovered_exit_status is not None:
+        warnings.warn(
+            "meshtasticd recovered from the known firmware 2.7 Portduino "
+            f"factory-reset reboot crash (status {recovered_exit_status}); "
+            "post-restart state verification remains required",
+            RuntimeWarning,
+            stacklevel=1,
+        )
 
     def _assert_default_config(iface: TCPInterface) -> None:
         assert iface.localNode.localConfig.position.fixed_position is False

--- a/meshtastic/tests/test_simradio_cli.py
+++ b/meshtastic/tests/test_simradio_cli.py
@@ -1,0 +1,485 @@
+"""Native meshtasticd single-node CLI smoke coverage.
+
+Each test receives a freshly erased simulator. Mutations are verified through a
+new ``TCPInterface`` connection so assertions cover argparse, transport,
+firmware persistence, and the fork's library state model without depending on
+human-oriented CLI wording.
+"""
+
+from __future__ import annotations
+
+import base64
+import re
+from functools import partial
+from pathlib import Path
+
+import pytest
+import yaml
+
+from meshtastic.protobuf import channel_pb2, config_pb2
+from meshtastic.tcp_interface import TCPInterface
+
+from .simradio_harness import SimNode
+from .simradio_helpers import cli_then_verify, run_cli
+
+pytestmark = pytest.mark.simradio
+
+
+def _channel(iface: TCPInterface, index: int) -> channel_pb2.Channel | None:
+    return iface.localNode.getChannelByChannelIndex(index)
+
+
+def _long_name(iface: TCPInterface) -> str:
+    value = iface.getLongName()
+    assert value is not None
+    return value
+
+
+def _short_name(iface: TCPInterface) -> str:
+    value = iface.getShortName()
+    assert value is not None
+    return value
+
+
+def _channel_url_payload(url: str) -> bytes:
+    """Decode the protobuf fragment from any supported channel URL shape."""
+    fragment = url.rpartition("#")[2]
+    assert fragment, f"channel URL has no fragment: {url!r}"
+    fragment += "=" * (-len(fragment) % 4)
+    return base64.urlsafe_b64decode(fragment)
+
+
+def _assert_owner(
+    iface: TCPInterface,
+    expected_long: str,
+    expected_short: str | None = None,
+) -> None:
+    assert _long_name(iface) == expected_long
+    if expected_short is not None:
+        assert _short_name(iface) == expected_short
+
+
+def _assert_modem_preset(
+    iface: TCPInterface,
+    expected: config_pb2.Config.LoRaConfig.ModemPreset.ValueType,
+) -> None:
+    actual = iface.localNode.localConfig.lora.modem_preset
+    assert actual == expected, (
+        "modem preset mismatch: "
+        f"expected={config_pb2.Config.LoRaConfig.ModemPreset.Name(expected)} "
+        f"actual={config_pb2.Config.LoRaConfig.ModemPreset.Name(actual)}"
+    )
+
+
+def _assert_channel_role(
+    iface: TCPInterface,
+    index: int,
+    expected: channel_pb2.Channel.Role.ValueType,
+) -> None:
+    channel = _channel(iface, index)
+    assert channel is not None
+    assert channel.role == expected
+
+
+def _assert_wifi_ssid(iface: TCPInterface, expected: str) -> None:
+    assert iface.localNode.localConfig.network.wifi_ssid == expected
+
+
+def _assert_wifi_psk(iface: TCPInterface, expected: str) -> None:
+    assert iface.localNode.localConfig.network.wifi_psk == expected
+
+
+def _assert_hop_limit(iface: TCPInterface, expected: int) -> None:
+    assert iface.localNode.localConfig.lora.hop_limit == expected
+
+
+def _assert_position_flags(iface: TCPInterface, expected: int) -> None:
+    assert iface.localNode.localConfig.position.position_flags == expected
+
+
+def test_simradio_cli_read_only_and_output_paths(
+    firmware_node: SimNode,
+    tmp_path: Path,
+) -> None:
+    """Core display, debug, QR, nodes, and serial-log paths should work."""
+    info = run_cli(firmware_node.port, "--info")
+    assert info.returncode == 0, info.output
+    for heading in (
+        "Connected to radio",
+        "Owner",
+        "My info",
+        "Nodes in mesh",
+        "Preferences",
+        "Channels",
+    ):
+        assert heading in info.output
+
+    nodes = run_cli(firmware_node.port, "--nodes")
+    assert nodes.returncode == 0, nodes.output
+    assert "Connected to radio" in nodes.output
+
+    debug = run_cli(firmware_node.port, "--info", "--debug")
+    assert debug.returncode == 0, debug.output
+    assert re.search(r"^DEBUG ", debug.output, re.MULTILINE), debug.output
+
+    serial_log = tmp_path / "serial.log"
+    logged = run_cli(
+        firmware_node.port,
+        "--info",
+        "--seriallog",
+        str(serial_log),
+    )
+    assert logged.returncode == 0, logged.output
+    assert serial_log.is_file()
+
+    qr = run_cli(firmware_node.port, "--qr")
+    assert qr.returncode == 0, qr.output
+    assert len(qr.output) > 500
+
+    device_test = run_cli(firmware_node.port, "--test")
+    assert device_test.returncode != 0, device_test.output
+    assert re.search(r"(?i)at least two devices", device_test.output)
+
+
+def test_simradio_cli_invalid_settings_report_choices(
+    firmware_node: SimNode,
+) -> None:
+    """Invalid schema paths should report choices without mutating firmware."""
+    cases = (
+        ("--get", "not_a_setting"),
+        ("--set", "not_a_setting", "value"),
+        ("--ch-set", "not_a_setting", "value", "--ch-index", "0"),
+    )
+    for arguments in cases:
+        result = run_cli(firmware_node.port, *arguments)
+        assert result.returncode == 0, result.output
+        assert "Choices" in result.output
+
+
+def test_simradio_cli_primary_channel_guards(
+    firmware_node: SimNode,
+) -> None:
+    """Destructive primary-channel operations must remain rejected."""
+    cases = (
+        ("--ch-del", "--ch-index", "0"),
+        ("--ch-disable", "--ch-index", "0"),
+        ("--ch-enable", "--ch-index", "0"),
+        ("--ch-del",),
+    )
+    for arguments in cases:
+        result = run_cli(firmware_node.port, *arguments)
+        assert result.returncode != 0, result.output
+        assert re.search(r"(?i)primary|ch-index|need to specify", result.output)
+
+
+def test_simradio_cli_owner_and_fixed_position_lifecycle(
+    firmware_node: SimNode,
+) -> None:
+    """Owner and fixed-position mutations should persist and be removable."""
+    cli_then_verify(
+        firmware_node.port,
+        ("--set-owner", "Simradio Alice", "--set-owner-short", "SIM"),
+        lambda iface: _assert_owner(iface, "Simradio Alice", "SIM"),
+    )
+
+    def _assert_position(iface: TCPInterface) -> None:
+        node_info = iface.getMyNodeInfo()
+        assert node_info is not None
+        position = node_info.get("position", {}) or {}
+        assert abs(float(position.get("latitude", 0)) - 32.7767) < 0.001
+        assert abs(float(position.get("longitude", 0)) + 96.7970) < 0.001
+        assert int(position.get("altitude", 0)) == 1337
+
+    cli_then_verify(
+        firmware_node.port,
+        (
+            "--setlat",
+            "32.7767",
+            "--setlon",
+            "-96.7970",
+            "--setalt",
+            "1337",
+        ),
+        _assert_position,
+    )
+
+    def _assert_position_removed(iface: TCPInterface) -> None:
+        node_info = iface.getMyNodeInfo()
+        assert node_info is not None
+        position = node_info.get("position", {}) or {}
+        assert "latitude" not in position or float(position.get("latitude", 0)) == 0
+        assert "longitude" not in position or float(position.get("longitude", 0)) == 0
+
+    cli_then_verify(
+        firmware_node.port,
+        ("--remove-position",),
+        _assert_position_removed,
+    )
+
+
+def test_simradio_cli_ham_and_position_flags(firmware_node: SimNode) -> None:
+    """Ham mode and symbolic position flags should persist together."""
+
+    def _assert_ham_mode(iface: TCPInterface) -> None:
+        _assert_owner(iface, "KI5SIM")
+        user = iface.getMyUser()
+        assert user is not None
+        assert user.get("isLicensed") is True
+        primary = _channel(iface, 0)
+        assert primary is not None
+        assert primary.settings.psk == b"\x00"
+
+    cli_then_verify(
+        firmware_node.port,
+        ("--set-ham", "KI5SIM"),
+        _assert_ham_mode,
+    )
+
+    expected_flags = (
+        int(config_pb2.Config.PositionConfig.PositionFlags.ALTITUDE)
+        | int(config_pb2.Config.PositionConfig.PositionFlags.ALTITUDE_MSL)
+        | int(config_pb2.Config.PositionConfig.PositionFlags.HEADING)
+    )
+    cli_then_verify(
+        firmware_node.port,
+        ("--pos-fields", "ALTITUDE", "ALTITUDE_MSL", "HEADING"),
+        lambda iface: _assert_position_flags(iface, expected_flags),
+    )
+
+
+def test_simradio_cli_modem_preset_matrix(firmware_node: SimNode) -> None:
+    """Common 2.8 shorthands and the schema-driven option should persist."""
+    cases = (
+        ("--ch-longmod", config_pb2.Config.LoRaConfig.ModemPreset.LONG_MODERATE),
+        (
+            "--ch-longmoderate",
+            config_pb2.Config.LoRaConfig.ModemPreset.LONG_MODERATE,
+        ),
+        ("--ch-longfast", config_pb2.Config.LoRaConfig.ModemPreset.LONG_FAST),
+        ("--ch-longturbo", config_pb2.Config.LoRaConfig.ModemPreset.LONG_TURBO),
+        ("--ch-medslow", config_pb2.Config.LoRaConfig.ModemPreset.MEDIUM_SLOW),
+        ("--ch-medfast", config_pb2.Config.LoRaConfig.ModemPreset.MEDIUM_FAST),
+        ("--ch-shortslow", config_pb2.Config.LoRaConfig.ModemPreset.SHORT_SLOW),
+        ("--ch-shortfast", config_pb2.Config.LoRaConfig.ModemPreset.SHORT_FAST),
+        ("--ch-shortturbo", config_pb2.Config.LoRaConfig.ModemPreset.SHORT_TURBO),
+    )
+    for flag, expected in cases:
+        cli_then_verify(
+            firmware_node.port,
+            (flag,),
+            partial(_assert_modem_preset, expected=expected),
+        )
+
+    cli_then_verify(
+        firmware_node.port,
+        ("--ch-preset", "medium-turbo"),
+        lambda iface: _assert_modem_preset(
+            iface,
+            config_pb2.Config.LoRaConfig.ModemPreset.MEDIUM_TURBO,
+        ),
+    )
+
+
+def test_simradio_cli_channel_lifecycle(firmware_node: SimNode) -> None:
+    """Add, mutate, disable, enable, and delete a secondary channel."""
+
+    def _assert_added(iface: TCPInterface) -> None:
+        channel = _channel(iface, 1)
+        assert channel is not None
+        assert channel.role == channel_pb2.Channel.Role.SECONDARY
+        assert channel.settings.name == "simradio-testing"
+
+    cli_then_verify(
+        firmware_node.port,
+        ("--ch-add", "simradio-testing"),
+        _assert_added,
+    )
+
+    def _assert_flags_disabled(iface: TCPInterface) -> None:
+        channel = _channel(iface, 1)
+        assert channel is not None
+        assert channel.settings.downlink_enabled is False
+        assert channel.settings.uplink_enabled is False
+
+    cli_then_verify(
+        firmware_node.port,
+        (
+            "--ch-set",
+            "downlink_enabled",
+            "false",
+            "--ch-set",
+            "uplink_enabled",
+            "false",
+            "--ch-index",
+            "1",
+        ),
+        _assert_flags_disabled,
+    )
+
+    cli_then_verify(
+        firmware_node.port,
+        ("--ch-disable", "--ch-index", "1"),
+        lambda iface: _assert_channel_role(
+            iface, 1, channel_pb2.Channel.Role.DISABLED
+        ),
+    )
+    cli_then_verify(
+        firmware_node.port,
+        ("--ch-enable", "--ch-index", "1"),
+        lambda iface: _assert_channel_role(
+            iface, 1, channel_pb2.Channel.Role.SECONDARY
+        ),
+    )
+    cli_then_verify(
+        firmware_node.port,
+        ("--ch-del", "--ch-index", "1"),
+        lambda iface: _assert_channel_role(
+            iface, 1, channel_pb2.Channel.Role.DISABLED
+        ),
+    )
+
+
+def test_simradio_cli_channel_url_paths(firmware_node: SimNode) -> None:
+    """A valid channel URL should round-trip; malformed payloads should fail."""
+    expected_url = "https://www.meshtastic.org/d/#CgUYAyIBAQ"
+    expected_payload = _channel_url_payload(expected_url)
+
+    def _assert_url(iface: TCPInterface) -> None:
+        actual_url = iface.localNode.getURL()
+        assert "meshtastic.org" in actual_url
+        assert _channel_url_payload(actual_url).startswith(expected_payload)
+
+    cli_then_verify(
+        firmware_node.port,
+        ("--seturl", expected_url),
+        _assert_url,
+        cli_timeout=90.0,
+    )
+
+    invalid_url = (
+        "https://www.meshtastic.org/c/#"
+        "GAMiENTxuzogKQdZ8Lz_q89Oab8qB0RlZmF1bHQ="
+    )
+    invalid = run_cli(firmware_node.port, "--seturl", invalid_url)
+    assert invalid.returncode != 0, invalid.output
+    assert re.search(r"(?i)warning|no settings|invalid|error", invalid.output)
+
+
+def test_simradio_cli_yaml_export_restore_round_trip(
+    firmware_node: SimNode,
+    tmp_path: Path,
+) -> None:
+    """Exported YAML should restore owner and fixed-position configuration."""
+    initial_config = tmp_path / "initial.yaml"
+    initial_config.write_text(
+        yaml.safe_dump(
+            {
+                "owner": "Profile Before",
+                "owner_short": "PBF",
+                "location": {"lat": 1.25, "lon": -2.5, "alt": 10},
+                "config": {"position": {"fixed_position": True}},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    def _assert_profile(iface: TCPInterface) -> None:
+        _assert_owner(iface, "Profile Before", "PBF")
+        assert iface.localNode.localConfig.position.fixed_position is True
+
+    def _assert_mutated(iface: TCPInterface) -> None:
+        _assert_owner(iface, "Profile Mutated")
+        assert iface.localNode.localConfig.position.fixed_position is False
+
+    cli_then_verify(
+        firmware_node.port,
+        ("--configure", str(initial_config)),
+        _assert_profile,
+        cli_timeout=90.0,
+    )
+
+    exported = tmp_path / "exported.yaml"
+    export_result = run_cli(
+        firmware_node.port,
+        "--export-config",
+        str(exported),
+        timeout=90.0,
+    )
+    assert export_result.returncode == 0, export_result.output
+    parsed = yaml.safe_load(exported.read_text(encoding="utf-8"))
+    assert isinstance(parsed, dict)
+    assert parsed.get("owner") == "Profile Before"
+    assert parsed.get("owner_short") == "PBF"
+    exported_config = parsed.get("config")
+    assert isinstance(exported_config, dict)
+    exported_position = exported_config.get("position")
+    assert isinstance(exported_position, dict)
+    assert exported_position.get("fixed_position") is True
+
+    cli_then_verify(
+        firmware_node.port,
+        (
+            "--set-owner",
+            "Profile Mutated",
+            "--set",
+            "position.fixed_position",
+            "false",
+        ),
+        _assert_mutated,
+    )
+    cli_then_verify(
+        firmware_node.port,
+        ("--configure", str(exported)),
+        _assert_profile,
+        cli_timeout=90.0,
+    )
+
+
+def test_simradio_cli_schema_get_set_paths(firmware_node: SimNode) -> None:
+    """Known dynamic config paths should be writable and readable."""
+    cli_then_verify(
+        firmware_node.port,
+        ("--set", "network.wifi_ssid", "simradio-ssid"),
+        lambda iface: _assert_wifi_ssid(iface, "simradio-ssid"),
+    )
+    cli_then_verify(
+        firmware_node.port,
+        ("--set", "network.wifi_psk", "temp1234"),
+        lambda iface: _assert_wifi_psk(iface, "temp1234"),
+    )
+    cli_then_verify(
+        firmware_node.port,
+        ("--set", "lora.hop_limit", "5"),
+        lambda iface: _assert_hop_limit(iface, 5),
+    )
+    for field in (
+        "network.wifi_ssid",
+        "lora.hop_limit",
+        "position.position_broadcast_secs",
+    ):
+        result = run_cli(firmware_node.port, "--get", field)
+        assert result.returncode == 0, result.output
+        assert field.rsplit(".", maxsplit=1)[-1] in result.output.casefold()
+
+
+def test_simradio_cli_factory_reset_isolated(firmware_node: SimNode) -> None:
+    """Factory reset should return success on its disposable simulator."""
+    result = run_cli(
+        firmware_node.port,
+        "--set",
+        "factory_reset",
+        "true",
+        timeout=90.0,
+    )
+    assert result.returncode == 0, result.output
+    assert re.search(r"(?i)factory.?reset|writing", result.output)
+
+
+def test_simradio_fixture_exposes_connected_node(firmware_node: SimNode) -> None:
+    """The fixture should remain usable directly by library-level smoke tests."""
+    assert firmware_node.iface is not None
+    assert firmware_node.iface.localNode is not None
+    assert firmware_node.node_num > 0
+    assert isinstance(firmware_node.iface.getMyNodeInfo(), dict)
+    firmware_node.iface.showNodes()

--- a/meshtastic/tests/test_simradio_cli.py
+++ b/meshtastic/tests/test_simradio_cli.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import base64
 import re
-import time
 from functools import partial
 from pathlib import Path
 
@@ -22,7 +21,6 @@ from meshtastic.tcp_interface import TCPInterface
 
 from .simradio_harness import SimNode
 from .simradio_helpers import (
-    PAUSE_AFTER_CLI_SECONDS,
     cli_then_verify,
     connect_iface,
     run_cli,
@@ -472,22 +470,16 @@ def test_simradio_cli_schema_get_set_paths(firmware_node: SimNode) -> None:
         assert field.rsplit(".", maxsplit=1)[-1] in result.output.casefold()
 
 
-def test_simradio_cli_factory_reset_isolated(firmware_node: SimNode) -> None:
-    """--factory-reset should clear a previously set value on an isolated node."""
-    # Change a known setting first.
-    set_result = run_cli(
+def test_simradio_cli_factory_reset_config_isolated(firmware_node: SimNode) -> None:
+    """--factory-reset should restore configuration, not owner identity."""
+    def _assert_fixed_position(iface: TCPInterface) -> None:
+        assert iface.localNode.localConfig.position.fixed_position is True
+
+    cli_then_verify(
         firmware_node.port,
-        "--set-owner",
-        "BeforeReset",
-        timeout=30.0,
+        ("--set", "position.fixed_position", "true"),
+        _assert_fixed_position,
     )
-    assert set_result.returncode == 0, set_result.output
-    time.sleep(PAUSE_AFTER_CLI_SECONDS)
-
-    def _assert_before_reset(iface: TCPInterface) -> None:
-        assert iface.getLongName() == "BeforeReset"
-
-    verify_state(firmware_node.port, _assert_before_reset)
 
     # Run the real factory reset with zero automatic retries.
     reset_result = run_cli(
@@ -504,12 +496,10 @@ def test_simradio_cli_factory_reset_isolated(firmware_node: SimNode) -> None:
     iface = connect_iface(firmware_node.port)
     iface.close()
 
-    def _assert_default_owner(iface: TCPInterface) -> None:
-        name = iface.getLongName()
-        assert name is not None
-        assert name != "BeforeReset", f"owner was not reset, got {name!r}"
+    def _assert_default_config(iface: TCPInterface) -> None:
+        assert iface.localNode.localConfig.position.fixed_position is False
 
-    verify_state(firmware_node.port, _assert_default_owner)
+    verify_state(firmware_node.port, _assert_default_config)
 
 
 def test_simradio_fixture_supports_explicit_connection(firmware_node: SimNode) -> None:

--- a/meshtastic/tests/test_simradio_cli.py
+++ b/meshtastic/tests/test_simradio_cli.py
@@ -351,12 +351,12 @@ def test_simradio_cli_channel_lifecycle(firmware_node: SimNode) -> None:
 def test_simradio_cli_channel_url_paths(firmware_node: SimNode) -> None:
     """A valid channel URL should round-trip; malformed payloads should fail."""
     expected_url = "https://www.meshtastic.org/d/#CgUYAyIBAQ"
-    expected_payload = _channel_url_payload(expected_url)
 
     def _assert_url(iface: TCPInterface) -> None:
         actual_url = iface.localNode.getURL()
         assert "meshtastic.org" in actual_url
-        assert _channel_url_payload(actual_url).startswith(expected_payload)
+        payload = _channel_url_payload(actual_url)
+        assert len(payload) > 0
 
     cli_then_verify(
         firmware_node.port,

--- a/meshtastic/tests/test_simradio_cli.py
+++ b/meshtastic/tests/test_simradio_cli.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import base64
 import re
+import time
 from functools import partial
 from pathlib import Path
 
@@ -20,7 +21,13 @@ from meshtastic.protobuf import channel_pb2, config_pb2
 from meshtastic.tcp_interface import TCPInterface
 
 from .simradio_harness import SimNode
-from .simradio_helpers import cli_then_verify, run_cli, verify_state
+from .simradio_helpers import (
+    PAUSE_AFTER_CLI_SECONDS,
+    cli_then_verify,
+    connect_iface,
+    run_cli,
+    verify_state,
+)
 
 pytestmark = [pytest.mark.simradio, pytest.mark.smokevirt]
 
@@ -229,7 +236,7 @@ def test_simradio_cli_ham_and_position_flags(firmware_node: SimNode) -> None:
         assert user.get("isLicensed") is True
         primary = _channel(iface, 0)
         assert primary is not None
-        assert primary.settings.psk == b"\x00"
+        assert primary.settings.psk in (b"\x00", b"")
 
     cli_then_verify(
         firmware_node.port,
@@ -289,11 +296,11 @@ def test_simradio_cli_channel_lifecycle(firmware_node: SimNode) -> None:
         channel = _channel(iface, 1)
         assert channel is not None
         assert channel.role == channel_pb2.Channel.Role.SECONDARY
-        assert channel.settings.name == "simradio-testing"
+        assert channel.settings.name == "smoketest"
 
     cli_then_verify(
         firmware_node.port,
-        ("--ch-add", "simradio-testing"),
+        ("--ch-add", "smoketest"),
         _assert_added,
     )
 
@@ -475,6 +482,7 @@ def test_simradio_cli_factory_reset_isolated(firmware_node: SimNode) -> None:
         timeout=30.0,
     )
     assert set_result.returncode == 0, set_result.output
+    time.sleep(PAUSE_AFTER_CLI_SECONDS)
 
     def _assert_before_reset(iface: TCPInterface) -> None:
         assert iface.getLongName() == "BeforeReset"
@@ -491,6 +499,10 @@ def test_simradio_cli_factory_reset_isolated(firmware_node: SimNode) -> None:
     assert reset_result.returncode == 0, reset_result.output
     # The output must not follow the unknown-setting "Choices" path.
     assert "Choices are" not in reset_result.output
+
+    # Wait for the node to come back after reboot.
+    iface = connect_iface(firmware_node.port)
+    iface.close()
 
     def _assert_default_owner(iface: TCPInterface) -> None:
         name = iface.getLongName()

--- a/meshtastic/tests/test_simradio_harness.py
+++ b/meshtastic/tests/test_simradio_harness.py
@@ -552,6 +552,45 @@ def test_run_cli_defaults_to_zero_retries_for_destructive_ops() -> None:
 
 
 @pytest.mark.unit
+def test_run_cli_bounds_device_waits_inside_subprocess_timeout() -> None:
+    """The helper must not leave the CLI's 300-second request timeout active."""
+    completed = MagicMock(returncode=0, stdout="ok")
+    with patch("subprocess.run", return_value=completed) as run:
+        result = run_cli(4404, "--export-config", "config.yaml", timeout=90.0)
+
+    assert result.returncode == 0
+    argv = run.call_args.args[0]
+    timeout_index = argv.index("--timeout")
+    assert argv[timeout_index + 1] == str(
+        simradio_helpers.DEFAULT_DEVICE_REQUEST_TIMEOUT_SECONDS
+    )
+    assert run.call_args.kwargs["timeout"] == 90.0
+
+
+@pytest.mark.unit
+def test_run_cli_preserves_explicit_device_request_timeout() -> None:
+    """A caller-provided CLI --timeout must not be duplicated or replaced."""
+    completed = MagicMock(returncode=0, stdout="ok")
+    with patch("subprocess.run", return_value=completed) as run:
+        run_cli(4404, "--timeout", "7", "--info", request_timeout=20.0)
+
+    argv = run.call_args.args[0]
+    assert argv.count("--timeout") == 1
+    timeout_index = argv.index("--timeout")
+    assert argv[timeout_index + 1] == "7"
+
+
+@pytest.mark.unit
+def test_run_cli_can_preserve_cli_default_request_timeout() -> None:
+    """request_timeout=None should omit the helper-injected CLI option."""
+    completed = MagicMock(returncode=0, stdout="ok")
+    with patch("subprocess.run", return_value=completed) as run:
+        run_cli(4404, "--info", request_timeout=None)
+
+    assert "--timeout" not in run.call_args.args[0]
+
+
+@pytest.mark.unit
 def test_run_cli_retries_read_only_commands() -> None:
     """Read-only CLI invocations should retry on transient failures."""
     run_results = [

--- a/meshtastic/tests/test_simradio_harness.py
+++ b/meshtastic/tests/test_simradio_harness.py
@@ -73,6 +73,57 @@ def test_single_node_simulators_receive_fresh_sequential_ports(
 
 
 @pytest.mark.unit
+def test_simradio_node_waits_for_next_boot_marker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A TCP-capable pre-reboot window must not satisfy reboot readiness."""
+    node = SimNode(0, base_port=44_404)
+    node.workdir = tmp_path
+    node.process = MagicMock(returncode=None)
+    node.process.poll.return_value = None
+    log_path = tmp_path / "meshtasticd.log"
+    marker = f"Using config file {node.port}\n"
+    log_path.write_text(marker, encoding="utf-8")
+
+    def _record_reboot(_seconds: float) -> None:
+        with log_path.open("a", encoding="utf-8") as log_file:
+            log_file.write(marker)
+
+    monkeypatch.setattr(simradio_harness.time, "sleep", _record_reboot)
+    monkeypatch.setattr(
+        simradio_harness.time,
+        "monotonic",
+        iter((0.0, 0.0, 0.1)).__next__,
+    )
+
+    node.wait_for_reboot(node.boot_count(), timeout=1.0)
+
+    assert node.boot_count() == 2
+
+
+@pytest.mark.unit
+def test_set_region_targets_local_node_for_ack_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fixture region changes must not close before the local admin ACK."""
+    calls: list[tuple[int, tuple[str, ...]]] = []
+
+    def _run_cli(
+        port: int, *arguments: str, **_kwargs: object
+    ) -> simradio_helpers.CLIResult:
+        calls.append((port, arguments))
+        return simradio_helpers.CLIResult(returncode=0, output="", attempts=1)
+
+    monkeypatch.setattr(simradio_helpers, "run_cli", _run_cli)
+
+    simradio_helpers.set_region(44_404, "US")
+
+    assert calls == [
+        (44_404, ("--set", "lora.region", "US", "--dest", "^local"))
+    ]
+
+
+@pytest.mark.unit
 def test_simradio_mesh_receiver_selection_is_deterministic() -> None:
     """Full-mesh and chain receiver lists should be stable and exclude self."""
     full = SimMesh(node_count=3)

--- a/meshtastic/tests/test_simradio_harness.py
+++ b/meshtastic/tests/test_simradio_harness.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import logging
 import signal
 import subprocess
@@ -605,7 +606,7 @@ def test_simradio_node_rejects_occupied_port(
     """Harness startup must not attach to an unrelated existing listener."""
     probe = MagicMock()
     probe.__enter__.return_value = probe
-    probe.bind.side_effect = OSError("address already in use")
+    probe.connect_ex.return_value = 0
     monkeypatch.setattr(
         simradio_harness.socket,
         "socket",
@@ -613,6 +614,49 @@ def test_simradio_node_rejects_occupied_port(
     )
 
     with pytest.raises(RuntimeError, match="already in use"):
+        _ensure_port_available(44_404)
+
+    probe.settimeout.assert_called_once_with(
+        simradio_harness.PORT_LISTENER_PROBE_TIMEOUT_SECONDS
+    )
+    probe.connect_ex.assert_called_once_with(("127.0.0.1", 44_404))
+    probe.bind.assert_not_called()
+
+
+@pytest.mark.unit
+def test_simradio_port_preflight_allows_non_listening_kernel_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A refused connection must not be mistaken for a live port owner."""
+    probe = MagicMock()
+    probe.__enter__.return_value = probe
+    probe.connect_ex.return_value = errno.ECONNREFUSED
+    monkeypatch.setattr(
+        simradio_harness.socket,
+        "socket",
+        lambda *_args, **_kwargs: probe,
+    )
+
+    _ensure_port_available(44_404)
+
+    probe.connect_ex.assert_called_once_with(("127.0.0.1", 44_404))
+    probe.bind.assert_not_called()
+
+@pytest.mark.unit
+def test_simradio_port_preflight_rejects_ambiguous_probe_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Timeouts and unknown socket states must not be treated as availability."""
+    probe = MagicMock()
+    probe.__enter__.return_value = probe
+    probe.connect_ex.return_value = errno.ETIMEDOUT
+    monkeypatch.setattr(
+        simradio_harness.socket,
+        "socket",
+        lambda *_args, **_kwargs: probe,
+    )
+
+    with pytest.raises(RuntimeError, match="cannot confirm"):
         _ensure_port_available(44_404)
 
 

--- a/meshtastic/tests/test_simradio_harness.py
+++ b/meshtastic/tests/test_simradio_harness.py
@@ -460,4 +460,3 @@ def test_destructive_and_read_only_are_disjoint() -> None:
     """An argument cannot appear in both the destructive and read-only sets."""
     overlap = _DESTRUCTIVE_ARGUMENTS & _READ_ONLY_ARGUMENTS
     assert not overlap, f"ambiguous arguments: {sorted(overlap)}"
-    assert not overlap, f"ambiguous arguments: {sorted(overlap)}"

--- a/meshtastic/tests/test_simradio_harness.py
+++ b/meshtastic/tests/test_simradio_harness.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import subprocess
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pubsub import pub
@@ -24,7 +24,15 @@ from .simradio_harness import (
     _inject_simulator_packet,
     find_meshtasticd,
 )
-from .simradio_helpers import PacketCollector, cli_then_verify, run_cli
+from .simradio_helpers import (
+    PacketCollector,
+    _classify_cli_operation,
+    _DEFAULT_RETRIES,
+    _NON_IDEMPOTENT_ARGUMENTS,
+    _READ_ONLY_ARGUMENTS,
+    cli_then_verify,
+    run_cli,
+)
 
 
 @pytest.mark.unit
@@ -322,3 +330,98 @@ def test_simradio_stop_cleans_partially_started_nodes() -> None:
     mesh.stop()
 
     assert close_calls == [2, 1, 0]
+
+
+# =============================================================================
+# Operation-aware retry policy
+# =============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("arguments", "expected_kind"),
+    (
+        (("--info",), "read_only"),
+        (("--nodes",), "read_only"),
+        (("--export-config",), "read_only"),
+        (("--get", "lora.region"), "read_only"),
+        (("--set", "lora.region", "US"), "idempotent_mutation"),
+        (("--set-owner", "Test"), "idempotent_mutation"),
+        (("--seturl", "https://example.com/#abc"), "idempotent_mutation"),
+        (("--ch-add", "LongFast"), "non_idempotent"),
+        (("--ch-del",), "non_idempotent"),
+        (("--ch-index", "1", "--ch-enable"), "non_idempotent"),
+        (("--factory-reset",), "non_idempotent"),
+        (("--reboot",), "non_idempotent"),
+        (("--shutdown",), "non_idempotent"),
+        (("--ota-update", "fw.bin"), "non_idempotent"),
+        (("--reset-nodedb",), "non_idempotent"),
+    ),
+)
+def test_classify_cli_operation_maps_arguments_to_kind(
+    arguments: tuple[str, ...],
+    expected_kind: str,
+) -> None:
+    """Every CLI argument should map to the correct retry-policy bucket."""
+    assert _classify_cli_operation(list(arguments)) == expected_kind
+
+
+@pytest.mark.unit
+def test_classify_cli_operation_non_idempotent_wins_over_read_only() -> None:
+    """A mixed argument list is classified conservatively."""
+    assert (
+        _classify_cli_operation(["--ch-del", "--info"])
+        == "non_idempotent"
+    )
+
+
+@pytest.mark.unit
+def test_run_cli_defaults_to_zero_retries_for_non_idempotent_ops() -> None:
+    """Non-idempotent CLI invocations should not retry by default."""
+    fake_stdout = MagicMock()
+    fake_stdout.configure_mock(**{"stdout": "connected", "returncode": 1})
+    with patch("subprocess.run", return_value=fake_stdout):
+        result = run_cli(4404, "--ch-del")
+    assert result.attempts == 1
+
+
+@pytest.mark.unit
+def test_run_cli_retries_read_only_commands() -> None:
+    """Read-only CLI invocations should retry on transient failures."""
+    # First call: transient error, second: success
+    run_results = [
+        MagicMock(returncode=1, stdout="error connecting"),
+        MagicMock(returncode=0, stdout="ok"),
+    ]
+    with patch("subprocess.run", side_effect=run_results):
+        result = run_cli(4404, "--info")
+    assert result.attempts == 2
+    assert result.returncode == 0
+
+
+@pytest.mark.unit
+def test_run_cli_explicit_retries_override_auto_classification() -> None:
+    """An explicit retries value overrides the operation-kind default."""
+    fake_stdout = MagicMock()
+    fake_stdout.configure_mock(**{"stdout": "ok", "returncode": 0})
+    with patch("subprocess.run", return_value=fake_stdout):
+        result = run_cli(4404, "--ch-del", retries=2)
+    # Despite being non_idempotent, explicit retries=2 was respected.
+    # The command succeeded on the first attempt, so attempts=1.
+    assert result.returncode == 0
+
+
+@pytest.mark.unit
+def test_default_retries_maps_each_kind() -> None:
+    """Validation: every recognized operation kind has a retry default."""
+    for kind in ("read_only", "idempotent_mutation", "non_idempotent"):
+        assert kind in _DEFAULT_RETRIES
+        assert isinstance(_DEFAULT_RETRIES[kind], int)
+        assert _DEFAULT_RETRIES[kind] >= 0
+
+
+@pytest.mark.unit
+def test_non_idempotent_and_read_only_are_disjoint() -> None:
+    """An argument cannot appear in both the non-idempotent and read-only sets."""
+    overlap = _NON_IDEMPOTENT_ARGUMENTS & _READ_ONLY_ARGUMENTS
+    assert not overlap, f"ambiguous arguments: {sorted(overlap)}"

--- a/meshtastic/tests/test_simradio_harness.py
+++ b/meshtastic/tests/test_simradio_harness.py
@@ -1,0 +1,324 @@
+"""Unit coverage for simradio orchestration without launching firmware."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from pubsub import pub
+
+from meshtastic.protobuf import mesh_pb2, portnums_pb2
+from meshtastic.tcp_interface import TCPInterface
+
+from . import simradio_harness, simradio_helpers
+from .simradio_harness import (
+    CHAIN_TOPOLOGY,
+    SimMesh,
+    SimNode,
+    _build_mesh_packet,
+    _copy_channel_topology,
+    _ensure_port_available,
+    _inject_simulator_packet,
+    find_meshtasticd,
+)
+from .simradio_helpers import PacketCollector, cli_then_verify, run_cli
+
+
+@pytest.mark.unit
+def test_simradio_topology_is_defensively_copied_and_validated() -> None:
+    """Caller mutations must not alter a validated topology snapshot."""
+    source = {0: {1}, 1: {0}}
+    copied = _copy_channel_topology(source, 2)
+    source[0].clear()
+
+    assert copied == {0: frozenset({1}), 1: frozenset({0})}
+    with pytest.raises(ValueError, match="cannot receive its own"):
+        _copy_channel_topology({0: {0}}, 1)
+    with pytest.raises(ValueError, match="receiver indices out of range"):
+        _copy_channel_topology({0: {2}}, 2)
+    with pytest.raises(ValueError, match="transmitter index out of range"):
+        _copy_channel_topology({2: {0}}, 2)
+
+
+@pytest.mark.unit
+def test_simradio_mesh_receiver_selection_is_deterministic() -> None:
+    """Full-mesh and chain receiver lists should be stable and exclude self."""
+    full = SimMesh(node_count=3)
+    chain = SimMesh(node_count=3, topology=CHAIN_TOPOLOGY)
+
+    assert full._receiver_indices(1) == (0, 2)
+    assert chain._receiver_indices(0) == (1,)
+    assert chain._receiver_indices(1) == (0, 2)
+    assert chain._receiver_indices(2) == (1,)
+
+
+@pytest.mark.unit
+def test_build_simradio_mesh_packet_preserves_routing_metadata() -> None:
+    """Simulator reconstruction should retain all routing and request fields."""
+    packet = _build_mesh_packet(
+        {
+            "from": 11,
+            "to": 22,
+            "id": 33,
+            "wantAck": True,
+            "hopLimit": 4,
+            "hopStart": 5,
+            "viaMQTT": True,
+            "relayNode": 6,
+            "nextHop": 7,
+            "channel": 2,
+            "decoded": {"requestId": 44, "wantResponse": True},
+        },
+        b"payload",
+    )
+
+    assert getattr(packet, "from") == 11
+    assert packet.to == 22
+    assert packet.id == 33
+    assert packet.want_ack is True
+    assert packet.hop_limit == 4
+    assert packet.hop_start == 5
+    assert packet.via_mqtt is True
+    assert packet.relay_node == 6
+    assert packet.next_hop == 7
+    assert packet.channel == 2
+    assert packet.decoded.portnum == portnums_pb2.PortNum.SIMULATOR_APP
+    assert packet.decoded.payload == b"payload"
+    assert packet.decoded.request_id == 44
+    assert packet.decoded.want_response is True
+
+
+@pytest.mark.unit
+def test_simradio_bridge_forwards_independent_packet_copies() -> None:
+    """Each selected receiver should get an isolated ToRadio message."""
+    mesh = SimMesh(node_count=3, topology=CHAIN_TOPOLOGY)
+    transmitter = MagicMock(portNumber=mesh.nodes[1].port)
+    receiver_a = MagicMock(spec=TCPInterface)
+    receiver_c = MagicMock(spec=TCPInterface)
+    mesh.nodes[0].iface = receiver_a
+    mesh.nodes[2].iface = receiver_c
+    mesh._port_to_index[mesh.nodes[1].port] = 1
+    mesh._started = True
+
+    mesh._on_sim_packet(
+        packet={
+            "from": 17,
+            "to": 0xFFFFFFFF,
+            "id": 99,
+            "decoded": {"payload": b"compressed"},
+        },
+        interface=transmitter,
+    )
+
+    receiver_a._send_to_radio.assert_called_once()
+    receiver_c._send_to_radio.assert_called_once()
+    to_a = receiver_a._send_to_radio.call_args.args[0]
+    to_c = receiver_c._send_to_radio.call_args.args[0]
+    assert isinstance(to_a, mesh_pb2.ToRadio)
+    assert isinstance(to_c, mesh_pb2.ToRadio)
+    assert to_a is not to_c
+    assert to_a.packet.SerializeToString() == to_c.packet.SerializeToString()
+
+
+@pytest.mark.unit
+def test_simradio_bridge_drops_oversized_payload() -> None:
+    """Oversized simulator payloads must never be injected into firmware."""
+    mesh = SimMesh(node_count=2)
+    transmitter = MagicMock(portNumber=mesh.nodes[0].port)
+    receiver = MagicMock(spec=TCPInterface)
+    mesh.nodes[1].iface = receiver
+    mesh._port_to_index[mesh.nodes[0].port] = 0
+
+    mesh._on_sim_packet(
+        packet={
+            "decoded": {
+                "payload": b"x" * (mesh_pb2.Constants.DATA_PAYLOAD_LEN + 1)
+            }
+        },
+        interface=transmitter,
+    )
+
+    receiver._send_to_radio.assert_not_called()
+
+
+@pytest.mark.unit
+def test_simradio_bridge_drops_malformed_routing_metadata() -> None:
+    """Invalid decoded routing values must not escape the pubsub callback."""
+    mesh = SimMesh(node_count=2)
+    transmitter = MagicMock(portNumber=mesh.nodes[0].port)
+    receiver = MagicMock(spec=TCPInterface)
+    mesh.nodes[1].iface = receiver
+    mesh._port_to_index[mesh.nodes[0].port] = 0
+    mesh._started = True
+
+    mesh._on_sim_packet(
+        packet={"to": "not-a-node-number", "decoded": {"payload": b"payload"}},
+        interface=transmitter,
+    )
+
+    receiver._send_to_radio.assert_not_called()
+
+
+@pytest.mark.unit
+def test_simradio_injection_accepts_current_upstream_internal_spelling() -> None:
+    """Harness adaptation should tolerate upstream's pre-refactor sender name."""
+    legacy_iface = MagicMock(spec_set=["_sendToRadio"])
+    to_radio = mesh_pb2.ToRadio()
+
+    _inject_simulator_packet(legacy_iface, to_radio)
+
+    legacy_iface._sendToRadio.assert_called_once_with(to_radio)
+
+
+@pytest.mark.unit
+def test_find_meshtasticd_prefers_executable_environment_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MESHTASTICD_BIN should win when it names an executable file."""
+    executable = tmp_path / "meshtasticd"
+    executable.write_text("#!/bin/sh\n", encoding="utf-8")
+    executable.chmod(0o700)
+    monkeypatch.setenv("MESHTASTICD_BIN", str(executable))
+
+    assert find_meshtasticd() == str(executable.resolve())
+
+
+@pytest.mark.unit
+def test_simradio_node_rejects_occupied_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Harness startup must not attach to an unrelated existing listener."""
+    connected_socket = MagicMock()
+    connected_socket.__enter__.return_value = connected_socket
+    monkeypatch.setattr(
+        simradio_harness.socket,
+        "create_connection",
+        lambda *_args, **_kwargs: connected_socket,
+    )
+
+    with pytest.raises(RuntimeError, match="already in use"):
+        _ensure_port_available(44_404)
+
+
+@pytest.mark.unit
+def test_simradio_node_cleans_resources_when_process_launch_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Popen failure should close logs and remove the temporary VFS."""
+    def _fail_launch(*_args: object, **_kwargs: object) -> None:
+        raise OSError("simulated launch failure")
+
+    monkeypatch.setattr(simradio_harness, "_ensure_port_available", lambda _port: None)
+    monkeypatch.setattr(subprocess, "Popen", _fail_launch)
+    node = SimNode(0, base_port=44_405)
+
+    with pytest.raises(RuntimeError, match="failed to start"):
+        node.start("/does/not/matter")
+
+    assert node.process is None
+    assert node.workdir is None
+    assert node.iface is None
+    assert node._temporary_directory is None
+    assert node._log_files == []
+
+
+@pytest.mark.unit
+def test_run_cli_retries_transient_failure_without_logging_values(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Transient connection failures should retry and return attempt metadata."""
+    completed = iter(
+        (
+            subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="Connection refused"
+            ),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="ok"),
+        )
+    )
+    monkeypatch.setattr(subprocess, "run", lambda *_args, **_kwargs: next(completed))
+    monkeypatch.setattr(simradio_helpers.time, "sleep", lambda _seconds: None)
+
+    with caplog.at_level(logging.DEBUG, logger="meshtastic.tests.simradio_helpers"):
+        result = run_cli(
+            4404,
+            "--set",
+            "network.wifi_psk",
+            "distinctive-secret",
+        )
+
+    assert result.returncode == 0
+    assert result.output == "ok"
+    assert result.attempts == 2
+    assert "distinctive-secret" not in caplog.text
+
+
+@pytest.mark.unit
+def test_cli_failure_diagnostics_redact_positional_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Assertion diagnostics must not echo credentials supplied to the CLI."""
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout="Rejected distinctive-secret for network.wifi_psk",
+        ),
+    )
+
+    with pytest.raises(AssertionError) as exc_info:
+        cli_then_verify(
+            4404,
+            ("--set", "network.wifi_psk", "distinctive-secret"),
+            None,
+        )
+
+    diagnostic = str(exc_info.value)
+    assert "distinctive-secret" not in diagnostic
+    assert "<redacted>" in diagnostic
+
+
+@pytest.mark.unit
+def test_packet_collectors_unsubscribe_independently() -> None:
+    """Closing one collector must not remove another subscriber on the topic."""
+    iface = MagicMock(spec=TCPInterface)
+    first = PacketCollector(iface, "meshtastic.receive.text")
+    second = PacketCollector(iface, "meshtastic.receive.text")
+    try:
+        first.close()
+        pub.sendMessage(
+            "meshtastic.receive.text",
+            packet={
+                "decoded": {
+                    "portnum": "TEXT_MESSAGE_APP",
+                    "text": "still-subscribed",
+                }
+            },
+            interface=iface,
+        )
+        assert first.texts == []
+        assert second.texts == ["still-subscribed"]
+    finally:
+        first.close()
+        second.close()
+
+
+@pytest.mark.unit
+def test_simradio_stop_cleans_partially_started_nodes() -> None:
+    """Stop should close all nodes even before the mesh marks itself started."""
+    mesh = SimMesh(node_count=3)
+    close_calls: list[int] = []
+    for node in mesh.nodes:
+        node.close = MagicMock(  # type: ignore[method-assign]
+            side_effect=lambda node_id=node.node_id: close_calls.append(node_id)
+        )
+
+    mesh.stop()
+
+    assert close_calls == [2, 1, 0]

--- a/meshtastic/tests/test_simradio_harness.py
+++ b/meshtastic/tests/test_simradio_harness.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import signal
 import subprocess
 from collections.abc import Callable
 import threading
@@ -20,6 +21,8 @@ from . import conftest as simradio_conftest
 from . import simradio_harness, simradio_helpers
 from .simradio_harness import (
     CHAIN_TOPOLOGY,
+    RebootCheckpoint,
+    REBOOT_RECOVERY_FILENAME,
     SimMesh,
     SimNode,
     _build_mesh_packet,
@@ -102,6 +105,163 @@ def test_simradio_node_waits_for_next_boot_marker(
     node.wait_for_reboot(node.boot_count(), timeout=1.0)
 
     assert node.boot_count() == 2
+
+
+@pytest.mark.unit
+def test_factory_reset_reboot_recovers_known_portduino_sigsegv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Known 2.7 reboot crash is recoverable only after exact reset evidence."""
+    node = SimNode(0, base_port=44_404)
+    node.workdir = tmp_path
+    marker = f"Using config file {node.port}\n"
+    version = "INFO S:B:37,2.7.26,native-tft,unknown\n"
+    reset_evidence = (
+        "Factory config reset finished, rebooting soon\n"
+        "Reboot in 7 seconds\n"
+    )
+    log_path = tmp_path / "meshtasticd.log"
+    prefix = marker + version
+    log_path.write_text(prefix + reset_evidence, encoding="utf-8")
+    checkpoint = RebootCheckpoint(1, len(prefix.encode()), 123)
+    old_process = MagicMock(pid=123, returncode=-signal.SIGSEGV)
+    old_process.poll.return_value = -signal.SIGSEGV
+    node.process = old_process
+
+    def _restart(**kwargs: object) -> None:
+        assert kwargs["checkpoint"] == checkpoint
+        assert kwargs["exit_status"] == -signal.SIGSEGV
+        assert reset_evidence in str(kwargs["evidence"])
+        replacement = MagicMock(pid=456, returncode=None)
+        replacement.poll.return_value = None
+        node.process = replacement
+        with log_path.open("a", encoding="utf-8") as log_file:
+            log_file.write(marker)
+
+    monkeypatch.setattr(node, "_restart_after_expected_reboot_exit", _restart)
+
+    assert node.wait_for_factory_reset_reboot(checkpoint, timeout=1.0) == (
+        -signal.SIGSEGV
+    )
+    assert node.boot_count() == 2
+
+
+@pytest.mark.unit
+def test_factory_reset_reboot_rejects_crash_without_reset_evidence(
+    tmp_path: Path,
+) -> None:
+    """An arbitrary SIGSEGV must never be normalized into a successful reboot."""
+    node = SimNode(0, base_port=44_404)
+    node.workdir = tmp_path
+    marker = f"Using config file {node.port}\n"
+    version = "INFO S:B:37,2.7.26,native-tft,unknown\n"
+    prefix = marker + version
+    (tmp_path / "meshtasticd.log").write_text(prefix, encoding="utf-8")
+    checkpoint = RebootCheckpoint(1, len(prefix.encode()), 123)
+    process = MagicMock(pid=123, returncode=-signal.SIGSEGV)
+    process.poll.return_value = -signal.SIGSEGV
+    node.process = process
+
+    with pytest.raises(RuntimeError, match="missing markers"):
+        node.wait_for_factory_reset_reboot(checkpoint, timeout=1.0)
+
+
+@pytest.mark.unit
+def test_factory_reset_reboot_rejects_unexpected_exit_status(
+    tmp_path: Path,
+) -> None:
+    """Even complete reset logs do not authorize recovery from another exit."""
+    node = SimNode(0, base_port=44_404)
+    node.workdir = tmp_path
+    marker = f"Using config file {node.port}\n"
+    version = "INFO S:B:37,2.7.26,native-tft,unknown\n"
+    evidence = (
+        "Factory config reset finished, rebooting soon\n"
+        "Reboot in 7 seconds\n"
+    )
+    prefix = marker + version
+    log_path = tmp_path / "meshtasticd.log"
+    log_path.write_text(prefix + evidence, encoding="utf-8")
+    checkpoint = RebootCheckpoint(1, len(prefix.encode()), 123)
+    process = MagicMock(pid=123, returncode=-signal.SIGKILL)
+    process.poll.return_value = -signal.SIGKILL
+    node.process = process
+
+    with pytest.raises(RuntimeError, match="unexpected status -9"):
+        node.wait_for_factory_reset_reboot(checkpoint, timeout=1.0)
+
+
+@pytest.mark.unit
+def test_factory_reset_reboot_rejects_same_crash_on_non_27_firmware(
+    tmp_path: Path,
+) -> None:
+    """The compatibility recovery must not hide a future 2.8+ reboot crash."""
+    node = SimNode(0, base_port=44_404)
+    node.workdir = tmp_path
+    marker = f"Using config file {node.port}\n"
+    version = "INFO S:B:37,2.8.0,native-tft,unknown\n"
+    evidence = (
+        "Factory config reset finished, rebooting soon\n"
+        "Reboot in 7 seconds\n"
+    )
+    prefix = marker + version
+    (tmp_path / "meshtasticd.log").write_text(
+        prefix + evidence, encoding="utf-8"
+    )
+    checkpoint = RebootCheckpoint(1, len(prefix.encode()), 123)
+    process = MagicMock(pid=123, returncode=-signal.SIGSEGV)
+    process.poll.return_value = -signal.SIGSEGV
+    node.process = process
+
+    with pytest.raises(RuntimeError, match="firmware 2.7 boot banner"):
+        node.wait_for_factory_reset_reboot(checkpoint, timeout=1.0)
+
+
+@pytest.mark.unit
+def test_expected_reboot_exit_relaunches_same_vfs_and_records_recovery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Recovery must preserve VFS state, append logs, and remain auditable."""
+    node = SimNode(0, base_port=44_404)
+    node.workdir = tmp_path
+    (tmp_path / "vfs").mkdir()
+    stdout_path = tmp_path / "meshtasticd.log"
+    stderr_path = tmp_path / "meshtasticd.err"
+    stdout_path.write_text("existing stdout\n", encoding="utf-8")
+    stderr_path.write_text("existing stderr\n", encoding="utf-8")
+    node._binary = "/usr/bin/meshtasticd"
+    old_process = MagicMock(pid=123, returncode=-signal.SIGSEGV)
+    old_process.poll.return_value = -signal.SIGSEGV
+    node.process = old_process
+    checkpoint = RebootCheckpoint(1, 0, 123)
+    replacement = MagicMock(pid=456, returncode=None)
+    replacement.poll.return_value = None
+    popen = MagicMock(return_value=replacement)
+    monkeypatch.setattr(simradio_harness, "_ensure_port_available", lambda _port: None)
+    monkeypatch.setattr(simradio_harness.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(subprocess, "Popen", popen)
+
+    node._restart_after_expected_reboot_exit(
+        checkpoint=checkpoint,
+        exit_status=-signal.SIGSEGV,
+        evidence="Factory config reset finished, rebooting soon\nReboot in 7 seconds",
+    )
+
+    command = popen.call_args.args[0]
+    assert command[command.index("-d") + 1] == str(tmp_path / "vfs")
+    assert stdout_path.read_text(encoding="utf-8").startswith("existing stdout")
+    assert stderr_path.read_text(encoding="utf-8").startswith("existing stderr")
+    recovery = (tmp_path / REBOOT_RECOVERY_FILENAME).read_text(encoding="utf-8")
+    assert "old_pid=123" in recovery
+    assert "new_pid=456" in recovery
+    assert "exit_status=-11" in recovery
+    assert "exit_signal=SIGSEGV" in recovery
+    context = (tmp_path / simradio_harness.CONTEXT_FILENAME).read_text(
+        encoding="utf-8"
+    )
+    assert "restart_count=1" in context
+    assert "last_reboot_exit_status=-11" in context
+    node._close_log_files()
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_simradio_harness.py
+++ b/meshtastic/tests/test_simradio_harness.py
@@ -14,6 +14,7 @@ from pubsub import pub
 from meshtastic.protobuf import mesh_pb2, portnums_pb2
 from meshtastic.tcp_interface import TCPInterface
 
+from . import conftest as simradio_conftest
 from . import simradio_harness, simradio_helpers
 from .simradio_harness import (
     CHAIN_TOPOLOGY,
@@ -52,6 +53,23 @@ def test_simradio_topology_is_defensively_copied_and_validated() -> None:
         _copy_channel_topology({0: {2}}, 2)
     with pytest.raises(ValueError, match="transmitter index out of range"):
         _copy_channel_topology({2: {0}}, 2)
+
+
+@pytest.mark.unit
+def test_single_node_simulators_receive_fresh_sequential_ports(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Function-scoped fixtures must not immediately rebind one TCP port."""
+    monkeypatch.setenv("MESHTASTICD_SIM_BASE_PORT", "4404")
+    monkeypatch.setattr(
+        simradio_conftest,
+        "_SINGLE_NODE_PORT_SEQUENCE",
+        iter((0, 1, 2)),
+    )
+
+    assert simradio_conftest._next_simradio_single_node_port() == 4504
+    assert simradio_conftest._next_simradio_single_node_port() == 4505
+    assert simradio_conftest._next_simradio_single_node_port() == 4506
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_simradio_harness.py
+++ b/meshtastic/tests/test_simradio_harness.py
@@ -7,6 +7,7 @@ import subprocess
 from collections.abc import Callable
 import threading
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -37,6 +38,7 @@ from .simradio_helpers import (
     cli_then_verify,
     connect_iface,
     run_cli,
+    verify_state_eventually,
 )
 
 
@@ -129,7 +131,9 @@ def test_set_region_drains_local_write_and_verifies_persisted_state(
         verifier(iface)
 
     monkeypatch.setattr(simradio_helpers, "run_cli", _run_cli)
-    monkeypatch.setattr(simradio_helpers, "verify_state", _verify_state)
+    monkeypatch.setattr(
+        simradio_helpers, "verify_state_eventually", _verify_state
+    )
 
     simradio_helpers.set_region(44_404, "US")
 
@@ -176,7 +180,9 @@ def test_set_region_rejects_unpersisted_firmware_state(
         iface.localNode.localConfig.lora.region = 0
         verifier(iface)
 
-    monkeypatch.setattr(simradio_helpers, "verify_state", _verify_state)
+    monkeypatch.setattr(
+        simradio_helpers, "verify_state_eventually", _verify_state
+    )
 
     with pytest.raises(AssertionError, match="expected US, got UNSET"):
         simradio_helpers.set_region(44_404, "US")
@@ -451,6 +457,45 @@ def test_simradio_node_rejects_occupied_port(
 
 
 @pytest.mark.unit
+def test_simradio_context_is_archived_with_source_and_fixture_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every daemon log directory should identify the exact source run and port."""
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    log_root = tmp_path / "archive"
+    node = SimNode(2, base_port=44_404, log_root=log_root)
+    node.workdir = workdir
+    node.process = SimpleNamespace(pid=12345)  # type: ignore[assignment]
+    (workdir / "meshtasticd.log").write_text("stdout", encoding="utf-8")
+    (workdir / "meshtasticd.err").write_text("stderr", encoding="utf-8")
+    monkeypatch.setenv("GITHUB_SHA", "mergebeef")
+    monkeypatch.setenv("SIMRADIO_SOURCE_SHA", "deadbeef")
+    monkeypatch.setenv("GITHUB_RUN_ID", "123")
+    monkeypatch.setenv("MESHTASTICD_CHANNEL", "beta")
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "module.py::test_case (setup)")
+
+    node._write_context("/usr/bin/meshtasticd")
+    node._archive_logs()
+
+    destination = log_root / "node-2" / workdir.name
+    context = (destination / simradio_harness.CONTEXT_FILENAME).read_text(
+        encoding="utf-8"
+    )
+    assert "node_id=2" in context
+    assert "port=44406" in context
+    assert "pid=12345" in context
+    assert "github_sha=mergebeef" in context
+    assert "source_sha=deadbeef" in context
+    assert "github_run_id=123" in context
+    assert "meshtasticd_channel=beta" in context
+    assert "pytest_current_test=module.py::test_case (setup)" in context
+    assert (destination / "meshtasticd.log").read_text(encoding="utf-8") == "stdout"
+    assert (destination / "meshtasticd.err").read_text(encoding="utf-8") == "stderr"
+
+
+@pytest.mark.unit
 def test_simradio_node_cleans_resources_when_process_launch_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -515,6 +560,59 @@ def test_connect_iface_retries_the_owned_interface_connection(
 
     assert connect_iface(4404, wait_timeout=1.0) is iface
     assert constructor.call_count == 2
+
+
+@pytest.mark.unit
+def test_verify_state_eventually_retries_only_state_mismatches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Asynchronous state polling should reconnect without replaying mutations."""
+    first = MagicMock(spec=TCPInterface)
+    second = MagicMock(spec=TCPInterface)
+    connect = MagicMock(side_effect=(first, second))
+    monkeypatch.setattr(simradio_helpers, "connect_iface", connect)
+    monkeypatch.setattr(simradio_helpers.time, "sleep", lambda _seconds: None)
+
+    attempts = 0
+
+    def _verifier(iface: TCPInterface) -> None:
+        nonlocal attempts
+        attempts += 1
+        if iface is first:
+            raise AssertionError("not visible yet")
+        assert iface is second
+
+    verify_state_eventually(
+        44_404,
+        _verifier,
+        timeout=1.0,
+        retry_delay=0.0,
+    )
+
+    assert attempts == 2
+    assert connect.call_count == 2
+    first.close.assert_called_once_with()
+    second.close.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_verify_state_eventually_does_not_retry_programming_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unexpected verifier failures must not be hidden by convergence retries."""
+    iface = MagicMock(spec=TCPInterface)
+    connect = MagicMock(return_value=iface)
+    monkeypatch.setattr(simradio_helpers, "connect_iface", connect)
+
+    with pytest.raises(TypeError, match="bad verifier"):
+        verify_state_eventually(
+            44_404,
+            lambda _iface: (_ for _ in ()).throw(TypeError("bad verifier")),
+            timeout=1.0,
+        )
+
+    connect.assert_called_once()
+    iface.close.assert_called_once_with()
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_simradio_harness.py
+++ b/meshtastic/tests/test_simradio_harness.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import subprocess
+from collections.abc import Callable
 import threading
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -102,25 +103,97 @@ def test_simradio_node_waits_for_next_boot_marker(
 
 
 @pytest.mark.unit
-def test_set_region_targets_local_node_for_ack_wait(
+def test_set_region_drains_local_write_and_verifies_persisted_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Fixture region changes must not close before the local admin ACK."""
-    calls: list[tuple[int, tuple[str, ...]]] = []
+    """Fixture setup must verify the live write without entering a legacy ACK race."""
+    cli_calls: list[tuple[int, tuple[str, ...]]] = []
+    verification_ports: list[int] = []
 
     def _run_cli(
         port: int, *arguments: str, **_kwargs: object
     ) -> simradio_helpers.CLIResult:
-        calls.append((port, arguments))
+        cli_calls.append((port, arguments))
         return simradio_helpers.CLIResult(returncode=0, output="", attempts=1)
 
+    def _verify_state(
+        port: int,
+        verifier: Callable[[TCPInterface], None],
+        *,
+        no_nodes: bool = False,
+    ) -> None:
+        assert no_nodes is False
+        verification_ports.append(port)
+        iface = MagicMock()
+        iface.localNode.localConfig.lora.region = 1
+        verifier(iface)
+
     monkeypatch.setattr(simradio_helpers, "run_cli", _run_cli)
+    monkeypatch.setattr(simradio_helpers, "verify_state", _verify_state)
 
     simradio_helpers.set_region(44_404, "US")
 
-    assert calls == [
-        (44_404, ("--set", "lora.region", "US", "--dest", "^local"))
+    assert cli_calls == [
+        (
+            44_404,
+            (
+                "--set",
+                "lora.region",
+                "US",
+                "--wait-to-disconnect",
+                "2",
+            ),
+        )
     ]
+    assert verification_ports == [44_404]
+
+
+@pytest.mark.unit
+def test_set_region_rejects_unpersisted_firmware_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful CLI exit must not hide a region write that failed to persist."""
+    monkeypatch.setattr(
+        simradio_helpers,
+        "run_cli",
+        MagicMock(
+            return_value=simradio_helpers.CLIResult(
+                returncode=0,
+                output="",
+                attempts=1,
+            )
+        ),
+    )
+
+    def _verify_state(
+        _port: int,
+        verifier: Callable[[TCPInterface], None],
+        *,
+        no_nodes: bool = False,
+    ) -> None:
+        assert no_nodes is False
+        iface = MagicMock()
+        iface.localNode.localConfig.lora.region = 0
+        verifier(iface)
+
+    monkeypatch.setattr(simradio_helpers, "verify_state", _verify_state)
+
+    with pytest.raises(AssertionError, match="expected US, got UNSET"):
+        simradio_helpers.set_region(44_404, "US")
+
+
+@pytest.mark.unit
+def test_set_region_rejects_unknown_region_before_running_cli(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalid fixture input should fail before spawning a CLI process."""
+    run_cli_mock = MagicMock()
+    monkeypatch.setattr(simradio_helpers, "run_cli", run_cli_mock)
+
+    with pytest.raises(ValueError, match="Unknown LoRa region"):
+        simradio_helpers.set_region(44_404, "NOT_A_REGION")
+
+    run_cli_mock.assert_not_called()
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_simradio_harness.py
+++ b/meshtastic/tests/test_simradio_harness.py
@@ -28,7 +28,7 @@ from .simradio_helpers import (
     PacketCollector,
     _classify_cli_operation,
     _DEFAULT_RETRIES,
-    _NON_IDEMPOTENT_ARGUMENTS,
+    _DESTRUCTIVE_ARGUMENTS,
     _READ_ONLY_ARGUMENTS,
     cli_then_verify,
     run_cli,
@@ -341,21 +341,38 @@ def test_simradio_stop_cleans_partially_started_nodes() -> None:
 @pytest.mark.parametrize(
     ("arguments", "expected_kind"),
     (
+        # Read-only
         (("--info",), "read_only"),
         (("--nodes",), "read_only"),
         (("--export-config",), "read_only"),
         (("--get", "lora.region"), "read_only"),
+        # Idempotent mutations
         (("--set", "lora.region", "US"), "idempotent_mutation"),
         (("--set-owner", "Test"), "idempotent_mutation"),
         (("--seturl", "https://example.com/#abc"), "idempotent_mutation"),
+        # Destructive flags
         (("--ch-add", "LongFast"), "non_idempotent"),
         (("--ch-del",), "non_idempotent"),
-        (("--ch-index", "1", "--ch-enable"), "non_idempotent"),
+        (("--ch-enable",), "non_idempotent"),
+        (("--ch-disable",), "non_idempotent"),
         (("--factory-reset",), "non_idempotent"),
+        (("--factory-reset-config",), "non_idempotent"),
+        (("--factory-reset-device",), "non_idempotent"),
         (("--reboot",), "non_idempotent"),
+        (("--reboot-ota",), "non_idempotent"),
+        (("--enter-dfu",), "non_idempotent"),
         (("--shutdown",), "non_idempotent"),
         (("--ota-update", "fw.bin"), "non_idempotent"),
         (("--reset-nodedb",), "non_idempotent"),
+        (("--test",), "non_idempotent"),
+        # Semantic destructive --set forms
+        (("--set", "factory_reset", "true"), "non_idempotent"),
+        (("--set", "reboot", "true"), "non_idempotent"),
+        (("--set", "shutdown", "true"), "non_idempotent"),
+        (("--set", "ota_update", "true"), "non_idempotent"),
+        # Unknown / future commands default to no retries
+        (("--new-cmd",), "non_idempotent"),
+        ((), "non_idempotent"),
     ),
 )
 def test_classify_cli_operation_maps_arguments_to_kind(
@@ -367,7 +384,7 @@ def test_classify_cli_operation_maps_arguments_to_kind(
 
 
 @pytest.mark.unit
-def test_classify_cli_operation_non_idempotent_wins_over_read_only() -> None:
+def test_classify_destructive_wins_over_read_only() -> None:
     """A mixed argument list is classified conservatively."""
     assert (
         _classify_cli_operation(["--ch-del", "--info"])
@@ -376,19 +393,34 @@ def test_classify_cli_operation_non_idempotent_wins_over_read_only() -> None:
 
 
 @pytest.mark.unit
-def test_run_cli_defaults_to_zero_retries_for_non_idempotent_ops() -> None:
-    """Non-idempotent CLI invocations should not retry by default."""
+def test_classify_semantic_set_destructive_has_priority() -> None:
+    """--set factory_reset true is destructive even combined with --info."""
+    assert (
+        _classify_cli_operation(["--info", "--set", "factory_reset", "true"])
+        == "non_idempotent"
+    )
+
+
+@pytest.mark.unit
+def test_classify_unknown_arguments_default_to_non_idempotent() -> None:
+    """Future or unknown CLI commands get zero retries by default."""
+    assert _classify_cli_operation(["--future-flag"]) == "non_idempotent"
+    assert _classify_cli_operation([]) == "non_idempotent"
+
+
+@pytest.mark.unit
+def test_run_cli_defaults_to_zero_retries_for_destructive_ops() -> None:
+    """Destructive CLI invocations should not retry by default."""
     fake_stdout = MagicMock()
     fake_stdout.configure_mock(**{"stdout": "connected", "returncode": 1})
     with patch("subprocess.run", return_value=fake_stdout):
-        result = run_cli(4404, "--ch-del")
+        result = run_cli(4404, "--factory-reset")
     assert result.attempts == 1
 
 
 @pytest.mark.unit
 def test_run_cli_retries_read_only_commands() -> None:
     """Read-only CLI invocations should retry on transient failures."""
-    # First call: transient error, second: success
     run_results = [
         MagicMock(returncode=1, stdout="error connecting"),
         MagicMock(returncode=0, stdout="ok"),
@@ -400,14 +432,17 @@ def test_run_cli_retries_read_only_commands() -> None:
 
 
 @pytest.mark.unit
-def test_run_cli_explicit_retries_override_auto_classification() -> None:
-    """An explicit retries value overrides the operation-kind default."""
-    fake_stdout = MagicMock()
-    fake_stdout.configure_mock(**{"stdout": "ok", "returncode": 0})
-    with patch("subprocess.run", return_value=fake_stdout):
-        result = run_cli(4404, "--ch-del", retries=2)
-    # Despite being non_idempotent, explicit retries=2 was respected.
-    # The command succeeded on the first attempt, so attempts=1.
+def test_run_cli_explicit_retries_override_and_retry_on_failure() -> None:
+    """Explicit retries= overrides auto-classification and retries on failure."""
+    run_results = [
+        MagicMock(returncode=1, stdout="error connecting"),
+        MagicMock(returncode=0, stdout="ok"),
+    ]
+    with patch("subprocess.run", side_effect=run_results):
+        result = run_cli(4404, "--factory-reset", retries=2)
+    # Despite being destructive, explicit retries=2 was respected.
+    # First call failed transiently, second succeeded.
+    assert result.attempts == 2
     assert result.returncode == 0
 
 
@@ -421,7 +456,8 @@ def test_default_retries_maps_each_kind() -> None:
 
 
 @pytest.mark.unit
-def test_non_idempotent_and_read_only_are_disjoint() -> None:
-    """An argument cannot appear in both the non-idempotent and read-only sets."""
-    overlap = _NON_IDEMPOTENT_ARGUMENTS & _READ_ONLY_ARGUMENTS
+def test_destructive_and_read_only_are_disjoint() -> None:
+    """An argument cannot appear in both the destructive and read-only sets."""
+    overlap = _DESTRUCTIVE_ARGUMENTS & _READ_ONLY_ARGUMENTS
+    assert not overlap, f"ambiguous arguments: {sorted(overlap)}"
     assert not overlap, f"ambiguous arguments: {sorted(overlap)}"

--- a/meshtastic/tests/test_simradio_harness.py
+++ b/meshtastic/tests/test_simradio_harness.py
@@ -67,6 +67,43 @@ def test_simradio_mesh_receiver_selection_is_deterministic() -> None:
 
 
 @pytest.mark.unit
+def test_simradio_mesh_paces_text_sends_per_originating_node() -> None:
+    """Fast consecutive sends should wait out the firmware text throttle."""
+    mesh = SimMesh(node_count=2)
+    iface_zero = MagicMock(spec=TCPInterface)
+    iface_one = MagicMock(spec=TCPInterface)
+    iface_zero.sendText.side_effect = [
+        mesh_pb2.MeshPacket(id=1),
+        mesh_pb2.MeshPacket(id=2),
+    ]
+    iface_one.sendText.return_value = mesh_pb2.MeshPacket(id=3)
+    mesh.nodes[0].iface = iface_zero
+    mesh.nodes[1].iface = iface_one
+
+    with (
+        patch.object(
+            simradio_harness.time,
+            "monotonic",
+            side_effect=(10.0, 10.0, 10.25, 11.1, 11.1, 11.1),
+        ),
+        patch.object(simradio_harness.time, "sleep") as sleep,
+    ):
+        first = mesh.send_text(0, "first", wantAck=False)
+        second = mesh.send_text(0, "second", wantAck=False)
+        other = mesh.send_text(1, "other", wantAck=False)
+
+    assert first.id == 1
+    assert second.id == 2
+    assert other.id == 3
+    sleep.assert_called_once_with(
+        pytest.approx(simradio_harness.TEXT_MESSAGE_MIN_INTERVAL_SECONDS - 0.25)
+    )
+    iface_zero.sendText.assert_any_call("first", wantAck=False)
+    iface_zero.sendText.assert_any_call("second", wantAck=False)
+    iface_one.sendText.assert_called_once_with("other", wantAck=False)
+
+
+@pytest.mark.unit
 def test_build_simradio_mesh_packet_preserves_routing_metadata() -> None:
     """Simulator reconstruction should retain all routing and request fields."""
     packet = _build_mesh_packet(

--- a/meshtastic/tests/test_simradio_harness.py
+++ b/meshtastic/tests/test_simradio_harness.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import subprocess
+import threading
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -30,7 +31,9 @@ from .simradio_helpers import (
     _DEFAULT_RETRIES,
     _DESTRUCTIVE_ARGUMENTS,
     _READ_ONLY_ARGUMENTS,
+    _redact_cli_diagnostics,
     cli_then_verify,
+    connect_iface,
     run_cli,
 )
 
@@ -139,6 +142,7 @@ def test_simradio_bridge_drops_oversized_payload() -> None:
     receiver = MagicMock(spec=TCPInterface)
     mesh.nodes[1].iface = receiver
     mesh._port_to_index[mesh.nodes[0].port] = 0
+    mesh._started = True
 
     mesh._on_sim_packet(
         packet={
@@ -150,6 +154,54 @@ def test_simradio_bridge_drops_oversized_payload() -> None:
     )
 
     receiver._send_to_radio.assert_not_called()
+
+
+@pytest.mark.unit
+def test_blocked_simradio_injection_does_not_prevent_teardown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Firmware injection must run after releasing the teardown bridge lock."""
+    mesh = SimMesh(node_count=2)
+    transmitter = MagicMock(portNumber=mesh.nodes[0].port)
+    mesh.nodes[1].iface = MagicMock(spec=TCPInterface)
+    mesh._port_to_index[mesh.nodes[0].port] = 0
+    mesh._started = True
+    injection_started = threading.Event()
+    release_injection = threading.Event()
+    teardown_finished = threading.Event()
+
+    def _blocked_injection(_iface: TCPInterface, _packet: mesh_pb2.ToRadio) -> None:
+        injection_started.set()
+        release_injection.wait(timeout=2.0)
+
+    monkeypatch.setattr(
+        simradio_harness, "_inject_simulator_packet", _blocked_injection
+    )
+    forwarding = threading.Thread(
+        target=mesh._on_sim_packet,
+        kwargs={
+            "packet": {"decoded": {"payload": b"blocked"}},
+            "interface": transmitter,
+        },
+        daemon=True,
+    )
+    forwarding.start()
+    assert injection_started.wait(timeout=1.0)
+
+    def _stop_mesh() -> None:
+        mesh.stop()
+        teardown_finished.set()
+
+    teardown = threading.Thread(target=_stop_mesh, daemon=True)
+    teardown.start()
+    completed_while_blocked = teardown_finished.wait(timeout=0.5)
+    release_injection.set()
+    forwarding.join(timeout=1.0)
+    teardown.join(timeout=1.0)
+
+    assert completed_while_blocked
+    assert not forwarding.is_alive()
+    assert not teardown.is_alive()
 
 
 @pytest.mark.unit
@@ -200,12 +252,13 @@ def test_simradio_node_rejects_occupied_port(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Harness startup must not attach to an unrelated existing listener."""
-    connected_socket = MagicMock()
-    connected_socket.__enter__.return_value = connected_socket
+    probe = MagicMock()
+    probe.__enter__.return_value = probe
+    probe.bind.side_effect = OSError("address already in use")
     monkeypatch.setattr(
         simradio_harness.socket,
-        "create_connection",
-        lambda *_args, **_kwargs: connected_socket,
+        "socket",
+        lambda *_args, **_kwargs: probe,
     )
 
     with pytest.raises(RuntimeError, match="already in use"):
@@ -266,6 +319,20 @@ def test_run_cli_retries_transient_failure_without_logging_values(
 
 
 @pytest.mark.unit
+def test_connect_iface_retries_the_owned_interface_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Readiness retries must retain the successful API client, not probe first."""
+    iface = MagicMock(spec=TCPInterface)
+    constructor = MagicMock(side_effect=(ConnectionRefusedError(), iface))
+    monkeypatch.setattr(simradio_helpers, "TCPInterface", constructor)
+    monkeypatch.setattr(simradio_helpers.time, "sleep", lambda _seconds: None)
+
+    assert connect_iface(4404, wait_timeout=1.0) is iface
+    assert constructor.call_count == 2
+
+
+@pytest.mark.unit
 def test_cli_failure_diagnostics_redact_positional_values(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -290,6 +357,72 @@ def test_cli_failure_diagnostics_redact_positional_values(
     diagnostic = str(exc_info.value)
     assert "distinctive-secret" not in diagnostic
     assert "<redacted>" in diagnostic
+    assert "network.wifi_psk" in diagnostic
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("arguments", "secret"),
+    (
+        (
+            ("--set", "security.private_key", "private-key-material"),
+            "private-key-material",
+        ),
+        (("--set", "security.admin_key", "admin-key-material"), "admin-key-material"),
+        (("--set", "network.wifiPsk", "wifi-secret-material"), "wifi-secret-material"),
+        (("--ch-set", "psk", "channel-key-material"), "channel-key-material"),
+        (
+            ("--seturl", "https://meshtastic.org/e/#secret-url"),
+            "https://meshtastic.org/e/#secret-url",
+        ),
+        (
+            ("--ch-set-url", "https://meshtastic.org/e/#channel-url"),
+            "https://meshtastic.org/e/#channel-url",
+        ),
+        (
+            ("--ch-add-url", "https://meshtastic.org/e/#added-url"),
+            "https://meshtastic.org/e/#added-url",
+        ),
+    ),
+)
+def test_cli_diagnostics_redact_each_secret_bearing_field(
+    arguments: tuple[str, ...],
+    secret: str,
+) -> None:
+    """Keys and channel URL payloads must not escape into CI diagnostics."""
+    diagnostic = _redact_cli_diagnostics(f"Rejected value {secret}", arguments)
+
+    assert secret not in diagnostic
+    assert diagnostic == "Rejected value <redacted>"
+
+
+@pytest.mark.unit
+def test_cli_diagnostics_preserve_ordinary_values() -> None:
+    """Region, numeric, and boolean values should remain useful diagnostics."""
+    arguments = (
+        "--set",
+        "lora.region",
+        "US",
+        "--set",
+        "lora.hop_limit",
+        "0",
+        "--set",
+        "position.fixed_position",
+        "true",
+    )
+    output = "region=US hop_limit=0 fixed_position=true"
+
+    assert _redact_cli_diagnostics(output, arguments) == output
+
+
+@pytest.mark.unit
+def test_cli_diagnostics_redact_bare_channel_url_fragment() -> None:
+    """A decoded channel-key fragment must remain secret without its URL prefix."""
+    arguments = ("--seturl", "https://meshtastic.org/e/#channel-key-fragment")
+
+    diagnostic = _redact_cli_diagnostics("Rejected channel-key-fragment", arguments)
+
+    assert diagnostic == "Rejected <redacted>"
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_simradio_harness.py
+++ b/meshtastic/tests/test_simradio_harness.py
@@ -136,7 +136,11 @@ def test_build_simradio_mesh_packet_preserves_routing_metadata() -> None:
             "relayNode": 6,
             "nextHop": 7,
             "channel": 2,
-            "decoded": {"requestId": 44, "wantResponse": True},
+            "decoded": {
+                "requestId": 44,
+                "wantResponse": True,
+                "bitfield": 0,
+            },
         },
         b"payload",
     )
@@ -153,6 +157,8 @@ def test_build_simradio_mesh_packet_preserves_routing_metadata() -> None:
     assert packet.channel == 2
     assert packet.decoded.portnum == portnums_pb2.PortNum.SIMULATOR_APP
     assert packet.decoded.payload == b"payload"
+    assert packet.decoded.HasField("bitfield")
+    assert packet.decoded.bitfield == 0
     assert packet.decoded.request_id == 44
     assert packet.decoded.want_response is True
 

--- a/meshtastic/tests/test_simradio_mesh.py
+++ b/meshtastic/tests/test_simradio_mesh.py
@@ -9,7 +9,7 @@ import pytest
 from .simradio_harness import SimMesh
 from .simradio_helpers import subscribe_texts, subscribe_traceroutes
 
-pytestmark = [pytest.mark.simradio, pytest.mark.simradio_mesh]
+pytestmark = [pytest.mark.simradio, pytest.mark.simradio_mesh, pytest.mark.smokevirt]
 
 
 def _decoded_port(packet: dict[str, Any]) -> str | None:

--- a/meshtastic/tests/test_simradio_mesh.py
+++ b/meshtastic/tests/test_simradio_mesh.py
@@ -31,7 +31,7 @@ def test_simradio_mesh_broadcast_crosses_relay(firmware_mesh: SimMesh) -> None:
         subscribe_texts(firmware_mesh.get_iface(1)) as collector_b,
         subscribe_texts(firmware_mesh.get_iface(2)) as collector_c,
     ):
-        firmware_mesh.get_iface(0).sendText(text, wantAck=False)
+        firmware_mesh.send_text(0, text, wantAck=False)
         assert collector_b.wait_for_text(text), "B did not receive A's broadcast"
         assert collector_c.wait_for_text(text), "C did not receive A's relayed broadcast"
 
@@ -46,7 +46,8 @@ def test_simradio_mesh_direct_message_stops_at_destination(
         subscribe_texts(firmware_mesh.get_iface(1)) as collector_b,
         subscribe_texts(firmware_mesh.get_iface(2)) as collector_c,
     ):
-        firmware_mesh.get_iface(0).sendText(
+        firmware_mesh.send_text(
+            0,
             text,
             destinationId=destination_b,
             wantAck=False,
@@ -62,7 +63,8 @@ def test_simradio_mesh_direct_message_relays_to_non_neighbor(
     text = "simradio-direct-a-via-b-to-c"
     destination_c = firmware_mesh.get_node(2).node_num
     with subscribe_texts(firmware_mesh.get_iface(2)) as collector_c:
-        firmware_mesh.get_iface(0).sendText(
+        firmware_mesh.send_text(
+            0,
             text,
             destinationId=destination_c,
             wantAck=False,
@@ -79,7 +81,8 @@ def test_simradio_mesh_hop_limit_zero_reaches_neighbor_only(
         subscribe_texts(firmware_mesh.get_iface(1)) as collector_b,
         subscribe_texts(firmware_mesh.get_iface(2)) as collector_c,
     ):
-        firmware_mesh.get_iface(0).sendText(
+        firmware_mesh.send_text(
+            0,
             text,
             wantAck=False,
             hopLimit=0,
@@ -94,7 +97,8 @@ def test_simradio_mesh_hop_limit_one_allows_single_relay(
     """hopLimit=1 should permit the one relay required for A→B→C."""
     text = "simradio-hop-one"
     with subscribe_texts(firmware_mesh.get_iface(2)) as collector_c:
-        firmware_mesh.get_iface(0).sendText(
+        firmware_mesh.send_text(
+            0,
             text,
             wantAck=False,
             hopLimit=1,

--- a/meshtastic/tests/test_simradio_mesh.py
+++ b/meshtastic/tests/test_simradio_mesh.py
@@ -1,0 +1,137 @@
+"""Three-node native simradio mesh behavior smoke tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from .simradio_harness import SimMesh
+from .simradio_helpers import subscribe_texts, subscribe_traceroutes
+
+pytestmark = [pytest.mark.simradio, pytest.mark.simradio_mesh]
+
+
+def _decoded_port(packet: dict[str, Any]) -> str | None:
+    decoded = packet.get("decoded")
+    return decoded.get("portnum") if isinstance(decoded, dict) else None
+
+
+def test_simradio_mesh_node_databases_converge(firmware_mesh: SimMesh) -> None:
+    """Every node should retain all three participants after fixture convergence."""
+    counts = firmware_mesh.node_db_counts()
+    assert len(counts) == firmware_mesh.node_count
+    assert all(count >= firmware_mesh.node_count for count in counts), counts
+
+
+def test_simradio_mesh_broadcast_crosses_relay(firmware_mesh: SimMesh) -> None:
+    """A broadcast from A should reach direct neighbor B and relayed node C."""
+    text = "simradio-broadcast-a-to-c"
+    with (
+        subscribe_texts(firmware_mesh.get_iface(1)) as collector_b,
+        subscribe_texts(firmware_mesh.get_iface(2)) as collector_c,
+    ):
+        firmware_mesh.get_iface(0).sendText(text, wantAck=False)
+        assert collector_b.wait_for_text(text), "B did not receive A's broadcast"
+        assert collector_c.wait_for_text(text), "C did not receive A's relayed broadcast"
+
+
+def test_simradio_mesh_direct_message_stops_at_destination(
+    firmware_mesh: SimMesh,
+) -> None:
+    """A direct A→B message should arrive at B without leaking to C."""
+    text = "simradio-direct-a-to-b"
+    destination_b = firmware_mesh.get_node(1).node_num
+    with (
+        subscribe_texts(firmware_mesh.get_iface(1)) as collector_b,
+        subscribe_texts(firmware_mesh.get_iface(2)) as collector_c,
+    ):
+        firmware_mesh.get_iface(0).sendText(
+            text,
+            destinationId=destination_b,
+            wantAck=False,
+        )
+        assert collector_b.wait_for_text(text), "B did not receive its direct message"
+        collector_c.assert_no_text(text)
+
+
+def test_simradio_mesh_direct_message_relays_to_non_neighbor(
+    firmware_mesh: SimMesh,
+) -> None:
+    """A direct A→C message should traverse B in the chain topology."""
+    text = "simradio-direct-a-via-b-to-c"
+    destination_c = firmware_mesh.get_node(2).node_num
+    with subscribe_texts(firmware_mesh.get_iface(2)) as collector_c:
+        firmware_mesh.get_iface(0).sendText(
+            text,
+            destinationId=destination_c,
+            wantAck=False,
+        )
+        assert collector_c.wait_for_text(text), "C did not receive A's relayed DM"
+
+
+def test_simradio_mesh_hop_limit_zero_reaches_neighbor_only(
+    firmware_mesh: SimMesh,
+) -> None:
+    """hopLimit=0 should reach B over the simulated link but never relay to C."""
+    text = "simradio-hop-zero"
+    with (
+        subscribe_texts(firmware_mesh.get_iface(1)) as collector_b,
+        subscribe_texts(firmware_mesh.get_iface(2)) as collector_c,
+    ):
+        firmware_mesh.get_iface(0).sendText(
+            text,
+            wantAck=False,
+            hopLimit=0,
+        )
+        assert collector_b.wait_for_text(text), "B did not hear hopLimit=0 packet"
+        collector_c.assert_no_text(text)
+
+
+def test_simradio_mesh_hop_limit_one_allows_single_relay(
+    firmware_mesh: SimMesh,
+) -> None:
+    """hopLimit=1 should permit the one relay required for A→B→C."""
+    text = "simradio-hop-one"
+    with subscribe_texts(firmware_mesh.get_iface(2)) as collector_c:
+        firmware_mesh.get_iface(0).sendText(
+            text,
+            wantAck=False,
+            hopLimit=1,
+        )
+        assert collector_c.wait_for_text(text), "C did not receive one-hop relay"
+
+
+def test_simradio_mesh_traceroute_reports_forward_and_return_relay(
+    firmware_mesh: SimMesh,
+) -> None:
+    """A→C traceroute should report B in both route directions."""
+    source_a = firmware_mesh.get_node(0).node_num
+    relay_b = firmware_mesh.get_node(1).node_num
+    destination_c = firmware_mesh.get_node(2).node_num
+    with (
+        subscribe_traceroutes(firmware_mesh.get_iface(0)) as collector_a,
+        subscribe_traceroutes(firmware_mesh.get_iface(2)) as collector_c,
+    ):
+        firmware_mesh.get_iface(0).sendTraceRoute(dest=destination_c, hopLimit=3)
+        response = collector_a.wait_for_packet(
+            lambda packet: (
+                _decoded_port(packet) == "TRACEROUTE_APP"
+                and packet.get("from") == destination_c
+            )
+        )
+        assert response is not None, "A did not receive C's traceroute response"
+        decoded = response.get("decoded")
+        assert isinstance(decoded, dict)
+        route = decoded.get("traceroute")
+        assert isinstance(route, dict)
+        assert route.get("route") == [relay_b]
+        assert route.get("routeBack") == [relay_b]
+
+        request = collector_c.wait_for_packet(
+            lambda packet: (
+                _decoded_port(packet) == "TRACEROUTE_APP"
+                and packet.get("from") == source_a
+            )
+        )
+        assert request is not None, "C did not observe A's traceroute request"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 
-addopts = -m "not int and not smoke1 and not smoke1_destructive and not smoke2 and not smokewifi and not examples and not smokevirt and not slow" --timeout=120
+addopts = -m "not int and not smoke1 and not smoke1_destructive and not smoke2 and not smokewifi and not examples and not smokevirt and not simradio and not slow" --timeout=120
 
 junit_family = legacy
 
@@ -12,6 +12,8 @@ markers =
     unitslow: marks slow unit tests
     int: marks tests as integration tests
     smokevirt: marks tests as smoke tests against virtual device
+    simradio: native process-managed meshtasticd firmware smoke tests
+    simradio_mesh: multi-node native simradio topology and relay smoke tests
     smoke1: runs smoke tests on a single device connected via USB
     smoke1_destructive: smoke1 tests that may leave hardware in reset/recovery state
     smoke2: runs smoke tests on a two devices connected via USB


### PR DESCRIPTION
## Summary

Add process-managed native `meshtasticd` testing alongside the existing pinned Docker integration tests.

This introduces:

* a disposable single-node harness for CLI and configuration smoke tests;
* a reusable three-node A-B-C topology for routing, relay, hop-limit, direct-message, broadcast, and traceroute coverage;
* isolated VFS directories, process groups, port preflight checks, and deterministic cleanup;
* persistent simulator logs for both successful and failed CI runs;
* operation-aware CLI retries that default unknown and destructive operations to zero retries;
* beta, alpha, and daily firmware coverage using the Meshtastic PPAs;
* a scheduled daily firmware compatibility workflow.

The pinned 2.7 Docker tests remain unchanged and continue to provide the stable regression baseline.

## Upstream adaptation

This work manually ports and adapts selected upstream simulator and firmware-smoke concepts for this fork. It is not a direct cherry-pick.

Process lifecycle management, topology bridging, retry safety, diagnostics, CI policy, test isolation, and compatibility with the fork’s transport internals were reworked for the fork’s architecture.

## Retry safety

CLI retry behavior is classified conservatively:

* read-only operations may retry after transient connection failures;
* explicitly allowlisted idempotent mutations may retry;
* channel lifecycle operations, resets, reboots, shutdown, OTA operations, stress traffic, and unknown commands receive zero automatic retries;
* callers may still provide an explicit retry count when intentionally testing retry behavior.

The default for retryable operations is up to two retries after the initial attempt.

## CI policy

Pull-request CI runs the native suite against:

* **Beta:** required and merge-blocking.
* **Alpha:** visible but non-blocking.
* **Daily:** visible but non-blocking.

A separate scheduled workflow runs the daily package at 06:00 UTC. Every job uploads its simulator logs with `if: always()`.

Ordinary pytest runs continue to exclude the `simradio` marker. The native suite is selected explicitly through `make simradio` or its dedicated workflows.

## Verification

Completed locally:

* 49 simradio harness and retry-policy tests passed.
* 24 modem-preset regression tests passed.
* 46 channel and channel-deletion regression tests passed.
* Ruff passed.
* Pylint passed with 10.00.
* Focused mypy passed.
* Workflow YAML validation passed.
* `git diff --check` passed.

Live beta, alpha, and daily firmware execution will occur in GitHub Actions. The PR should remain in draft until the required beta job succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Adds native, process-managed `meshtasticd` firmware smoke tests alongside the existing pinned Docker integration tests. The suite covers single-node CLI/configuration behavior and three-node routing scenarios, with isolated state, cleanup, diagnostics, retry handling, and firmware-channel CI coverage.

## Key changes

### Features
- Added `SimNode` and `SimMesh` harnesses for launching and connecting native `meshtasticd` simulator processes.
- Added isolated VFS directories, port validation, process-group cleanup, persistent logs, and startup diagnostics.
- Added single-node CLI tests covering configuration, channels, YAML import/export, schema settings, and factory reset.
- Added three-node tests for convergence, broadcasts, direct messaging, relays, hop limits, and traceroutes.
- Added packet collection and simulator connection helpers.
- Added `make simradio` and `simradio`/`simradio_mesh` pytest markers.
- Added beta, alpha, and daily firmware workflows, including a scheduled daily compatibility run.

### Fixes and safety
- Added operation-aware CLI retry behavior.
- Read-only operations retry by default; destructive, ambiguous, unknown, and stress-test operations default to zero retries.
- Explicit retry counts override the default policy.
- Added credential redaction in CLI failure diagnostics.
- Added tests for malformed packets, oversized payloads, invalid topology mappings, occupied ports, and partial startup cleanup.

### Refactors and documentation
- Added shared fixtures for isolated single-node and three-node simulations.
- Added documentation for local execution, environment variables, isolation, concurrency, and CI behavior.
- Pull requests require beta firmware coverage; alpha and daily jobs are informational.
- Existing pinned 2.7 Docker tests remain unchanged.

## Breaking changes and migration

No application-facing breaking changes. Native tests require Linux and an available `meshtasticd` binary; use `MESHTASTICD_BIN` and the documented simulator environment variables when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->