### PR TITLE
Restrict Docker Build to release.published only

### DIFF
--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -1,7 +1,11 @@
 name: Docker Build and Publish
 
+# Build and publish the mtjk Docker image to ghcr.io only on release.
+# Manual dispatch is intentionally disabled to avoid stray `dev-master-*`
+# tags. The job-level `if:` further skips any release whose target branch
+# is master, so this workflow does not fire on master updates.
+
 on:
-  workflow_dispatch: {}
   release:
     types: [published]
 
@@ -15,7 +19,7 @@ permissions:
 
 jobs:
   docker-build:
-    if: ${{ github.ref_name != 'master' && (github.event_name != 'release' || github.event.release.target_commitish != 'master') }}
+    if: ${{ github.event.release.target_commitish != 'master' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
 


### PR DESCRIPTION
Remove the workflow_dispatch trigger so manual runs never create stray tags containing the branch name (e.g. VERSION-dev-master-<sha>). The only entry point is now release.published, whose tag is derived from the release version.  The job  simplifies to the one check that matters: skip releases whose target branch is master.

All other workflows were verified: none build Docker images or fire on master push / PR events.