### PR TITLE
Make CLI factory reset wait for local ACK and skip noProto

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -2121,9 +2121,20 @@ def onConnected(interface: MeshInterface) -> None:
             skip_ack_wait = True
 
             full = bool(args.factory_reset_device)
-            interface.getNode(args.dest, False, **getNode_kwargs).factoryReset(
-                full=full
-            )
+            reset_node = interface.getNode(args.dest, False, **getNode_kwargs)
+            reset_request = reset_node.factoryReset(full=full)
+            if (
+                reset_request is not None
+                and _is_local_destination(interface, args.dest)
+            ):
+                # Local admin commands are queued asynchronously.  Firmware
+                # schedules factory reset several seconds after handling the
+                # packet, so wait for its ACK before closing the transport;
+                # otherwise the CLI can report success while dropping the
+                # reset request during disconnect.  Remote Node.factoryReset()
+                # already owns its ACK wait.
+                _cli_print("Waiting for factory reset command acknowledgment")
+                reset_node.iface.waitForAckNak()
             # Guard the isinstance check: SerialInterface may be a mock or not resolve in tests.
             _serial_interface_cls = getattr(
                 meshtastic.serial_interface, "SerialInterface", None

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -6161,6 +6161,50 @@ def test_post_seturl_stability_check_triggers_reconnect_when_disconnected(
 
 
 @pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_main_factory_reset_local_waits_for_ack_before_close(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Local factory reset must be delivered before the CLI closes its transport."""
+    sys.argv = ["", "--factory-reset"]
+    mt_config.args = sys.argv  # type: ignore[assignment]
+    iface = MagicMock(autospec=SerialInterface)
+    iface.__enter__ = MagicMock(return_value=iface)
+    iface.__exit__ = MagicMock(return_value=None)
+    reset_node = iface.getNode.return_value
+    reset_node.iface = iface
+    reset_node.factoryReset.return_value = object()
+
+    with patch("meshtastic.serial_interface.SerialInterface", return_value=iface):
+        main()
+
+    out, err = capsys.readouterr()
+    reset_node.factoryReset.assert_called_once_with(full=False)
+    iface.waitForAckNak.assert_called_once_with()
+    assert "Waiting for factory reset command acknowledgment" in out
+    assert err == ""
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_main_factory_reset_skips_ack_wait_when_send_is_disabled() -> None:
+    """A noProto reset returning None must not enter an impossible ACK wait."""
+    sys.argv = ["", "--factory-reset"]
+    mt_config.args = sys.argv  # type: ignore[assignment]
+    iface = MagicMock(autospec=SerialInterface)
+    iface.__enter__ = MagicMock(return_value=iface)
+    iface.__exit__ = MagicMock(return_value=None)
+    reset_node = iface.getNode.return_value
+    reset_node.iface = iface
+    reset_node.factoryReset.return_value = None
+
+    with patch("meshtastic.serial_interface.SerialInterface", return_value=iface):
+        main()
+
+    iface.waitForAckNak.assert_not_called()
+
+
+@pytest.mark.unit
 def test_post_factory_reset_ready_probe_closes_and_probes_reconnect() -> None:
     iface = cast(Any, object.__new__(SerialInterface))
     iface.connect = MagicMock()


### PR DESCRIPTION
## Summary by Sourcery

Ensure CLI factory reset waits for acknowledgment on local requests while avoiding ACK waits for noProto resets.

Bug Fixes:
- Prevent local factory reset commands from being dropped by keeping the transport open until an ACK is received.
- Avoid entering an ACK wait when factory reset is performed via noProto where no acknowledgment will be sent.

Tests:
- Add unit tests verifying the CLI waits for ACK on local factory reset before closing the transport.
- Add unit test ensuring ACK wait is skipped when factory reset uses noProto and returns no request object.