### PR TITLE
Extract CLI parser orchestration behind compatibility facade

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -31,23 +31,24 @@ import meshtastic.util
 from meshtastic import BROADCAST_ADDR, LOCAL_ADDR, mt_config, remote_hardware
 from meshtastic.cli.values import (
     is_local_destination as _is_local_destination,
-    looks_like_integer_literal as _looks_like_integer_literal,  # noqa: F401 - legacy __main__ compatibility export
+    looks_like_integer_literal as _looks_like_integer_literal,  # noqa: F401,W0611 - legacy __main__ compatibility export
     parse_bitfield_value as _parse_bitfield_value,
-    parse_integer_literal as _parse_integer_literal,  # noqa: F401 - legacy __main__ compatibility export
-    parse_modem_preset_name as _parse_modem_preset_name,  # noqa: F401 - legacy __main__ compatibility export
+    parse_integer_literal as _parse_integer_literal,  # noqa: F401,W0611 - legacy __main__ compatibility export
+    parse_modem_preset_name as _parse_modem_preset_name,  # noqa: F401,W0611 - legacy __main__ compatibility export
 )
 # COMPAT_STABLE_SHIM: Preserve legacy imports from meshtastic.cli.parser.
+# pylint: disable=unused-import
 from meshtastic.cli.parser import (
     _MODEM_PRESET_SHORTHANDS,
-    addChannelConfigArgs,  # noqa: F401 - legacy __main__ compatibility export
-    addConfigArgs,  # noqa: F401 - legacy __main__ compatibility export
-    addConnectionArgs,  # noqa: F401 - legacy __main__ compatibility export
-    addImportExportArgs,  # noqa: F401 - legacy __main__ compatibility export
-    addLocalActionArgs,  # noqa: F401 - legacy __main__ compatibility export
-    addPositionConfigArgs,  # noqa: F401 - legacy __main__ compatibility export
-    addRemoteActionArgs,  # noqa: F401 - legacy __main__ compatibility export
-    addRemoteAdminArgs,  # noqa: F401 - legacy __main__ compatibility export
-    addSelectionArgs,  # noqa: F401 - legacy __main__ compatibility export
+    addChannelConfigArgs,  # noqa: F401,W0611 - legacy __main__ compatibility export
+    addConfigArgs,  # noqa: F401,W0611 - legacy __main__ compatibility export
+    addConnectionArgs,  # noqa: F401,W0611 - legacy __main__ compatibility export
+    addImportExportArgs,  # noqa: F401,W0611 - legacy __main__ compatibility export
+    addLocalActionArgs,  # noqa: F401,W0611 - legacy __main__ compatibility export
+    addPositionConfigArgs,  # noqa: F401,W0611 - legacy __main__ compatibility export
+    addRemoteActionArgs,  # noqa: F401,W0611 - legacy __main__ compatibility export
+    addRemoteAdminArgs,  # noqa: F401,W0611 - legacy __main__ compatibility export
+    addSelectionArgs,  # noqa: F401,W0611 - legacy __main__ compatibility export
     parse_cli_args,
 )
 from meshtastic.configure_verify import (

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -48,6 +48,7 @@ from meshtastic.cli.parser import (
     addRemoteActionArgs,  # noqa: F401 - legacy __main__ compatibility export
     addRemoteAdminArgs,  # noqa: F401 - legacy __main__ compatibility export
     addSelectionArgs,  # noqa: F401 - legacy __main__ compatibility export
+    parse_cli_args,
 )
 from meshtastic.configure_verify import (
     _verify_channel_url_against_state,
@@ -3632,235 +3633,19 @@ def common() -> None:
 
 
 def initParser() -> None:
-    """Configure the global CLI ArgumentParser by registering all Meshtastic command.
-
-    groups, enable shell autocompletion if available, parse command-line
-    arguments, and store the parser and parsed arguments on mt_config.
-
-    Raises
-    ------
-    RuntimeError
-        if mt_config.parser is not initialized before calling.
-    """
+    """Parse CLI arguments and update the legacy global ``mt_config`` state."""
     parser = mt_config.parser
     if parser is None:
         raise RuntimeError(
             "mt_config.parser must be initialized before calling initParser()"
         )
-
-    # The "Help" group includes the help option and other informational stuff about the CLI itself
-    outerHelpGroup = parser.add_argument_group("Help")
-    helpGroup = outerHelpGroup.add_mutually_exclusive_group()
-    helpGroup.add_argument(
-        "-h", "--help", action="help", help="show this help message and exit"
+    mt_config.args = parse_cli_args(
+        parser,
+        version=get_active_version(),
+        argcomplete_module=argcomplete,
     )
-
-    the_version = get_active_version()
-    helpGroup.add_argument("--version", action="version", version=f"{the_version}")
-
-    helpGroup.add_argument(
-        "--support",
-        action="store_true",
-        help="Show support info (useful when troubleshooting an issue)",
-    )
-
-    # Connection arguments to indicate a device to connect to
-    parser = addConnectionArgs(parser)
-
-    # Selection arguments to denote nodes and channels to use
-    parser = addSelectionArgs(parser)
-
-    # Arguments concerning viewing and setting configuration
-    parser = addImportExportArgs(parser)
-    parser = addConfigArgs(parser)
-    parser = addPositionConfigArgs(parser)
-    parser = addChannelConfigArgs(parser)
-
-    # Arguments for sending or requesting things from the local device
-    parser = addLocalActionArgs(parser)
-
-    # Arguments for sending or requesting things from the mesh
-    parser = addRemoteActionArgs(parser)
-    parser = addRemoteAdminArgs(parser)
-
-    # All the rest of the arguments
-    group = parser.add_argument_group("Miscellaneous arguments")
-
-    group.add_argument(
-        "--seriallog",
-        help="Log device serial output to either 'none' or a filename to append to.  Defaults to '%(const)s' if no filename specified.",
-        nargs="?",
-        const="stdout",
-        default=None,
-        metavar="LOG_DESTINATION",
-    )
-
-    group.add_argument(
-        "--ack",
-        help="Use in combination with compatible actions (e.g. --sendtext) to wait for an acknowledgment.",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--timeout",
-        help="How long to wait for replies. Default %(default)ss.",
-        default=300.0,
-        type=float,
-        metavar="SECONDS",
-    )
-
-    group.add_argument(
-        "--no-nodes",
-        help="Request that the node not send node info to the client. "
-        "Will break things that depend on the nodedb, but will speed up startup. Requires 2.3.11+ firmware.",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--debug",
-        help="Show detailed debug log messages (connection diagnostics, config streaming, retries)",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--debuglib",
-        help="Show debug log messages for the meshtastic library only (not dependencies)",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--quiet",
-        help="Suppress non-essential output; show only warnings and errors",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--test",
-        help="Run stress test against all connected Meshtastic devices",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--wait-to-disconnect",
-        help="How many seconds to wait before disconnecting from the device.",
-        const="5",
-        nargs="?",
-        action="store",
-        metavar="SECONDS",
-    )
-
-    group.add_argument(
-        "--noproto",
-        help="Don't start the API, just function as a dumb serial terminal.",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--listen",
-        help="Just stay open and listen to the protobuf stream. Enables debug logging.",
-        action="store_true",
-    )
-
-    group.add_argument(
-        "--no-time",
-        help="Deprecated. Retained for backwards compatibility in scripts, but is a no-op.",
-        action="store_true",
-    )
-
-    power_group = parser.add_argument_group(
-        "Power Testing", "Options for power testing/logging."
-    )
-
-    power_supply_group = power_group.add_mutually_exclusive_group()
-
-    power_supply_group.add_argument(
-        "--power-riden",
-        help="Talk to a Riden power-supply. You must specify the device path, i.e. /dev/ttyUSBxxx",
-    )
-
-    power_supply_group.add_argument(
-        "--power-ppk2-meter",
-        help="Talk to a Nordic Power Profiler Kit 2 (in meter mode)",
-        action="store_true",
-    )
-
-    power_supply_group.add_argument(
-        "--power-ppk2-supply",
-        help="Talk to a Nordic Power Profiler Kit 2 (in supply mode)",
-        action="store_true",
-    )
-
-    power_supply_group.add_argument(
-        "--power-sim",
-        help="Use a simulated power meter (for development)",
-        action="store_true",
-    )
-
-    power_group.add_argument(
-        "--power-voltage",
-        help="Set the specified voltage on the power-supply. Be VERY careful, you can burn things up.",
-    )
-
-    power_group.add_argument(
-        "--power-stress",
-        help="Perform power monitor stress testing, to capture a power consumption profile for the device (also requires --power-mon)",
-        action="store_true",
-    )
-
-    power_group.add_argument(
-        "--power-wait",
-        help="Prompt the user to wait for device reset before looking for device serial ports (some boards kill power to USB serial port)",
-        action="store_true",
-    )
-
-    power_group.add_argument(
-        "--slog",
-        help="Store structured-logs (slogs) for this run, optionally you can specify a destination directory",
-        nargs="?",
-        default=None,
-        const="default",
-    )
-
-    remoteHardwareArgs = parser.add_argument_group(
-        "Remote Hardware", "Arguments related to the Remote Hardware module"
-    )
-
-    remoteHardwareArgs.add_argument(
-        "--gpio-wrb", nargs=2, help="Set a particular GPIO # to 1 or 0", action="append"
-    )
-
-    remoteHardwareArgs.add_argument(
-        "--gpio-rd", help="Read from a GPIO mask (ex: '0x10')"
-    )
-
-    remoteHardwareArgs.add_argument(
-        "--gpio-watch", help="Start watching a GPIO mask for changes (ex: '0x10')"
-    )
-
-    have_tunnel = platform.system() == "Linux"
-    if have_tunnel:
-        tunnelArgs = parser.add_argument_group(
-            "Tunnel", "Arguments related to establishing a tunnel device over the mesh."
-        )
-        tunnelArgs.add_argument(
-            "--tunnel",
-            action="store_true",
-            help="Create a TUN tunnel device for forwarding IP packets over the mesh",
-        )
-        tunnelArgs.add_argument(
-            "--subnet",
-            dest="tunnel_net",
-            help="Sets the local-end subnet address for the TUN IP bridge. (ex: 10.115' which is the default)",
-            default=None,
-        )
-
-    parser.set_defaults(deprecated=None)
-
-    if argcomplete is not None:
-        argcomplete.autocomplete(parser)
-    args = parser.parse_args()
-    mt_config.args = args
     mt_config.parser = parser
+
 
 
 def main() -> None:

--- a/meshtastic/cli/parser.py
+++ b/meshtastic/cli/parser.py
@@ -1058,4 +1058,3 @@ def parse_cli_args(
         autocomplete = argcomplete_module.autocomplete
         autocomplete(parser)
     return parser.parse_args()
-    return parser

--- a/meshtastic/cli/parser.py
+++ b/meshtastic/cli/parser.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import argparse
 import platform
+import sys
+from collections.abc import Sequence
 from typing import Protocol
 
 from meshtastic.cli.values import parse_modem_preset_name as _parse_modem_preset_name
@@ -836,16 +838,33 @@ def parse_cli_args(
     *,
     version: str,
     argcomplete_module: _ArgcompleteModule | None = None,
+    argv: Sequence[str] | None = None,
 ) -> argparse.Namespace:
-    """Configure the global CLI ArgumentParser by registering all Meshtastic command.
+    """Register all Meshtastic argument groups and parse the command line.
 
-    groups, enable shell autocompletion if available, parse command-line
-    arguments, and store the parser and parsed arguments on mt_config.
+    Registers help, connection, selection, import/export, configuration,
+    position, channel, local action, remote action, remote admin, and
+    miscellaneous argument groups on ``parser``, optionally enables shell
+    autocompletion via ``argcomplete_module``, and parses arguments.
 
-    Raises
-    ------
-    RuntimeError
-        if mt_config.parser is not initialized before calling.
+    Parameters
+    ----------
+    parser : argparse.ArgumentParser
+        The parser to configure with Meshtastic-specific argument groups.
+    version : str
+        Version string reported when ``--version`` is requested.
+    argcomplete_module : _ArgcompleteModule | None
+        Optional module exposing an ``autocomplete(parser)`` callable (the
+        ``argcomplete`` package). When provided, autocompletion is enabled.
+    argv : Sequence[str] | None
+        Argument vector to parse. When ``None`` (the default), ``sys.argv[1:]``
+        is used. Pass an explicit sequence to make parsing deterministic in
+        tests and embedded callers.
+
+    Returns
+    -------
+    argparse.Namespace
+        The parsed arguments.
     """
     # The "Help" group includes the help option and other informational stuff about the CLI itself
     outerHelpGroup = parser.add_argument_group("Help")
@@ -1057,4 +1076,4 @@ def parse_cli_args(
     if argcomplete_module is not None:
         autocomplete = argcomplete_module.autocomplete
         autocomplete(parser)
-    return parser.parse_args()
+    return parser.parse_args(argv if argv is not None else sys.argv[1:])

--- a/meshtastic/cli/parser.py
+++ b/meshtastic/cli/parser.py
@@ -3,8 +3,18 @@
 from __future__ import annotations
 
 import argparse
+import platform
+from typing import Protocol
 
 from meshtastic.cli.values import parse_modem_preset_name as _parse_modem_preset_name
+
+
+class _ArgcompleteModule(Protocol):
+    """Structural type for the optional argcomplete dependency."""
+
+    def autocomplete(self, parser: argparse.ArgumentParser) -> object:
+        """Enable shell completion for ``parser``."""
+
 
 _MODEM_PRESET_SHORTHANDS: tuple[tuple[tuple[str, ...], str, str, str], ...] = (
     (
@@ -819,4 +829,233 @@ def addRemoteAdminArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
         metavar="TIMESTAMP",
     )
 
+    return parser
+
+def parse_cli_args(
+    parser: argparse.ArgumentParser,
+    *,
+    version: str,
+    argcomplete_module: _ArgcompleteModule | None = None,
+) -> argparse.Namespace:
+    """Configure the global CLI ArgumentParser by registering all Meshtastic command.
+
+    groups, enable shell autocompletion if available, parse command-line
+    arguments, and store the parser and parsed arguments on mt_config.
+
+    Raises
+    ------
+    RuntimeError
+        if mt_config.parser is not initialized before calling.
+    """
+    # The "Help" group includes the help option and other informational stuff about the CLI itself
+    outerHelpGroup = parser.add_argument_group("Help")
+    helpGroup = outerHelpGroup.add_mutually_exclusive_group()
+    helpGroup.add_argument(
+        "-h", "--help", action="help", help="show this help message and exit"
+    )
+
+    helpGroup.add_argument("--version", action="version", version=version)
+
+    helpGroup.add_argument(
+        "--support",
+        action="store_true",
+        help="Show support info (useful when troubleshooting an issue)",
+    )
+
+    # Connection arguments to indicate a device to connect to
+    parser = addConnectionArgs(parser)
+
+    # Selection arguments to denote nodes and channels to use
+    parser = addSelectionArgs(parser)
+
+    # Arguments concerning viewing and setting configuration
+    parser = addImportExportArgs(parser)
+    parser = addConfigArgs(parser)
+    parser = addPositionConfigArgs(parser)
+    parser = addChannelConfigArgs(parser)
+
+    # Arguments for sending or requesting things from the local device
+    parser = addLocalActionArgs(parser)
+
+    # Arguments for sending or requesting things from the mesh
+    parser = addRemoteActionArgs(parser)
+    parser = addRemoteAdminArgs(parser)
+
+    # All the rest of the arguments
+    group = parser.add_argument_group("Miscellaneous arguments")
+
+    group.add_argument(
+        "--seriallog",
+        help="Log device serial output to either 'none' or a filename to append to.  Defaults to '%(const)s' if no filename specified.",
+        nargs="?",
+        const="stdout",
+        default=None,
+        metavar="LOG_DESTINATION",
+    )
+
+    group.add_argument(
+        "--ack",
+        help="Use in combination with compatible actions (e.g. --sendtext) to wait for an acknowledgment.",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--timeout",
+        help="How long to wait for replies. Default %(default)ss.",
+        default=300.0,
+        type=float,
+        metavar="SECONDS",
+    )
+
+    group.add_argument(
+        "--no-nodes",
+        help="Request that the node not send node info to the client. "
+        "Will break things that depend on the nodedb, but will speed up startup. Requires 2.3.11+ firmware.",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--debug",
+        help="Show detailed debug log messages (connection diagnostics, config streaming, retries)",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--debuglib",
+        help="Show debug log messages for the meshtastic library only (not dependencies)",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--quiet",
+        help="Suppress non-essential output; show only warnings and errors",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--test",
+        help="Run stress test against all connected Meshtastic devices",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--wait-to-disconnect",
+        help="How many seconds to wait before disconnecting from the device.",
+        const="5",
+        nargs="?",
+        action="store",
+        metavar="SECONDS",
+    )
+
+    group.add_argument(
+        "--noproto",
+        help="Don't start the API, just function as a dumb serial terminal.",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--listen",
+        help="Just stay open and listen to the protobuf stream. Enables debug logging.",
+        action="store_true",
+    )
+
+    group.add_argument(
+        "--no-time",
+        help="Deprecated. Retained for backwards compatibility in scripts, but is a no-op.",
+        action="store_true",
+    )
+
+    power_group = parser.add_argument_group(
+        "Power Testing", "Options for power testing/logging."
+    )
+
+    power_supply_group = power_group.add_mutually_exclusive_group()
+
+    power_supply_group.add_argument(
+        "--power-riden",
+        help="Talk to a Riden power-supply. You must specify the device path, i.e. /dev/ttyUSBxxx",
+    )
+
+    power_supply_group.add_argument(
+        "--power-ppk2-meter",
+        help="Talk to a Nordic Power Profiler Kit 2 (in meter mode)",
+        action="store_true",
+    )
+
+    power_supply_group.add_argument(
+        "--power-ppk2-supply",
+        help="Talk to a Nordic Power Profiler Kit 2 (in supply mode)",
+        action="store_true",
+    )
+
+    power_supply_group.add_argument(
+        "--power-sim",
+        help="Use a simulated power meter (for development)",
+        action="store_true",
+    )
+
+    power_group.add_argument(
+        "--power-voltage",
+        help="Set the specified voltage on the power-supply. Be VERY careful, you can burn things up.",
+    )
+
+    power_group.add_argument(
+        "--power-stress",
+        help="Perform power monitor stress testing, to capture a power consumption profile for the device (also requires --power-mon)",
+        action="store_true",
+    )
+
+    power_group.add_argument(
+        "--power-wait",
+        help="Prompt the user to wait for device reset before looking for device serial ports (some boards kill power to USB serial port)",
+        action="store_true",
+    )
+
+    power_group.add_argument(
+        "--slog",
+        help="Store structured-logs (slogs) for this run, optionally you can specify a destination directory",
+        nargs="?",
+        default=None,
+        const="default",
+    )
+
+    remoteHardwareArgs = parser.add_argument_group(
+        "Remote Hardware", "Arguments related to the Remote Hardware module"
+    )
+
+    remoteHardwareArgs.add_argument(
+        "--gpio-wrb", nargs=2, help="Set a particular GPIO # to 1 or 0", action="append"
+    )
+
+    remoteHardwareArgs.add_argument(
+        "--gpio-rd", help="Read from a GPIO mask (ex: '0x10')"
+    )
+
+    remoteHardwareArgs.add_argument(
+        "--gpio-watch", help="Start watching a GPIO mask for changes (ex: '0x10')"
+    )
+
+    have_tunnel = platform.system() == "Linux"
+    if have_tunnel:
+        tunnelArgs = parser.add_argument_group(
+            "Tunnel", "Arguments related to establishing a tunnel device over the mesh."
+        )
+        tunnelArgs.add_argument(
+            "--tunnel",
+            action="store_true",
+            help="Create a TUN tunnel device for forwarding IP packets over the mesh",
+        )
+        tunnelArgs.add_argument(
+            "--subnet",
+            dest="tunnel_net",
+            help="Sets the local-end subnet address for the TUN IP bridge. (ex: 10.115' which is the default)",
+            default=None,
+        )
+
+    parser.set_defaults(deprecated=None)
+
+    if argcomplete_module is not None:
+        autocomplete = argcomplete_module.autocomplete
+        autocomplete(parser)
+    return parser.parse_args()
     return parser

--- a/meshtastic/tests/test_cli_parser_orchestration.py
+++ b/meshtastic/tests/test_cli_parser_orchestration.py
@@ -1,0 +1,35 @@
+"""Focused tests for parser orchestration outside the legacy entry module."""
+
+import argparse
+from unittest.mock import MagicMock
+
+import pytest
+
+from meshtastic.cli.parser import parse_cli_args
+
+
+@pytest.mark.unit
+def test_parse_cli_args_registers_version_and_returns_namespace() -> None:
+    parser = argparse.ArgumentParser(add_help=False)
+    args = parse_cli_args(parser, version="9.9.9", argcomplete_module=None)
+    assert isinstance(args, argparse.Namespace)
+
+
+@pytest.mark.unit
+def test_parse_cli_args_calls_optional_argcomplete(monkeypatch) -> None:
+    parser = argparse.ArgumentParser(add_help=False)
+    autocomplete = MagicMock()
+    module = MagicMock(autocomplete=autocomplete)
+    monkeypatch.setattr("sys.argv", ["meshtastic"])
+    parse_cli_args(parser, version="9.9.9", argcomplete_module=module)
+    autocomplete.assert_called_once_with(parser)
+
+
+@pytest.mark.unit
+def test_parse_cli_args_version_action_uses_supplied_version(monkeypatch, capsys) -> None:
+    parser = argparse.ArgumentParser(add_help=False)
+    monkeypatch.setattr("sys.argv", ["meshtastic", "--version"])
+    with pytest.raises(SystemExit) as excinfo:
+        parse_cli_args(parser, version="9.9.9", argcomplete_module=None)
+    assert excinfo.value.code == 0
+    assert capsys.readouterr().out == "9.9.9\n"

--- a/meshtastic/tests/test_cli_parser_orchestration.py
+++ b/meshtastic/tests/test_cli_parser_orchestration.py
@@ -9,7 +9,10 @@ from meshtastic.cli.parser import parse_cli_args
 
 
 @pytest.mark.unit
-def test_parse_cli_args_registers_version_and_returns_namespace() -> None:
+def test_parse_cli_args_registers_version_and_returns_namespace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("sys.argv", ["meshtastic"])
     parser = argparse.ArgumentParser(add_help=False)
     args = parse_cli_args(parser, version="9.9.9", argcomplete_module=None)
     assert isinstance(args, argparse.Namespace)

--- a/meshtastic/tests/test_cli_parser_orchestration.py
+++ b/meshtastic/tests/test_cli_parser_orchestration.py
@@ -19,7 +19,9 @@ def test_parse_cli_args_registers_version_and_returns_namespace(
 
 
 @pytest.mark.unit
-def test_parse_cli_args_calls_optional_argcomplete(monkeypatch) -> None:
+def test_parse_cli_args_calls_optional_argcomplete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     parser = argparse.ArgumentParser(add_help=False)
     autocomplete = MagicMock()
     module = MagicMock(autocomplete=autocomplete)
@@ -29,7 +31,9 @@ def test_parse_cli_args_calls_optional_argcomplete(monkeypatch) -> None:
 
 
 @pytest.mark.unit
-def test_parse_cli_args_version_action_uses_supplied_version(monkeypatch, capsys) -> None:
+def test_parse_cli_args_version_action_uses_supplied_version(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
     parser = argparse.ArgumentParser(add_help=False)
     monkeypatch.setattr("sys.argv", ["meshtastic", "--version"])
     with pytest.raises(SystemExit) as excinfo:


### PR DESCRIPTION
## Summary by Sourcery

Extract CLI argument parsing orchestration into a reusable helper in meshtastic.cli.parser and adapt the legacy entrypoint to use it while preserving compatibility.

Enhancements:
- Introduce a parse_cli_args helper in meshtastic.cli.parser to encapsulate full CLI argument registration and parsing, including optional argcomplete integration and platform-specific tunnel options.
- Refine legacy __main__ imports and linter annotations to treat CLI helpers as compatibility exports without triggering unused-import warnings.

Tests:
- Add focused unit tests covering parse_cli_args behavior, including version wiring, return type, and interaction with an optional argcomplete module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change moves CLI parser construction and argument parsing into a shared `parse_cli_args` function while keeping `meshtastic.__main__` compatible with existing imports and behavior. It also adds focused tests for parser orchestration and isolates `sys.argv` in the existing CLI parsing test.

### Key changes

**Features**
- Added `parse_cli_args()` to centralize CLI parser setup.
- Added optional argcomplete support.
- Added platform-specific tunnel arguments on Linux.
- Preserved version, help, and existing CLI option groups.

**Refactors**
- Simplified `initParser()` to delegate parsing to `parse_cli_args()`.
- Kept legacy parser and value imports available through the compatibility facade.
- Added typing for the optional argcomplete module.

**Fixes**
- Added tests covering namespace creation, autocompletion, and version output.
- Updated `test_parse_cli_args` to monkeypatch `sys.argv`, preventing pytest arguments from being parsed.

No breaking changes or migration steps are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->