### PR TITLE
Redact configure credentials and channel URLs

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1065,13 +1065,8 @@ def _display_pref_name(comp_name: str) -> str:
     )
 
 
-_SECRET_PREF_NAMES: frozenset[str] = frozenset(
+_SECRET_PREF_FIELDS: frozenset[str] = frozenset(
     {
-        "wifi_ssid",
-        "wifi_psk",
-        "username",
-        "password",
-        "fixed_pin",
         "psk",
         "channel_psk",
         "private_key",
@@ -1083,6 +1078,16 @@ _SECRET_PREF_NAMES: frozenset[str] = frozenset(
         "auth_token",
     }
 )
+_SECRET_PREF_PATHS: frozenset[str] = frozenset(
+    {
+        "network.wifi_ssid",
+        "network.wifi_psk",
+        "mqtt.username",
+        "mqtt.password",
+        "bluetooth.fixed_pin",
+        "security.session_passkey",
+    }
+)
 
 
 class _NamedConfigType(Protocol):
@@ -1092,8 +1097,12 @@ class _NamedConfigType(Protocol):
 
 
 def _redact_pref_value(name: str, value: str) -> str:
-    """Return a redacted placeholder for secret-bearing pref names."""
-    return "<redacted>" if name in _SECRET_PREF_NAMES else value
+    """Return a redacted placeholder for secret-bearing preference paths."""
+    normalized = _normalize_pref_name(name)
+    field_name = normalized.rsplit(".", maxsplit=1)[-1]
+    if normalized in _SECRET_PREF_PATHS or field_name in _SECRET_PREF_FIELDS:
+        return "<redacted>"
+    return value
 
 
 def getPref(node: Any, comp_name: str, *, allow_secrets: bool = False) -> bool:
@@ -1226,7 +1235,7 @@ def getPref(node: Any, comp_name: str, *, allow_secrets: bool = False) -> bool:
                 uni_name,
                 pref_value,
                 repeated=repeated,
-                secret_name=snake_name,
+                secret_name=f"{config_type.name}.{snake_name}",
             )
         else:
             for field in config_values.ListFields():
@@ -1236,7 +1245,7 @@ def getPref(node: Any, comp_name: str, *, allow_secrets: bool = False) -> bool:
                     field[0].name,
                     field[1],
                     repeated=repeated,
-                    secret_name=field[0].name,
+                    secret_name=f"{config_type.name}.{field[0].name}",
                 )
     else:
         # Always show whole field for remote node
@@ -1431,7 +1440,7 @@ def setPref(config: Any, comp_name: str, raw_val: Any) -> bool:
         val = meshtastic.util.fromStr(raw_val)
     else:
         val = raw_val
-    logger.debug("val:%s", _redact_pref_value(snake_name, meshtastic.util.toStr(val)))
+    logger.debug("val:%s", _redact_pref_value(comp_name, meshtastic.util.toStr(val)))
 
     if snake_name == "wifi_psk" and len(str(raw_val)) < 8:
         print("Warning: network.wifi_psk must be 8 or more characters.")
@@ -1480,7 +1489,7 @@ def setPref(config: Any, comp_name: str, raw_val: Any) -> bool:
             del getattr(config_values, pref.name)[:]
         else:
             display_value = _redact_pref_value(
-                snake_name, meshtastic.util.toStr(raw_val)
+                comp_name, meshtastic.util.toStr(raw_val)
             )
             _cli_print(f"Adding '{display_value}' to the {pref.name} list")
             cur_vals = [
@@ -1492,7 +1501,7 @@ def setPref(config: Any, comp_name: str, raw_val: Any) -> bool:
         return True
 
     prefix = f"{'.'.join(name[0:-1])}." if config_type.message_type is not None else ""
-    display_value = _redact_pref_value(snake_name, meshtastic.util.toStr(raw_val))
+    display_value = _redact_pref_value(comp_name, meshtastic.util.toStr(raw_val))
     _cli_print(f"Set {prefix}{uni_name} to {display_value}")
 
     return True
@@ -1599,6 +1608,33 @@ def _pace_configure_write(
     """Yield briefly between section writes while keeping transactions short."""
     if remaining_writes > 0:
         sleep_fn(CONFIG_WRITE_PACE_SECONDS)
+
+
+def _apply_configure_channel_url(
+    interface: MeshInterface,
+    raw_channel_url: Any,
+    *,
+    config_key: str,
+    node_dest: Any,
+    get_node_kwargs: dict[str, Any],
+) -> bool:
+    """Validate and apply one configured channel URL without exposing it."""
+    if not isinstance(raw_channel_url, str):
+        _cli_exit(f"ERROR: {config_key} must be a string.")
+    requested_channel_url = raw_channel_url.strip()
+    if not requested_channel_url:
+        _cli_exit(f"ERROR: {config_key} must not be blank.")
+
+    target_node = interface.getNode(node_dest, **get_node_kwargs)
+    if _channel_url_matches_current_device_state(target_node, requested_channel_url):
+        _cli_print("Channel url already matches device state; skipping apply.")
+        logger.info("Skipping setURL apply because channel URL already matches.")
+        return False
+
+    _cli_print("Setting channel url to <redacted>")
+    target_node.setURL(requested_channel_url)
+    time.sleep(CONFIG_SETURL_DELAY_SECONDS)
+    return True
 
 
 def _handle_configure_command(
@@ -1774,51 +1810,21 @@ def _handle_configure_command(
         )
         time.sleep(CONFIG_APPLY_DELAY_SECONDS)
 
-    if "channel_url" in configuration:
+    channel_url_key = (
+        "channel_url" if "channel_url" in configuration else "channelUrl"
+    )
+    if channel_url_key in configuration:
         if not phase1_started:
             _cli_print(CONFIGURE_PHASE1_HEADER)
             phase1_started = True
-        raw_channel_url = configuration["channel_url"]
-        if not isinstance(raw_channel_url, str):
-            _cli_exit("ERROR: channel_url must be a string.")
-        requested_channel_url = raw_channel_url.strip()
-        if not requested_channel_url:
-            _cli_exit("ERROR: channel_url must not be blank.")
-        target_node = interface.getNode(args.dest, **getNode_kwargs)
-        if _channel_url_matches_current_device_state(
-            target_node, requested_channel_url
-        ):
-            _cli_print("Channel url already matches device state; skipping apply.")
-            logger.info("Skipping setURL apply because channel URL already matches.")
-        else:
-            phase1_may_reconnect = True
-            seturl_executed = True
-            _cli_print("Setting channel url to <redacted>")
-            target_node.setURL(requested_channel_url)
-            time.sleep(CONFIG_SETURL_DELAY_SECONDS)
-
-    if "channelUrl" in configuration:
-        if not phase1_started:
-            _cli_print(CONFIGURE_PHASE1_HEADER)
-            phase1_started = True
-        raw_channel_url = configuration["channelUrl"]
-        if not isinstance(raw_channel_url, str):
-            _cli_exit("ERROR: channelUrl must be a string.")
-        requested_channel_url = raw_channel_url.strip()
-        if not requested_channel_url:
-            _cli_exit("ERROR: channelUrl must not be blank.")
-        target_node = interface.getNode(args.dest, **getNode_kwargs)
-        if _channel_url_matches_current_device_state(
-            target_node, requested_channel_url
-        ):
-            _cli_print("Channel url already matches device state; skipping apply.")
-            logger.info("Skipping setURL apply because channel URL already matches.")
-        else:
-            phase1_may_reconnect = True
-            seturl_executed = True
-            _cli_print("Setting channel url to <redacted>")
-            target_node.setURL(requested_channel_url)
-            time.sleep(CONFIG_SETURL_DELAY_SECONDS)
+        seturl_executed = _apply_configure_channel_url(
+            interface,
+            configuration[channel_url_key],
+            config_key=channel_url_key,
+            node_dest=args.dest,
+            get_node_kwargs=getNode_kwargs,
+        )
+        phase1_may_reconnect = seturl_executed
 
     if phase1_started:
         _cli_print("Phase 1 complete.")

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1067,12 +1067,17 @@ def _display_pref_name(comp_name: str) -> str:
 
 _SECRET_PREF_NAMES: frozenset[str] = frozenset(
     {
+        "wifi_ssid",
         "wifi_psk",
+        "username",
+        "password",
+        "fixed_pin",
         "psk",
         "channel_psk",
         "private_key",
         "public_key",
         "admin_key",
+        "session_passkey",
         "secret",
         "api_key",
         "auth_token",
@@ -1788,7 +1793,7 @@ def _handle_configure_command(
         else:
             phase1_may_reconnect = True
             seturl_executed = True
-            _cli_print(f"Setting channel url to {requested_channel_url}")
+            _cli_print("Setting channel url to <redacted>")
             target_node.setURL(requested_channel_url)
             time.sleep(CONFIG_SETURL_DELAY_SECONDS)
 
@@ -1811,7 +1816,7 @@ def _handle_configure_command(
         else:
             phase1_may_reconnect = True
             seturl_executed = True
-            _cli_print(f"Setting channel url to {requested_channel_url}")
+            _cli_print("Setting channel url to <redacted>")
             target_node.setURL(requested_channel_url)
             time.sleep(CONFIG_SETURL_DELAY_SECONDS)
 

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -6323,3 +6323,37 @@ def test_resolve_pref_accepts_nested_message_field() -> None:
         config,
         "meshBeacon.broadcastOfferChannel.psk",
     )
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_set_pref_redacts_network_mqtt_and_pin_credentials(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Configure progress output must not disclose local network or broker credentials."""
+    local_config = localonly_pb2.LocalConfig()
+    module_config = localonly_pb2.LocalModuleConfig()
+
+    assert setPref(local_config, "network.wifi_ssid", "Private LAN") is True
+    assert setPref(local_config, "network.wifi_psk", "distinctive-passphrase") is True
+    assert setPref(local_config, "bluetooth.fixed_pin", "123456") is True
+    assert setPref(module_config, "mqtt.username", "private-user") is True
+    assert setPref(module_config, "mqtt.password", "private-password") is True
+
+    out, err = capsys.readouterr()
+    assert out.count("<redacted>") == 5
+    for secret in (
+        "Private LAN",
+        "distinctive-passphrase",
+        "123456",
+        "private-user",
+        "private-password",
+    ):
+        assert secret not in out
+    assert local_config.network.wifi_ssid == "Private LAN"
+    assert local_config.network.wifi_psk == "distinctive-passphrase"
+    assert local_config.bluetooth.fixed_pin == 123456
+    assert module_config.mqtt.username == "private-user"
+    assert module_config.mqtt.password == "private-password"
+    assert err == ""
+

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -1735,7 +1735,7 @@ def test_main_set_valid(
             main()
             out, err = capsys.readouterr()
             assert re.search(r"Connected to radio", out, re.MULTILINE)
-            assert re.search(r"Set network.wifi_ssid to foo", out, re.MULTILINE)
+            assert re.search(r"Set network.wifi_ssid to <redacted>", out, re.MULTILINE)
             assert err == ""
             mo.assert_called()
 
@@ -2024,7 +2024,7 @@ def test_main_set_valid_camel_case(
             main()
             out, err = capsys.readouterr()
             assert re.search(r"Connected to radio", out, re.MULTILINE)
-            assert re.search(r"Set network.wifiSsid to foo", out, re.MULTILINE)
+            assert re.search(r"Set network.wifiSsid to <redacted>", out, re.MULTILINE)
             assert err == ""
             mo.assert_called()
 
@@ -6357,3 +6357,97 @@ def test_set_pref_redacts_network_mqtt_and_pin_credentials(
     assert module_config.mqtt.password == "private-password"
     assert err == ""
 
+
+@pytest.mark.unit
+def test_secret_redaction_is_scoped_to_sensitive_preference_paths() -> None:
+    assert main_module._redact_pref_value("mqtt.username", "alice") == "<redacted>"
+    assert main_module._redact_pref_value("unrelated.username", "alice") == "alice"
+    assert main_module._redact_pref_value("unrelated.password", "visible") == "visible"
+
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [(123, "must be a string"), ("   ", "must not be blank")],
+)
+def test_apply_configure_channel_url_rejects_invalid_values(
+    value: object,
+    message: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    interface = MagicMock()
+
+    with pytest.raises(SystemExit) as excinfo:
+        main_module._apply_configure_channel_url(
+            interface,
+            value,
+            config_key="channel_url",
+            node_dest=None,
+            get_node_kwargs={},
+        )
+
+    assert excinfo.value.code == 1
+    assert message in capsys.readouterr().err
+    interface.getNode.assert_not_called()
+
+
+
+@pytest.mark.unit
+def test_apply_configure_channel_url_skips_matching_state(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    interface = MagicMock()
+    target_node = interface.getNode.return_value
+    monkeypatch.setattr(
+        main_module,
+        "_channel_url_matches_current_device_state",
+        lambda _node, _url: True,
+    )
+
+    applied = main_module._apply_configure_channel_url(
+        interface,
+        " https://meshtastic.org/e/#CgYSAQABAA ",
+        config_key="channelUrl",
+        node_dest=123,
+        get_node_kwargs={"wantResponse": True},
+    )
+
+    assert applied is False
+    interface.getNode.assert_called_once_with(123, wantResponse=True)
+    target_node.setURL.assert_not_called()
+    assert "already matches" in capsys.readouterr().out
+
+
+
+@pytest.mark.unit
+def test_apply_configure_channel_url_redacts_and_applies(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    interface = MagicMock()
+    target_node = interface.getNode.return_value
+    sleep = MagicMock()
+    monkeypatch.setattr(
+        main_module,
+        "_channel_url_matches_current_device_state",
+        lambda _node, _url: False,
+    )
+    monkeypatch.setattr(main_module.time, "sleep", sleep)
+    channel_url = "https://meshtastic.org/e/#sensitive"
+
+    applied = main_module._apply_configure_channel_url(
+        interface,
+        channel_url,
+        config_key="channel_url",
+        node_dest=None,
+        get_node_kwargs={},
+    )
+
+    assert applied is True
+    target_node.setURL.assert_called_once_with(channel_url)
+    sleep.assert_called_once_with(main_module.CONFIG_SETURL_DELAY_SECONDS)
+    output = capsys.readouterr().out
+    assert "<redacted>" in output
+    assert channel_url not in output

--- a/meshtastic/tests/test_main_configure_reconnect.py
+++ b/meshtastic/tests/test_main_configure_reconnect.py
@@ -394,3 +394,31 @@ def test_post_seturl_stability_check_triggers_reconnect_when_disconnected(
     )
     iface.connect.assert_called()
     iface.waitForConfig.assert_called_once()
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_configure_redacts_channel_url_progress_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Channel URLs contain channel keys and must not be echoed while applying YAML."""
+    secret_url = "https://meshtastic.org/e/#distinctive-channel-key"
+    config_path = tmp_path / "channel.yaml"
+    config_path.write_text(yaml.safe_dump({"channel_url": secret_url}), encoding="utf-8")
+    target_node = MagicMock()
+    target_node.getURL.return_value = "https://meshtastic.org/e/#old-key"
+    iface = MagicMock()
+    iface.getNode.return_value = target_node
+    iface.localNode = target_node
+    args = SimpleNamespace(configure=[str(config_path)], dest=main_module.LOCAL_ADDR)
+    monkeypatch.setattr(main_module.time, "sleep", lambda _seconds: None)
+
+    main_module._handle_configure_command(iface, args, {})
+
+    out, err = capsys.readouterr()
+    target_node.setURL.assert_called_once_with(secret_url)
+    assert "Setting channel url to <redacted>" in out
+    assert secret_url not in out
+    assert "distinctive-channel-key" not in out
+    assert err == ""


### PR DESCRIPTION
## Summary by Sourcery

Redact sensitive credentials and channel URLs from CLI progress output when configuring devices.

Enhancements:
- Extend the set of preference names treated as secrets to include Wi-Fi SSID, MQTT usernames/passwords, Bluetooth PINs, and session passkeys.
- Suppress printing the actual channel URL in configure progress messages, replacing it with a redacted placeholder.

Tests:
- Add unit tests to verify that setting secret preferences does not echo their values and that channel URL configuration output is properly redacted.