### PR TITLE
Extract CLI serial reconnect runtime

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -23,6 +23,7 @@ import yaml
 from google.protobuf.json_format import MessageToDict
 from pubsub import pub
 
+import meshtastic.cli.runtime as cli_runtime
 import meshtastic.ota
 import meshtastic.serial_interface
 import meshtastic.tcp_interface
@@ -47,13 +48,6 @@ from meshtastic.cli.parser import (
     addRemoteActionArgs,  # noqa: F401 - legacy __main__ compatibility export
     addRemoteAdminArgs,  # noqa: F401 - legacy __main__ compatibility export
     addSelectionArgs,  # noqa: F401 - legacy __main__ compatibility export
-)
-from meshtastic.cli.runtime import (
-    _is_serial_reconnect_client,  # noqa: F401 - legacy __main__ compatibility export
-    _listen_loop_poll_once,
-    _poll_serial_reconnect,  # noqa: F401 - legacy __main__ compatibility export
-    _serial_should_reconnect,  # noqa: F401 - legacy __main__ compatibility export
-    _serial_transport_is_live,  # noqa: F401 - legacy __main__ compatibility export
 )
 from meshtastic.configure_verify import (
     _verify_channel_url_against_state,
@@ -81,6 +75,21 @@ from meshtastic.version import (
     PROJECT_DISPLAY_NAME,
     get_active_version,
 )
+
+# COMPAT_STABLE_SHIM: Preserve legacy private imports while runtime owns behavior.
+MAIN_LOOP_IDLE_SLEEP_SECONDS = cli_runtime.MAIN_LOOP_IDLE_SLEEP_SECONDS
+SERIAL_RECONNECT_RETRY_SECONDS = cli_runtime.SERIAL_RECONNECT_RETRY_SECONDS
+SERIAL_LISTEN_CONNECTED_SLEEP_SECONDS = (
+    cli_runtime.SERIAL_LISTEN_CONNECTED_SLEEP_SECONDS
+)
+SERIAL_RX_THREAD_JOIN_TIMEOUT_SECONDS = (
+    cli_runtime.SERIAL_RX_THREAD_JOIN_TIMEOUT_SECONDS
+)
+_is_serial_reconnect_client = cli_runtime._is_serial_reconnect_client
+_serial_transport_is_live = cli_runtime._serial_transport_is_live
+_serial_should_reconnect = cli_runtime._serial_should_reconnect
+_poll_serial_reconnect = cli_runtime._poll_serial_reconnect
+_listen_loop_poll_once = cli_runtime._listen_loop_poll_once
 
 argcomplete: ModuleType | None = None
 try:
@@ -3580,7 +3589,7 @@ def common() -> None:
                 ):  # loop until someone presses ctrlc
                     try:
                         while True:
-                            if _listen_loop_poll_once(client):
+                            if cli_runtime._listen_loop_poll_once(client):
                                 continue
                     except KeyboardInterrupt:
                         logger.info("Exiting due to keyboard interrupt")

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -48,6 +48,13 @@ from meshtastic.cli.parser import (
     addRemoteAdminArgs,  # noqa: F401 - legacy __main__ compatibility export
     addSelectionArgs,  # noqa: F401 - legacy __main__ compatibility export
 )
+from meshtastic.cli.runtime import (
+    _is_serial_reconnect_client,  # noqa: F401 - legacy __main__ compatibility export
+    _listen_loop_poll_once,
+    _poll_serial_reconnect,  # noqa: F401 - legacy __main__ compatibility export
+    _serial_should_reconnect,  # noqa: F401 - legacy __main__ compatibility export
+    _serial_transport_is_live,  # noqa: F401 - legacy __main__ compatibility export
+)
 from meshtastic.configure_verify import (
     _verify_channel_url_against_state,
     _verify_requested_fields,
@@ -227,16 +234,12 @@ OTA_RETRY_DELAY_SECONDS: float = 2.0
 OTA_MAX_RETRIES: int = 5
 
 # Keep-alive sleep interval for main loop (effectively infinite wait)
-MAIN_LOOP_IDLE_SLEEP_SECONDS = 1000
 """Sleep duration for the CLI main loop when listening on non-serial interfaces."""
 
-SERIAL_RECONNECT_RETRY_SECONDS = 0.5
 """Polling interval for serial reconnect attempts after device reboot/disconnect."""
 
-SERIAL_LISTEN_CONNECTED_SLEEP_SECONDS = 2.0
 """Sleep duration when a serial listen session is connected and healthy."""
 
-SERIAL_RX_THREAD_JOIN_TIMEOUT_SECONDS = 5.0
 """Timeout for joining the old reader thread before reconnecting."""
 
 
@@ -3604,109 +3607,14 @@ def common() -> None:
 
 
 
-def _is_serial_reconnect_client(client: MeshInterface) -> bool:
-    """Return True if *client* is a real SerialInterface that supports reconnect.
-
-    Uses a guarded isinstance check that is safe even when tests patch
-    ``SerialInterface`` with a MagicMock. Does **not** rely on
-    ``devPath`` because auto-detected devices intentionally reset
-    ``devPath = None`` during reconnect so port detection can re-run.
-    """
-    serial_cls = getattr(meshtastic.serial_interface, "SerialInterface", None)
-    return isinstance(serial_cls, type) and isinstance(client, serial_cls)
 
 
-def _serial_transport_is_live(client: MeshInterface) -> bool:
-    """Check if a serial interface has a live transport (stream open, reader alive).
-
-    In noProto mode, ``isConnected`` is never set because the protocol handshake
-    is skipped. This helper checks transport-level liveness instead: the stream
-    exists and is open, and the reader thread is alive.
-    """
-    stream = getattr(client, "stream", None)
-    if stream is None or not getattr(stream, "is_open", True):
-        return False
-    rx_thread = getattr(client, "_rxThread", None)
-    if rx_thread is None or not rx_thread.is_alive():
-        return False
-    return True
 
 
-def _serial_should_reconnect(client: MeshInterface) -> bool:
-    """Return True if a serial client needs reconnect attention.
-
-    For protocol mode: reconnect when ``isConnected`` is cleared.
-    For noProto mode: reconnect when the transport itself is dead.
-    """
-    if getattr(client, "_wantExit", False):
-        return False
-    if getattr(client, "noProto", False):
-        return not _serial_transport_is_live(client)
-    return not client.isConnected.is_set()
 
 
-def _poll_serial_reconnect(client: MeshInterface) -> None:
-    """Attempt one round of serial reconnection, sleeping on failure.
-
-    Catches connection-related errors and retryable MeshInterfaceError.
-    Waits for the old reader thread to exit before reconnecting.
-    """
-    logger.debug("Serial reconnect poll: transport is down, attempting connect...")
-
-    # Wait for the old reader thread to exit before reconnecting
-    rx_thread = getattr(client, "_rxThread", None)
-    if rx_thread is not None and rx_thread.is_alive():
-        rx_thread.join(timeout=SERIAL_RX_THREAD_JOIN_TIMEOUT_SECONDS)
-        if rx_thread.is_alive():
-            logger.warning(
-                "Reader thread is still alive after join timeout; delaying reconnect."
-            )
-            time.sleep(SERIAL_RECONNECT_RETRY_SECONDS)
-            return
-
-    try:
-        client.connect()  # type: ignore[attr-defined]
-        if client.isConnected.is_set() or _serial_transport_is_live(client):
-            logger.info("Serial reconnected.")
-        else:
-            logger.debug("Reconnect returned but interface is not live yet.")
-            time.sleep(SERIAL_RECONNECT_RETRY_SECONDS)
-    except Exception as exc:
-        # Route all exceptions through the serial retry classifier when available.
-        # Unconditionally retry OS/connection errors; conditionally retry
-        # MeshInterfaceError based on _is_retryable_connect_error().
-        if isinstance(exc, (ConnectionError, OSError, TimeoutError)):
-            retryable = True
-        elif isinstance(exc, MeshInterface.MeshInterfaceError):
-            retryable = bool(
-                hasattr(client, "_is_retryable_connect_error")
-                and client._is_retryable_connect_error(exc)
-            )
-        else:
-            retryable = False
-
-        if retryable:
-            logger.debug("Reconnect attempt failed (retryable): %s", exc)
-            time.sleep(SERIAL_RECONNECT_RETRY_SECONDS)
-        else:
-            raise
 
 
-def _listen_loop_poll_once(client: MeshInterface) -> bool:
-    """Execute one iteration of the persistent listen loop.
-
-    Returns True if the caller should ``continue`` immediately (reconnect
-    was attempted, timing is self-contained), False if the caller should
-    proceed to the next iteration normally (sleep already handled).
-    """
-    if _is_serial_reconnect_client(client):
-        if _serial_should_reconnect(client):
-            _poll_serial_reconnect(client)
-            return True  # reconnect timing is self-contained, skip main sleep
-        time.sleep(SERIAL_LISTEN_CONNECTED_SLEEP_SECONDS)
-    else:
-        time.sleep(MAIN_LOOP_IDLE_SLEEP_SECONDS)
-    return False
 
 
 # ---------------------------------------------------------------------------

--- a/meshtastic/cli/runtime.py
+++ b/meshtastic/cli/runtime.py
@@ -1,0 +1,119 @@
+"""Serial reconnect and CLI listen-loop runtime helpers."""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import meshtastic.serial_interface
+from meshtastic.mesh_interface import MeshInterface
+
+logger = logging.getLogger(__name__)
+
+MAIN_LOOP_IDLE_SLEEP_SECONDS = 1000
+
+SERIAL_RECONNECT_RETRY_SECONDS = 0.5
+
+SERIAL_LISTEN_CONNECTED_SLEEP_SECONDS = 2.0
+
+SERIAL_RX_THREAD_JOIN_TIMEOUT_SECONDS = 5.0
+
+def _is_serial_reconnect_client(client: MeshInterface) -> bool:
+    """Return True if *client* is a real SerialInterface that supports reconnect.
+
+    Uses a guarded isinstance check that is safe even when tests patch
+    ``SerialInterface`` with a MagicMock. Does **not** rely on
+    ``devPath`` because auto-detected devices intentionally reset
+    ``devPath = None`` during reconnect so port detection can re-run.
+    """
+    serial_cls = getattr(meshtastic.serial_interface, "SerialInterface", None)
+    return isinstance(serial_cls, type) and isinstance(client, serial_cls)
+
+def _serial_transport_is_live(client: MeshInterface) -> bool:
+    """Check if a serial interface has a live transport (stream open, reader alive).
+
+    In noProto mode, ``isConnected`` is never set because the protocol handshake
+    is skipped. This helper checks transport-level liveness instead: the stream
+    exists and is open, and the reader thread is alive.
+    """
+    stream = getattr(client, "stream", None)
+    if stream is None or not getattr(stream, "is_open", True):
+        return False
+    rx_thread = getattr(client, "_rxThread", None)
+    if rx_thread is None or not rx_thread.is_alive():
+        return False
+    return True
+
+def _serial_should_reconnect(client: MeshInterface) -> bool:
+    """Return True if a serial client needs reconnect attention.
+
+    For protocol mode: reconnect when ``isConnected`` is cleared.
+    For noProto mode: reconnect when the transport itself is dead.
+    """
+    if getattr(client, "_wantExit", False):
+        return False
+    if getattr(client, "noProto", False):
+        return not _serial_transport_is_live(client)
+    return not client.isConnected.is_set()
+
+def _poll_serial_reconnect(client: MeshInterface) -> None:
+    """Attempt one round of serial reconnection, sleeping on failure.
+
+    Catches connection-related errors and retryable MeshInterfaceError.
+    Waits for the old reader thread to exit before reconnecting.
+    """
+    logger.debug("Serial reconnect poll: transport is down, attempting connect...")
+
+    # Wait for the old reader thread to exit before reconnecting
+    rx_thread = getattr(client, "_rxThread", None)
+    if rx_thread is not None and rx_thread.is_alive():
+        rx_thread.join(timeout=SERIAL_RX_THREAD_JOIN_TIMEOUT_SECONDS)
+        if rx_thread.is_alive():
+            logger.warning(
+                "Reader thread is still alive after join timeout; delaying reconnect."
+            )
+            time.sleep(SERIAL_RECONNECT_RETRY_SECONDS)
+            return
+
+    try:
+        client.connect()  # type: ignore[attr-defined]
+        if client.isConnected.is_set() or _serial_transport_is_live(client):
+            logger.info("Serial reconnected.")
+        else:
+            logger.debug("Reconnect returned but interface is not live yet.")
+            time.sleep(SERIAL_RECONNECT_RETRY_SECONDS)
+    except Exception as exc:
+        # Route all exceptions through the serial retry classifier when available.
+        # Unconditionally retry OS/connection errors; conditionally retry
+        # MeshInterfaceError based on _is_retryable_connect_error().
+        if isinstance(exc, (ConnectionError, OSError, TimeoutError)):
+            retryable = True
+        elif isinstance(exc, MeshInterface.MeshInterfaceError):
+            retryable = bool(
+                hasattr(client, "_is_retryable_connect_error")
+                and client._is_retryable_connect_error(exc)
+            )
+        else:
+            retryable = False
+
+        if retryable:
+            logger.debug("Reconnect attempt failed (retryable): %s", exc)
+            time.sleep(SERIAL_RECONNECT_RETRY_SECONDS)
+        else:
+            raise
+
+def _listen_loop_poll_once(client: MeshInterface) -> bool:
+    """Execute one iteration of the persistent listen loop.
+
+    Returns True if the caller should ``continue`` immediately (reconnect
+    was attempted, timing is self-contained), False if the caller should
+    proceed to the next iteration normally (sleep already handled).
+    """
+    if _is_serial_reconnect_client(client):
+        if _serial_should_reconnect(client):
+            _poll_serial_reconnect(client)
+            return True  # reconnect timing is self-contained, skip main sleep
+        time.sleep(SERIAL_LISTEN_CONNECTED_SLEEP_SECONDS)
+    else:
+        time.sleep(MAIN_LOOP_IDLE_SLEEP_SECONDS)
+    return False

--- a/meshtastic/cli/runtime.py
+++ b/meshtastic/cli/runtime.py
@@ -10,13 +10,18 @@ from meshtastic.mesh_interface import MeshInterface
 
 logger = logging.getLogger(__name__)
 
+# Sleep interval for persistent non-serial listen sessions.
 MAIN_LOOP_IDLE_SLEEP_SECONDS = 1000
 
+# Delay before retrying a failed serial reconnect attempt.
 SERIAL_RECONNECT_RETRY_SECONDS = 0.5
 
+# Polling interval while a serial listen session remains healthy.
 SERIAL_LISTEN_CONNECTED_SLEEP_SECONDS = 2.0
 
+# Maximum wait for an old serial reader thread to stop.
 SERIAL_RX_THREAD_JOIN_TIMEOUT_SECONDS = 5.0
+
 
 def _is_serial_reconnect_client(client: MeshInterface) -> bool:
     """Return True if *client* is a real SerialInterface that supports reconnect.
@@ -28,6 +33,7 @@ def _is_serial_reconnect_client(client: MeshInterface) -> bool:
     """
     serial_cls = getattr(meshtastic.serial_interface, "SerialInterface", None)
     return isinstance(serial_cls, type) and isinstance(client, serial_cls)
+
 
 def _serial_transport_is_live(client: MeshInterface) -> bool:
     """Check if a serial interface has a live transport (stream open, reader alive).
@@ -44,6 +50,7 @@ def _serial_transport_is_live(client: MeshInterface) -> bool:
         return False
     return True
 
+
 def _serial_should_reconnect(client: MeshInterface) -> bool:
     """Return True if a serial client needs reconnect attention.
 
@@ -55,6 +62,7 @@ def _serial_should_reconnect(client: MeshInterface) -> bool:
     if getattr(client, "noProto", False):
         return not _serial_transport_is_live(client)
     return not client.isConnected.is_set()
+
 
 def _poll_serial_reconnect(client: MeshInterface) -> None:
     """Attempt one round of serial reconnection, sleeping on failure.
@@ -101,6 +109,7 @@ def _poll_serial_reconnect(client: MeshInterface) -> None:
             time.sleep(SERIAL_RECONNECT_RETRY_SECONDS)
         else:
             raise
+
 
 def _listen_loop_poll_once(client: MeshInterface) -> bool:
     """Execute one iteration of the persistent listen loop.

--- a/meshtastic/tests/test_cli_runtime.py
+++ b/meshtastic/tests/test_cli_runtime.py
@@ -1,0 +1,46 @@
+"""Focused tests for CLI serial reconnect helpers."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import meshtastic.cli.runtime as runtime
+
+
+@pytest.mark.unit
+def test_serial_transport_live_requires_open_stream_and_reader() -> None:
+    client = SimpleNamespace(stream=SimpleNamespace(isOpen=True), _rxThread=MagicMock())
+    client._rxThread.is_alive.return_value = True
+    assert runtime._serial_transport_is_live(client)
+    client._rxThread.is_alive.return_value = False
+    assert not runtime._serial_transport_is_live(client)
+
+
+@pytest.mark.unit
+def test_serial_should_reconnect_requires_lost_connection() -> None:
+    client = SimpleNamespace(isConnected=MagicMock(), stream=None, _rxThread=None)
+    client.isConnected.is_set.return_value = False
+    assert runtime._serial_should_reconnect(client)
+    client.isConnected.is_set.return_value = True
+    assert not runtime._serial_should_reconnect(client)
+
+
+@pytest.mark.unit
+def test_listen_loop_poll_once_sleeps_long_when_non_serial(monkeypatch) -> None:
+    client = object()
+    sleep = MagicMock()
+    monkeypatch.setattr(runtime.time, "sleep", sleep)
+    assert runtime._listen_loop_poll_once(client) is False
+    sleep.assert_called_once_with(runtime.MAIN_LOOP_IDLE_SLEEP_SECONDS)
+
+
+@pytest.mark.unit
+def test_listen_loop_poll_once_reconnects_serial(monkeypatch) -> None:
+    client = MagicMock()
+    monkeypatch.setattr(runtime, "_is_serial_reconnect_client", lambda _client: True)
+    monkeypatch.setattr(runtime, "_serial_should_reconnect", lambda _client: True)
+    poll = MagicMock()
+    monkeypatch.setattr(runtime, "_poll_serial_reconnect", poll)
+    assert runtime._listen_loop_poll_once(client)
+    poll.assert_called_once_with(client)

--- a/meshtastic/tests/test_cli_runtime.py
+++ b/meshtastic/tests/test_cli_runtime.py
@@ -1,46 +1,135 @@
 """Focused tests for CLI serial reconnect helpers."""
 
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
 
+import meshtastic.__main__ as main_module
 import meshtastic.cli.runtime as runtime
+from meshtastic.mesh_interface import MeshInterface
+
+
+def _mesh_client(**attributes: object) -> MeshInterface:
+    """Build a minimal duck-typed client for private runtime helpers."""
+    return cast(MeshInterface, SimpleNamespace(**attributes))
+
+
+@pytest.mark.unit
+def test_main_runtime_compatibility_exports_reference_runtime_module() -> None:
+    """Legacy ``__main__`` imports remain aliases, not duplicate runtime state."""
+    assert main_module.MAIN_LOOP_IDLE_SLEEP_SECONDS == runtime.MAIN_LOOP_IDLE_SLEEP_SECONDS
+    assert (
+        main_module.SERIAL_RECONNECT_RETRY_SECONDS
+        == runtime.SERIAL_RECONNECT_RETRY_SECONDS
+    )
+    assert (
+        main_module.SERIAL_LISTEN_CONNECTED_SLEEP_SECONDS
+        == runtime.SERIAL_LISTEN_CONNECTED_SLEEP_SECONDS
+    )
+    assert (
+        main_module.SERIAL_RX_THREAD_JOIN_TIMEOUT_SECONDS
+        == runtime.SERIAL_RX_THREAD_JOIN_TIMEOUT_SECONDS
+    )
+    assert main_module._is_serial_reconnect_client is runtime._is_serial_reconnect_client
+    assert main_module._serial_transport_is_live is runtime._serial_transport_is_live
+    assert main_module._serial_should_reconnect is runtime._serial_should_reconnect
+    assert main_module._poll_serial_reconnect is runtime._poll_serial_reconnect
+    assert main_module._listen_loop_poll_once is runtime._listen_loop_poll_once
 
 
 @pytest.mark.unit
 def test_serial_transport_live_requires_open_stream_and_reader() -> None:
-    client = SimpleNamespace(stream=SimpleNamespace(isOpen=True), _rxThread=MagicMock())
-    client._rxThread.is_alive.return_value = True
+    reader = MagicMock()
+    reader.is_alive.return_value = True
+    client = _mesh_client(
+        stream=SimpleNamespace(is_open=True),
+        _rxThread=reader,
+    )
+
     assert runtime._serial_transport_is_live(client)
-    client._rxThread.is_alive.return_value = False
+
+    client = _mesh_client(
+        stream=SimpleNamespace(is_open=False),
+        _rxThread=reader,
+    )
+    assert not runtime._serial_transport_is_live(client)
+
+    reader.is_alive.return_value = False
+    client = _mesh_client(
+        stream=SimpleNamespace(is_open=True),
+        _rxThread=reader,
+    )
     assert not runtime._serial_transport_is_live(client)
 
 
 @pytest.mark.unit
 def test_serial_should_reconnect_requires_lost_connection() -> None:
-    client = SimpleNamespace(isConnected=MagicMock(), stream=None, _rxThread=None)
-    client.isConnected.is_set.return_value = False
+    connected = MagicMock()
+    client = _mesh_client(
+        noProto=False,
+        _wantExit=False,
+        isConnected=connected,
+    )
+
+    connected.is_set.return_value = False
     assert runtime._serial_should_reconnect(client)
-    client.isConnected.is_set.return_value = True
+
+    connected.is_set.return_value = True
     assert not runtime._serial_should_reconnect(client)
 
 
 @pytest.mark.unit
-def test_listen_loop_poll_once_sleeps_long_when_non_serial(monkeypatch) -> None:
-    client = object()
+def test_serial_should_reconnect_noproto_uses_transport_liveness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport_live = MagicMock(return_value=False)
+    monkeypatch.setattr(runtime, "_serial_transport_is_live", transport_live)
+    client = _mesh_client(noProto=True, _wantExit=False)
+
+    assert runtime._serial_should_reconnect(client)
+
+    transport_live.return_value = True
+    assert not runtime._serial_should_reconnect(client)
+    assert transport_live.call_count == 2
+
+
+@pytest.mark.unit
+def test_serial_should_not_reconnect_when_exit_requested() -> None:
+    connected = MagicMock()
+    connected.is_set.return_value = False
+    client = _mesh_client(
+        noProto=False,
+        _wantExit=True,
+        isConnected=connected,
+    )
+
+    assert not runtime._serial_should_reconnect(client)
+    connected.is_set.assert_not_called()
+
+
+@pytest.mark.unit
+def test_listen_loop_poll_once_sleeps_long_when_non_serial(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _mesh_client()
     sleep = MagicMock()
     monkeypatch.setattr(runtime.time, "sleep", sleep)
+
     assert runtime._listen_loop_poll_once(client) is False
     sleep.assert_called_once_with(runtime.MAIN_LOOP_IDLE_SLEEP_SECONDS)
 
 
 @pytest.mark.unit
-def test_listen_loop_poll_once_reconnects_serial(monkeypatch) -> None:
-    client = MagicMock()
+def test_listen_loop_poll_once_reconnects_serial(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _mesh_client()
     monkeypatch.setattr(runtime, "_is_serial_reconnect_client", lambda _client: True)
     monkeypatch.setattr(runtime, "_serial_should_reconnect", lambda _client: True)
     poll = MagicMock()
     monkeypatch.setattr(runtime, "_poll_serial_reconnect", poll)
+
     assert runtime._listen_loop_poll_once(client)
     poll.assert_called_once_with(client)

--- a/meshtastic/tests/test_serial_reconnect.py
+++ b/meshtastic/tests/test_serial_reconnect.py
@@ -1,20 +1,20 @@
 """Unit tests for serial disconnect/reconnect and noProto propagation."""
 
 import threading
-import time
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from ..__main__ import (
+from ..cli.runtime import (
+    MAIN_LOOP_IDLE_SLEEP_SECONDS,
     SERIAL_LISTEN_CONNECTED_SLEEP_SECONDS,
+    SERIAL_RECONNECT_RETRY_SECONDS,
     SERIAL_RX_THREAD_JOIN_TIMEOUT_SECONDS,
     _is_serial_reconnect_client,
     _listen_loop_poll_once,
+    _poll_serial_reconnect,
     _serial_should_reconnect,
     _serial_transport_is_live,
-    _poll_serial_reconnect,
-    SERIAL_RECONNECT_RETRY_SECONDS,
 )
 from ..mesh_interface import MeshInterface
 
@@ -167,7 +167,7 @@ def test_poll_reconnect_waits_for_dead_reader_thread() -> None:
 
     client._rxThread.join.side_effect = _simulate_join_exit
 
-    with patch("meshtastic.__main__.time"):
+    with patch("meshtastic.cli.runtime.time"):
         _poll_serial_reconnect(client)
 
     client._rxThread.join.assert_called_once_with(
@@ -183,7 +183,7 @@ def test_poll_reconnect_returns_if_reader_still_alive() -> None:
     client = _make_serial_mock(is_connected=False)
     client._rxThread.is_alive.return_value = True  # stays alive
 
-    with patch("meshtastic.__main__.time") as mock_time:
+    with patch("meshtastic.cli.runtime.time") as mock_time:
         _poll_serial_reconnect(client)
 
     client._rxThread.join.assert_called_once_with(
@@ -201,7 +201,7 @@ def test_poll_reconnect_swallows_oserror() -> None:
     client.connect.side_effect = OSError("device gone")
     _simulate_reader_exit(client)
 
-    with patch("meshtastic.__main__.time") as mock_time:
+    with patch("meshtastic.cli.runtime.time") as mock_time:
         _poll_serial_reconnect(client)
 
     mock_time.sleep.assert_called_once_with(SERIAL_RECONNECT_RETRY_SECONDS)
@@ -216,7 +216,7 @@ def test_poll_reconnect_swallows_retryable_mesh_error() -> None:
     client.connect.side_effect = MeshInterface.MeshInterfaceError("device not found")
     _simulate_reader_exit(client)
 
-    with patch("meshtastic.__main__.time") as mock_time:
+    with patch("meshtastic.cli.runtime.time") as mock_time:
         _poll_serial_reconnect(client)
 
     mock_time.sleep.assert_called_once_with(SERIAL_RECONNECT_RETRY_SECONDS)
@@ -408,7 +408,7 @@ def test_poll_reconnect_sleeps_when_connect_returns_not_live() -> None:
     # connect() succeeds (no exception) but doesn't set isConnected or transport
     client.connect.return_value = None
 
-    with patch("meshtastic.__main__.time") as mock_time:
+    with patch("meshtastic.cli.runtime.time") as mock_time:
         _poll_serial_reconnect(client)
 
     client.connect.assert_called_once()
@@ -431,12 +431,12 @@ def test_listen_loop_serial_connected_sleeps_connected_interval(
     def fake_sleep(secs: float) -> None:
         sleep_calls.append(secs)
 
-    monkeypatch.setattr(time, "sleep", fake_sleep)
+    monkeypatch.setattr("meshtastic.cli.runtime.time.sleep", fake_sleep)
     monkeypatch.setattr(
-        "meshtastic.__main__._is_serial_reconnect_client", lambda c: True
+        "meshtastic.cli.runtime._is_serial_reconnect_client", lambda c: True
     )
     monkeypatch.setattr(
-        "meshtastic.__main__._serial_should_reconnect", lambda c: False
+        "meshtastic.cli.runtime._serial_should_reconnect", lambda c: False
     )
 
     client = MagicMock()
@@ -453,12 +453,12 @@ def test_listen_loop_serial_needs_reconnect_returns_true(
     """When serial client needs reconnect, poll returns True (skip main sleep)."""
 
     monkeypatch.setattr(
-        "meshtastic.__main__._is_serial_reconnect_client", lambda c: True
+        "meshtastic.cli.runtime._is_serial_reconnect_client", lambda c: True
     )
     monkeypatch.setattr(
-        "meshtastic.__main__._serial_should_reconnect", lambda c: True
+        "meshtastic.cli.runtime._serial_should_reconnect", lambda c: True
     )
-    monkeypatch.setattr("meshtastic.__main__._poll_serial_reconnect", lambda c: None)
+    monkeypatch.setattr("meshtastic.cli.runtime._poll_serial_reconnect", lambda c: None)
 
     client = MagicMock()
     result = _listen_loop_poll_once(client)
@@ -472,16 +472,14 @@ def test_listen_loop_non_serial_sleeps_idle_interval(
 ) -> None:
     """Non-serial clients sleep MAIN_LOOP_IDLE_SLEEP_SECONDS."""
 
-    from ..__main__ import MAIN_LOOP_IDLE_SLEEP_SECONDS
-
     sleep_calls: list[float] = []
 
     def fake_sleep(secs: float) -> None:
         sleep_calls.append(secs)
 
-    monkeypatch.setattr(time, "sleep", fake_sleep)
+    monkeypatch.setattr("meshtastic.cli.runtime.time.sleep", fake_sleep)
     monkeypatch.setattr(
-        "meshtastic.__main__._is_serial_reconnect_client", lambda c: False
+        "meshtastic.cli.runtime._is_serial_reconnect_client", lambda c: False
     )
 
     client = MagicMock()


### PR DESCRIPTION
## Summary by Sourcery

Extract CLI serial reconnect and listen-loop runtime logic into a dedicated module and wire it into the main CLI entrypoint.

Enhancements:
- Introduce meshtastic.cli.runtime module to encapsulate serial reconnect and listen-loop timing helpers formerly in __main__.
- Centralize CLI runtime timing constants (idle sleep, reconnect retry, join timeouts) in the new runtime module for reuse and clarity.

Tests:
- Add focused unit tests for CLI runtime helpers covering transport liveness, reconnect decisions, and listen-loop behaviour for serial and non-serial clients.