### PR TITLE
Quiet and bound post-factory-reset reconnect probe

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -16,7 +16,7 @@ import platform
 import sys
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from types import ModuleType
 from typing import Any, NoReturn, Protocol, cast
 
@@ -731,6 +731,29 @@ def _send_local_factory_reset_and_wait(
     return None
 
 
+@contextlib.contextmanager
+def _temporary_instance_attributes(
+    instance: Any, overrides: dict[str, Any]
+) -> Iterator[None]:
+    """Temporarily override instance attributes and restore their exact prior state."""
+    missing = object()
+    instance_values = vars(instance)
+    previous_values = {
+        name: instance_values.get(name, missing) for name in overrides
+    }
+    try:
+        for name, value in overrides.items():
+            setattr(instance, name, value)
+        yield
+    finally:
+        for name, previous in previous_values.items():
+            if previous is missing:
+                with contextlib.suppress(AttributeError):
+                    delattr(instance, name)
+            else:
+                setattr(instance, name, previous)
+
+
 def _post_factory_reset_ready_probe(interface: MeshInterface) -> None:
     """Close, briefly probe serial readiness, then release the port for the next command."""
     if not isinstance(interface, meshtastic.serial_interface.SerialInterface):
@@ -754,43 +777,28 @@ def _post_factory_reset_ready_probe(interface: MeshInterface) -> None:
         "_connect_retry_budget_seconds": FACTORY_RESET_READY_PROBE_TIMEOUT_SECONDS,
         "_suppress_connect_failure_logging": True,
     }
-    missing = object()
-    previous_values = {
-        name: getattr(interface, name, missing) for name in probe_overrides
-    }
-    for name, value in probe_overrides.items():
-        setattr(interface, name, value)
-
     probe_start = time.monotonic()
-    try:
-        interface.connect()
-        logger.debug(
-            "Factory reset: reconnect probe succeeded in %.2fs.",
-            time.monotonic() - probe_start,
-        )
-    except Exception as exc:
-        logger.info(
-            "Factory reset accepted; device is still rebooting after %.1fs "
-            "and the next command will reconnect normally (%s).",
-            time.monotonic() - probe_start,
-            exc,
-        )
-    finally:
-        for name, previous in previous_values.items():
-            if previous is missing:
-                try:
-                    delattr(interface, name)
-                except AttributeError:
-                    pass
-            else:
-                setattr(interface, name, previous)
+    with _temporary_instance_attributes(interface, probe_overrides):
         try:
-            interface.close()
-        except Exception:
+            interface.connect()
             logger.debug(
-                "Factory reset: final serial close failed.",
-                exc_info=True,
+                "Factory reset: reconnect probe succeeded in %.2fs.",
+                time.monotonic() - probe_start,
             )
+        except Exception as exc:
+            logger.info(
+                "Factory reset accepted; device is still rebooting after %.1fs "
+                "and the next command will reconnect normally (%s).",
+                time.monotonic() - probe_start,
+                exc,
+            )
+    try:
+        interface.close()
+    except Exception:
+        logger.debug(
+            "Factory reset: final serial close failed.",
+            exc_info=True,
+        )
 
 
 def _validate_non_empty_mapping_sections(

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -732,7 +732,7 @@ def _send_local_factory_reset_and_wait(
 
 
 def _post_factory_reset_ready_probe(interface: MeshInterface) -> None:
-    """Close, probe transport reconnect readiness, and close again for a clean next command."""
+    """Close, briefly probe serial readiness, then release the port for the next command."""
     if not isinstance(interface, meshtastic.serial_interface.SerialInterface):
         return
 
@@ -749,6 +749,18 @@ def _post_factory_reset_ready_probe(interface: MeshInterface) -> None:
         "Factory reset: probing reconnect readiness (timeout=%.1fs)...",
         FACTORY_RESET_READY_PROBE_TIMEOUT_SECONDS,
     )
+    probe_overrides = {
+        "_connect_wait_timeout_seconds": FACTORY_RESET_READY_PROBE_TIMEOUT_SECONDS,
+        "_connect_retry_budget_seconds": FACTORY_RESET_READY_PROBE_TIMEOUT_SECONDS,
+        "_suppress_connect_failure_logging": True,
+    }
+    missing = object()
+    previous_values = {
+        name: getattr(interface, name, missing) for name in probe_overrides
+    }
+    for name, value in probe_overrides.items():
+        setattr(interface, name, value)
+
     probe_start = time.monotonic()
     try:
         interface.connect()
@@ -756,12 +768,22 @@ def _post_factory_reset_ready_probe(interface: MeshInterface) -> None:
             "Factory reset: reconnect probe succeeded in %.2fs.",
             time.monotonic() - probe_start,
         )
-    except Exception:
-        logger.warning(
-            "Factory reset: reconnect probe did not complete before timeout.",
-            exc_info=True,
+    except Exception as exc:
+        logger.info(
+            "Factory reset accepted; device is still rebooting after %.1fs "
+            "and the next command will reconnect normally (%s).",
+            time.monotonic() - probe_start,
+            exc,
         )
     finally:
+        for name, previous in previous_values.items():
+            if previous is missing:
+                try:
+                    delattr(interface, name)
+                except AttributeError:
+                    pass
+            else:
+                setattr(interface, name, previous)
         try:
             interface.close()
         except Exception:

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -1479,7 +1479,12 @@ class MeshInterface:  # pylint: disable=R0902
                             getattr(self, "_last_disconnect_source", "unknown"),
                         )
                         raise MeshInterface.MeshInterfaceError(abort_reason_str)
-                logger.error(
+                log_timeout = (
+                    logger.debug
+                    if getattr(self, "_suppress_connect_failure_logging", False)
+                    else logger.error
+                )
+                log_timeout(
                     "Timed out waiting for connection completion (isConnected=%s, failure=%r, last_disconnect_source=%s)",
                     self.isConnected.is_set(),
                     self.failure,

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -259,6 +259,10 @@ class MeshInterface:  # pylint: disable=R0902
     _queue_wait_timeout_seconds: ClassVar[float] = QUEUE_WAIT_TIMEOUT_SECONDS
     _last_disconnect_source: str | None
 
+    # Optional instance-only overrides used by bounded reconnect probes.
+    _connect_wait_timeout_seconds: float
+    _suppress_connect_failure_logging: bool
+
     class MeshInterfaceError(Exception):
         """An exception class for general mesh interface errors."""
 
@@ -1427,6 +1431,21 @@ class MeshInterface:  # pylint: disable=R0902
         """
         return self._node_view.getRingtone()
 
+    def _connection_timeout_override(
+        self, attribute_name: str, default: float | None = None
+    ) -> float | None:
+        """Return a non-negative numeric connection timeout override, if configured."""
+        value = getattr(self, attribute_name, default)
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return default
+        return max(0.0, float(value))
+
+    def _connect_failure_log_level(self) -> int:
+        """Return the log level for expected versus ordinary connection failures."""
+        if getattr(self, "_suppress_connect_failure_logging", False):
+            return logging.DEBUG
+        return logging.ERROR
+
     def _wait_connected(self, timeout: float = 30.0) -> None:
         """Wait until the interface is marked connected or the timeout elapses.
 
@@ -1479,12 +1498,8 @@ class MeshInterface:  # pylint: disable=R0902
                             getattr(self, "_last_disconnect_source", "unknown"),
                         )
                         raise MeshInterface.MeshInterfaceError(abort_reason_str)
-                log_timeout = (
-                    logger.debug
-                    if getattr(self, "_suppress_connect_failure_logging", False)
-                    else logger.error
-                )
-                log_timeout(
+                logger.log(
+                    self._connect_failure_log_level(),
                     "Timed out waiting for connection completion (isConnected=%s, failure=%r, last_disconnect_source=%s)",
                     self.isConnected.is_set(),
                     self.failure,

--- a/meshtastic/serial_interface.py
+++ b/meshtastic/serial_interface.py
@@ -261,7 +261,13 @@ class SerialInterface(StreamInterface):
     def connect(self) -> None:
         """Reconnect by reopening serial stream when needed, then run StreamInterface connect."""
         connect_start = time.monotonic()
-        retry_deadline = time.monotonic() + SERIAL_CONNECT_RETRY_BUDGET_SECONDS
+        retry_budget = getattr(
+            self, "_connect_retry_budget_seconds", SERIAL_CONNECT_RETRY_BUDGET_SECONDS
+        )
+        retry_deadline = time.monotonic() + max(0.0, float(retry_budget))
+        suppress_failure_logging = bool(
+            getattr(self, "_suppress_connect_failure_logging", False)
+        )
         for attempt in range(1, SERIAL_CONNECT_MAX_ATTEMPTS + 1):
             attempt_start = time.monotonic()
             stream = self.stream
@@ -297,7 +303,10 @@ class SerialInterface(StreamInterface):
                 return
             except Exception as exc:
                 if not self._is_retryable_connect_error(exc):
-                    logger.error(
+                    log_failure = (
+                        logger.debug if suppress_failure_logging else logger.error
+                    )
+                    log_failure(
                         "Serial connect attempt %d failed with non-retryable error after %.2fs: %s",
                         attempt,
                         time.monotonic() - connect_start,
@@ -306,7 +315,10 @@ class SerialInterface(StreamInterface):
                     raise
                 remaining = retry_deadline - time.monotonic()
                 if attempt >= SERIAL_CONNECT_MAX_ATTEMPTS or remaining <= 0:
-                    logger.error(
+                    log_failure = (
+                        logger.debug if suppress_failure_logging else logger.error
+                    )
+                    log_failure(
                         "Serial connect retry budget exhausted after %.2fs (attempt %d/%d). Last error: %s",
                         time.monotonic() - connect_start,
                         attempt,

--- a/meshtastic/serial_interface.py
+++ b/meshtastic/serial_interface.py
@@ -65,6 +65,8 @@ SERIAL_PORT_PATH_EMPTY_ERROR = (
 class SerialInterface(StreamInterface):
     """Interface class for meshtastic devices over a serial link."""
 
+    _connect_retry_budget_seconds: float
+
     devPath: str | None
     stream: serial.Serial | BinaryIO | None
 
@@ -261,13 +263,11 @@ class SerialInterface(StreamInterface):
     def connect(self) -> None:
         """Reconnect by reopening serial stream when needed, then run StreamInterface connect."""
         connect_start = time.monotonic()
-        retry_budget = getattr(
-            self, "_connect_retry_budget_seconds", SERIAL_CONNECT_RETRY_BUDGET_SECONDS
+        retry_budget = self._connection_timeout_override(
+            "_connect_retry_budget_seconds", SERIAL_CONNECT_RETRY_BUDGET_SECONDS
         )
-        retry_deadline = time.monotonic() + max(0.0, float(retry_budget))
-        suppress_failure_logging = bool(
-            getattr(self, "_suppress_connect_failure_logging", False)
-        )
+        assert retry_budget is not None
+        retry_deadline = time.monotonic() + retry_budget
         for attempt in range(1, SERIAL_CONNECT_MAX_ATTEMPTS + 1):
             attempt_start = time.monotonic()
             stream = self.stream
@@ -303,10 +303,8 @@ class SerialInterface(StreamInterface):
                 return
             except Exception as exc:
                 if not self._is_retryable_connect_error(exc):
-                    log_failure = (
-                        logger.debug if suppress_failure_logging else logger.error
-                    )
-                    log_failure(
+                    logger.log(
+                        self._connect_failure_log_level(),
                         "Serial connect attempt %d failed with non-retryable error after %.2fs: %s",
                         attempt,
                         time.monotonic() - connect_start,
@@ -315,10 +313,8 @@ class SerialInterface(StreamInterface):
                     raise
                 remaining = retry_deadline - time.monotonic()
                 if attempt >= SERIAL_CONNECT_MAX_ATTEMPTS or remaining <= 0:
-                    log_failure = (
-                        logger.debug if suppress_failure_logging else logger.error
-                    )
-                    log_failure(
+                    logger.log(
+                        self._connect_failure_log_level(),
                         "Serial connect retry budget exhausted after %.2fs (attempt %d/%d). Last error: %s",
                         time.monotonic() - connect_start,
                         attempt,

--- a/meshtastic/stream_interface.py
+++ b/meshtastic/stream_interface.py
@@ -262,7 +262,13 @@ class StreamInterface(MeshInterface):
         try:
             self._start_config()
             if not self.noProto:  # Wait for the db download if using the protocol
-                self._wait_connected()
+                connect_wait_timeout = getattr(
+                    self, "_connect_wait_timeout_seconds", None
+                )
+                if isinstance(connect_wait_timeout, (int, float)):
+                    self._wait_connected(timeout=max(0.0, float(connect_wait_timeout)))
+                else:
+                    self._wait_connected()
                 self._stable_path = self._resolve_stable_path()
         except Exception:
             # If protocol startup fails after reader launch, tear down to avoid

--- a/meshtastic/stream_interface.py
+++ b/meshtastic/stream_interface.py
@@ -262,13 +262,13 @@ class StreamInterface(MeshInterface):
         try:
             self._start_config()
             if not self.noProto:  # Wait for the db download if using the protocol
-                connect_wait_timeout = getattr(
-                    self, "_connect_wait_timeout_seconds", None
+                connect_wait_timeout = self._connection_timeout_override(
+                    "_connect_wait_timeout_seconds"
                 )
-                if isinstance(connect_wait_timeout, (int, float)):
-                    self._wait_connected(timeout=max(0.0, float(connect_wait_timeout)))
-                else:
+                if connect_wait_timeout is None:
                     self._wait_connected()
+                else:
+                    self._wait_connected(timeout=connect_wait_timeout)
                 self._stable_path = self._resolve_stable_path()
         except Exception:
             # If protocol startup fails after reader launch, tear down to avoid

--- a/meshtastic/tests/test_main_factory_reset.py
+++ b/meshtastic/tests/test_main_factory_reset.py
@@ -4,6 +4,7 @@
 
 import sys
 import threading
+import logging
 import time
 from types import SimpleNamespace
 from typing import Any, cast
@@ -398,4 +399,34 @@ def test_post_factory_reset_ready_probe_closes_and_probes_reconnect() -> None:
     main_module._post_factory_reset_ready_probe(cast(Any, iface))
 
     iface.connect.assert_called_once()
+    assert iface.close.call_count >= 2
+
+@pytest.mark.unit
+def test_post_factory_reset_ready_probe_bounds_and_quiets_expected_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A still-rebooting device should produce one concise info line, not a traceback."""
+    iface = cast(Any, object.__new__(SerialInterface))
+    iface.close = MagicMock()
+
+    def _connect() -> None:
+        assert iface._connect_wait_timeout_seconds == (
+            main_module.FACTORY_RESET_READY_PROBE_TIMEOUT_SECONDS
+        )
+        assert iface._connect_retry_budget_seconds == (
+            main_module.FACTORY_RESET_READY_PROBE_TIMEOUT_SECONDS
+        )
+        assert iface._suppress_connect_failure_logging is True
+        raise RuntimeError("device still rebooting")
+
+    iface.connect = MagicMock(side_effect=_connect)
+
+    with caplog.at_level(logging.DEBUG):
+        main_module._post_factory_reset_ready_probe(cast(Any, iface))
+
+    assert "device is still rebooting" in caplog.text
+    assert "Traceback" not in caplog.text
+    assert not hasattr(iface, "_connect_wait_timeout_seconds")
+    assert not hasattr(iface, "_connect_retry_budget_seconds")
+    assert not hasattr(iface, "_suppress_connect_failure_logging")
     assert iface.close.call_count >= 2

--- a/meshtastic/tests/test_main_factory_reset.py
+++ b/meshtastic/tests/test_main_factory_reset.py
@@ -2,9 +2,9 @@
 
 # pylint: disable=C0302,W0613,R0917
 
+import logging
 import sys
 import threading
-import logging
 import time
 from types import SimpleNamespace
 from typing import Any, cast
@@ -55,6 +55,8 @@ def _mock_newer_version_check(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+
+
 @pytest.mark.parametrize(
     ("reset_flag", "expected_full"),
     [("--factory-reset", False), ("--factory-reset-device", True)],
@@ -430,3 +432,63 @@ def test_post_factory_reset_ready_probe_bounds_and_quiets_expected_failure(
     assert not hasattr(iface, "_connect_retry_budget_seconds")
     assert not hasattr(iface, "_suppress_connect_failure_logging")
     assert iface.close.call_count >= 2
+
+@pytest.mark.unit
+def test_temporary_instance_attributes_restores_existing_and_missing_values() -> None:
+    instance = SimpleNamespace(existing="before")
+
+    with main_module._temporary_instance_attributes(
+        instance, {"existing": "during", "temporary": 42}
+    ):
+        assert instance.existing == "during"
+        assert instance.temporary == 42
+
+    assert instance.existing == "before"
+    assert not hasattr(instance, "temporary")
+
+
+@pytest.mark.unit
+def test_temporary_instance_attributes_does_not_shadow_inherited_values() -> None:
+    class WithInheritedValue:
+        inherited = "class-value"
+
+    instance = WithInheritedValue()
+
+    with main_module._temporary_instance_attributes(
+        instance, {"inherited": "temporary"}
+    ):
+        assert instance.inherited == "temporary"
+        assert vars(instance)["inherited"] == "temporary"
+
+    assert instance.inherited == "class-value"
+    assert "inherited" not in vars(instance)
+
+
+@pytest.mark.unit
+def test_post_factory_reset_ready_probe_restores_existing_overrides() -> None:
+    iface = cast(Any, object.__new__(SerialInterface))
+    iface.close = MagicMock()
+    iface.connect = MagicMock()
+    iface._connect_wait_timeout_seconds = 11.0
+    iface._connect_retry_budget_seconds = 12.0
+    iface._suppress_connect_failure_logging = False
+
+    main_module._post_factory_reset_ready_probe(cast(Any, iface))
+
+    assert iface._connect_wait_timeout_seconds == 11.0
+    assert iface._connect_retry_budget_seconds == 12.0
+    assert iface._suppress_connect_failure_logging is False
+
+
+@pytest.mark.unit
+def test_post_factory_reset_ready_probe_logs_final_close_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    iface = cast(Any, object.__new__(SerialInterface))
+    iface.connect = MagicMock()
+    iface.close = MagicMock(side_effect=[None, RuntimeError("close failed")])
+
+    with caplog.at_level(logging.DEBUG):
+        main_module._post_factory_reset_ready_probe(cast(Any, iface))
+
+    assert "Factory reset: final serial close failed" in caplog.text

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -4833,3 +4833,23 @@ def test_queue_wait_abort_reason_allows_connected_interface() -> None:
     with MeshInterface(noProto=True) as iface:
         iface.isConnected.set()
         assert iface._queue_wait_abort_reason() is None
+
+
+@pytest.mark.unit
+def test_connection_probe_overrides_are_normalized() -> None:
+    iface = MeshInterface(noProto=True)
+    iface.__dict__["_probe_timeout"] = -2.5
+    assert iface._connection_timeout_override("_probe_timeout") == 0.0
+    iface.__dict__["_probe_timeout"] = True
+    assert iface._connection_timeout_override("_probe_timeout", 3.0) == 3.0
+    iface.__dict__["_probe_timeout"] = "invalid"
+    assert iface._connection_timeout_override("_probe_timeout") is None
+
+
+
+@pytest.mark.unit
+def test_connect_failure_log_level_respects_quiet_probe_mode() -> None:
+    iface = MeshInterface(noProto=True)
+    assert iface._connect_failure_log_level() == logging.ERROR
+    iface._suppress_connect_failure_logging = True
+    assert iface._connect_failure_log_level() == logging.DEBUG

--- a/meshtastic/tests/test_serial_interface.py
+++ b/meshtastic/tests/test_serial_interface.py
@@ -440,3 +440,31 @@ def test_port_existence_check_raises_for_missing_device(
     iface.devPath = "/dev/ttyUSB0"
     with pytest.raises(MeshInterface.MeshInterfaceError, match="does not exist"):
         iface._open_serial_stream()
+
+
+@pytest.mark.unit
+def test_serial_connect_logs_quietly_when_probe_retry_budget_is_exhausted(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    iface = object.__new__(SerialInterface)
+    iface.devPath = "/dev/ttyUSB0"
+    iface._dev_path_auto_detected = False
+    iface._connect_retry_budget_seconds = 0.0
+    iface._suppress_connect_failure_logging = True
+    stream = MagicMock()
+    stream.is_open = True
+    iface.stream = stream
+    iface._connect_lock = threading.Lock()
+    transient_error = MeshInterface.MeshInterfaceError(
+        "Connection lost while waiting for connection completion (stream.closed)"
+    )
+
+    with (
+        caplog.at_level(logging.DEBUG),
+        patch.object(StreamInterface, "connect", side_effect=transient_error),
+    ):
+        with pytest.raises(MeshInterface.MeshInterfaceError):
+            iface.connect()
+
+    assert "Serial connect retry budget exhausted" in caplog.text
+    assert not any(record.levelno >= logging.ERROR for record in caplog.records)

--- a/meshtastic/tests/test_stream_interface.py
+++ b/meshtastic/tests/test_stream_interface.py
@@ -669,3 +669,28 @@ def test_resolve_stable_path_finds_first_matching_alias() -> None:
         assert result == "/dev/serial/by-id/usb-bar-device"
     finally:
         iface.close()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_connect_uses_temporary_wait_timeout_override() -> None:
+    iface = StreamInterface(noProto=True, connectNow=False)
+    try:
+        iface._provides_own_stream = True  # type: ignore[attr-defined]
+        iface.stream = None
+        iface.noProto = False
+        iface._connect_wait_timeout_seconds = 1.25
+        iface._rxThread = MagicMock()
+        iface._rxThread.is_alive.return_value = False
+        iface._rxThread.ident = None
+        with (
+            patch.object(iface, "_start_config"),
+            patch.object(iface, "_wait_connected") as wait_connected,
+            patch.object(iface, "_resolve_stable_path", return_value=None),
+        ):
+            iface.connect()
+
+        wait_connected.assert_called_once_with(timeout=1.25)
+    finally:
+        iface.noProto = True
+        iface.close()


### PR DESCRIPTION
## Summary by Sourcery

Bound and quiet the post-factory-reset serial reconnect probe by temporarily overriding connection timeouts and logging behavior, ensuring the device can keep rebooting while the next command reconnects cleanly.

Bug Fixes:
- Prevent noisy error and traceback logging when the serial device is still rebooting after a factory reset by treating this as an expected condition.

Enhancements:
- Allow connect logic to accept per-call overrides for wait timeout, retry budget, and failure logging suppression, and use these to perform a short, non-intrusive readiness probe after factory reset.

Tests:
- Add unit coverage to verify the factory-reset reconnect probe respects overridden timeouts, suppresses traceback logging, restores interface attributes afterward, and still closes the port multiple times as expected.