### PR TITLE
Apply linting cleanups, refresh Trunk config, bump patch

### DIFF
--- a/.github/workflows/daily_simradio.yml
+++ b/.github/workflows/daily_simradio.yml
@@ -2,7 +2,7 @@ name: Daily SimRadio Firmware
 
 on:
   schedule:
-    - cron: "0 6 * * *"
+    - cron: 0 6 * * *
   workflow_dispatch: {}
 
 permissions:
@@ -14,7 +14,7 @@ env:
   POETRY_INSTALL_ARGS: --all-extras --with dev,powermon
   MESHTASTICD_SIM_LOG_DIR: ${{ github.workspace }}/.meshtasticd-logs/simradio/daily
   SIMRADIO_RESULT_DIR: ${{ github.workspace }}/.test-results/simradio/daily
-  MESHTASTICD_CHANNEL: "daily"
+  MESHTASTICD_CHANNEL: daily
   SIMRADIO_SOURCE_SHA: ${{ github.sha }}
 
 concurrency:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -89,14 +89,14 @@ lint:
     - grype@0.110.0
     - actionlint@1.7.12
     - black@26.5.1
-    - checkov@3.3.1
+    - checkov@3.3.8
     - git-diff-check
     - gitleaks@8.30.1
     - isort@8.0.1
-    - markdownlint@0.49.0
+    - markdownlint@0.49.1
     - osv-scanner@2.3.5
-    - prettier@3.8.4
-    - ruff@0.15.18
+    - prettier@3.9.5
+    - ruff@0.15.22
     - shellcheck@0.11.0
     - shfmt@3.6.0
     - taplo@0.10.0

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -18,6 +18,10 @@ lint:
     - pylint
     - pyright
     - renovate
+    # actionlint's --fix mangles pinned action `uses:` references (concatenates
+    # the resolved version onto the existing line, breaking the YAML). Disable
+    # until upstream fixes the autofix; pinact already covers action currency.
+    - actionlint
   ignore:
     - linters: [ALL]
       paths:
@@ -87,7 +91,6 @@ lint:
   enabled:
     - pinact@4.0.0
     - grype@0.110.0
-    - actionlint@1.7.12
     - black@26.5.1
     - checkov@3.3.8
     - git-diff-check

--- a/bin/container-entrypoint.sh
+++ b/bin/container-entrypoint.sh
@@ -12,10 +12,10 @@ set -eu
 bin='meshtastic'
 
 # run command if it is not starting with a "-" and is an executable in PATH
-if [ "${#}" -le 0 ] || \
-   [ "${1#-}" != "${1}" ] || \
-   [ -d "${1}" ] || \
-   ! command -v "${1}" > '/dev/null' 2>&1; then
+if [ "${#}" -le 0 ] ||
+	[ "${1#-}" != "${1}" ] ||
+	[ -d "${1}" ] ||
+	! command -v "${1}" >'/dev/null' 2>&1; then
 	entrypoint='true'
 fi
 

--- a/examples/meshtastic_serial_message_reader.py
+++ b/examples/meshtastic_serial_message_reader.py
@@ -14,12 +14,15 @@ from datetime import datetime
 from typing import Any, Optional
 
 from pubsub import pub
+
 import meshtastic.serial_interface
 
 _TZ_NAME = time.tzname[time.localtime().tm_isdst > 0]
 
 
-def on_receive(packet: dict[str, Any], interface: Any) -> None:  # pylint: disable=unused-argument
+def on_receive(  # pylint: disable=unused-argument
+    packet: dict[str, Any], interface: Any
+) -> None:
     """Print a compact line for each received text packet."""
     decoded = packet.get("decoded", {})
     if decoded.get("portnum") != "TEXT_MESSAGE_APP":
@@ -37,8 +40,12 @@ def on_receive(packet: dict[str, Any], interface: Any) -> None:  # pylint: disab
 
 def main() -> int:
     """Connect over serial and print inbound text messages."""
-    parser = argparse.ArgumentParser(description="Read incoming Meshtastic text over serial")
-    parser.add_argument("--port", default=None, help="Serial port path (default: auto-detect)")
+    parser = argparse.ArgumentParser(
+        description="Read incoming Meshtastic text over serial"
+    )
+    parser.add_argument(
+        "--port", default=None, help="Serial port path (default: auto-detect)"
+    )
     args = parser.parse_args()
 
     pub.subscribe(on_receive, "meshtastic.receive")

--- a/examples/tcp_connection_info_once.py
+++ b/examples/tcp_connection_info_once.py
@@ -10,6 +10,7 @@ Cleanup/error handling: explicit connect failure message and clean close on call
 import argparse
 
 from pubsub import pub
+
 import meshtastic.tcp_interface
 
 
@@ -21,7 +22,9 @@ def on_connection(interface, topic=pub.AUTO_TOPIC):  # pylint: disable=unused-ar
 
 def main() -> int:
     """Parse args, connect, and wait for established callback."""
-    parser = argparse.ArgumentParser(description="Print radio info on TCP connect and exit")
+    parser = argparse.ArgumentParser(
+        description="Print radio info on TCP connect and exit"
+    )
     parser.add_argument("host", help="TCP hostname or IP of the Meshtastic node")
     args = parser.parse_args()
 

--- a/examples/tcp_pubsub_send_and_receive.py
+++ b/examples/tcp_pubsub_send_and_receive.py
@@ -11,6 +11,7 @@ import argparse
 import time
 
 from pubsub import pub
+
 from meshtastic.tcp_interface import TCPInterface
 
 

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -29,27 +29,32 @@ import meshtastic.serial_interface
 import meshtastic.tcp_interface
 import meshtastic.util
 from meshtastic import BROADCAST_ADDR, LOCAL_ADDR, mt_config, remote_hardware
-from meshtastic.cli.values import (
-    is_local_destination as _is_local_destination,
-    looks_like_integer_literal as _looks_like_integer_literal,  # noqa: F401,W0611 - legacy __main__ compatibility export
-    parse_bitfield_value as _parse_bitfield_value,
-    parse_integer_literal as _parse_integer_literal,  # noqa: F401,W0611 - legacy __main__ compatibility export
-    parse_modem_preset_name as _parse_modem_preset_name,  # noqa: F401,W0611 - legacy __main__ compatibility export
-)
+
 # COMPAT_STABLE_SHIM: Preserve legacy imports from meshtastic.cli.parser.
 # pylint: disable=unused-import
-from meshtastic.cli.parser import (
+from meshtastic.cli.parser import (  # noqa: F401,W0611 - legacy __main__ compatibility export
     _MODEM_PRESET_SHORTHANDS,
-    addChannelConfigArgs,  # noqa: F401,W0611 - legacy __main__ compatibility export
-    addConfigArgs,  # noqa: F401,W0611 - legacy __main__ compatibility export
-    addConnectionArgs,  # noqa: F401,W0611 - legacy __main__ compatibility export
-    addImportExportArgs,  # noqa: F401,W0611 - legacy __main__ compatibility export
-    addLocalActionArgs,  # noqa: F401,W0611 - legacy __main__ compatibility export
-    addPositionConfigArgs,  # noqa: F401,W0611 - legacy __main__ compatibility export
-    addRemoteActionArgs,  # noqa: F401,W0611 - legacy __main__ compatibility export
-    addRemoteAdminArgs,  # noqa: F401,W0611 - legacy __main__ compatibility export
-    addSelectionArgs,  # noqa: F401,W0611 - legacy __main__ compatibility export
+    addChannelConfigArgs,
+    addConfigArgs,
+    addConnectionArgs,
+    addImportExportArgs,
+    addLocalActionArgs,
+    addPositionConfigArgs,
+    addRemoteActionArgs,
+    addRemoteAdminArgs,
+    addSelectionArgs,
     parse_cli_args,
+)
+from meshtastic.cli.values import is_local_destination as _is_local_destination
+from meshtastic.cli.values import (  # noqa: F401,W0611 - legacy __main__ compatibility export
+    looks_like_integer_literal as _looks_like_integer_literal,
+)
+from meshtastic.cli.values import parse_bitfield_value as _parse_bitfield_value
+from meshtastic.cli.values import (  # noqa: F401,W0611 - legacy __main__ compatibility export
+    parse_integer_literal as _parse_integer_literal,
+)
+from meshtastic.cli.values import (  # noqa: F401,W0611 - legacy __main__ compatibility export
+    parse_modem_preset_name as _parse_modem_preset_name,
 )
 from meshtastic.configure_verify import (
     _verify_channel_url_against_state,
@@ -57,13 +62,13 @@ from meshtastic.configure_verify import (
 )
 from meshtastic.host_port import parseHostAndPort
 from meshtastic.interfaces.ble import BLEInterface
-from meshtastic.mesh_interface import MeshInterface
 from meshtastic.lockdown import (
     build_lockdown_auth,
     read_lockdown_passphrase_file,
     send_lockdown_auth,
     validate_lockdown_passphrase,
 )
+from meshtastic.mesh_interface import MeshInterface
 from meshtastic.protobuf import (
     admin_pb2,
     channel_pb2,
@@ -168,14 +173,6 @@ BITFIELD_ENUMS = {
 # the historical behavior when callers supply more than one shorthand: later
 # options win. ``--ch-preset`` below is the scalable path for every enum value
 # present in the active protobuf schema, including future additions.
-
-
-
-
-
-
-
-
 
 
 # ==============================================================================
@@ -556,8 +553,6 @@ def _post_seturl_stability_check(
     return False
 
 
-
-
 def _send_local_factory_reset_and_wait(
     reset_node: Any,
     *,
@@ -635,7 +630,11 @@ def _send_local_factory_reset_and_wait(
             if remaining <= 0:
                 break
 
-            if scoped_wait_available and callable(wait_for_request_ack) and callable(raise_wait_error):
+            if (
+                scoped_wait_available
+                and callable(wait_for_request_ack)
+                and callable(raise_wait_error)
+            ):
                 completed = wait_for_request_ack(
                     "receivedNak",
                     request_id,
@@ -2535,7 +2534,7 @@ def onConnected(interface: MeshInterface) -> None:
                 )
 
         if preset_val is not None:
-            _set_simple_config(preset_val)  # type: ignore[arg-type]
+            _set_simple_config(preset_val)
 
         if args.ch_set or args.ch_enable or args.ch_disable:
             closeNow = True
@@ -2639,7 +2638,9 @@ def onConnected(interface: MeshInterface) -> None:
         if args.show_region_presets:
             closeNow = True
             if not _is_local_destination(interface, args.dest):
-                print("Region/preset capabilities are available only from the local node.")
+                print(
+                    "Region/preset capabilities are available only from the local node."
+                )
             elif not interface.regionPresets:
                 print(
                     "This firmware did not provide usable region/preset compatibility metadata; "
@@ -2648,14 +2649,18 @@ def onConnected(interface: MeshInterface) -> None:
             else:
                 for region, info in sorted(interface.regionPresets.items()):
                     try:
-                        region_name = config_pb2.Config.LoRaConfig.RegionCode.Name(cast(Any, region))
+                        region_name = config_pb2.Config.LoRaConfig.RegionCode.Name(
+                            cast(Any, region)
+                        )
                     except ValueError:
                         region_name = f"REGION_{region}"
                     preset_names = []
                     for value in info.presets:
                         try:
                             preset_names.append(
-                                config_pb2.Config.LoRaConfig.ModemPreset.Name(cast(Any, value))
+                                config_pb2.Config.LoRaConfig.ModemPreset.Name(
+                                    cast(Any, value)
+                                )
                             )
                         except ValueError:
                             preset_names.append(f"PRESET_{value}")
@@ -2687,11 +2692,18 @@ def onConnected(interface: MeshInterface) -> None:
         if lockdown_action is not None:
             closeNow = True
             if not _is_local_destination(interface, args.dest):
-                _cli_exit("Lockdown commands apply only to the directly connected local node.")
-            if lockdown_action in {"provision", "lock-now", "disable"} and not args.lockdown_yes:
-                confirmation = input(
-                    f"Type 'yes' to confirm lockdown {lockdown_action}: "
-                ).strip().casefold()
+                _cli_exit(
+                    "Lockdown commands apply only to the directly connected local node."
+                )
+            if (
+                lockdown_action in {"provision", "lock-now", "disable"}
+                and not args.lockdown_yes
+            ):
+                confirmation = (
+                    input(f"Type 'yes' to confirm lockdown {lockdown_action}: ")
+                    .strip()
+                    .casefold()
+                )
                 if confirmation != "yes":
                     _cli_exit("Aborted.")
             try:
@@ -2719,7 +2731,9 @@ def onConnected(interface: MeshInterface) -> None:
                             )
                             if entered != confirmed:
                                 _cli_exit("Lockdown passphrases do not match.")
-                        passphrase = validate_lockdown_passphrase(entered.encode("utf-8"))
+                        passphrase = validate_lockdown_passphrase(
+                            entered.encode("utf-8")
+                        )
                 auth = build_lockdown_auth(
                     passphrase,
                     boots_remaining=args.lockdown_boots,
@@ -3600,34 +3614,6 @@ def common() -> None:
         # sys.exit(0)
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 # ---------------------------------------------------------------------------
 # End of reconnect helpers
 # ---------------------------------------------------------------------------
@@ -3646,7 +3632,6 @@ def initParser() -> None:
         argcomplete_module=argcomplete,
     )
     mt_config.parser = parser
-
 
 
 def main() -> None:

--- a/meshtastic/admin_response.py
+++ b/meshtastic/admin_response.py
@@ -17,9 +17,7 @@ _REQUEST_TO_RESPONSE: dict[str, str] = {
     "get_device_metadata_request": "get_device_metadata_response",
     "get_ringtone_request": "get_ringtone_response",
     "get_device_connection_status_request": "get_device_connection_status_response",
-    "get_node_remote_hardware_pins_request": (
-        "get_node_remote_hardware_pins_response"
-    ),
+    "get_node_remote_hardware_pins_request": ("get_node_remote_hardware_pins_response"),
     "get_ui_config_request": "get_ui_config_response",
 }
 
@@ -85,7 +83,7 @@ class AdminResponseContract:
             return False
         if self.response_subtype is None:
             return True
-        response = getattr(raw, self.response_variant)
+        response: admin_pb2.AdminMessage = getattr(raw, self.response_variant)
         return response.WhichOneof("payload_variant") == self.response_subtype
 
 

--- a/meshtastic/cli/parser.py
+++ b/meshtastic/cli/parser.py
@@ -81,6 +81,7 @@ _MODEM_PRESET_SHORTHANDS: tuple[tuple[tuple[str, ...], str, str, str], ...] = (
     ),
 )
 
+
 def addConnectionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     """Register connection-related command-line arguments (serial, TCP, and BLE) on the given parser.
 
@@ -148,6 +149,7 @@ def addConnectionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParse
 
     return parser
 
+
 def addSelectionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     """Add destination and channel selection arguments to the provided ArgumentParser.
 
@@ -186,6 +188,7 @@ def addSelectionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser
 
     return parser
 
+
 def addImportExportArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     """Register CLI options for importing a YAML configuration file and exporting device configuration as YAML.
 
@@ -217,6 +220,7 @@ def addImportExportArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPar
         help="Export device config as YAML (to stdout if no file given)",
     )
     return parser
+
 
 def addConfigArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     """Add configuration-related CLI arguments to the given ArgumentParser.
@@ -361,6 +365,7 @@ def addConfigArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
 
     return parser
 
+
 def addChannelConfigArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     """Add channel-related CLI options to the provided argument parser.
 
@@ -470,6 +475,7 @@ def addChannelConfigArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPa
 
     return parser
 
+
 def addPositionConfigArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     """Add command-line arguments for configuring fixed position and which position fields to send.
 
@@ -525,6 +531,7 @@ def addPositionConfigArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentP
         action="store",
     )
     return parser
+
 
 def addLocalActionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     """Register CLI arguments for local-only actions that query or display information from the local node.
@@ -635,6 +642,7 @@ def addLocalActionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
 
     return parser
 
+
 def addRemoteActionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     """Register remote-action CLI flags on the provided ArgumentParser.
 
@@ -703,6 +711,7 @@ def addRemoteActionArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPar
     )
 
     return parser
+
 
 def addRemoteAdminArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     """Add command-line options for remote administrative actions that require admin privileges.
@@ -832,6 +841,7 @@ def addRemoteAdminArgs(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
     )
 
     return parser
+
 
 def parse_cli_args(
     parser: argparse.ArgumentParser,

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -400,10 +400,7 @@ class MeshInterface:  # pylint: disable=R0902
         """Set the queueStatus attribute directly."""
         self.queueStatus = queue_status
 
-
-    def getRegionPresetInfo(
-        self, region: int | str | None
-    ) -> RegionPresetInfo | None:
+    def getRegionPresetInfo(self, region: int | str | None) -> RegionPresetInfo | None:
         """Return firmware-declared compatibility data for ``region``, if present.
 
         ``region`` may be the protobuf enum integer, its stringified form, or

--- a/meshtastic/mesh_interface_runtime/receive_pipeline.py
+++ b/meshtastic/mesh_interface_runtime/receive_pipeline.py
@@ -20,7 +20,6 @@ from meshtastic import (
     publishingThread,
 )
 from meshtastic._topics import LOCKDOWN_STATUS_TOPIC
-from meshtastic.region_presets import decode_region_preset_map
 from meshtastic.protobuf import (
     channel_pb2,
     config_pb2,
@@ -28,6 +27,7 @@ from meshtastic.protobuf import (
     module_config_pb2,
     portnums_pb2,
 )
+from meshtastic.region_presets import decode_region_preset_map
 from meshtastic.util import stripnl
 
 if TYPE_CHECKING:
@@ -347,7 +347,6 @@ class ReceivePipeline:
                 raw=raw_map,
             )
         ]
-
 
     def _handle_from_radio_lockdown_status(
         self, context: _FromRadioContext

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -938,9 +938,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
 
         # Reject reserved node numbers so generation/import invariants match
         if node_num == 0 or node_num >= 0xFFFFFFFF:
-            self._raise_interface_error(
-                f"Invalid node number for contact: {node_num}"
-            )
+            self._raise_interface_error(f"Invalid node number for contact: {node_num}")
 
         def _read_user_snapshot() -> dict[str, Any] | None:
             nodes_by_num = self.iface.nodesByNum

--- a/meshtastic/tests/conftest.py
+++ b/meshtastic/tests/conftest.py
@@ -5,8 +5,8 @@
 
 import argparse
 import copy
-import itertools
 import importlib
+import itertools
 import math
 import os
 import shutil
@@ -51,9 +51,7 @@ def _skip_simradio_if_unavailable() -> None:
     if not is_compatible_host():
         pytest.skip("native meshtasticd simulator tests require Linux")
     if find_meshtasticd() is None:
-        pytest.skip(
-            "meshtasticd not found; set MESHTASTICD_BIN or install it on PATH"
-        )
+        pytest.skip("meshtasticd not found; set MESHTASTICD_BIN or install it on PATH")
 
 
 def _simradio_base_port() -> int:

--- a/meshtastic/tests/simradio_harness.py
+++ b/meshtastic/tests/simradio_harness.py
@@ -22,8 +22,8 @@ import subprocess
 import tempfile
 import threading
 import time
-from dataclasses import dataclass
 from collections.abc import Collection, Mapping
+from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any, BinaryIO, Literal
@@ -56,9 +56,7 @@ FACTORY_RESET_REBOOT_MARKERS = (
     "Factory config reset finished, rebooting soon",
     "Reboot in ",
 )
-KNOWN_FACTORY_RESET_REBOOT_EXIT_CODES: frozenset[int] = frozenset(
-    {-signal.SIGSEGV}
-)
+KNOWN_FACTORY_RESET_REBOOT_EXIT_CODES: frozenset[int] = frozenset({-signal.SIGSEGV})
 KNOWN_FACTORY_RESET_REBOOT_VERSION_RE = re.compile(r"\bS:B:\d+,2\.7\.\d+,")
 
 CHAIN_TOPOLOGY: Mapping[int, frozenset[int]] = MappingProxyType(
@@ -121,7 +119,9 @@ def _copy_channel_topology(
             raise ValueError(f"Topology transmitter index out of range: {transmitter}")
         normalized_receivers = frozenset(receivers)
         if transmitter in normalized_receivers:
-            raise ValueError(f"Topology node {transmitter} cannot receive its own packet")
+            raise ValueError(
+                f"Topology node {transmitter} cannot receive its own packet"
+            )
         invalid = sorted(
             receiver
             for receiver in normalized_receivers
@@ -282,9 +282,11 @@ class SimNode:
             ("restart_count", str(self._restart_count)),
             (
                 "last_reboot_exit_status",
-                ""
-                if self._last_reboot_exit_status is None
-                else str(self._last_reboot_exit_status),
+                (
+                    ""
+                    if self._last_reboot_exit_status is None
+                    else str(self._last_reboot_exit_status)
+                ),
             ),
         )
         content = "".join(f"{key}={value}\n" for key, value in values)
@@ -420,7 +422,9 @@ class SimNode:
                     status not in KNOWN_FACTORY_RESET_REBOOT_EXIT_CODES
                     or missing_markers
                 ):
-                    marker_detail = ", ".join(repr(marker) for marker in missing_markers)
+                    marker_detail = ", ".join(
+                        repr(marker) for marker in missing_markers
+                    )
                     raise RuntimeError(
                         f"meshtasticd node {self.node_id} exited with unexpected "
                         f"status {status} while waiting for factory-reset reboot; "
@@ -776,9 +780,11 @@ class SimMesh:
     def node_db_counts(self) -> list[int]:
         """Return current node-database sizes for diagnostics."""
         return [
-            len(node.iface.nodes)
-            if node.iface is not None and node.iface.nodes is not None
-            else 0
+            (
+                len(node.iface.nodes)
+                if node.iface is not None and node.iface.nodes is not None
+                else 0
+            )
             for node in self.nodes
         ]
 
@@ -835,7 +841,9 @@ class SimMesh:
                 logger.warning("Dropping simulator packet with non-bytes payload")
                 return
         if len(payload) > mesh_pb2.Constants.DATA_PAYLOAD_LEN:
-            logger.warning("Dropping oversized simulator payload: %d bytes", len(payload))
+            logger.warning(
+                "Dropping oversized simulator payload: %d bytes", len(payload)
+            )
             return
         try:
             base_packet = _build_mesh_packet(packet, payload)

--- a/meshtastic/tests/simradio_helpers.py
+++ b/meshtastic/tests/simradio_helpers.py
@@ -460,9 +460,7 @@ def cli_then_verify(
     """Run a CLI action, assert its result, then verify state independently."""
     result = run_cli(port, *arguments, timeout=cli_timeout)
     if expected_returncode is not None and result.returncode != expected_returncode:
-        option_names = [
-            argument for argument in arguments if argument.startswith("--")
-        ]
+        option_names = [argument for argument in arguments if argument.startswith("--")]
         raise AssertionError(
             f"CLI returned {result.returncode}; expected {expected_returncode}.\n"
             f"Command options: {option_names!r}\n"

--- a/meshtastic/tests/test_admin_response_contracts.py
+++ b/meshtastic/tests/test_admin_response_contracts.py
@@ -147,7 +147,9 @@ def test_contract_maps_named_config_and_module_enum_values() -> None:
 
 
 @pytest.mark.unit
-def test_matcher_exception_does_not_consume_handler(caplog: pytest.LogCaptureFixture) -> None:
+def test_matcher_exception_does_not_consume_handler(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     iface = MeshInterface(noProto=True)
     callback = MagicMock()
 

--- a/meshtastic/tests/test_cli_contact.py
+++ b/meshtastic/tests/test_cli_contact.py
@@ -69,9 +69,7 @@ def test_add_contact_url_with_dest_uses_remote(monkeypatch: pytest.MonkeyPatch) 
         "https://meshtastic.org/v/#CKqkvZgIElEKCSE4MzBmNTIyYRIQUm9hZHJ1bm5lciBSaWRnZRoE"
         "UktTTiIGAAAAAAAAKAk4AkIgRxo_Fw_ergQIhRqBbrHasLYy3gU-Ay8hrhu4OVnIPQc="
     )
-    monkeypatch.setattr(
-        sys, "argv", ["", "--add-contact", url, "--dest", "!12345678"]
-    )
+    monkeypatch.setattr(sys, "argv", ["", "--add-contact", url, "--dest", "!12345678"])
     iface, local_node, remote_node = _make_cli_mocks()
     with patch("meshtastic.serial_interface.SerialInterface", return_value=iface):
         main()

--- a/meshtastic/tests/test_cli_runtime.py
+++ b/meshtastic/tests/test_cli_runtime.py
@@ -19,7 +19,9 @@ def _mesh_client(**attributes: object) -> MeshInterface:
 @pytest.mark.unit
 def test_main_runtime_compatibility_exports_reference_runtime_module() -> None:
     """Legacy ``__main__`` imports remain aliases, not duplicate runtime state."""
-    assert main_module.MAIN_LOOP_IDLE_SLEEP_SECONDS == runtime.MAIN_LOOP_IDLE_SLEEP_SECONDS
+    assert (
+        main_module.MAIN_LOOP_IDLE_SLEEP_SECONDS == runtime.MAIN_LOOP_IDLE_SLEEP_SECONDS
+    )
     assert (
         main_module.SERIAL_RECONNECT_RETRY_SECONDS
         == runtime.SERIAL_RECONNECT_RETRY_SECONDS
@@ -32,7 +34,9 @@ def test_main_runtime_compatibility_exports_reference_runtime_module() -> None:
         main_module.SERIAL_RX_THREAD_JOIN_TIMEOUT_SECONDS
         == runtime.SERIAL_RX_THREAD_JOIN_TIMEOUT_SECONDS
     )
-    assert main_module._is_serial_reconnect_client is runtime._is_serial_reconnect_client
+    assert (
+        main_module._is_serial_reconnect_client is runtime._is_serial_reconnect_client
+    )
     assert main_module._serial_transport_is_live is runtime._serial_transport_is_live
     assert main_module._serial_should_reconnect is runtime._serial_should_reconnect
     assert main_module._poll_serial_reconnect is runtime._poll_serial_reconnect

--- a/meshtastic/tests/test_cli_values.py
+++ b/meshtastic/tests/test_cli_values.py
@@ -73,7 +73,9 @@ def test_parse_bitfield_value_rejects_invalid_values(value: object) -> None:
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("destination", [BROADCAST_ADDR, LOCAL_ADDR, "!25d6e474", "0x25D6E474", "634840180"])
+@pytest.mark.parametrize(
+    "destination", [BROADCAST_ADDR, LOCAL_ADDR, "!25d6e474", "0x25D6E474", "634840180"]
+)
 def test_is_local_destination_accepts_supported_forms(destination: str) -> None:
     interface = SimpleNamespace(myInfo=SimpleNamespace(my_node_num=int("25d6e474", 16)))
     assert is_local_destination(interface, destination)

--- a/meshtastic/tests/test_contact_url.py
+++ b/meshtastic/tests/test_contact_url.py
@@ -200,7 +200,9 @@ def test_contact_url_roundtrip(
 
 
 @st.composite
-def contact_url_roundtrip_params(draw: st.DrawFn) -> tuple[int, dict[str, Any], bool, bool]:
+def contact_url_roundtrip_params(
+    draw: st.DrawFn,
+) -> tuple[int, dict[str, Any], bool, bool]:
     """Hypothesis strategy: generate a full node config and roundtrip flags."""
     should_ignore = draw(st.booleans())
     manually_verified = draw(st.booleans())
@@ -265,7 +267,9 @@ def contact_url_roundtrip_params(draw: st.DrawFn) -> tuple[int, dict[str, Any], 
 @pytest.mark.unitslow
 @settings(deadline=None)
 @given(contact_url_roundtrip_params())
-def test_contact_url_roundtrip_hypothesis(params: tuple[int, dict[str, Any], bool, bool]) -> None:
+def test_contact_url_roundtrip_hypothesis(
+    params: tuple[int, dict[str, Any], bool, bool],
+) -> None:
     """Property: roundtrip preserves data across random field configurations."""
     node_num, node_data, should_ignore, manually_verified = params
 
@@ -363,9 +367,7 @@ def test_addContactURL_raises_for_oversized_payload() -> None:
 
     # Craft a fragment whose encoded length exceeds the pre-decode guard
     huge_fragment = "A" * 6000
-    with pytest.raises(
-        MeshInterface.MeshInterfaceError, match="fragment too large"
-    ):
+    with pytest.raises(MeshInterface.MeshInterfaceError, match="fragment too large"):
         anode.addContactURL(f"https://meshtastic.org/v/#{huge_fragment}")
 
 
@@ -385,9 +387,7 @@ def test_addContactURL_rejects_broadcast_node_num() -> None:
     contact.user.id = "!ffffffff"
     data = contact.SerializeToString()
     encoded = b64mod.urlsafe_b64encode(data).decode("ascii").rstrip("=")
-    with pytest.raises(
-        MeshInterface.MeshInterfaceError, match="Invalid node number"
-    ):
+    with pytest.raises(MeshInterface.MeshInterfaceError, match="Invalid node number"):
         anode.addContactURL(f"https://meshtastic.org/v/#{encoded}")
 
 
@@ -406,9 +406,7 @@ def test_addContactURL_rejects_zero_node_num() -> None:
     contact.user.id = "!00000000"
     data = contact.SerializeToString()
     encoded = b64mod.urlsafe_b64encode(data).decode("ascii").rstrip("=")
-    with pytest.raises(
-        MeshInterface.MeshInterfaceError, match="Invalid node number"
-    ):
+    with pytest.raises(MeshInterface.MeshInterfaceError, match="Invalid node number"):
         anode.addContactURL(f"https://meshtastic.org/v/#{encoded}")
 
 

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -5779,12 +5779,6 @@ def test_printConfig_skips_non_message_sections(
     assert err == ""
 
 
-
-
-
-
-
-
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_main_configure_owner_values_use_normalized_strings(
@@ -5808,12 +5802,6 @@ def test_main_configure_owner_values_use_normalized_strings(
         call(long_name="Normalized Owner"),
         call(long_name=None, short_name="NO"),
     ]
-
-
-
-
-
-
 
 
 @pytest.mark.unit
@@ -5870,36 +5858,6 @@ def test_main_configure_rejects_owner_short_aliases(
     assert "ownerShort" in err
     target_node.beginSettingsTransaction.assert_not_called()
     target_node.setOwner.assert_not_called()
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_main_configure_reconnect.py
+++ b/meshtastic/tests/test_main_configure_reconnect.py
@@ -13,21 +13,22 @@ import pytest
 import yaml
 
 import meshtastic.__main__ as main_module
-
-# from ..ble_interface import BLEInterface
-
-# from ..radioconfig_pb2 import UserPreferences
-# import meshtastic.config_pb2
-from ..protobuf import config_pb2, localonly_pb2
-
-# from ..remote_hardware import onGPIOreceive
-# from ..config_pb2 import Config
-
 from meshtastic.tests.test_main import (
     _build_configure_interface,
     _patch_fast_monotonic,
     _run_main_configure_file,
 )
+
+# from ..radioconfig_pb2 import UserPreferences
+# import meshtastic.config_pb2
+from ..protobuf import config_pb2, localonly_pb2
+
+# from ..ble_interface import BLEInterface
+
+
+# from ..remote_hardware import onGPIOreceive
+# from ..config_pb2 import Config
+
 
 SDS_DISABLED_SENTINEL: int = 4_294_967_295
 MAIN_LOCAL_ADDR: str = cast(str, main_module.__dict__["LOCAL_ADDR"])
@@ -51,6 +52,7 @@ def _mock_newer_version_check(monkeypatch: pytest.MonkeyPatch) -> None:
         Pytest monkeypatching fixture.
     """
     monkeypatch.setattr("meshtastic.util.check_if_newer_version", lambda: None)
+
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
@@ -82,6 +84,7 @@ def test_main_configure_phase3_verified_with_matching_config_values(
     _run_main_configure_file(config_path, iface, monkeypatch)
     out, _ = capsys.readouterr()
     assert "All settings verified" in out
+
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
@@ -126,6 +129,7 @@ def test_main_configure_phase1_direct_write_order(
     ]
     assert relevant == expected
 
+
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_main_configure_channel_url_is_terminal_phase1_write(
@@ -159,6 +163,7 @@ def test_main_configure_channel_url_is_terminal_phase1_write(
         "setOwner",
     ):
         assert method not in after_seturl
+
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
@@ -196,6 +201,7 @@ def test_main_configure_seturl_unstable_aborts_before_phase2(
     _, err = capsys.readouterr()
     assert "transport did not stabilize" in err
 
+
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_main_configure_seturl_stable_proceeds_to_phase2(
@@ -229,6 +235,7 @@ def test_main_configure_seturl_stable_proceeds_to_phase2(
     target_node.beginSettingsTransaction.assert_called_once()
     target_node.commitSettingsTransaction.assert_called_once()
 
+
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_main_configure_phase3_no_reconnect_needed(
@@ -245,6 +252,7 @@ def test_main_configure_phase3_no_reconnect_needed(
     _run_main_configure_file(config_path, iface, monkeypatch)
     out, _ = capsys.readouterr()
     assert "no reboot expected" in out
+
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
@@ -269,6 +277,7 @@ def test_main_configure_channel_url_only_reports_possible_reconnect(
     assert "Configuration applied (no reboot expected)." not in out
     target_node.setURL.assert_called_once()
 
+
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_main_configure_channel_url_skip_when_already_matching(
@@ -291,6 +300,7 @@ def test_main_configure_channel_url_skip_when_already_matching(
     assert "Channel url already matches device state; skipping apply." in out
     assert "Configuration applied (no reboot expected)." in out
     target_node.setURL.assert_not_called()
+
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
@@ -358,6 +368,7 @@ def test_main_configure_phase3_channel_url_verified(
     _run_main_configure_file(config_path, iface, monkeypatch)
     out, _ = capsys.readouterr()
     assert "Could not fully verify" in out
+
 
 @pytest.mark.unit
 def test_post_seturl_stability_check_triggers_reconnect_when_disconnected(

--- a/meshtastic/tests/test_main_factory_reset.py
+++ b/meshtastic/tests/test_main_factory_reset.py
@@ -17,12 +17,13 @@ from meshtastic.__main__ import (
     main,
 )
 
-# from ..ble_interface import BLEInterface
-
 # from ..radioconfig_pb2 import UserPreferences
 # import meshtastic.config_pb2
 from ..serial_interface import SerialInterface
 from ..util import Acknowledgment
+
+# from ..ble_interface import BLEInterface
+
 
 # from ..remote_hardware import onGPIOreceive
 # from ..config_pb2 import Config
@@ -49,6 +50,7 @@ def _mock_newer_version_check(monkeypatch: pytest.MonkeyPatch) -> None:
         Pytest monkeypatching fixture.
     """
     monkeypatch.setattr("meshtastic.util.check_if_newer_version", lambda: None)
+
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
@@ -93,19 +95,20 @@ def test_main_factory_reset_local_accepts_ack_before_close(
     iface._wait_for_request_ack.assert_called_once()
     wait_args, wait_kwargs = iface._wait_for_request_ack.call_args
     assert wait_args[:2] == ("receivedNak", 123)
-    assert 0 < wait_kwargs["timeout_seconds"] <= (
-        main_module.FACTORY_RESET_ACCEPTANCE_POLL_SECONDS
+    assert (
+        0
+        < wait_kwargs["timeout_seconds"]
+        <= (main_module.FACTORY_RESET_ACCEPTANCE_POLL_SECONDS)
     )
     iface._raise_wait_error_if_present.assert_called_once_with(
         "receivedNak", request_id=123
     )
-    iface._retire_wait_request.assert_called_once_with(
-        "receivedNak", request_id=123
-    )
+    iface._retire_wait_request.assert_called_once_with("receivedNak", request_id=123)
     iface.waitForAckNak.assert_not_called()
     assert iface._acknowledgment.receivedImplAck is False
     assert "Waiting for factory reset acknowledgment or reboot disconnect" in out
     assert err == ""
+
 
 @pytest.mark.unit
 def test_local_factory_reset_accepts_transient_reboot_disconnect() -> None:
@@ -147,6 +150,7 @@ def test_local_factory_reset_accepts_transient_reboot_disconnect() -> None:
     assert request.id == 456
     iface._retire_wait_request.assert_called_once_with("receivedNak", request_id=456)
 
+
 @pytest.mark.unit
 def test_local_factory_reset_accepts_implicit_ack_with_legacy_completion_flag() -> None:
     """A valid implicit ACK must win over the legacy receivedNak completion latch."""
@@ -181,6 +185,7 @@ def test_local_factory_reset_accepts_implicit_ack_with_legacy_completion_flag() 
     assert request is not None
     assert request.id == 457
     iface._raise_wait_error_if_present.assert_called()
+
 
 @pytest.mark.unit
 def test_local_factory_reset_accepts_tcp_socket_generation_change() -> None:
@@ -224,6 +229,7 @@ def test_local_factory_reset_accepts_tcp_socket_generation_change() -> None:
     # firmware-defined seven-second reboot window.
     assert iface._timeout.expireTimeout == 0.01
 
+
 @pytest.mark.unit
 def test_local_factory_reset_ignores_socket_change_before_send_returns() -> None:
     """A transport change before a concrete request returns is not acceptance."""
@@ -257,6 +263,7 @@ def test_local_factory_reset_ignores_socket_change_before_send_returns() -> None
             full=False,
             timeout=0.01,
         )
+
 
 @pytest.mark.unit
 def test_local_factory_reset_ignores_pre_send_disconnect_event() -> None:
@@ -293,6 +300,7 @@ def test_local_factory_reset_ignores_pre_send_disconnect_event() -> None:
 
     iface._retire_wait_request.assert_called_once_with("receivedNak", request_id=654)
 
+
 @pytest.mark.unit
 def test_local_factory_reset_times_out_without_ack_or_disconnect() -> None:
     """A queued reset without ACK, NAK, or reboot remains a hard failure."""
@@ -321,6 +329,7 @@ def test_local_factory_reset_times_out_without_ack_or_disconnect() -> None:
         )
 
     iface._retire_wait_request.assert_called_once_with("receivedNak", request_id=789)
+
 
 @pytest.mark.unit
 def test_local_factory_reset_nak_remains_failure() -> None:
@@ -357,6 +366,7 @@ def test_local_factory_reset_nak_remains_failure() -> None:
     )
     iface._retire_wait_request.assert_called_once_with("receivedNak", request_id=987)
 
+
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_main_factory_reset_skips_ack_wait_when_send_is_disabled() -> None:
@@ -377,6 +387,7 @@ def test_main_factory_reset_skips_ack_wait_when_send_is_disabled() -> None:
     iface._raise_wait_error_if_present.assert_not_called()
     iface._retire_wait_request.assert_not_called()
     iface.waitForAckNak.assert_not_called()
+
 
 @pytest.mark.unit
 def test_post_factory_reset_ready_probe_closes_and_probes_reconnect() -> None:

--- a/meshtastic/tests/test_main_firmware_28.py
+++ b/meshtastic/tests/test_main_firmware_28.py
@@ -10,16 +10,17 @@ from unittest.mock import MagicMock
 import pytest
 
 import meshtastic.__main__ as main_module
-from meshtastic.region_presets import RegionPresetInfo, decode_region_preset_map
 from meshtastic.__main__ import (
     initParser,
 )
-
-# from ..ble_interface import BLEInterface
+from meshtastic.region_presets import RegionPresetInfo, decode_region_preset_map
 
 # from ..radioconfig_pb2 import UserPreferences
 # import meshtastic.config_pb2
 from ..protobuf import config_pb2, mesh_pb2
+
+# from ..ble_interface import BLEInterface
+
 
 # from ..remote_hardware import onGPIOreceive
 # from ..config_pb2 import Config
@@ -47,6 +48,7 @@ def _mock_newer_version_check(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     monkeypatch.setattr("meshtastic.util.check_if_newer_version", lambda: None)
 
+
 def _run_region_preset_cli(
     monkeypatch: pytest.MonkeyPatch,
     *extra_args: str,
@@ -72,12 +74,14 @@ def _run_region_preset_cli(
     main_module.onConnected(interface)
     return interface
 
+
 def _init_lockdown_cli(monkeypatch: pytest.MonkeyPatch, *cli_args: str) -> None:
     effective_args = list(cli_args)
     if "--dest" not in effective_args:
         effective_args.extend(("--dest", MAIN_LOCAL_ADDR))
     monkeypatch.setattr(sys, "argv", ["meshtastic", *effective_args])
     initParser()
+
 
 def _run_lockdown_cli(
     monkeypatch: pytest.MonkeyPatch,
@@ -95,6 +99,7 @@ def _run_lockdown_cli(
     main_module.onConnected(interface)
     return interface, build, send
 
+
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_show_region_presets_reports_absent_metadata_and_closes(
@@ -109,6 +114,7 @@ def test_show_region_presets_reports_absent_metadata_and_closes(
     output = capsys.readouterr().out
     assert "did not provide usable region/preset compatibility metadata" in output
     interface.close.assert_called_once_with()
+
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
@@ -141,6 +147,7 @@ def test_lockdown_cli_unlock_from_file(
         interface, build.return_value, timeout=20.0, allow_reboot_without_status=False
     )
     assert "Lockdown status: UNLOCKED" in capsys.readouterr().out
+
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
@@ -185,6 +192,7 @@ def test_show_region_presets_reports_malformed_metadata(
     assert dict(interface.regionPresets) == {}
     interface.close.assert_called_once_with()
 
+
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_show_region_presets_rejects_remote_destination(
@@ -201,6 +209,7 @@ def test_show_region_presets_rejects_remote_destination(
     output = capsys.readouterr().out
     assert "available only from the local node" in output
     interface.close.assert_called_once_with()
+
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
@@ -232,6 +241,7 @@ def test_show_region_presets_formats_known_unknown_and_licensed_values(
     assert "REGION_999: default=PRESET_997; presets=PRESET_998" in output
     interface.close.assert_called_once_with()
 
+
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_region_preset_cli_without_flag_does_not_read_capability_state(
@@ -251,6 +261,7 @@ def test_region_preset_cli_without_flag_does_not_read_capability_state(
     main_module.onConnected(interface)
 
     assert "region/preset" not in capsys.readouterr().out
+
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
@@ -326,8 +337,7 @@ def test_lockdown_cli_rejects_unacknowledged_command_line_secret(
     assert exc_info.value.code == 1
     assert (
         "--lockdown-passphrase requires "
-        "--insecure-lockdown-passphrase-on-command-line"
-        in capsys.readouterr().err
+        "--insecure-lockdown-passphrase-on-command-line" in capsys.readouterr().err
     )
     validate.assert_not_called()
     build.assert_not_called()
@@ -359,6 +369,7 @@ def test_lockdown_cli_command_line_secret_formats_unknown_state_and_backoff(
     assert "Lockdown status: STATE_999" in output
     assert "Retry backoff: 7s" in output
 
+
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_lockdown_cli_provision_confirmation_abort(
@@ -375,6 +386,7 @@ def test_lockdown_cli_provision_confirmation_abort(
         main_module.onConnected(interface)
 
     assert "Aborted." in capsys.readouterr().err
+
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
@@ -394,6 +406,7 @@ def test_lockdown_cli_provision_rejects_mismatched_interactive_passphrases(
         main_module.onConnected(interface)
 
     assert "Lockdown passphrases do not match." in capsys.readouterr().err
+
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
@@ -426,6 +439,7 @@ def test_lockdown_cli_provision_reports_auth_failure(
     assert "Lockdown status: UNLOCK_FAILED" in captured.out
     assert "Lockdown authentication failed." in captured.err
 
+
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_lockdown_cli_lock_now_allows_reboot_without_status(
@@ -441,6 +455,7 @@ def test_lockdown_cli_lock_now_allows_reboot_without_status(
     assert build.call_args.kwargs["lock_now"] is True
     assert send.call_args.kwargs["allow_reboot_without_status"] is True
     assert "device may already be rebooting" in capsys.readouterr().out
+
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
@@ -461,6 +476,7 @@ def test_lockdown_cli_disable_sets_disable_flag(
     )
     assert build.call_args.kwargs["disable"] is True
 
+
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_lockdown_cli_accepts_explicit_local_destination(
@@ -477,6 +493,7 @@ def test_lockdown_cli_accepts_explicit_local_destination(
     )
     send.assert_called_once()
     interface.close.assert_called_once_with()
+
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
@@ -532,6 +549,7 @@ def test_lockdown_cli_maps_passphrase_errors_to_user_facing_exit(
 
     assert expected in capsys.readouterr().err
 
+
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_lockdown_cli_maps_invalid_limits_to_user_facing_exit(
@@ -559,6 +577,7 @@ def test_lockdown_cli_maps_invalid_limits_to_user_facing_exit(
     output = capsys.readouterr().err
     assert "Invalid lockdown options" in output
     assert "boots_remaining must be between 0 and 255" in output
+
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
@@ -596,6 +615,7 @@ def test_lockdown_cli_maps_send_failures_to_user_facing_exit(
     assert "Lockdown command failed" in output
     assert str(error) in output
 
+
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_lockdown_cli_interactive_unlock_uses_single_prompt(
@@ -616,6 +636,7 @@ def test_lockdown_cli_interactive_unlock_uses_single_prompt(
     getpass_mock.assert_called_once_with("Lockdown passphrase: ")
     validate_mock.assert_called_once_with(b"secret")
     assert build.call_args.args == (b"secret",)
+
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")

--- a/meshtastic/tests/test_node.py
+++ b/meshtastic/tests/test_node.py
@@ -1360,9 +1360,7 @@ def test_deleteChannel_writes_only_changed_complete_cache_slots(
         for call in anode._send_admin.call_args_list
     )
     assert anode.channels is not None
-    assert [channel.index for channel in anode.channels] == list(
-        range(CHANNEL_LIMIT)
-    )
+    assert [channel.index for channel in anode.channels] == list(range(CHANNEL_LIMIT))
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_receive_pipeline.py
+++ b/meshtastic/tests/test_receive_pipeline.py
@@ -490,7 +490,9 @@ class TestHandleFromRadioRegionPresets:
 
         assert mock_interface.regionPresetMap is not from_radio.region_presets
         assert mock_interface.regionPresetMap == from_radio.region_presets
-        assert mock_interface.regionPresets[config_pb2.Config.LoRaConfig.US].presets == (
+        assert mock_interface.regionPresets[
+            config_pb2.Config.LoRaConfig.US
+        ].presets == (
             config_pb2.Config.LoRaConfig.LONG_FAST,
             config_pb2.Config.LoRaConfig.LONG_SLOW,
         )
@@ -520,7 +522,6 @@ class TestHandleFromRadioLockdownStatus:
         assert mock_interface.lockdownStatus.state == mesh_pb2.LockdownStatus.LOCKED
         assert result[0].topic == "meshtastic.lockdown_status"
         assert result[0].payload["status"].backoff_seconds == 12
-
 
 
 class TestHandleFromRadioNodeInfo:

--- a/meshtastic/tests/test_serial_reconnect.py
+++ b/meshtastic/tests/test_serial_reconnect.py
@@ -161,6 +161,7 @@ def test_poll_reconnect_waits_for_dead_reader_thread() -> None:
     client.connect.return_value = None
     # After connect, mark as connected
     client.connect.side_effect = lambda: client.isConnected.set()
+
     # Simulate thread dying after join
     def _simulate_join_exit(**kw: object) -> None:
         client._rxThread.is_alive.return_value = False
@@ -403,7 +404,9 @@ def test_transport_dead_when_rx_thread_missing() -> None:
 def test_poll_reconnect_sleeps_when_connect_returns_not_live() -> None:
     """If connect() returns but interface isn't live, sleep before returning."""
 
-    client = _make_serial_mock(is_connected=False, stream_open=False, reader_alive=False)
+    client = _make_serial_mock(
+        is_connected=False, stream_open=False, reader_alive=False
+    )
     _simulate_reader_exit(client)
     # connect() succeeds (no exception) but doesn't set isConnected or transport
     client.connect.return_value = None

--- a/meshtastic/tests/test_simradio_cli.py
+++ b/meshtastic/tests/test_simradio_cli.py
@@ -326,9 +326,7 @@ def test_simradio_cli_channel_lifecycle(firmware_node: SimNode) -> None:
     cli_then_verify(
         firmware_node.port,
         ("--ch-disable", "--ch-index", "1"),
-        lambda iface: _assert_channel_role(
-            iface, 1, channel_pb2.Channel.Role.DISABLED
-        ),
+        lambda iface: _assert_channel_role(iface, 1, channel_pb2.Channel.Role.DISABLED),
     )
     cli_then_verify(
         firmware_node.port,
@@ -340,9 +338,7 @@ def test_simradio_cli_channel_lifecycle(firmware_node: SimNode) -> None:
     cli_then_verify(
         firmware_node.port,
         ("--ch-del", "--ch-index", "1"),
-        lambda iface: _assert_channel_role(
-            iface, 1, channel_pb2.Channel.Role.DISABLED
-        ),
+        lambda iface: _assert_channel_role(iface, 1, channel_pb2.Channel.Role.DISABLED),
     )
 
 
@@ -364,8 +360,7 @@ def test_simradio_cli_channel_url_paths(firmware_node: SimNode) -> None:
     )
 
     invalid_url = (
-        "https://www.meshtastic.org/c/#"
-        "GAMiENTxuzogKQdZ8Lz_q89Oab8qB0RlZmF1bHQ="
+        "https://www.meshtastic.org/c/#" "GAMiENTxuzogKQdZ8Lz_q89Oab8qB0RlZmF1bHQ="
     )
     invalid = run_cli(firmware_node.port, "--seturl", invalid_url)
     assert invalid.returncode != 0, invalid.output
@@ -475,6 +470,7 @@ def test_simradio_cli_schema_get_set_paths(firmware_node: SimNode) -> None:
 
 def test_simradio_cli_factory_reset_config_isolated(firmware_node: SimNode) -> None:
     """--factory-reset should restore configuration, not owner identity."""
+
     def _assert_fixed_position(iface: TCPInterface) -> None:
         assert iface.localNode.localConfig.position.fixed_position is True
 

--- a/meshtastic/tests/test_simradio_harness.py
+++ b/meshtastic/tests/test_simradio_harness.py
@@ -6,8 +6,8 @@ import errno
 import logging
 import signal
 import subprocess
-from collections.abc import Callable
 import threading
+from collections.abc import Callable
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -22,8 +22,8 @@ from . import conftest as simradio_conftest
 from . import simradio_harness, simradio_helpers
 from .simradio_harness import (
     CHAIN_TOPOLOGY,
-    RebootCheckpoint,
     REBOOT_RECOVERY_FILENAME,
+    RebootCheckpoint,
     SimMesh,
     SimNode,
     _build_mesh_packet,
@@ -33,11 +33,11 @@ from .simradio_harness import (
     find_meshtasticd,
 )
 from .simradio_helpers import (
-    PacketCollector,
-    _classify_cli_operation,
     _DEFAULT_RETRIES,
     _DESTRUCTIVE_ARGUMENTS,
     _READ_ONLY_ARGUMENTS,
+    PacketCollector,
+    _classify_cli_operation,
     _redact_cli_diagnostics,
     cli_then_verify,
     connect_iface,
@@ -118,8 +118,7 @@ def test_factory_reset_reboot_recovers_known_portduino_sigsegv(
     marker = f"Using config file {node.port}\n"
     version = "INFO S:B:37,2.7.26,native-tft,unknown\n"
     reset_evidence = (
-        "Factory config reset finished, rebooting soon\n"
-        "Reboot in 7 seconds\n"
+        "Factory config reset finished, rebooting soon\n" "Reboot in 7 seconds\n"
     )
     log_path = tmp_path / "meshtasticd.log"
     prefix = marker + version
@@ -176,10 +175,7 @@ def test_factory_reset_reboot_rejects_unexpected_exit_status(
     node.workdir = tmp_path
     marker = f"Using config file {node.port}\n"
     version = "INFO S:B:37,2.7.26,native-tft,unknown\n"
-    evidence = (
-        "Factory config reset finished, rebooting soon\n"
-        "Reboot in 7 seconds\n"
-    )
+    evidence = "Factory config reset finished, rebooting soon\n" "Reboot in 7 seconds\n"
     prefix = marker + version
     log_path = tmp_path / "meshtasticd.log"
     log_path.write_text(prefix + evidence, encoding="utf-8")
@@ -201,14 +197,9 @@ def test_factory_reset_reboot_rejects_same_crash_on_non_27_firmware(
     node.workdir = tmp_path
     marker = f"Using config file {node.port}\n"
     version = "INFO S:B:37,2.8.0,native-tft,unknown\n"
-    evidence = (
-        "Factory config reset finished, rebooting soon\n"
-        "Reboot in 7 seconds\n"
-    )
+    evidence = "Factory config reset finished, rebooting soon\n" "Reboot in 7 seconds\n"
     prefix = marker + version
-    (tmp_path / "meshtasticd.log").write_text(
-        prefix + evidence, encoding="utf-8"
-    )
+    (tmp_path / "meshtasticd.log").write_text(prefix + evidence, encoding="utf-8")
     checkpoint = RebootCheckpoint(1, len(prefix.encode()), 123)
     process = MagicMock(pid=123, returncode=-signal.SIGSEGV)
     process.poll.return_value = -signal.SIGSEGV
@@ -257,9 +248,7 @@ def test_expected_reboot_exit_relaunches_same_vfs_and_records_recovery(
     assert "new_pid=456" in recovery
     assert "exit_status=-11" in recovery
     assert "exit_signal=SIGSEGV" in recovery
-    context = (tmp_path / simradio_harness.CONTEXT_FILENAME).read_text(
-        encoding="utf-8"
-    )
+    context = (tmp_path / simradio_harness.CONTEXT_FILENAME).read_text(encoding="utf-8")
     assert "restart_count=1" in context
     assert "last_reboot_exit_status=-11" in context
     node._close_log_files()
@@ -292,9 +281,7 @@ def test_set_region_drains_local_write_and_verifies_persisted_state(
         verifier(iface)
 
     monkeypatch.setattr(simradio_helpers, "run_cli", _run_cli)
-    monkeypatch.setattr(
-        simradio_helpers, "verify_state_eventually", _verify_state
-    )
+    monkeypatch.setattr(simradio_helpers, "verify_state_eventually", _verify_state)
 
     simradio_helpers.set_region(44_404, "US")
 
@@ -341,9 +328,7 @@ def test_set_region_rejects_unpersisted_firmware_state(
         iface.localNode.localConfig.lora.region = 0
         verifier(iface)
 
-    monkeypatch.setattr(
-        simradio_helpers, "verify_state_eventually", _verify_state
-    )
+    monkeypatch.setattr(simradio_helpers, "verify_state_eventually", _verify_state)
 
     with pytest.raises(AssertionError, match="expected US, got UNSET"):
         simradio_helpers.set_region(44_404, "US")
@@ -498,9 +483,7 @@ def test_simradio_bridge_drops_oversized_payload() -> None:
 
     mesh._on_sim_packet(
         packet={
-            "decoded": {
-                "payload": b"x" * (mesh_pb2.Constants.DATA_PAYLOAD_LEN + 1)
-            }
+            "decoded": {"payload": b"x" * (mesh_pb2.Constants.DATA_PAYLOAD_LEN + 1)}
         },
         interface=transmitter,
     )
@@ -642,6 +625,7 @@ def test_simradio_port_preflight_allows_non_listening_kernel_state(
     probe.connect_ex.assert_called_once_with(("127.0.0.1", 44_404))
     probe.bind.assert_not_called()
 
+
 @pytest.mark.unit
 def test_simradio_port_preflight_rejects_ambiguous_probe_result(
     monkeypatch: pytest.MonkeyPatch,
@@ -704,6 +688,7 @@ def test_simradio_node_cleans_resources_when_process_launch_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A Popen failure should close logs and remove the temporary VFS."""
+
     def _fail_launch(*_args: object, **_kwargs: object) -> None:
         raise OSError("simulated launch failure")
 
@@ -1006,10 +991,7 @@ def test_classify_cli_operation_maps_arguments_to_kind(
 @pytest.mark.unit
 def test_classify_destructive_wins_over_read_only() -> None:
     """A mixed argument list is classified conservatively."""
-    assert (
-        _classify_cli_operation(["--ch-del", "--info"])
-        == "non_idempotent"
-    )
+    assert _classify_cli_operation(["--ch-del", "--info"]) == "non_idempotent"
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_simradio_mesh.py
+++ b/meshtastic/tests/test_simradio_mesh.py
@@ -33,7 +33,9 @@ def test_simradio_mesh_broadcast_crosses_relay(firmware_mesh: SimMesh) -> None:
     ):
         firmware_mesh.send_text(0, text, wantAck=False)
         assert collector_b.wait_for_text(text), "B did not receive A's broadcast"
-        assert collector_c.wait_for_text(text), "C did not receive A's relayed broadcast"
+        assert collector_c.wait_for_text(
+            text
+        ), "C did not receive A's relayed broadcast"
 
 
 def test_simradio_mesh_direct_message_stops_at_destination(

--- a/meshtastic/tests/test_util.py
+++ b/meshtastic/tests/test_util.py
@@ -2097,7 +2097,10 @@ def test_flagsFromList_roundtrip(flags: int) -> None:
 
     for flag_type in (_EXCLUDED_MODULES, _POSITION_FLAGS):
         names = [
-            n for n in flags_to_list(flag_type, flags)  # pyright: ignore[reportArgumentType]
+            n
+            for n in flags_to_list(
+                flag_type, flags
+            )  # pyright: ignore[reportArgumentType]
             if not n.startswith("UNKNOWN_ADDITIONAL_FLAGS(")
         ]
         if names:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Includes PEP 561 py.typed marker for type checker support
 [tool.poetry]
 name = "mtjk"
-version = "2.7.10.post1"
+version = "2.7.10.post2"
 description = "Python API & client shell for talking to Meshtastic devices"
 authors = ["Meshtastic Developers (upstream project authors)"]
 maintainers = ["Jeremiah K. <jeremiahk@gmx.com>"]


### PR DESCRIPTION
## Summary by Sourcery

Apply linting and formatting cleanups across CLI, tests, and examples, update tooling configuration, and bump the Python package patch version.

Enhancements:
- Refine meshtastic CLI imports and minor control-flow formatting to satisfy linting while preserving legacy compatibility exports.
- Tidy tests and support utilities with consistent formatting, imports, and assertion layout for improved readability and style conformance.
- Adjust example scripts for clearer argparse setup and message handlers while aligning with lint rules.
- Clarify type handling in admin response matching and related helpers without changing behavior.

Build:
- Bump the project version from 2.7.10.post1 to 2.7.10.post2 in pyproject configuration.

CI:
- Update Trunk lint configuration by disabling actionlint autofix, refreshing tool versions, and refining linter enablement settings.

Tests:
- Normalize simradio and CLI-related test helpers and expectations for consistent style and maintainability.