### PR TITLE
Implement local factory reset with reboot handling in firmware 2.7

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -124,9 +124,7 @@ BITFIELD_ENUMS = {
 # the historical behavior when callers supply more than one shorthand: later
 # options win. ``--ch-preset`` below is the scalable path for every enum value
 # present in the active protobuf schema, including future additions.
-_MODEM_PRESET_SHORTHANDS: tuple[
-    tuple[tuple[str, ...], str, str, str], ...
-] = (
+_MODEM_PRESET_SHORTHANDS: tuple[tuple[tuple[str, ...], str, str, str], ...] = (
     (
         ("--ch-vlongslow",),
         "ch_vlongslow",
@@ -244,7 +242,9 @@ def _parse_bitfield_value(flag_type: Any, raw_val: Any) -> int:
         )
 
     if val < 0:
-        raise ValueError(f"Invalid bitfield value {raw_val!r}. Expected a non-negative integer.")
+        raise ValueError(
+            f"Invalid bitfield value {raw_val!r}. Expected a non-negative integer."
+        )
     return val
 
 
@@ -668,17 +668,16 @@ def _send_local_factory_reset_and_wait(
     full: bool,
     timeout: float | None = None,
 ) -> mesh_pb2.MeshPacket | None:
-    """Send a local factory reset and accept either ACK/NAK or reboot disconnect.
+    """Send a local factory reset and wait for ACK/NAK or reboot transport loss.
 
-    Firmware 2.7 clears its channel table while processing a configuration reset.
-    It still generates the routing ACK internally, but the now-invalid channel can
-    prevent that ACK from being forwarded to the connected phone API.  The reset
-    itself schedules a reboot, so a connection-loss transition after a successfully
-    queued request is an equally strong acceptance signal for this destructive local
-    operation.  Firmware 2.8 forwards the ACK normally and takes the fast path.
+    Firmware 2.7 can execute the reset and schedule its reboot without forwarding
+    the resulting routing ACK to PhoneAPI after the reset clears the channel
+    table.  Firmware 2.8 normally forwards the ACK.  For this destructive local
+    operation, a transport interruption observed *after* the request was queued
+    is therefore also evidence that firmware accepted the command.
 
-    A timeout remains a hard failure: if neither an ACK/NAK nor a reboot disconnect
-    is observed, the caller cannot know that firmware accepted the command.
+    Explicit routing errors and a deadline with neither signal remain hard
+    failures.  The caller still reconnects and verifies the post-reset state.
     """
     reset_interface = reset_node.iface
     disconnect_observed = threading.Event()
@@ -691,8 +690,8 @@ def _send_local_factory_reset_and_wait(
     acknowledgment = getattr(reset_interface, "_acknowledgment", None)
     reset_acknowledgment = getattr(acknowledgment, "reset", None)
     if callable(reset_acknowledgment):
-        # A stale ACK/NAK from an earlier admin operation must never satisfy this
-        # destructive request's acceptance wait.
+        # A stale compatibility flag from an earlier command must never satisfy
+        # this destructive request's acceptance wait.
         reset_acknowledgment()
 
     pub.subscribe(_on_connection_lost, "meshtastic.connection.lost")
@@ -702,70 +701,118 @@ def _send_local_factory_reset_and_wait(
         request = reset_node.factoryReset(full=full)
         if request is None:
             return None
-        request_queued.set()
 
         raw_request_id = getattr(request, "id", None)
         if isinstance(raw_request_id, int) and not isinstance(raw_request_id, bool):
             request_id = raw_request_id if raw_request_id > 0 else None
+        request_queued.set()
 
-        if timeout is None:
-            raw_timeout = getattr(
-                getattr(reset_interface, "_timeout", None),
-                "expireTimeout",
-                FACTORY_RESET_ACCEPTANCE_TIMEOUT_SECONDS,
-            )
-            configured_timeout = (
-                float(raw_timeout)
-                if isinstance(raw_timeout, (int, float)) and raw_timeout > 0
-                else FACTORY_RESET_ACCEPTANCE_TIMEOUT_SECONDS
-            )
-            timeout = min(
-                configured_timeout,
-                FACTORY_RESET_ACCEPTANCE_TIMEOUT_SECONDS,
-            )
+        # Snapshot the active transport only after sendData returned a concrete
+        # packet.  A stale disconnect or reconnect that happened before the send
+        # completed cannot prove this reset was accepted.
+        missing_transport = object()
+        socket_after_send = getattr(reset_interface, "socket", missing_transport)
+        stream_after_send = getattr(reset_interface, "stream", missing_transport)
+
+        acceptance_timeout = (
+            FACTORY_RESET_ACCEPTANCE_TIMEOUT_SECONDS
+            if timeout is None
+            else float(timeout)
+        )
+        if acceptance_timeout <= 0:
+            raise ValueError("factory reset acceptance timeout must be positive")
+
+        wait_for_request_ack = getattr(reset_interface, "_wait_for_request_ack", None)
+        raise_wait_error = getattr(
+            reset_interface, "_raise_wait_error_if_present", None
+        )
+        scoped_wait_available = (
+            request_id is not None
+            and callable(wait_for_request_ack)
+            and callable(raise_wait_error)
+        )
 
         _cli_print("Waiting for factory reset acknowledgment or reboot disconnect")
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            if acknowledgment is not None:
+        deadline = time.monotonic() + acceptance_timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+
+            if scoped_wait_available and callable(wait_for_request_ack) and callable(raise_wait_error):
+                completed = wait_for_request_ack(
+                    "receivedNak",
+                    request_id,
+                    timeout_seconds=min(
+                        FACTORY_RESET_ACCEPTANCE_POLL_SECONDS,
+                        remaining,
+                    ),
+                )
+                if completed:
+                    # Request-scoped wait state distinguishes a successful ACK
+                    # from an explicit routing error.  The legacy receivedNak
+                    # attribute is only a completion latch and is not itself
+                    # evidence of rejection.
+                    raise_wait_error("receivedNak", request_id=request_id)
+                    return request
+            else:
+                # Compatibility fallback for minimal/legacy interfaces without
+                # request-scoped wait helpers.  Check actual ACK kinds before the
+                # shared receivedNak completion flag because implicit ACK handling
+                # can set both in older runtimes.
+                if callable(raise_wait_error):
+                    raise_wait_error("receivedNak", request_id=request_id)
+                received_ack = bool(getattr(acknowledgment, "receivedAck", False))
+                received_implicit_ack = bool(
+                    getattr(acknowledgment, "receivedImplAck", False)
+                )
+                if received_ack or received_implicit_ack:
+                    return request
                 if bool(getattr(acknowledgment, "receivedNak", False)):
-                    raise_wait_error = getattr(
-                        reset_interface, "_raise_wait_error_if_present", None
-                    )
-                    if callable(raise_wait_error):
-                        raise_wait_error("receivedNak", request_id=request_id)
                     raise reset_interface.MeshInterfaceError(
                         "Factory reset request was rejected by the device"
                     )
-                if bool(getattr(acknowledgment, "receivedAck", False)) or bool(
-                    getattr(acknowledgment, "receivedImplAck", False)
-                ):
-                    if callable(reset_acknowledgment):
-                        reset_acknowledgment()
-                    return request
+                time.sleep(
+                    min(
+                        FACTORY_RESET_ACCEPTANCE_POLL_SECONDS,
+                        remaining,
+                    )
+                )
 
             connected_event = getattr(reset_interface, "isConnected", None)
+            connected = True
+            is_set = getattr(connected_event, "is_set", None)
+            if callable(is_set):
+                connected = bool(is_set())
+
+            current_socket = getattr(reset_interface, "socket", missing_transport)
+            current_stream = getattr(reset_interface, "stream", missing_transport)
+            socket_replaced = (
+                socket_after_send is not missing_transport
+                and current_socket is not socket_after_send
+            )
+            stream_replaced = (
+                stream_after_send is not missing_transport
+                and current_stream is not stream_after_send
+            )
             if (
-                connected_event is not None
-                and callable(getattr(connected_event, "is_set", None))
+                disconnect_observed.is_set()
+                or not connected
+                or socket_replaced
+                or stream_replaced
             ):
-                connected = bool(connected_event.is_set())
-            else:
-                connected = True
-            if disconnect_observed.is_set() or not connected:
+                # Check request-scoped errors one final time so an explicit NAK
+                # wins over a nearly simultaneous transport loss.
+                if callable(raise_wait_error):
+                    raise_wait_error("receivedNak", request_id=request_id)
                 logger.info(
-                    "Device disconnected after local factory reset request; "
+                    "Device transport changed after local factory reset request; "
                     "treating reboot as command acceptance."
                 )
                 return request
 
-            time.sleep(
-                min(
-                    FACTORY_RESET_ACCEPTANCE_POLL_SECONDS,
-                    max(0.0, deadline - time.monotonic()),
-                )
-            )
-
+        if callable(raise_wait_error):
+            raise_wait_error("receivedNak", request_id=request_id)
         raise reset_interface.MeshInterfaceError(
             "Timed out waiting for a factory reset acknowledgment or reboot disconnect"
         )
@@ -773,6 +820,8 @@ def _send_local_factory_reset_and_wait(
         retire_wait = getattr(reset_interface, "_retire_wait_request", None)
         if callable(retire_wait) and request_id is not None:
             retire_wait("receivedNak", request_id=request_id)
+        if callable(reset_acknowledgment):
+            reset_acknowledgment()
         try:
             pub.unsubscribe(_on_connection_lost, "meshtastic.connection.lost")
         except Exception:
@@ -2558,7 +2607,10 @@ def onConnected(interface: MeshInterface) -> None:
             if len(node.localConfig.ListFields()) == 0:
                 lora_descriptor = node.localConfig.DESCRIPTOR.fields_by_name.get("lora")
                 if lora_descriptor is None:
-                    _cli_exit("The active protobuf schema does not provide LoRa configuration", 1)
+                    _cli_exit(
+                        "The active protobuf schema does not provide LoRa configuration",
+                        1,
+                    )
                 node.requestConfig(lora_descriptor)
             node.localConfig.lora.modem_preset = modem_preset
             node.writeConfig("lora")
@@ -2568,9 +2620,7 @@ def onConnected(interface: MeshInterface) -> None:
         preset_val = None
         for _, destination, preset_name, _ in _MODEM_PRESET_SHORTHANDS:
             if getattr(args, destination, False):
-                preset_val = config_pb2.Config.LoRaConfig.ModemPreset.Value(
-                    preset_name
-                )
+                preset_val = config_pb2.Config.LoRaConfig.ModemPreset.Value(preset_name)
 
         generic_preset_name = getattr(args, "ch_preset", None)
         if generic_preset_name is not None:

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -14,6 +14,7 @@ import logging
 import os
 import platform
 import sys
+import threading
 import time
 from types import ModuleType
 from typing import Any, NoReturn, Protocol
@@ -270,6 +271,12 @@ SETURL_STABILITY_TIMEOUT_SECONDS = 30.0
 
 FACTORY_RESET_READY_PROBE_TIMEOUT_SECONDS = 20.0
 """Timeout for post-reset reconnect probe inside factory-reset command."""
+
+FACTORY_RESET_ACCEPTANCE_TIMEOUT_SECONDS = 20.0
+"""Maximum time to observe a local reset ACK/NAK or reboot disconnect."""
+
+FACTORY_RESET_ACCEPTANCE_POLL_SECONDS = 0.05
+"""Polling interval while waiting for local reset command acceptance."""
 
 CONFIGURE_PHASE1_HEADER = (
     "Phase 1: Applying direct configuration "
@@ -653,6 +660,128 @@ def _is_local_destination(interface: MeshInterface, dest: str) -> bool:
         return parsed_dest_num == my_node_num
     except Exception:
         return False
+
+
+def _send_local_factory_reset_and_wait(
+    reset_node: Any,
+    *,
+    full: bool,
+    timeout: float | None = None,
+) -> mesh_pb2.MeshPacket | None:
+    """Send a local factory reset and accept either ACK/NAK or reboot disconnect.
+
+    Firmware 2.7 clears its channel table while processing a configuration reset.
+    It still generates the routing ACK internally, but the now-invalid channel can
+    prevent that ACK from being forwarded to the connected phone API.  The reset
+    itself schedules a reboot, so a connection-loss transition after a successfully
+    queued request is an equally strong acceptance signal for this destructive local
+    operation.  Firmware 2.8 forwards the ACK normally and takes the fast path.
+
+    A timeout remains a hard failure: if neither an ACK/NAK nor a reboot disconnect
+    is observed, the caller cannot know that firmware accepted the command.
+    """
+    reset_interface = reset_node.iface
+    disconnect_observed = threading.Event()
+    request_queued = threading.Event()
+
+    def _on_connection_lost(interface: MeshInterface) -> None:
+        if request_queued.is_set() and interface is reset_interface:
+            disconnect_observed.set()
+
+    acknowledgment = getattr(reset_interface, "_acknowledgment", None)
+    reset_acknowledgment = getattr(acknowledgment, "reset", None)
+    if callable(reset_acknowledgment):
+        # A stale ACK/NAK from an earlier admin operation must never satisfy this
+        # destructive request's acceptance wait.
+        reset_acknowledgment()
+
+    pub.subscribe(_on_connection_lost, "meshtastic.connection.lost")
+    request: mesh_pb2.MeshPacket | None = None
+    request_id: int | None = None
+    try:
+        request = reset_node.factoryReset(full=full)
+        if request is None:
+            return None
+        request_queued.set()
+
+        raw_request_id = getattr(request, "id", None)
+        if isinstance(raw_request_id, int) and not isinstance(raw_request_id, bool):
+            request_id = raw_request_id if raw_request_id > 0 else None
+
+        if timeout is None:
+            raw_timeout = getattr(
+                getattr(reset_interface, "_timeout", None),
+                "expireTimeout",
+                FACTORY_RESET_ACCEPTANCE_TIMEOUT_SECONDS,
+            )
+            configured_timeout = (
+                float(raw_timeout)
+                if isinstance(raw_timeout, (int, float)) and raw_timeout > 0
+                else FACTORY_RESET_ACCEPTANCE_TIMEOUT_SECONDS
+            )
+            timeout = min(
+                configured_timeout,
+                FACTORY_RESET_ACCEPTANCE_TIMEOUT_SECONDS,
+            )
+
+        _cli_print("Waiting for factory reset acknowledgment or reboot disconnect")
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if acknowledgment is not None:
+                if bool(getattr(acknowledgment, "receivedNak", False)):
+                    raise_wait_error = getattr(
+                        reset_interface, "_raise_wait_error_if_present", None
+                    )
+                    if callable(raise_wait_error):
+                        raise_wait_error("receivedNak", request_id=request_id)
+                    raise reset_interface.MeshInterfaceError(
+                        "Factory reset request was rejected by the device"
+                    )
+                if bool(getattr(acknowledgment, "receivedAck", False)) or bool(
+                    getattr(acknowledgment, "receivedImplAck", False)
+                ):
+                    if callable(reset_acknowledgment):
+                        reset_acknowledgment()
+                    return request
+
+            connected_event = getattr(reset_interface, "isConnected", None)
+            if (
+                connected_event is not None
+                and callable(getattr(connected_event, "is_set", None))
+            ):
+                connected = bool(connected_event.is_set())
+            else:
+                connected = True
+            if disconnect_observed.is_set() or not connected:
+                logger.info(
+                    "Device disconnected after local factory reset request; "
+                    "treating reboot as command acceptance."
+                )
+                return request
+
+            time.sleep(
+                min(
+                    FACTORY_RESET_ACCEPTANCE_POLL_SECONDS,
+                    max(0.0, deadline - time.monotonic()),
+                )
+            )
+
+        raise reset_interface.MeshInterfaceError(
+            "Timed out waiting for a factory reset acknowledgment or reboot disconnect"
+        )
+    finally:
+        retire_wait = getattr(reset_interface, "_retire_wait_request", None)
+        if callable(retire_wait) and request_id is not None:
+            retire_wait("receivedNak", request_id=request_id)
+        try:
+            pub.unsubscribe(_on_connection_lost, "meshtastic.connection.lost")
+        except Exception:
+            logger.debug(
+                "Factory reset: failed to remove connection-loss observer.",
+                exc_info=True,
+            )
+
+    return None
 
 
 def _post_factory_reset_ready_probe(interface: MeshInterface) -> None:
@@ -2122,19 +2251,15 @@ def onConnected(interface: MeshInterface) -> None:
 
             full = bool(args.factory_reset_device)
             reset_node = interface.getNode(args.dest, False, **getNode_kwargs)
-            reset_request = reset_node.factoryReset(full=full)
-            if (
-                reset_request is not None
-                and _is_local_destination(interface, args.dest)
-            ):
-                # Local admin commands are queued asynchronously.  Firmware
-                # schedules factory reset several seconds after handling the
-                # packet, so wait for its ACK before closing the transport;
-                # otherwise the CLI can report success while dropping the
-                # reset request during disconnect.  Remote Node.factoryReset()
-                # already owns its ACK wait.
-                _cli_print("Waiting for factory reset command acknowledgment")
-                reset_node.iface.waitForAckNak()
+            is_local_reset = _is_local_destination(interface, args.dest)
+            if is_local_reset:
+                _send_local_factory_reset_and_wait(
+                    reset_node,
+                    full=full,
+                )
+            else:
+                # Remote Node.factoryReset() owns its ACK wait.
+                reset_node.factoryReset(full=full)
             # Guard the isinstance check: SerialInterface may be a mock or not resolve in tests.
             _serial_interface_cls = getattr(
                 meshtastic.serial_interface, "SerialInterface", None

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -1768,6 +1768,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
         wantResponse: bool = False,
         onResponse: Callable[[dict[str, Any]], Any] | None = None,
         adminIndex: int | None = None,
+        responseWaitAttr: str | None = None,
     ) -> mesh_pb2.MeshPacket | None:
         """Send an AdminMessage to this Node's admin channel.
 
@@ -1783,6 +1784,10 @@ class Node:  # pylint: disable=too-many-instance-attributes
             Channel index to use for the admin message; when None the node's
             configured admin channel is used. Pass 0 to force channel 0.
             (Default value = None)
+        responseWaitAttr : str | None
+            Optional internal request-scoped wait attribute registered before
+            transmission. This prevents fast responses from racing the caller's
+            post-send wait setup. (Default value = None)
 
         Returns
         -------
@@ -1795,6 +1800,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
             want_response=wantResponse,
             on_response=onResponse,
             admin_index=adminIndex,
+            response_wait_attr=responseWaitAttr,
         )
 
     def ensureSessionKey(self, adminIndex: int | None = None) -> None:

--- a/meshtastic/node_runtime/settings_runtime/admin.py
+++ b/meshtastic/node_runtime/settings_runtime/admin.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+WAIT_ATTR_NAK = "receivedNak"
+
 
 class _NodeAdminCommandRuntime:
     """Owns generic admin-command session/callback/send policy for command family methods."""
@@ -233,6 +235,7 @@ class _NodeAdminCommandRuntime:
             return self._node._send_admin(  # noqa: SLF001
                 message,
                 onResponse=self._node.onAckNak,
+                responseWaitAttr=WAIT_ATTR_NAK,
             )
         return self._send_command(
             message,

--- a/meshtastic/node_runtime/transport_runtime/admin.py
+++ b/meshtastic/node_runtime/transport_runtime/admin.py
@@ -31,6 +31,7 @@ class _NodeAdminTransportRuntime:
         want_response: bool = False,
         on_response: Callable[[dict[str, Any]], Any] | None = None,
         admin_index: int | None = None,
+        response_wait_attr: str | None = None,
     ) -> mesh_pb2.MeshPacket | None:
         """Send an AdminMessage via iface.sendData with preserved transport semantics.
 
@@ -44,6 +45,9 @@ class _NodeAdminTransportRuntime:
             Callback invoked when response is received. Default is None.
         admin_index : int | None, optional
             Channel index for admin messages. None auto-detects. Default is None.
+        response_wait_attr : str | None, optional
+            Internal request-scoped wait attribute to register before the packet
+            is sent. Default is None.
 
         Returns
         -------
@@ -73,13 +77,23 @@ class _NodeAdminTransportRuntime:
                 type(passkey).__name__,
             )
 
+        send_kwargs: dict[str, Any] = {
+            "portNum": portnums_pb2.PortNum.ADMIN_APP,
+            "wantAck": True,
+            "wantResponse": want_response,
+            "onResponse": on_response,
+            "channelIndex": resolved_admin_index,
+            "pkiEncrypted": True,
+        }
+        if response_wait_attr is not None:
+            send_kwargs["response_wait_attr"] = response_wait_attr
+            return self._node.iface._send_data_with_wait(
+                outbound_message,
+                self._node.nodeNum,
+                **send_kwargs,
+            )
         return self._node.iface.sendData(
             outbound_message,
             self._node.nodeNum,
-            portNum=portnums_pb2.PortNum.ADMIN_APP,
-            wantAck=True,
-            wantResponse=want_response,
-            onResponse=on_response,
-            channelIndex=resolved_admin_index,
-            pkiEncrypted=True,
+            **send_kwargs,
         )

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -163,9 +163,7 @@ def test_main_init_parser_help_mentions_list_fields(
     ("flag", "destination"),
     (
         pytest.param("--ch-longmod", "ch_longmod", id="long-moderate-short"),
-        pytest.param(
-            "--ch-longmoderate", "ch_longmod", id="long-moderate-long"
-        ),
+        pytest.param("--ch-longmoderate", "ch_longmod", id="long-moderate-long"),
         pytest.param("--ch-longturbo", "ch_longturbo", id="long-turbo"),
         pytest.param("--ch-shortturbo", "ch_shortturbo", id="short-turbo"),
     ),
@@ -6228,9 +6226,7 @@ def test_local_factory_reset_accepts_transient_reboot_disconnect() -> None:
             time.sleep(0.01)
             # Model a fast reconnect: the pubsub edge must remain observable even
             # though isConnected is already set again by the time the wait polls.
-            main_module.pub.sendMessage(
-                "meshtastic.connection.lost", interface=iface
-            )
+            main_module.pub.sendMessage("meshtastic.connection.lost", interface=iface)
             connected.set()
 
         threading.Thread(target=_disconnect_after_send, daemon=True).start()
@@ -6246,9 +6242,121 @@ def test_local_factory_reset_accepts_transient_reboot_disconnect() -> None:
 
     assert request is not None
     assert request.id == 456
-    iface._retire_wait_request.assert_called_once_with(
-        "receivedNak", request_id=456
+    iface._retire_wait_request.assert_called_once_with("receivedNak", request_id=456)
+
+
+@pytest.mark.unit
+def test_local_factory_reset_accepts_implicit_ack_with_legacy_completion_flag() -> None:
+    """A valid implicit ACK must win over the legacy receivedNak completion latch."""
+    connected = threading.Event()
+    connected.set()
+    acknowledgment = Acknowledgment()
+    iface = SimpleNamespace(
+        isConnected=connected,
+        _acknowledgment=acknowledgment,
+        _retire_wait_request=MagicMock(),
+        _raise_wait_error_if_present=MagicMock(),
+        MeshInterfaceError=RuntimeError,
     )
+
+    def _factory_reset(*, full: bool) -> SimpleNamespace:
+        assert full is False
+        acknowledgment.receivedImplAck = True
+        acknowledgment.receivedNak = True
+        return SimpleNamespace(id=457)
+
+    reset_node = SimpleNamespace(
+        iface=iface,
+        factoryReset=MagicMock(side_effect=_factory_reset),
+    )
+
+    request = main_module._send_local_factory_reset_and_wait(
+        reset_node,
+        full=False,
+        timeout=0.5,
+    )
+
+    assert request is not None
+    assert request.id == 457
+    iface._raise_wait_error_if_present.assert_called()
+
+
+@pytest.mark.unit
+def test_local_factory_reset_accepts_tcp_socket_generation_change() -> None:
+    """A TCP reconnect is observable even when isConnected never clears."""
+    connected = threading.Event()
+    connected.set()
+    original_socket = object()
+    iface = SimpleNamespace(
+        isConnected=connected,
+        socket=original_socket,
+        stream=None,
+        _acknowledgment=Acknowledgment(),
+        _timeout=SimpleNamespace(expireTimeout=0.01),
+        _retire_wait_request=MagicMock(),
+        MeshInterfaceError=RuntimeError,
+    )
+    reset_node = SimpleNamespace(iface=iface)
+
+    def _factory_reset(*, full: bool) -> SimpleNamespace:
+        assert full is False
+
+        def _replace_socket() -> None:
+            time.sleep(0.05)
+            iface.socket = object()
+
+        threading.Thread(target=_replace_socket, daemon=True).start()
+        return SimpleNamespace(id=458)
+
+    reset_node.factoryReset = MagicMock(side_effect=_factory_reset)
+
+    started = time.monotonic()
+    request = main_module._send_local_factory_reset_and_wait(
+        reset_node,
+        full=False,
+    )
+
+    assert request is not None
+    assert request.id == 458
+    assert time.monotonic() - started >= 0.04
+    # The interface's ordinary 10 ms timeout must not truncate the reset's
+    # firmware-defined seven-second reboot window.
+    assert iface._timeout.expireTimeout == 0.01
+
+
+@pytest.mark.unit
+def test_local_factory_reset_ignores_socket_change_before_send_returns() -> None:
+    """A transport change before a concrete request returns is not acceptance."""
+    connected = threading.Event()
+    connected.set()
+    iface = SimpleNamespace(
+        isConnected=connected,
+        socket=object(),
+        stream=None,
+        _acknowledgment=Acknowledgment(),
+        _retire_wait_request=MagicMock(),
+        MeshInterfaceError=RuntimeError,
+    )
+
+    def _factory_reset(*, full: bool) -> SimpleNamespace:
+        assert full is False
+        iface.socket = object()
+        return SimpleNamespace(id=459)
+
+    reset_node = SimpleNamespace(
+        iface=iface,
+        factoryReset=MagicMock(side_effect=_factory_reset),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Timed out waiting for a factory reset acknowledgment or reboot disconnect",
+    ):
+        main_module._send_local_factory_reset_and_wait(
+            reset_node,
+            full=False,
+            timeout=0.01,
+        )
 
 
 @pytest.mark.unit
@@ -6266,9 +6374,7 @@ def test_local_factory_reset_ignores_pre_send_disconnect_event() -> None:
 
     def _factory_reset(*, full: bool) -> SimpleNamespace:
         assert full is False
-        main_module.pub.sendMessage(
-            "meshtastic.connection.lost", interface=iface
-        )
+        main_module.pub.sendMessage("meshtastic.connection.lost", interface=iface)
         return SimpleNamespace(id=654)
 
     reset_node = SimpleNamespace(
@@ -6286,9 +6392,7 @@ def test_local_factory_reset_ignores_pre_send_disconnect_event() -> None:
             timeout=0.01,
         )
 
-    iface._retire_wait_request.assert_called_once_with(
-        "receivedNak", request_id=654
-    )
+    iface._retire_wait_request.assert_called_once_with("receivedNak", request_id=654)
 
 
 @pytest.mark.unit
@@ -6318,45 +6422,43 @@ def test_local_factory_reset_times_out_without_ack_or_disconnect() -> None:
             timeout=0.01,
         )
 
-    iface._retire_wait_request.assert_called_once_with(
-        "receivedNak", request_id=789
-    )
+    iface._retire_wait_request.assert_called_once_with("receivedNak", request_id=789)
 
 
 @pytest.mark.unit
 def test_local_factory_reset_nak_remains_failure() -> None:
-    """Disconnect compatibility must never convert an explicit NAK to success."""
+    """A request-scoped routing error must win over any transport signal."""
     connected = threading.Event()
     connected.set()
-    acknowledgment = Acknowledgment()
     iface = SimpleNamespace(
         isConnected=connected,
-        _acknowledgment=acknowledgment,
-        _timeout=SimpleNamespace(expireTimeout=1.0),
-        _raise_wait_error_if_present=MagicMock(),
+        socket=object(),
+        stream=None,
+        _acknowledgment=Acknowledgment(),
+        _wait_for_request_ack=MagicMock(return_value=True),
+        _raise_wait_error_if_present=MagicMock(
+            side_effect=RuntimeError("Routing error on response: NOT_AUTHORIZED")
+        ),
+        _retire_wait_request=MagicMock(),
         MeshInterfaceError=RuntimeError,
     )
-
-    def _factory_reset(*, full: bool) -> SimpleNamespace:
-        assert full is False
-        acknowledgment.receivedNak = True
-        return SimpleNamespace(id=987)
-
     reset_node = SimpleNamespace(
         iface=iface,
-        factoryReset=MagicMock(side_effect=_factory_reset),
+        factoryReset=MagicMock(return_value=SimpleNamespace(id=987)),
     )
 
-    with pytest.raises(RuntimeError, match="Factory reset request was rejected"):
+    with pytest.raises(RuntimeError, match="Routing error on response: NOT_AUTHORIZED"):
         main_module._send_local_factory_reset_and_wait(
             reset_node,
             full=False,
             timeout=0.5,
         )
 
+    iface._wait_for_request_ack.assert_called_once()
     iface._raise_wait_error_if_present.assert_called_once_with(
         "receivedNak", request_id=987
     )
+    iface._retire_wait_request.assert_called_once_with("receivedNak", request_id=987)
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -10,6 +10,7 @@ import platform
 import re
 import sys
 import threading
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Callable, cast
@@ -49,6 +50,7 @@ from ..protobuf import config_pb2, localonly_pb2
 from ..protobuf.channel_pb2 import Channel  # pylint: disable=E0611
 from ..serial_interface import SerialInterface
 from ..tcp_interface import TCPInterface
+from ..util import Acknowledgment
 
 # from ..remote_hardware import onGPIOreceive
 # from ..config_pb2 import Config
@@ -6162,27 +6164,199 @@ def test_post_seturl_stability_check_triggers_reconnect_when_disconnected(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-def test_main_factory_reset_local_waits_for_ack_before_close(
+@pytest.mark.parametrize(
+    ("reset_flag", "expected_full"),
+    [("--factory-reset", False), ("--factory-reset-device", True)],
+)
+def test_main_factory_reset_local_accepts_ack_before_close(
     capsys: pytest.CaptureFixture[str],
+    reset_flag: str,
+    expected_full: bool,
 ) -> None:
-    """Local factory reset must be delivered before the CLI closes its transport."""
-    sys.argv = ["", "--factory-reset"]
+    """Both local reset variants should accept their correlated ACK before closing."""
+    sys.argv = ["", reset_flag]
     mt_config.args = sys.argv  # type: ignore[assignment]
     iface = MagicMock(autospec=SerialInterface)
     iface.__enter__ = MagicMock(return_value=iface)
     iface.__exit__ = MagicMock(return_value=None)
+    iface.isConnected = threading.Event()
+    iface.isConnected.set()
+    iface._acknowledgment = Acknowledgment()
+    iface._acknowledgment.receivedAck = True  # stale state must be cleared
+    iface._timeout.expireTimeout = 1.0
     reset_node = iface.getNode.return_value
     reset_node.iface = iface
-    reset_node.factoryReset.return_value = object()
+
+    def _factory_reset(*, full: bool) -> SimpleNamespace:
+        assert full is expected_full
+        assert iface._acknowledgment.receivedAck is False
+        iface._acknowledgment.receivedImplAck = True
+        return SimpleNamespace(id=123)
+
+    reset_node.factoryReset.side_effect = _factory_reset
 
     with patch("meshtastic.serial_interface.SerialInterface", return_value=iface):
         main()
 
     out, err = capsys.readouterr()
-    reset_node.factoryReset.assert_called_once_with(full=False)
-    iface.waitForAckNak.assert_called_once_with()
-    assert "Waiting for factory reset command acknowledgment" in out
+    reset_node.factoryReset.assert_called_once_with(full=expected_full)
+    iface.waitForAckNak.assert_not_called()
+    assert iface._acknowledgment.receivedImplAck is False
+    assert "Waiting for factory reset acknowledgment or reboot disconnect" in out
     assert err == ""
+
+
+@pytest.mark.unit
+def test_local_factory_reset_accepts_transient_reboot_disconnect() -> None:
+    """A 2.7-style dropped ACK is accepted only after reboot disconnect is observed."""
+    connected = threading.Event()
+    connected.set()
+    iface = SimpleNamespace(
+        isConnected=connected,
+        _acknowledgment=Acknowledgment(),
+        _timeout=SimpleNamespace(expireTimeout=1.0),
+        _retire_wait_request=MagicMock(),
+        MeshInterfaceError=RuntimeError,
+    )
+    reset_node = SimpleNamespace(iface=iface)
+
+    def _factory_reset(*, full: bool) -> SimpleNamespace:
+        assert full is False
+        request = SimpleNamespace(id=456)
+
+        def _disconnect_after_send() -> None:
+            time.sleep(0.01)
+            # Model a fast reconnect: the pubsub edge must remain observable even
+            # though isConnected is already set again by the time the wait polls.
+            main_module.pub.sendMessage(
+                "meshtastic.connection.lost", interface=iface
+            )
+            connected.set()
+
+        threading.Thread(target=_disconnect_after_send, daemon=True).start()
+        return request
+
+    reset_node.factoryReset = MagicMock(side_effect=_factory_reset)
+
+    request = main_module._send_local_factory_reset_and_wait(
+        reset_node,
+        full=False,
+        timeout=0.5,
+    )
+
+    assert request is not None
+    assert request.id == 456
+    iface._retire_wait_request.assert_called_once_with(
+        "receivedNak", request_id=456
+    )
+
+
+@pytest.mark.unit
+def test_local_factory_reset_ignores_pre_send_disconnect_event() -> None:
+    """A stale disconnect published before the request is queued cannot prove acceptance."""
+    connected = threading.Event()
+    connected.set()
+    iface = SimpleNamespace(
+        isConnected=connected,
+        _acknowledgment=Acknowledgment(),
+        _timeout=SimpleNamespace(expireTimeout=0.01),
+        _retire_wait_request=MagicMock(),
+        MeshInterfaceError=RuntimeError,
+    )
+
+    def _factory_reset(*, full: bool) -> SimpleNamespace:
+        assert full is False
+        main_module.pub.sendMessage(
+            "meshtastic.connection.lost", interface=iface
+        )
+        return SimpleNamespace(id=654)
+
+    reset_node = SimpleNamespace(
+        iface=iface,
+        factoryReset=MagicMock(side_effect=_factory_reset),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Timed out waiting for a factory reset acknowledgment or reboot disconnect",
+    ):
+        main_module._send_local_factory_reset_and_wait(
+            reset_node,
+            full=False,
+            timeout=0.01,
+        )
+
+    iface._retire_wait_request.assert_called_once_with(
+        "receivedNak", request_id=654
+    )
+
+
+@pytest.mark.unit
+def test_local_factory_reset_times_out_without_ack_or_disconnect() -> None:
+    """A queued reset without ACK, NAK, or reboot remains a hard failure."""
+    connected = threading.Event()
+    connected.set()
+    iface = SimpleNamespace(
+        isConnected=connected,
+        _acknowledgment=Acknowledgment(),
+        _timeout=SimpleNamespace(expireTimeout=0.01),
+        _retire_wait_request=MagicMock(),
+        MeshInterfaceError=RuntimeError,
+    )
+    reset_node = SimpleNamespace(
+        iface=iface,
+        factoryReset=MagicMock(return_value=SimpleNamespace(id=789)),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Timed out waiting for a factory reset acknowledgment or reboot disconnect",
+    ):
+        main_module._send_local_factory_reset_and_wait(
+            reset_node,
+            full=False,
+            timeout=0.01,
+        )
+
+    iface._retire_wait_request.assert_called_once_with(
+        "receivedNak", request_id=789
+    )
+
+
+@pytest.mark.unit
+def test_local_factory_reset_nak_remains_failure() -> None:
+    """Disconnect compatibility must never convert an explicit NAK to success."""
+    connected = threading.Event()
+    connected.set()
+    acknowledgment = Acknowledgment()
+    iface = SimpleNamespace(
+        isConnected=connected,
+        _acknowledgment=acknowledgment,
+        _timeout=SimpleNamespace(expireTimeout=1.0),
+        _raise_wait_error_if_present=MagicMock(),
+        MeshInterfaceError=RuntimeError,
+    )
+
+    def _factory_reset(*, full: bool) -> SimpleNamespace:
+        assert full is False
+        acknowledgment.receivedNak = True
+        return SimpleNamespace(id=987)
+
+    reset_node = SimpleNamespace(
+        iface=iface,
+        factoryReset=MagicMock(side_effect=_factory_reset),
+    )
+
+    with pytest.raises(RuntimeError, match="Factory reset request was rejected"):
+        main_module._send_local_factory_reset_and_wait(
+            reset_node,
+            full=False,
+            timeout=0.5,
+        )
+
+    iface._raise_wait_error_if_present.assert_called_once_with(
+        "receivedNak", request_id=987
+    )
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -40,6 +40,7 @@ class _FakeSendAdminProtocol(Protocol):
         wantResponse: bool = False,
         onResponse: Callable[[dict[str, Any]], Any] | None = None,
         adminIndex: int | None = None,
+        responseWaitAttr: str | None = None,
     ) -> mesh_pb2.MeshPacket | None: ...
 
 
@@ -142,6 +143,7 @@ def _make_fake_send_admin(
         wantResponse: bool = False,
         onResponse: Callable[[dict[str, Any]], Any] | None = None,
         adminIndex: int | None = None,
+        responseWaitAttr: str | None = None,
     ) -> mesh_pb2.MeshPacket | None:
         if sent_messages is not None:
             sent_messages.append(msg)
@@ -150,6 +152,7 @@ def _make_fake_send_admin(
             captured["wantResponse"] = wantResponse
             captured["onResponse"] = onResponse
             captured["adminIndex"] = adminIndex
+            captured["responseWaitAttr"] = responseWaitAttr
         if expected_want_response is not None:
             assert wantResponse is expected_want_response
         if response_payload is not None:

--- a/meshtastic/tests/test_node_runtime_settings.py
+++ b/meshtastic/tests/test_node_runtime_settings.py
@@ -746,6 +746,10 @@ class TestNodeAdminCommandRuntime:
             mock_local_node_for_admin._send_admin.call_args.kwargs["onResponse"]
             is mock_local_node_for_admin.onAckNak
         )
+        assert (
+            mock_local_node_for_admin._send_admin.call_args.kwargs["responseWaitAttr"]
+            == "receivedNak"
+        )
         mock_local_node_for_admin.iface.waitForAckNak.assert_not_called()
 
     @pytest.mark.unit
@@ -765,6 +769,10 @@ class TestNodeAdminCommandRuntime:
         assert (
             mock_local_node_for_admin._send_admin.call_args.kwargs["onResponse"]
             is mock_local_node_for_admin.onAckNak
+        )
+        assert (
+            mock_local_node_for_admin._send_admin.call_args.kwargs["responseWaitAttr"]
+            == "receivedNak"
         )
         mock_local_node_for_admin.iface.waitForAckNak.assert_not_called()
 

--- a/meshtastic/tests/test_node_runtime_transport.py
+++ b/meshtastic/tests/test_node_runtime_transport.py
@@ -51,6 +51,7 @@ def mock_iface() -> MagicMock:
         spec=[
             "_acknowledgment",
             "sendData",
+            "_send_data_with_wait",
             "_get_or_create_by_num",
             "localNode",
             "waitForAckNak",
@@ -58,6 +59,7 @@ def mock_iface() -> MagicMock:
     )
     iface._acknowledgment = Acknowledgment()
     iface.sendData = MagicMock(return_value=mesh_pb2.MeshPacket())
+    iface._send_data_with_wait = MagicMock(return_value=mesh_pb2.MeshPacket())
     iface._get_or_create_by_num = MagicMock(return_value={})
     iface.waitForAckNak = MagicMock()
     return iface
@@ -269,6 +271,21 @@ class TestNodeAdminTransportRuntime:
         outbound_message = call_args[0][0]
         assert outbound_message.session_passkey == b"test_passkey"
         assert message.session_passkey == b""
+
+    @pytest.mark.unit
+    def test_send_admin_preregisters_request_scoped_wait(
+        self, mock_local_node: MagicMock
+    ) -> None:
+        """response_wait_attr uses the race-free send path before transmission."""
+        runtime = _NodeAdminTransportRuntime(mock_local_node)
+        message = admin_pb2.AdminMessage()
+
+        runtime._send_admin(message, response_wait_attr="receivedNak")
+
+        mock_local_node.iface._send_data_with_wait.assert_called_once()
+        call_kwargs = mock_local_node.iface._send_data_with_wait.call_args.kwargs
+        assert call_kwargs["response_wait_attr"] == "receivedNak"
+        mock_local_node.iface.sendData.assert_not_called()
 
     @pytest.mark.unit
     def test_send_admin_passes_correct_parameters_to_senddata(


### PR DESCRIPTION
## Summary by Sourcery

Handle local factory reset acceptance for firmware 2.7/2.8 by treating either explicit ACK/NAK or a reboot-triggered disconnect as the completion signal, and update the CLI behavior and tests accordingly.

New Features:
- Support local factory reset on the destination device via a dedicated CLI flag that drives a full reset path.

Enhancements:
- Introduce a helper to send local factory reset commands and wait for either an acknowledgment or reboot-related disconnect with bounded timeout and polling.
- Adjust CLI factory reset handling to use the new acceptance helper for local resets while keeping remote reset behavior unchanged.

Tests:
- Expand and refactor unit tests around local factory reset to cover both reset flags, reboot disconnect handling, stale disconnect events, timeout paths, and NAK rejection semantics.