### PR TITLE
Extract CLI value parsing helpers

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -28,6 +28,13 @@ import meshtastic.serial_interface
 import meshtastic.tcp_interface
 import meshtastic.util
 from meshtastic import BROADCAST_ADDR, LOCAL_ADDR, mt_config, remote_hardware
+from meshtastic.cli.values import (
+    is_local_destination as _is_local_destination,
+    looks_like_integer_literal as _looks_like_integer_literal,  # noqa: F401 - legacy __main__ compatibility export
+    parse_bitfield_value as _parse_bitfield_value,
+    parse_integer_literal as _parse_integer_literal,  # noqa: F401 - legacy __main__ compatibility export
+    parse_modem_preset_name as _parse_modem_preset_name,  # noqa: F401 - legacy __main__ compatibility export
+)
 from meshtastic.configure_verify import (
     _verify_channel_url_against_state,
     _verify_requested_fields,
@@ -194,64 +201,12 @@ _MODEM_PRESET_SHORTHANDS: tuple[tuple[tuple[str, ...], str, str, str], ...] = (
 )
 
 
-def _parse_modem_preset_name(value: str) -> str:
-    """Normalize and validate a modem preset against the active schema."""
-    normalized = value.strip().replace("-", "_").upper()
-    try:
-        config_pb2.Config.LoRaConfig.ModemPreset.Value(normalized)
-    except ValueError as exc:
-        choices = ", ".join(config_pb2.Config.LoRaConfig.ModemPreset.keys())
-        raise argparse.ArgumentTypeError(
-            f"Unknown modem preset {value!r}. Available presets: {choices}"
-        ) from exc
-    return normalized
 
 
-def _looks_like_integer_literal(value: str) -> bool:
-    stripped = value.strip()
-    if not stripped:
-        return False
-    if stripped[0] in "+-":
-        stripped = stripped[1:]
-    return bool(stripped) and stripped[0].isdigit()
 
 
-def _parse_integer_literal(value: str) -> int:
-    stripped = value.strip()
-    if not stripped:
-        raise ValueError("empty integer literal")
-    unsigned = stripped[1:] if stripped[0] in "+-" else stripped
-    if unsigned.lower().startswith(("0x", "0b")):
-        return int(stripped, 0)
-    return int(stripped, 10)
 
 
-def _parse_bitfield_value(flag_type: Any, raw_val: Any) -> int:
-    if isinstance(raw_val, int):
-        val = raw_val
-    elif isinstance(raw_val, str):
-        stripped = raw_val.strip()
-        if _looks_like_integer_literal(stripped):
-            try:
-                val = _parse_integer_literal(stripped)
-            except ValueError as e:
-                raise ValueError(
-                    f"Invalid numeric bitfield value {raw_val!r}. Expected decimal, "
-                    "hex with 0x prefix, binary with 0b prefix, or comma-separated flag names."
-                ) from e
-        else:
-            flag_names = [n.strip() for n in stripped.split(",") if n.strip()]
-            val = meshtastic.util.flagsFromList(flag_type, flag_names)
-    else:
-        raise ValueError(
-            f"Invalid bitfield value {raw_val!r}. Expected integer, numeric string, or flag names."
-        )
-
-    if val < 0:
-        raise ValueError(
-            f"Invalid bitfield value {raw_val!r}. Expected a non-negative integer."
-        )
-    return val
 
 
 # ==============================================================================
@@ -636,36 +591,6 @@ def _post_seturl_stability_check(
     return False
 
 
-def _is_local_destination(interface: MeshInterface, dest: str) -> bool:
-    dest_value = str(dest).strip()
-    if dest_value in (BROADCAST_ADDR, LOCAL_ADDR):
-        return True
-
-    def _parse_dest_node_num(value: str) -> int | None:
-        if value.isdecimal():
-            return int(value)
-        normalized = value.casefold()
-        hex_part = ""
-        if normalized.startswith("!"):
-            hex_part = normalized[1:]
-        elif normalized.startswith("0x"):
-            hex_part = normalized[2:]
-        if not hex_part:
-            return None
-        try:
-            return int(hex_part, 16)
-        except ValueError:
-            return None
-
-    try:
-        my_info = interface.myInfo
-        if my_info is None:
-            return False
-        my_node_num = int(my_info.my_node_num)
-        parsed_dest_num = _parse_dest_node_num(dest_value)
-        return parsed_dest_num == my_node_num
-    except Exception:
-        return False
 
 
 def _send_local_factory_reset_and_wait(

--- a/meshtastic/cli/__init__.py
+++ b/meshtastic/cli/__init__.py
@@ -1,0 +1,5 @@
+"""Internal command-line implementation package.
+
+The public console entry points remain in :mod:`meshtastic.__main__`; this package
+contains testable implementation seams used by that compatibility module.
+"""

--- a/meshtastic/cli/values.py
+++ b/meshtastic/cli/values.py
@@ -3,11 +3,21 @@
 from __future__ import annotations
 
 import argparse
-from typing import Any
+from typing import Any, Protocol
 
 import meshtastic.util
 from meshtastic import BROADCAST_ADDR, LOCAL_ADDR
 from meshtastic.protobuf import config_pb2
+
+
+class HasNodeInfo(Protocol):
+    """Structural interface accepted by :func:`is_local_destination`.
+
+    Decouples node-identity lookups from the concrete ``MeshInterface`` so
+    that static type checking works without pulling in the full interface.
+    """
+
+    myInfo: Any
 
 
 def parse_modem_preset_name(value: str) -> str:
@@ -92,7 +102,7 @@ def _parse_destination_node_number(value: str) -> int | None:
         return None
 
 
-def is_local_destination(interface: Any, destination: str) -> bool:
+def is_local_destination(interface: HasNodeInfo, destination: str) -> bool:
     """Return whether a destination identifies the directly connected local node."""
     destination_value = str(destination).strip()
     if destination_value in (BROADCAST_ADDR, LOCAL_ADDR):

--- a/meshtastic/cli/values.py
+++ b/meshtastic/cli/values.py
@@ -1,0 +1,109 @@
+"""Pure value parsing and destination helpers for the Meshtastic CLI."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+import meshtastic.util
+from meshtastic import BROADCAST_ADDR, LOCAL_ADDR
+from meshtastic.protobuf import config_pb2
+
+
+def parse_modem_preset_name(value: str) -> str:
+    """Normalize and validate a modem preset against the active schema."""
+    normalized = value.strip().replace("-", "_").upper()
+    try:
+        config_pb2.Config.LoRaConfig.ModemPreset.Value(normalized)
+    except ValueError as exc:
+        choices = ", ".join(config_pb2.Config.LoRaConfig.ModemPreset.keys())
+        raise argparse.ArgumentTypeError(
+            f"Unknown modem preset {value!r}. Available presets: {choices}"
+        ) from exc
+    return normalized
+
+
+def looks_like_integer_literal(value: str) -> bool:
+    """Return whether ``value`` begins like a supported signed integer literal."""
+    stripped = value.strip()
+    if not stripped:
+        return False
+    if stripped[0] in "+-":
+        stripped = stripped[1:]
+    return bool(stripped) and stripped[0].isdigit()
+
+
+def parse_integer_literal(value: str) -> int:
+    """Parse decimal, hexadecimal, or binary integer text."""
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError("empty integer literal")
+    unsigned = stripped[1:] if stripped[0] in "+-" else stripped
+    if unsigned.lower().startswith(("0x", "0b")):
+        return int(stripped, 0)
+    return int(stripped, 10)
+
+
+def parse_bitfield_value(flag_type: Any, raw_value: Any) -> int:
+    """Parse an integer or comma-separated protobuf flag-name bitfield."""
+    if isinstance(raw_value, int):
+        value = raw_value
+    elif isinstance(raw_value, str):
+        stripped = raw_value.strip()
+        if looks_like_integer_literal(stripped):
+            try:
+                value = parse_integer_literal(stripped)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Invalid numeric bitfield value {raw_value!r}. Expected decimal, "
+                    "hex with 0x prefix, binary with 0b prefix, or comma-separated flag names."
+                ) from exc
+        else:
+            flag_names = [name.strip() for name in stripped.split(",") if name.strip()]
+            value = meshtastic.util.flagsFromList(flag_type, flag_names)
+    else:
+        raise ValueError(
+            f"Invalid bitfield value {raw_value!r}. Expected integer, numeric string, or flag names."
+        )
+
+    if value < 0:
+        raise ValueError(
+            f"Invalid bitfield value {raw_value!r}. Expected a non-negative integer."
+        )
+    return value
+
+
+def _parse_destination_node_number(value: str) -> int | None:
+    """Parse decimal, ``!hex``, or ``0xhex`` node-number forms."""
+    if value.isdecimal():
+        return int(value)
+    normalized = value.casefold()
+    if normalized.startswith("!"):
+        hex_part = normalized[1:]
+    elif normalized.startswith("0x"):
+        hex_part = normalized[2:]
+    else:
+        return None
+    if not hex_part:
+        return None
+    try:
+        return int(hex_part, 16)
+    except ValueError:
+        return None
+
+
+def is_local_destination(interface: Any, destination: str) -> bool:
+    """Return whether a destination identifies the directly connected local node."""
+    destination_value = str(destination).strip()
+    if destination_value in (BROADCAST_ADDR, LOCAL_ADDR):
+        return True
+
+    try:
+        my_info = interface.myInfo
+        if my_info is None:
+            return False
+        my_node_num = int(my_info.my_node_num)
+    except (AttributeError, TypeError, ValueError):
+        return False
+
+    return _parse_destination_node_number(destination_value) == my_node_num

--- a/meshtastic/tests/test_cli_values.py
+++ b/meshtastic/tests/test_cli_values.py
@@ -1,5 +1,6 @@
 """Focused tests for pure CLI value helpers."""
 
+import argparse
 from types import SimpleNamespace
 
 import pytest
@@ -49,15 +50,19 @@ def test_parse_modem_preset_name_normalizes_schema_name() -> None:
 
 @pytest.mark.unit
 def test_parse_modem_preset_name_lists_choices_on_error() -> None:
-    with pytest.raises(Exception, match="Available presets"):
+    with pytest.raises(argparse.ArgumentTypeError, match="Available presets"):
         parse_modem_preset_name("not-real")
 
 
 @pytest.mark.unit
 def test_parse_bitfield_value_accepts_numbers_and_names() -> None:
     enum = config_pb2.Config.DisplayConfig.OledType
+    # Numeric inputs
     assert parse_bitfield_value(enum, 3) == 3
     assert parse_bitfield_value(enum, "0x3") == 3
+    # Comma-separated flag names (exercises flagsFromList path)
+    # OLED_SSD1306=1, OLED_SH1106=2 → combined = 3
+    assert parse_bitfield_value(enum, "OLED_SSD1306,OLED_SH1106") == 3
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_cli_values.py
+++ b/meshtastic/tests/test_cli_values.py
@@ -1,0 +1,87 @@
+"""Focused tests for pure CLI value helpers."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from meshtastic import BROADCAST_ADDR, LOCAL_ADDR
+from meshtastic.cli.values import (
+    is_local_destination,
+    looks_like_integer_literal,
+    parse_bitfield_value,
+    parse_integer_literal,
+    parse_modem_preset_name,
+)
+from meshtastic.protobuf import config_pb2
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", ["0", "-2", "+3", "0x10", "0b11"])
+def test_integer_literal_detection_accepts_supported_forms(value: str) -> None:
+    assert looks_like_integer_literal(value)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", ["", "  ", "+", "-", "LONG_FAST"])
+def test_integer_literal_detection_rejects_non_numeric_forms(value: str) -> None:
+    assert not looks_like_integer_literal(value)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("10", 10), ("-10", -10), ("0x10", 16), ("-0x10", -16), ("0b11", 3)],
+)
+def test_parse_integer_literal(value: str, expected: int) -> None:
+    assert parse_integer_literal(value) == expected
+
+
+@pytest.mark.unit
+def test_parse_integer_literal_rejects_empty_text() -> None:
+    with pytest.raises(ValueError, match="empty integer literal"):
+        parse_integer_literal(" ")
+
+
+@pytest.mark.unit
+def test_parse_modem_preset_name_normalizes_schema_name() -> None:
+    assert parse_modem_preset_name("long-fast") == "LONG_FAST"
+
+
+@pytest.mark.unit
+def test_parse_modem_preset_name_lists_choices_on_error() -> None:
+    with pytest.raises(Exception, match="Available presets"):
+        parse_modem_preset_name("not-real")
+
+
+@pytest.mark.unit
+def test_parse_bitfield_value_accepts_numbers_and_names() -> None:
+    enum = config_pb2.Config.DisplayConfig.OledType
+    assert parse_bitfield_value(enum, 3) == 3
+    assert parse_bitfield_value(enum, "0x3") == 3
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", [-1, "-1", object()])
+def test_parse_bitfield_value_rejects_invalid_values(value: object) -> None:
+    with pytest.raises(ValueError, match="Invalid bitfield value"):
+        parse_bitfield_value(config_pb2.Config.DisplayConfig.OledType, value)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("destination", [BROADCAST_ADDR, LOCAL_ADDR, "!25d6e474", "0x25D6E474", "634840180"])
+def test_is_local_destination_accepts_supported_forms(destination: str) -> None:
+    interface = SimpleNamespace(myInfo=SimpleNamespace(my_node_num=int("25d6e474", 16)))
+    assert is_local_destination(interface, destination)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("destination", ["!bad", "0x", "123", "!00000001"])
+def test_is_local_destination_rejects_other_nodes(destination: str) -> None:
+    interface = SimpleNamespace(myInfo=SimpleNamespace(my_node_num=int("25d6e474", 16)))
+    assert not is_local_destination(interface, destination)
+
+
+@pytest.mark.unit
+def test_is_local_destination_handles_missing_or_invalid_local_info() -> None:
+    assert not is_local_destination(SimpleNamespace(myInfo=None), "123")
+    assert not is_local_destination(SimpleNamespace(myInfo=object()), "123")


### PR DESCRIPTION
## Summary by Sourcery

Extract and centralize CLI value parsing and destination helper logic into a new meshtastic.cli package, improving reuse and test coverage while keeping existing __main__ entry points compatible.

New Features:
- Introduce a dedicated meshtastic.cli.values module for CLI value parsing and destination helper utilities.

Enhancements:
- Refactor existing modem preset, integer literal, bitfield, and local destination parsing logic out of meshtastic.__main__ into reusable helpers under meshtastic.cli.
- Add a meshtastic.cli package to host internal, testable CLI implementation seams.

Tests:
- Add focused unit tests covering CLI value parsing helpers and local destination detection.