### PR TITLE
Add USB-only lockdown client workflows

### DIFF
--- a/meshtastic/LOCKDOWN.md
+++ b/meshtastic/LOCKDOWN.md
@@ -3,7 +3,7 @@
 Lockdown passphrases are sent in cleartext by the firmware protocol and are therefore
 supported only on `SerialInterface` USB connections. The Python API refuses TCP and BLE.
 
-The public `meshtastic.lockdown` helpers validate 1–32 byte passphrases, require
+The public `meshtastic.lockdown` helpers validate 1–32-byte passphrases, require
 operator-only permissions for passphrase files, send an unencrypted local `ADMIN_APP`
 request, and wait for the structured `meshtastic.lockdown_status` event. The interface
 also retains the most recent defensive protobuf copy in `lockdownStatus`.
@@ -11,4 +11,4 @@ also retains the most recent defensive protobuf copy in `lockdownStatus`.
 CLI actions are `--lockdown-provision`, `--lockdown-unlock`,
 `--lockdown-lock-now`, and `--lockdown-disable`. Destructive actions require
 `--lockdown-yes` or typed confirmation. Prefer `--lockdown-passphrase-file` with mode
-0600; command-line passphrases require an explicit insecure acknowledgement.
+0600; command-line passphrases require explicit acknowledgement of insecure usage.

--- a/meshtastic/LOCKDOWN.md
+++ b/meshtastic/LOCKDOWN.md
@@ -1,0 +1,14 @@
+# USB lockdown client support
+
+Lockdown passphrases are sent in cleartext by the firmware protocol and are therefore
+supported only on `SerialInterface` USB connections. The Python API refuses TCP and BLE.
+
+The public `meshtastic.lockdown` helpers validate 1–32 byte passphrases, require
+operator-only permissions for passphrase files, send an unencrypted local `ADMIN_APP`
+request, and wait for the structured `meshtastic.lockdown_status` event. The interface
+also retains the most recent defensive protobuf copy in `lockdownStatus`.
+
+CLI actions are `--lockdown-provision`, `--lockdown-unlock`,
+`--lockdown-lock-now`, and `--lockdown-disable`. Destructive actions require
+`--lockdown-yes` or typed confirmation. Prefer `--lockdown-passphrase-file` with mode
+0600; command-line passphrases require an explicit insecure acknowledgement.

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -2796,7 +2796,7 @@ def onConnected(interface: MeshInterface) -> None:
         )
         if lockdown_action is not None:
             closeNow = True
-            if args.dest != BROADCAST_ADDR:
+            if not _is_local_destination(interface, args.dest):
                 _cli_exit("Lockdown commands apply only to the directly connected local node.")
             if lockdown_action in {"provision", "lock-now", "disable"} and not args.lockdown_yes:
                 confirmation = input(

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -35,6 +35,12 @@ from meshtastic.configure_verify import (
 from meshtastic.host_port import parseHostAndPort
 from meshtastic.interfaces.ble import BLEInterface
 from meshtastic.mesh_interface import MeshInterface
+from meshtastic.lockdown import (
+    build_lockdown_auth,
+    read_lockdown_passphrase_file,
+    send_lockdown_auth,
+    validate_lockdown_passphrase,
+)
 from meshtastic.protobuf import (
     admin_pb2,
     channel_pb2,
@@ -2775,6 +2781,81 @@ def onConnected(interface: MeshInterface) -> None:
                         f"presets={','.join(preset_names)}"
                     )
 
+        lockdown_action = next(
+            (
+                name
+                for name, enabled in (
+                    ("provision", args.lockdown_provision),
+                    ("unlock", args.lockdown_unlock),
+                    ("lock-now", args.lockdown_lock_now),
+                    ("disable", args.lockdown_disable),
+                )
+                if enabled
+            ),
+            None,
+        )
+        if lockdown_action is not None:
+            closeNow = True
+            if args.dest != BROADCAST_ADDR:
+                _cli_exit("Lockdown commands apply only to the directly connected local node.")
+            if lockdown_action in {"provision", "lock-now", "disable"} and not args.lockdown_yes:
+                confirmation = input(
+                    f"Type 'yes' to confirm lockdown {lockdown_action}: "
+                ).strip().casefold()
+                if confirmation != "yes":
+                    _cli_exit("Aborted.")
+            passphrase = b""
+            if lockdown_action != "lock-now":
+                if args.lockdown_passphrase_file:
+                    passphrase = read_lockdown_passphrase_file(
+                        args.lockdown_passphrase_file
+                    )
+                elif args.lockdown_passphrase is not None:
+                    if not args.insecure_lockdown_passphrase_on_command_line:
+                        _cli_exit(
+                            "--lockdown-passphrase requires "
+                            "--insecure-lockdown-passphrase-on-command-line; "
+                            "prefer an operator-only file or interactive entry."
+                        )
+                    passphrase = validate_lockdown_passphrase(
+                        args.lockdown_passphrase.encode("utf-8")
+                    )
+                else:
+                    entered = getpass.getpass("Lockdown passphrase: ")
+                    if lockdown_action == "provision":
+                        confirmed = getpass.getpass(
+                            "Lockdown passphrase (confirm): "
+                        )
+                        if entered != confirmed:
+                            _cli_exit("Lockdown passphrases do not match.")
+                    passphrase = validate_lockdown_passphrase(entered.encode("utf-8"))
+            auth = build_lockdown_auth(
+                passphrase,
+                boots_remaining=args.lockdown_boots,
+                valid_until_epoch=args.lockdown_valid_until,
+                max_session_seconds=args.lockdown_max_session_seconds,
+                lock_now=lockdown_action == "lock-now",
+                disable=lockdown_action == "disable",
+            )
+            status = send_lockdown_auth(
+                interface,
+                auth,
+                timeout=args.lockdown_wait,
+                allow_reboot_without_status=lockdown_action == "lock-now",
+            )
+            if status is None:
+                print("Lockdown command accepted; device may already be rebooting.")
+            else:
+                try:
+                    state_name = mesh_pb2.LockdownStatus.State.Name(status.state)
+                except ValueError:
+                    state_name = f"STATE_{status.state}"
+                print(f"Lockdown status: {state_name}")
+                if status.backoff_seconds:
+                    print(f"Retry backoff: {status.backoff_seconds}s")
+                if status.state == mesh_pb2.LockdownStatus.UNLOCK_FAILED:
+                    _cli_exit("Lockdown authentication failed.")
+
         if args.info:
             print("")
             # If we aren't trying to talk to our local node, don't show it
@@ -4099,6 +4180,67 @@ def addLocalActionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
         "--info",
         help="Read and display the radio config information",
         action="store_true",
+    )
+
+    lockdown_actions = group.add_mutually_exclusive_group()
+    lockdown_actions.add_argument(
+        "--lockdown-provision",
+        action="store_true",
+        help="Provision or unlock a hardened device over USB serial",
+    )
+    lockdown_actions.add_argument(
+        "--lockdown-unlock",
+        action="store_true",
+        help="Authenticate this USB connection to a provisioned hardened device",
+    )
+    lockdown_actions.add_argument(
+        "--lockdown-lock-now",
+        action="store_true",
+        help="Revoke current lockdown sessions and reboot into the locked state",
+    )
+    lockdown_actions.add_argument(
+        "--lockdown-disable",
+        action="store_true",
+        help="Disable lockdown, revert encrypted storage to plaintext, and reboot",
+    )
+    group.add_argument(
+        "--lockdown-passphrase-file",
+        help="Read the passphrase from an operator-only (0600) file",
+    )
+    group.add_argument(
+        "--lockdown-passphrase",
+        help="INSECURE: passphrase on argv; requires explicit acknowledgement",
+    )
+    group.add_argument(
+        "--insecure-lockdown-passphrase-on-command-line",
+        action="store_true",
+        help="Acknowledge that an argv passphrase is exposed in shell history and ps",
+    )
+    group.add_argument(
+        "--lockdown-boots", type=int, default=0, help="Authorized boot-count limit"
+    )
+    group.add_argument(
+        "--lockdown-valid-until",
+        type=int,
+        default=0,
+        help="Authorization expiration as a Unix epoch (0 disables)",
+    )
+    group.add_argument(
+        "--lockdown-max-session-seconds",
+        type=int,
+        default=0,
+        help="Maximum unlocked session duration in seconds (0 uses firmware policy)",
+    )
+    group.add_argument(
+        "--lockdown-wait",
+        type=float,
+        default=20.0,
+        help="Seconds to wait for structured LockdownStatus",
+    )
+    group.add_argument(
+        "--lockdown-yes",
+        action="store_true",
+        help="Skip typed confirmation for destructive lockdown actions",
     )
 
     group.add_argument(

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -2804,45 +2804,51 @@ def onConnected(interface: MeshInterface) -> None:
                 ).strip().casefold()
                 if confirmation != "yes":
                     _cli_exit("Aborted.")
-            passphrase = b""
-            if lockdown_action != "lock-now":
-                if args.lockdown_passphrase_file:
-                    passphrase = read_lockdown_passphrase_file(
-                        args.lockdown_passphrase_file
-                    )
-                elif args.lockdown_passphrase is not None:
-                    if not args.insecure_lockdown_passphrase_on_command_line:
-                        _cli_exit(
-                            "--lockdown-passphrase requires "
-                            "--insecure-lockdown-passphrase-on-command-line; "
-                            "prefer an operator-only file or interactive entry."
+            try:
+                passphrase = b""
+                if lockdown_action != "lock-now":
+                    if args.lockdown_passphrase_file:
+                        passphrase = read_lockdown_passphrase_file(
+                            args.lockdown_passphrase_file
                         )
-                    passphrase = validate_lockdown_passphrase(
-                        args.lockdown_passphrase.encode("utf-8")
-                    )
-                else:
-                    entered = getpass.getpass("Lockdown passphrase: ")
-                    if lockdown_action == "provision":
-                        confirmed = getpass.getpass(
-                            "Lockdown passphrase (confirm): "
+                    elif args.lockdown_passphrase is not None:
+                        if not args.insecure_lockdown_passphrase_on_command_line:
+                            _cli_exit(
+                                "--lockdown-passphrase requires "
+                                "--insecure-lockdown-passphrase-on-command-line; "
+                                "prefer an operator-only file or interactive entry."
+                            )
+                        passphrase = validate_lockdown_passphrase(
+                            args.lockdown_passphrase.encode("utf-8")
                         )
-                        if entered != confirmed:
-                            _cli_exit("Lockdown passphrases do not match.")
-                    passphrase = validate_lockdown_passphrase(entered.encode("utf-8"))
-            auth = build_lockdown_auth(
-                passphrase,
-                boots_remaining=args.lockdown_boots,
-                valid_until_epoch=args.lockdown_valid_until,
-                max_session_seconds=args.lockdown_max_session_seconds,
-                lock_now=lockdown_action == "lock-now",
-                disable=lockdown_action == "disable",
-            )
-            status = send_lockdown_auth(
-                interface,
-                auth,
-                timeout=args.lockdown_wait,
-                allow_reboot_without_status=lockdown_action == "lock-now",
-            )
+                    else:
+                        entered = getpass.getpass("Lockdown passphrase: ")
+                        if lockdown_action == "provision":
+                            confirmed = getpass.getpass(
+                                "Lockdown passphrase (confirm): "
+                            )
+                            if entered != confirmed:
+                                _cli_exit("Lockdown passphrases do not match.")
+                        passphrase = validate_lockdown_passphrase(entered.encode("utf-8"))
+                auth = build_lockdown_auth(
+                    passphrase,
+                    boots_remaining=args.lockdown_boots,
+                    valid_until_epoch=args.lockdown_valid_until,
+                    max_session_seconds=args.lockdown_max_session_seconds,
+                    lock_now=lockdown_action == "lock-now",
+                    disable=lockdown_action == "disable",
+                )
+            except (OSError, ValueError) as exc:
+                _cli_exit(f"Invalid lockdown options: {exc}")
+            try:
+                status = send_lockdown_auth(
+                    interface,
+                    auth,
+                    timeout=args.lockdown_wait,
+                    allow_reboot_without_status=lockdown_action == "lock-now",
+                )
+            except (TimeoutError, ValueError, RuntimeError) as exc:
+                _cli_exit(f"Lockdown command failed: {exc}")
             if status is None:
                 print("Lockdown command accepted; device may already be rebooting.")
             else:

--- a/meshtastic/_topics.py
+++ b/meshtastic/_topics.py
@@ -1,0 +1,3 @@
+"""Internal pubsub topic names shared across runtime modules."""
+
+LOCKDOWN_STATUS_TOPIC = "meshtastic.lockdown_status"

--- a/meshtastic/lockdown.py
+++ b/meshtastic/lockdown.py
@@ -6,16 +6,13 @@ import os
 import stat
 import threading
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from pubsub import pub
 
+from meshtastic._topics import LOCKDOWN_STATUS_TOPIC
 from meshtastic.protobuf import admin_pb2, mesh_pb2, portnums_pb2
+from meshtastic.serial_interface import SerialInterface
 
-if TYPE_CHECKING:
-    from meshtastic.serial_interface import SerialInterface
-
-LOCKDOWN_STATUS_TOPIC = "meshtastic.lockdown_status"
 DEFAULT_LOCKDOWN_TIMEOUT_SECONDS = 20.0
 
 
@@ -31,7 +28,7 @@ def read_lockdown_passphrase_file(path: str | os.PathLike[str]) -> bytes:
     """Read an operator-only passphrase file, refusing group/world access."""
     target = Path(path)
     mode = stat.S_IMODE(target.stat().st_mode)
-    if mode & 0o077:
+    if os.name != "nt" and mode & 0o077:
         raise PermissionError(
             f"{target} mode is {oct(mode)}; lockdown passphrase files must be operator-only (0600)"
         )
@@ -43,10 +40,8 @@ def read_lockdown_passphrase_file(path: str | os.PathLike[str]) -> bytes:
     return validate_lockdown_passphrase(value)
 
 
-def _require_usb_serial(interface: object) -> "SerialInterface":
+def _require_usb_serial(interface: object) -> SerialInterface:
     """Reject BLE/TCP transports because the passphrase is cleartext on wire."""
-    from meshtastic.serial_interface import SerialInterface
-
     if not isinstance(interface, SerialInterface):
         raise ValueError(
             "lockdown authentication is USB-serial only; refusing BLE/TCP transport"
@@ -99,7 +94,9 @@ def send_lockdown_auth(
     event = threading.Event()
     result: list[mesh_pb2.LockdownStatus] = []
 
-    def _on_status(*, interface: object, status: mesh_pb2.LockdownStatus) -> None:
+    def _on_status(
+        *, interface: object, status: mesh_pb2.LockdownStatus, **_kwargs: object
+    ) -> None:
         if interface is not target_interface:
             return
         copied = mesh_pb2.LockdownStatus()

--- a/meshtastic/lockdown.py
+++ b/meshtastic/lockdown.py
@@ -1,0 +1,130 @@
+"""USB-only client helpers for firmware lockdown provisioning and control."""
+
+from __future__ import annotations
+
+import os
+import stat
+import threading
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pubsub import pub
+
+from meshtastic.protobuf import admin_pb2, mesh_pb2, portnums_pb2
+
+if TYPE_CHECKING:
+    from meshtastic.serial_interface import SerialInterface
+
+LOCKDOWN_STATUS_TOPIC = "meshtastic.lockdown_status"
+DEFAULT_LOCKDOWN_TIMEOUT_SECONDS = 20.0
+
+
+def validate_lockdown_passphrase(passphrase: bytes) -> bytes:
+    """Validate and defensively copy a lockdown passphrase."""
+    value = bytes(passphrase)
+    if not 1 <= len(value) <= 32:
+        raise ValueError("lockdown passphrase must be 1..32 bytes")
+    return value
+
+
+def read_lockdown_passphrase_file(path: str | os.PathLike[str]) -> bytes:
+    """Read an operator-only passphrase file, refusing group/world access."""
+    target = Path(path)
+    mode = stat.S_IMODE(target.stat().st_mode)
+    if mode & 0o077:
+        raise PermissionError(
+            f"{target} mode is {oct(mode)}; lockdown passphrase files must be operator-only (0600)"
+        )
+    value = target.read_bytes()
+    if value.endswith(b"\r\n"):
+        value = value[:-2]
+    elif value.endswith(b"\n"):
+        value = value[:-1]
+    return validate_lockdown_passphrase(value)
+
+
+def _require_usb_serial(interface: object) -> "SerialInterface":
+    """Reject BLE/TCP transports because the passphrase is cleartext on wire."""
+    from meshtastic.serial_interface import SerialInterface
+
+    if not isinstance(interface, SerialInterface):
+        raise ValueError(
+            "lockdown authentication is USB-serial only; refusing BLE/TCP transport"
+        )
+    return interface
+
+
+def build_lockdown_auth(
+    passphrase: bytes = b"",
+    *,
+    boots_remaining: int = 0,
+    valid_until_epoch: int = 0,
+    max_session_seconds: int = 0,
+    lock_now: bool = False,
+    disable: bool = False,
+) -> admin_pb2.LockdownAuth:
+    """Build a bounded LockdownAuth request without silently truncating input."""
+    if passphrase:
+        passphrase = validate_lockdown_passphrase(passphrase)
+    if not 0 <= boots_remaining <= 255:
+        raise ValueError("boots_remaining must be between 0 and 255")
+    if valid_until_epoch < 0 or max_session_seconds < 0:
+        raise ValueError("lockdown time limits must not be negative")
+    auth = admin_pb2.LockdownAuth(
+        passphrase=passphrase,
+        boots_remaining=boots_remaining,
+        valid_until_epoch=valid_until_epoch,
+        max_session_seconds=max_session_seconds,
+        lock_now=lock_now,
+        disable=disable,
+    )
+    return auth
+
+
+def send_lockdown_auth(
+    interface: object,
+    auth: admin_pb2.LockdownAuth,
+    *,
+    timeout: float = DEFAULT_LOCKDOWN_TIMEOUT_SECONDS,
+    allow_reboot_without_status: bool = False,
+) -> mesh_pb2.LockdownStatus | None:
+    """Send one local USB lockdown command and await its structured status."""
+    serial_interface = _require_usb_serial(interface)
+    if timeout <= 0:
+        raise ValueError("timeout must be positive")
+    my_info = serial_interface.myInfo
+    if my_info is None:
+        raise RuntimeError("device did not provide my_info")
+
+    event = threading.Event()
+    result: list[mesh_pb2.LockdownStatus] = []
+
+    def _on_status(*, interface: object, status: mesh_pb2.LockdownStatus) -> None:
+        if interface is not target_interface:
+            return
+        copied = mesh_pb2.LockdownStatus()
+        copied.CopyFrom(status)
+        result.append(copied)
+        event.set()
+
+    target_interface = serial_interface
+    pub.subscribe(_on_status, LOCKDOWN_STATUS_TOPIC)
+    try:
+        admin = admin_pb2.AdminMessage()
+        admin.lockdown_auth.CopyFrom(auth)
+        serial_interface.sendData(
+            admin,
+            my_info.my_node_num,
+            portNum=portnums_pb2.PortNum.ADMIN_APP,
+            wantAck=True,
+            channelIndex=0,
+            pkiEncrypted=False,
+            priority=mesh_pb2.MeshPacket.Priority.RELIABLE,
+        )
+        if event.wait(timeout):
+            return result[-1]
+        if allow_reboot_without_status:
+            return None
+        raise TimeoutError("no LockdownStatus received before timeout")
+    finally:
+        pub.unsubscribe(_on_status, LOCKDOWN_STATUS_TOPIC)

--- a/meshtastic/lockdown.py
+++ b/meshtastic/lockdown.py
@@ -14,6 +14,7 @@ from meshtastic.protobuf import admin_pb2, mesh_pb2, portnums_pb2
 from meshtastic.serial_interface import SerialInterface
 
 DEFAULT_LOCKDOWN_TIMEOUT_SECONDS = 20.0
+_HAS_POSIX_FILE_PERMISSIONS = os.name != "nt"
 
 
 def validate_lockdown_passphrase(passphrase: bytes) -> bytes:
@@ -28,11 +29,14 @@ def read_lockdown_passphrase_file(path: str | os.PathLike[str]) -> bytes:
     """Read an operator-only passphrase file, refusing group/world access."""
     target = Path(path)
     mode = stat.S_IMODE(target.stat().st_mode)
-    if os.name != "nt" and mode & 0o077:
+    if _HAS_POSIX_FILE_PERMISSIONS and mode & 0o077:
         raise PermissionError(
             f"{target} mode is {oct(mode)}; lockdown passphrase files must be operator-only (0600)"
         )
     value = target.read_bytes()
+    # Strip exactly one conventional text-file line ending. Passphrases are
+    # arbitrary bytes, so removing every trailing CR/LF would silently alter a
+    # passphrase that intentionally ends with one of those bytes.
     if value.endswith(b"\r\n"):
         value = value[:-2]
     elif value.endswith(b"\n"):
@@ -92,19 +96,19 @@ def send_lockdown_auth(
         raise RuntimeError("device did not provide my_info")
 
     event = threading.Event()
-    result: list[mesh_pb2.LockdownStatus] = []
+    result: mesh_pb2.LockdownStatus | None = None
 
     def _on_status(
         *, interface: object, status: mesh_pb2.LockdownStatus, **_kwargs: object
     ) -> None:
-        if interface is not target_interface:
+        nonlocal result
+        if interface is not serial_interface:
             return
         copied = mesh_pb2.LockdownStatus()
         copied.CopyFrom(status)
-        result.append(copied)
+        result = copied
         event.set()
 
-    target_interface = serial_interface
     pub.subscribe(_on_status, LOCKDOWN_STATUS_TOPIC)
     try:
         admin = admin_pb2.AdminMessage()
@@ -119,7 +123,7 @@ def send_lockdown_auth(
             priority=mesh_pb2.MeshPacket.Priority.RELIABLE,
         )
         if event.wait(timeout):
-            return result[-1]
+            return result
         if allow_reboot_without_status:
             return None
         raise TimeoutError("no LockdownStatus received before timeout")

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -302,6 +302,7 @@ class MeshInterface:  # pylint: disable=R0902
         )
         self.regionPresetMap: mesh_pb2.LoRaRegionPresetMap | None = None
         self.regionPresets: Mapping[int, RegionPresetInfo] = MappingProxyType({})
+        self.lockdownStatus: mesh_pb2.LockdownStatus | None = None
         # ------------------------------------------------------------------
         # Locking contract for MeshInterface shared state.
         #

--- a/meshtastic/mesh_interface_runtime/receive_pipeline.py
+++ b/meshtastic/mesh_interface_runtime/receive_pipeline.py
@@ -41,6 +41,7 @@ _FROM_RADIO_BRANCHES: tuple[
 ] = (
     (lambda fr, _ctx: fr.HasField("my_info"), "my_info"),
     (lambda fr, _ctx: fr.HasField("metadata"), "metadata"),
+    (lambda fr, _ctx: fr.HasField("lockdown_status"), "lockdown_status"),
     (lambda fr, _ctx: fr.HasField("region_presets"), "region_presets"),
     (lambda fr, _ctx: fr.HasField("node_info"), "node_info"),
     (
@@ -283,6 +284,7 @@ class ReceivePipeline:
             self._from_radio_dispatch_map_cache = {
                 "my_info": self._handle_from_radio_my_info,
                 "metadata": self._handle_from_radio_metadata,
+                "lockdown_status": self._handle_from_radio_lockdown_status,
                 "region_presets": self._handle_from_radio_region_presets,
                 "node_info": self._handle_from_radio_node_info,
                 "config_complete_id": self._handle_from_radio_config_complete_id,
@@ -323,7 +325,7 @@ class ReceivePipeline:
         logger.debug("Received device metadata: %s", stripnl(from_radio.metadata))
         return []
 
-    def _handle_from_radio_region_presets(
+def _handle_from_radio_region_presets(
         self, context: _FromRadioContext
     ) -> list[_PublicationIntent]:
         """Store and publish firmware-declared LoRa compatibility metadata."""
@@ -342,6 +344,20 @@ class ReceivePipeline:
                 "meshtastic.region_presets",
                 region_presets=decoded,
                 raw=raw_map,
+            )
+        ]
+
+    def _handle_from_radio_lockdown_status(
+        self, context: _FromRadioContext
+    ) -> list[_PublicationIntent]:
+        """Store and publish one per-connection firmware lockdown status."""
+        status = mesh_pb2.LockdownStatus()
+        status.CopyFrom(context.message.lockdown_status)
+        with self._node_db_lock:
+            self._interface.lockdownStatus = status
+        return [
+            self._publication_intent(
+                "meshtastic.lockdown_status", status=status
             )
         ]
 

--- a/meshtastic/mesh_interface_runtime/receive_pipeline.py
+++ b/meshtastic/mesh_interface_runtime/receive_pipeline.py
@@ -326,7 +326,7 @@ class ReceivePipeline:
         logger.debug("Received device metadata: %s", stripnl(from_radio.metadata))
         return []
 
-def _handle_from_radio_region_presets(
+    def _handle_from_radio_region_presets(
         self, context: _FromRadioContext
     ) -> list[_PublicationIntent]:
         """Store and publish firmware-declared LoRa compatibility metadata."""
@@ -347,6 +347,7 @@ def _handle_from_radio_region_presets(
                 raw=raw_map,
             )
         ]
+
 
     def _handle_from_radio_lockdown_status(
         self, context: _FromRadioContext

--- a/meshtastic/mesh_interface_runtime/receive_pipeline.py
+++ b/meshtastic/mesh_interface_runtime/receive_pipeline.py
@@ -19,6 +19,7 @@ from meshtastic import (
     protocols,
     publishingThread,
 )
+from meshtastic._topics import LOCKDOWN_STATUS_TOPIC
 from meshtastic.region_presets import decode_region_preset_map
 from meshtastic.protobuf import (
     channel_pb2,
@@ -355,11 +356,7 @@ def _handle_from_radio_region_presets(
         status.CopyFrom(context.message.lockdown_status)
         with self._node_db_lock:
             self._interface.lockdownStatus = status
-        return [
-            self._publication_intent(
-                "meshtastic.lockdown_status", status=status
-            )
-        ]
+        return [self._publication_intent(LOCKDOWN_STATUS_TOPIC, status=status)]
 
     def _handle_from_radio_node_info(
         self, context: _FromRadioContext

--- a/meshtastic/tests/test_lockdown.py
+++ b/meshtastic/tests/test_lockdown.py
@@ -1,0 +1,90 @@
+"""Tests for USB-only firmware lockdown client helpers."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from pubsub import pub
+
+from meshtastic.lockdown import (
+    LOCKDOWN_STATUS_TOPIC,
+    build_lockdown_auth,
+    read_lockdown_passphrase_file,
+    send_lockdown_auth,
+    validate_lockdown_passphrase,
+)
+from meshtastic.protobuf import mesh_pb2, portnums_pb2
+from meshtastic.serial_interface import SerialInterface
+from meshtastic.tcp_interface import TCPInterface
+
+
+@pytest.mark.unit
+def test_validate_lockdown_passphrase_enforces_wire_bounds() -> None:
+    assert validate_lockdown_passphrase(b"secret") == b"secret"
+    with pytest.raises(ValueError, match="1..32"):
+        validate_lockdown_passphrase(b"")
+    with pytest.raises(ValueError, match="1..32"):
+        validate_lockdown_passphrase(b"x" * 33)
+
+
+@pytest.mark.unit
+def test_read_lockdown_passphrase_file_requires_operator_only_permissions(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "passphrase"
+    path.write_bytes(b"secret\n")
+    path.chmod(0o600)
+    assert read_lockdown_passphrase_file(path) == b"secret"
+    path.chmod(0o640)
+    with pytest.raises(PermissionError, match="operator-only"):
+        read_lockdown_passphrase_file(path)
+
+
+@pytest.mark.unit
+def test_build_lockdown_auth_rejects_out_of_range_limits() -> None:
+    auth = build_lockdown_auth(
+        b"secret", boots_remaining=3, max_session_seconds=90, disable=True
+    )
+    assert auth.passphrase == b"secret"
+    assert auth.boots_remaining == 3
+    assert auth.max_session_seconds == 90
+    assert auth.disable is True
+    with pytest.raises(ValueError, match="0 and 255"):
+        build_lockdown_auth(b"secret", boots_remaining=256)
+
+
+@pytest.mark.unit
+def test_send_lockdown_auth_is_serial_only_and_uses_plain_local_admin() -> None:
+    tcp = MagicMock(spec=TCPInterface)
+    with pytest.raises(ValueError, match="USB-serial only"):
+        send_lockdown_auth(tcp, build_lockdown_auth(b"secret"), timeout=0.1)
+
+    serial = MagicMock(spec=SerialInterface)
+    serial.myInfo = mesh_pb2.MyNodeInfo(my_node_num=123)
+
+    def _send(*_args: object, **kwargs: object) -> mesh_pb2.MeshPacket:
+        assert kwargs["portNum"] == portnums_pb2.PortNum.ADMIN_APP
+        assert kwargs["wantAck"] is True
+        assert kwargs["pkiEncrypted"] is False
+        pub.sendMessage(
+            LOCKDOWN_STATUS_TOPIC,
+            interface=serial,
+            status=mesh_pb2.LockdownStatus(
+                state=mesh_pb2.LockdownStatus.UNLOCKED
+            ),
+        )
+        return mesh_pb2.MeshPacket(id=7)
+
+    serial.sendData.side_effect = _send
+    status = send_lockdown_auth(serial, build_lockdown_auth(b"secret"), timeout=0.5)
+    assert status is not None
+    assert status.state == mesh_pb2.LockdownStatus.UNLOCKED
+
+
+@pytest.mark.unit
+def test_send_lockdown_auth_times_out_without_status() -> None:
+    serial = MagicMock(spec=SerialInterface)
+    serial.myInfo = mesh_pb2.MyNodeInfo(my_node_num=123)
+    serial.sendData.return_value = mesh_pb2.MeshPacket(id=7)
+    with pytest.raises(TimeoutError, match="LockdownStatus"):
+        send_lockdown_auth(serial, build_lockdown_auth(b"secret"), timeout=0.01)

--- a/meshtastic/tests/test_lockdown.py
+++ b/meshtastic/tests/test_lockdown.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 from pubsub import pub
 
+import meshtastic.lockdown as lockdown_module
 from meshtastic.lockdown import (
     LOCKDOWN_STATUS_TOPIC,
     build_lockdown_auth,
@@ -14,6 +15,7 @@ from meshtastic.lockdown import (
     send_lockdown_auth,
     validate_lockdown_passphrase,
 )
+from meshtastic.mesh_interface import MeshInterface
 from meshtastic.protobuf import mesh_pb2, portnums_pb2
 from meshtastic.serial_interface import SerialInterface
 from meshtastic.tcp_interface import TCPInterface
@@ -134,3 +136,173 @@ def test_send_lockdown_auth_times_out_without_status() -> None:
     serial.sendData.return_value = mesh_pb2.MeshPacket(id=7)
     with pytest.raises(TimeoutError, match="LockdownStatus"):
         send_lockdown_auth(serial, build_lockdown_auth(b"secret"), timeout=0.01)
+
+
+@pytest.mark.unit
+def test_mesh_interface_initializes_lockdown_status() -> None:
+    with MeshInterface(noProto=True) as interface:
+        assert interface.lockdownStatus is None
+
+
+@pytest.mark.unit
+def test_read_lockdown_passphrase_file_strips_crlf(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "passphrase-crlf"
+    path.write_bytes(b"secret\r\n")
+    path.chmod(0o600)
+    assert read_lockdown_passphrase_file(path) == b"secret"
+
+
+@pytest.mark.unit
+def test_read_lockdown_passphrase_file_skips_posix_mode_check_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "passphrase-windows"
+    path.write_bytes(b"secret\n")
+    path.chmod(0o666)
+    monkeypatch.setattr(lockdown_module, "_HAS_POSIX_FILE_PERMISSIONS", False)
+    assert read_lockdown_passphrase_file(path) == b"secret"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    (
+        ({"valid_until_epoch": -1}, "must not be negative"),
+        ({"max_session_seconds": -1}, "must not be negative"),
+        ({"boots_remaining": -1}, "between 0 and 255"),
+    ),
+)
+def test_build_lockdown_auth_rejects_all_invalid_limits(
+    kwargs: dict[str, int], message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        build_lockdown_auth(b"secret", **kwargs)
+
+
+@pytest.mark.unit
+def test_build_lockdown_auth_supports_lock_now_without_passphrase() -> None:
+    auth = build_lockdown_auth(lock_now=True)
+    assert auth.passphrase == b""
+    assert auth.lock_now is True
+
+
+@pytest.mark.unit
+def test_send_lockdown_auth_validates_timeout_and_my_info() -> None:
+    serial = MagicMock(spec=SerialInterface)
+    serial.myInfo = mesh_pb2.MyNodeInfo(my_node_num=123)
+    with pytest.raises(ValueError, match="timeout must be positive"):
+        send_lockdown_auth(serial, build_lockdown_auth(b"secret"), timeout=0)
+
+    serial.myInfo = None
+    with pytest.raises(RuntimeError, match="my_info"):
+        send_lockdown_auth(serial, build_lockdown_auth(b"secret"), timeout=0.1)
+
+
+@pytest.mark.unit
+def test_send_lockdown_auth_ignores_other_interface_status_and_allows_reboot() -> None:
+    serial = MagicMock(spec=SerialInterface)
+    serial.myInfo = mesh_pb2.MyNodeInfo(my_node_num=123)
+    other = MagicMock(spec=SerialInterface)
+
+    def _send(*_args: object, **_kwargs: object) -> mesh_pb2.MeshPacket:
+        pub.sendMessage(
+            LOCKDOWN_STATUS_TOPIC,
+            interface=other,
+            status=mesh_pb2.LockdownStatus(state=mesh_pb2.LockdownStatus.UNLOCKED),
+        )
+        return mesh_pb2.MeshPacket(id=9)
+
+    serial.sendData.side_effect = _send
+    assert (
+        send_lockdown_auth(
+            serial,
+            build_lockdown_auth(lock_now=True),
+            timeout=0.01,
+            allow_reboot_without_status=True,
+        )
+        is None
+    )
+
+
+@pytest.mark.unit
+def test_send_lockdown_auth_returns_defensive_status_copy_and_unsubscribes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    serial = MagicMock(spec=SerialInterface)
+    serial.myInfo = mesh_pb2.MyNodeInfo(my_node_num=123)
+    listeners: list[object] = []
+    unsubscribed: list[object] = []
+
+    monkeypatch.setattr(
+        pub, "subscribe", lambda listener, _topic: listeners.append(listener)
+    )
+    monkeypatch.setattr(
+        pub, "unsubscribe", lambda listener, _topic: unsubscribed.append(listener)
+    )
+
+    source = mesh_pb2.LockdownStatus(state=mesh_pb2.LockdownStatus.UNLOCKED)
+
+    def _send(
+        payload: object, destination: int, **kwargs: object
+    ) -> mesh_pb2.MeshPacket:
+        assert destination == 123
+        assert kwargs == {
+            "portNum": portnums_pb2.PortNum.ADMIN_APP,
+            "wantAck": True,
+            "channelIndex": 0,
+            "pkiEncrypted": False,
+            "priority": mesh_pb2.MeshPacket.Priority.RELIABLE,
+        }
+        assert payload.lockdown_auth.passphrase == b"secret"  # type: ignore[attr-defined]
+        listener = listeners[-1]
+        assert callable(listener)
+        listener(interface=serial, status=source)
+        source.state = mesh_pb2.LockdownStatus.UNLOCK_FAILED
+        return mesh_pb2.MeshPacket(id=10)
+
+    serial.sendData.side_effect = _send
+    status = send_lockdown_auth(serial, build_lockdown_auth(b"secret"), timeout=0.5)
+
+    assert status is not None
+    assert status is not source
+    assert status.state == mesh_pb2.LockdownStatus.UNLOCKED
+    assert unsubscribed == listeners
+
+
+@pytest.mark.unit
+def test_send_lockdown_auth_unsubscribes_when_send_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    serial = MagicMock(spec=SerialInterface)
+    serial.myInfo = mesh_pb2.MyNodeInfo(my_node_num=123)
+    listener: object | None = None
+    unsubscribed: list[object] = []
+
+    def _subscribe(candidate: object, _topic: str) -> None:
+        nonlocal listener
+        listener = candidate
+
+    monkeypatch.setattr(pub, "subscribe", _subscribe)
+    monkeypatch.setattr(
+        pub, "unsubscribe", lambda candidate, _topic: unsubscribed.append(candidate)
+    )
+    serial.sendData.side_effect = OSError("USB disconnected")
+
+    with pytest.raises(OSError, match="USB disconnected"):
+        send_lockdown_auth(serial, build_lockdown_auth(b"secret"), timeout=0.5)
+
+    assert listener is not None
+    assert unsubscribed == [listener]
+
+
+@pytest.mark.unit
+def test_read_lockdown_passphrase_file_preserves_value_without_line_ending(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "passphrase-no-newline"
+    path.write_bytes(b"secret")
+    path.chmod(0o600)
+    assert read_lockdown_passphrase_file(path) == b"secret"

--- a/meshtastic/tests/test_lockdown.py
+++ b/meshtastic/tests/test_lockdown.py
@@ -1,5 +1,6 @@
 """Tests for USB-only firmware lockdown client helpers."""
 
+import os
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -35,9 +36,21 @@ def test_read_lockdown_passphrase_file_requires_operator_only_permissions(
     path.write_bytes(b"secret\n")
     path.chmod(0o600)
     assert read_lockdown_passphrase_file(path) == b"secret"
+    if os.name == "nt":
+        return
     path.chmod(0o640)
     with pytest.raises(PermissionError, match="operator-only"):
         read_lockdown_passphrase_file(path)
+
+
+@pytest.mark.unit
+def test_read_lockdown_passphrase_file_strips_only_one_line_ending(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "passphrase-multiline"
+    path.write_bytes(b"secret\n\n")
+    path.chmod(0o600)
+    assert read_lockdown_passphrase_file(path) == b"secret\n"
 
 
 @pytest.mark.unit
@@ -69,11 +82,44 @@ def test_send_lockdown_auth_is_serial_only_and_uses_plain_local_admin() -> None:
         pub.sendMessage(
             LOCKDOWN_STATUS_TOPIC,
             interface=serial,
-            status=mesh_pb2.LockdownStatus(
-                state=mesh_pb2.LockdownStatus.UNLOCKED
-            ),
+            status=mesh_pb2.LockdownStatus(state=mesh_pb2.LockdownStatus.UNLOCKED),
         )
         return mesh_pb2.MeshPacket(id=7)
+
+    serial.sendData.side_effect = _send
+    status = send_lockdown_auth(serial, build_lockdown_auth(b"secret"), timeout=0.5)
+    assert status is not None
+    assert status.state == mesh_pb2.LockdownStatus.UNLOCKED
+
+
+@pytest.mark.unit
+def test_send_lockdown_auth_status_listener_tolerates_extra_keywords(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    serial = MagicMock(spec=SerialInterface)
+    serial.myInfo = mesh_pb2.MyNodeInfo(my_node_num=123)
+    listeners: list[object] = []
+
+    def _subscribe(listener: object, topic: str) -> None:
+        assert topic == LOCKDOWN_STATUS_TOPIC
+        listeners.append(listener)
+
+    def _unsubscribe(listener: object, topic: str) -> None:
+        assert topic == LOCKDOWN_STATUS_TOPIC
+        assert listener in listeners
+
+    monkeypatch.setattr(pub, "subscribe", _subscribe)
+    monkeypatch.setattr(pub, "unsubscribe", _unsubscribe)
+
+    def _send(*_args: object, **_kwargs: object) -> mesh_pb2.MeshPacket:
+        listener = listeners[-1]
+        assert callable(listener)
+        listener(
+            interface=serial,
+            status=mesh_pb2.LockdownStatus(state=mesh_pb2.LockdownStatus.UNLOCKED),
+            source="future-publisher",
+        )
+        return mesh_pb2.MeshPacket(id=8)
 
     serial.sendData.side_effect = _send
     status = send_lockdown_auth(serial, build_lockdown_auth(b"secret"), timeout=0.5)

--- a/meshtastic/tests/test_lockdown.py
+++ b/meshtastic/tests/test_lockdown.py
@@ -179,7 +179,7 @@ def test_build_lockdown_auth_rejects_all_invalid_limits(
     kwargs: dict[str, int], message: str
 ) -> None:
     with pytest.raises(ValueError, match=message):
-        build_lockdown_auth(b"secret", **kwargs)
+        build_lockdown_auth(b"secret", **kwargs)  # type: ignore[arg-type]
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -47,7 +47,7 @@ from ..node import Node
 # from ..radioconfig_pb2 import UserPreferences
 # import meshtastic.config_pb2
 from ..ota import OTAError, OTATransportError
-from ..protobuf import config_pb2, localonly_pb2
+from ..protobuf import config_pb2, localonly_pb2, mesh_pb2
 from ..protobuf.channel_pb2 import Channel  # pylint: disable=E0611
 from ..serial_interface import SerialInterface
 from ..tcp_interface import TCPInterface
@@ -6830,6 +6830,31 @@ def _run_region_preset_cli(
     return interface
 
 
+def _init_lockdown_cli(monkeypatch: pytest.MonkeyPatch, *cli_args: str) -> None:
+    effective_args = list(cli_args)
+    if "--dest" not in effective_args:
+        effective_args.extend(("--dest", MAIN_LOCAL_ADDR))
+    monkeypatch.setattr(sys, "argv", ["meshtastic", *effective_args])
+    initParser()
+
+
+def _run_lockdown_cli(
+    monkeypatch: pytest.MonkeyPatch,
+    *cli_args: str,
+    status: mesh_pb2.LockdownStatus | None = None,
+) -> tuple[MagicMock, MagicMock, MagicMock]:
+    _init_lockdown_cli(monkeypatch, *cli_args)
+    interface = MagicMock()
+    interface.devPath = ""
+    interface.myInfo = SimpleNamespace(my_node_num=int("25d6e474", 16))
+    build = MagicMock(return_value=object())
+    send = MagicMock(return_value=status)
+    monkeypatch.setattr(main_module, "build_lockdown_auth", build)
+    monkeypatch.setattr(main_module, "send_lockdown_auth", send)
+    main_module.onConnected(interface)
+    return interface, build, send
+
+
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_show_region_presets_reports_absent_metadata_and_closes(
@@ -6844,6 +6869,39 @@ def test_show_region_presets_reports_absent_metadata_and_closes(
     output = capsys.readouterr().out
     assert "did not provide usable region/preset compatibility metadata" in output
     interface.close.assert_called_once_with()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_lockdown_cli_unlock_from_file(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    read_file = MagicMock(return_value=b"file-secret")
+    monkeypatch.setattr(main_module, "read_lockdown_passphrase_file", read_file)
+    status = mesh_pb2.LockdownStatus(state=mesh_pb2.LockdownStatus.UNLOCKED)
+
+    interface, build, send = _run_lockdown_cli(
+        monkeypatch,
+        "--lockdown-unlock",
+        "--lockdown-passphrase-file",
+        "/tmp/secret",
+        status=status,
+    )
+
+    read_file.assert_called_once_with("/tmp/secret")
+    build.assert_called_once_with(
+        b"file-secret",
+        boots_remaining=0,
+        valid_until_epoch=0,
+        max_session_seconds=0,
+        lock_now=False,
+        disable=False,
+    )
+    send.assert_called_once_with(
+        interface, build.return_value, timeout=20.0, allow_reboot_without_status=False
+    )
+    assert "Lockdown status: UNLOCKED" in capsys.readouterr().out
 
 
 @pytest.mark.unit
@@ -6932,4 +6990,369 @@ def test_region_preset_cli_without_flag_does_not_read_capability_state(
     main_module.onConnected(interface)
 
     assert "region/preset" not in capsys.readouterr().out
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_lockdown_cli_rejects_remote_destination(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--lockdown-unlock",
+            "--lockdown-passphrase",
+            "secret",
+            "--dest",
+            "!deadbeef",
+        ],
+    )
+    initParser()
+    interface = MagicMock()
+    interface.devPath = ""
+    interface.myInfo = SimpleNamespace(my_node_num=int("25d6e474", 16))
+    with pytest.raises(SystemExit):
+        main_module.onConnected(interface)
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_lockdown_cli_rejects_unacknowledged_command_line_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--lockdown-unlock",
+            "--lockdown-passphrase",
+            "secret",
+            "--dest",
+            MAIN_LOCAL_ADDR,
+        ],
+    )
+    initParser()
+    interface = MagicMock()
+    interface.devPath = ""
+    interface.myInfo = SimpleNamespace(my_node_num=int("25d6e474", 16))
+    with pytest.raises(SystemExit):
+        main_module.onConnected(interface)
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_lockdown_cli_command_line_secret_formats_unknown_state_and_backoff(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    validate = MagicMock(return_value=b"secret")
+    monkeypatch.setattr(main_module, "validate_lockdown_passphrase", validate)
+    status = mesh_pb2.LockdownStatus(state=999, backoff_seconds=7)  # type: ignore[arg-type]
+
+    _interface, build, _send = _run_lockdown_cli(
+        monkeypatch,
+        "--lockdown-unlock",
+        "--lockdown-passphrase",
+        "secret",
+        "--insecure-lockdown-passphrase-on-command-line",
+        status=status,
+    )
+
+    validate.assert_called_once_with(b"secret")
+    assert build.call_args.args == (b"secret",)
+    output = capsys.readouterr().out
+    assert "Lockdown status: STATE_999" in output
+    assert "Retry backoff: 7s" in output
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_lockdown_cli_provision_confirmation_abort(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr("builtins.input", lambda _prompt: "no")
+    _init_lockdown_cli(monkeypatch, "--lockdown-provision")
+    interface = MagicMock()
+    interface.devPath = ""
+    interface.myInfo = SimpleNamespace(my_node_num=int("25d6e474", 16))
+
+    with pytest.raises(SystemExit):
+        main_module.onConnected(interface)
+
+    assert "Aborted." in capsys.readouterr().err
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_lockdown_cli_provision_rejects_mismatched_interactive_passphrases(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr("builtins.input", lambda _prompt: "yes")
+    prompts = iter(["secret", "different"])
+    monkeypatch.setattr(main_module.getpass, "getpass", lambda _prompt: next(prompts))
+    _init_lockdown_cli(monkeypatch, "--lockdown-provision")
+    interface = MagicMock()
+    interface.devPath = ""
+    interface.myInfo = SimpleNamespace(my_node_num=int("25d6e474", 16))
+
+    with pytest.raises(SystemExit):
+        main_module.onConnected(interface)
+
+    assert "Lockdown passphrases do not match." in capsys.readouterr().err
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_lockdown_cli_provision_reports_auth_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr("builtins.input", lambda _prompt: "yes")
+    prompts = iter(["secret", "secret"])
+    monkeypatch.setattr(main_module.getpass, "getpass", lambda _prompt: next(prompts))
+    monkeypatch.setattr(
+        main_module, "validate_lockdown_passphrase", lambda value: value
+    )
+    failed = mesh_pb2.LockdownStatus(state=mesh_pb2.LockdownStatus.UNLOCK_FAILED)
+    _init_lockdown_cli(monkeypatch, "--lockdown-provision")
+    interface = MagicMock()
+    interface.devPath = ""
+    interface.myInfo = SimpleNamespace(my_node_num=int("25d6e474", 16))
+    monkeypatch.setattr(
+        main_module, "build_lockdown_auth", MagicMock(return_value=object())
+    )
+    monkeypatch.setattr(
+        main_module, "send_lockdown_auth", MagicMock(return_value=failed)
+    )
+
+    with pytest.raises(SystemExit):
+        main_module.onConnected(interface)
+
+    captured = capsys.readouterr()
+    assert "Lockdown status: UNLOCK_FAILED" in captured.out
+    assert "Lockdown authentication failed." in captured.err
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_lockdown_cli_lock_now_allows_reboot_without_status(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _interface, build, send = _run_lockdown_cli(
+        monkeypatch,
+        "--lockdown-lock-now",
+        "--lockdown-yes",
+        status=None,
+    )
+    assert build.call_args.kwargs["lock_now"] is True
+    assert send.call_args.kwargs["allow_reboot_without_status"] is True
+    assert "device may already be rebooting" in capsys.readouterr().out
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_lockdown_cli_disable_sets_disable_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        main_module, "read_lockdown_passphrase_file", lambda _path: b"secret"
+    )
+    status = mesh_pb2.LockdownStatus(state=mesh_pb2.LockdownStatus.UNLOCKED)
+    _interface, build, _send = _run_lockdown_cli(
+        monkeypatch,
+        "--lockdown-disable",
+        "--lockdown-yes",
+        "--lockdown-passphrase-file",
+        "/tmp/secret",
+        status=status,
+    )
+    assert build.call_args.kwargs["disable"] is True
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_lockdown_cli_accepts_explicit_local_destination(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    status = mesh_pb2.LockdownStatus(state=mesh_pb2.LockdownStatus.UNLOCKED)
+    interface, _build, send = _run_lockdown_cli(
+        monkeypatch,
+        "--lockdown-lock-now",
+        "--lockdown-yes",
+        "--dest",
+        MAIN_LOCAL_ADDR,
+        status=status,
+    )
+    send.assert_called_once()
+    interface.close.assert_called_once_with()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+@pytest.mark.parametrize(
+    ("cli_args", "error", "expected"),
+    (
+        (
+            (
+                "--lockdown-unlock",
+                "--lockdown-passphrase",
+                "",
+                "--insecure-lockdown-passphrase-on-command-line",
+            ),
+            ValueError("lockdown passphrase must be 1..32 bytes"),
+            "Invalid lockdown options",
+        ),
+        (
+            (
+                "--lockdown-unlock",
+                "--lockdown-passphrase-file",
+                "/tmp/insecure-secret",
+            ),
+            PermissionError(
+                "/tmp/insecure-secret mode is 0o640; "
+                "lockdown passphrase files must be operator-only (0600)"
+            ),
+            "operator-only (0600)",
+        ),
+    ),
+)
+def test_lockdown_cli_maps_passphrase_errors_to_user_facing_exit(
+    monkeypatch: pytest.MonkeyPatch,
+    cli_args: tuple[str, ...],
+    error: Exception,
+    expected: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _init_lockdown_cli(monkeypatch, *cli_args)
+    interface = MagicMock()
+    interface.devPath = ""
+    interface.myInfo = SimpleNamespace(my_node_num=1)
+    if "--lockdown-passphrase-file" in cli_args:
+        monkeypatch.setattr(
+            main_module, "read_lockdown_passphrase_file", MagicMock(side_effect=error)
+        )
+    else:
+        monkeypatch.setattr(
+            main_module, "validate_lockdown_passphrase", MagicMock(side_effect=error)
+        )
+
+    with pytest.raises(SystemExit):
+        main_module.onConnected(interface)
+
+    assert expected in capsys.readouterr().err
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_lockdown_cli_maps_invalid_limits_to_user_facing_exit(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        main_module, "read_lockdown_passphrase_file", lambda _path: b"secret"
+    )
+    _init_lockdown_cli(
+        monkeypatch,
+        "--lockdown-unlock",
+        "--lockdown-passphrase-file",
+        "/tmp/secret",
+        "--lockdown-boots",
+        "-1",
+    )
+    interface = MagicMock()
+    interface.devPath = ""
+    interface.myInfo = SimpleNamespace(my_node_num=1)
+
+    with pytest.raises(SystemExit):
+        main_module.onConnected(interface)
+
+    output = capsys.readouterr().err
+    assert "Invalid lockdown options" in output
+    assert "boots_remaining must be between 0 and 255" in output
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+@pytest.mark.parametrize(
+    "error",
+    (
+        TimeoutError("no LockdownStatus received before timeout"),
+        ValueError("lockdown authentication is USB-serial only"),
+        RuntimeError("device did not provide my_info"),
+    ),
+)
+def test_lockdown_cli_maps_send_failures_to_user_facing_exit(
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        main_module, "read_lockdown_passphrase_file", lambda _path: b"secret"
+    )
+    monkeypatch.setattr(main_module, "send_lockdown_auth", MagicMock(side_effect=error))
+    _init_lockdown_cli(
+        monkeypatch,
+        "--lockdown-unlock",
+        "--lockdown-passphrase-file",
+        "/tmp/secret",
+    )
+    interface = MagicMock()
+    interface.devPath = ""
+    interface.myInfo = SimpleNamespace(my_node_num=1)
+
+    with pytest.raises(SystemExit):
+        main_module.onConnected(interface)
+
+    output = capsys.readouterr().err
+    assert "Lockdown command failed" in output
+    assert str(error) in output
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_lockdown_cli_interactive_unlock_uses_single_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    getpass_mock = MagicMock(return_value="secret")
+    validate_mock = MagicMock(return_value=b"secret")
+    monkeypatch.setattr(main_module.getpass, "getpass", getpass_mock)
+    monkeypatch.setattr(main_module, "validate_lockdown_passphrase", validate_mock)
+    status = mesh_pb2.LockdownStatus(state=mesh_pb2.LockdownStatus.UNLOCKED)
+
+    _interface, build, _send = _run_lockdown_cli(
+        monkeypatch,
+        "--lockdown-unlock",
+        status=status,
+    )
+
+    getpass_mock.assert_called_once_with("Lockdown passphrase: ")
+    validate_mock.assert_called_once_with(b"secret")
+    assert build.call_args.args == (b"secret",)
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_lockdown_cli_without_action_does_not_call_lockdown_helpers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _init_lockdown_cli(monkeypatch)
+    interface = MagicMock()
+    interface.devPath = ""
+    interface.myInfo = SimpleNamespace(my_node_num=int("25d6e474", 16))
+    build = MagicMock()
+    send = MagicMock()
+    monkeypatch.setattr(main_module, "build_lockdown_auth", build)
+    monkeypatch.setattr(main_module, "send_lockdown_auth", send)
+
+    main_module.onConnected(interface)
+
+    build.assert_not_called()
+    send.assert_not_called()
     interface.close.assert_not_called()

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -195,6 +195,30 @@ def test_main_init_parser_accepts_region_preset_capability_flag(
 
 
 @pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_main_init_parser_accepts_usb_lockdown_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--lockdown-unlock",
+            "--lockdown-passphrase-file",
+            "/tmp/secret",
+            "--lockdown-wait",
+            "12",
+        ],
+    )
+    initParser()
+    assert mt_config.args is not None
+    assert mt_config.args.lockdown_unlock is True
+    assert mt_config.args.lockdown_passphrase_file == "/tmp/secret"
+    assert mt_config.args.lockdown_wait == 12.0
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     ("raw_value", "expected"),
     (

--- a/meshtastic/tests/test_receive_pipeline.py
+++ b/meshtastic/tests/test_receive_pipeline.py
@@ -498,6 +498,30 @@ class TestHandleFromRadioRegionPresets:
         assert result[0].topic == "meshtastic.region_presets"
 
 
+class TestHandleFromRadioLockdownStatus:
+    """Tests for structured per-connection lockdown status dispatch."""
+
+    @pytest.mark.unit
+    def test_handle_lockdown_status_stores_copy_and_publishes(
+        self, receive_pipeline: ReceivePipeline, mock_interface: MagicMock
+    ) -> None:
+        from_radio = mesh_pb2.FromRadio()
+        from_radio.lockdown_status.state = mesh_pb2.LockdownStatus.LOCKED
+        from_radio.lockdown_status.backoff_seconds = 12
+        context = _FromRadioContext(
+            message=from_radio,
+            message_dict=_LazyMessageDict(from_radio),
+            config_id=None,
+        )
+
+        result = receive_pipeline._handle_from_radio_lockdown_status(context)
+
+        assert mock_interface.lockdownStatus is not from_radio.lockdown_status
+        assert mock_interface.lockdownStatus.state == mesh_pb2.LockdownStatus.LOCKED
+        assert result[0].topic == "meshtastic.lockdown_status"
+        assert result[0].payload["status"].backoff_seconds == 12
+
+
 
 class TestHandleFromRadioNodeInfo:
     """Tests for _handle_from_radio_node_info method (lines 344-365)."""


### PR DESCRIPTION
## Summary by Sourcery

Introduce USB-serial-only firmware lockdown client support across CLI, runtime, and Python API.

New Features:
- Add CLI lockdown actions for provisioning, unlocking, locking now, and disabling hardened devices over USB with configurable limits and timeouts.
- Expose Python helpers in meshtastic.lockdown for validating passphrases, reading secure passphrase files, building lockdown auth requests, and sending USB-only admin commands while tracking structured status.
- Extend the receive pipeline and MeshInterface to handle and retain per-connection LockdownStatus messages on a shared pubsub topic.

Enhancements:
- Add confirmation and error mapping for lockdown-related CLI options to provide clear, user-facing failures and safeguards around destructive actions.

Documentation:
- Add LOCKDOWN.md documenting USB lockdown client behavior, security constraints, helper APIs, and CLI usage.

Tests:
- Add comprehensive unit tests for lockdown CLI workflows, lockdown helper functions, LockdownStatus receive handling, and MeshInterface lockdown state initialization.