### PR TITLE
Pace configure section writes to avoid TX queue stalls

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -16,6 +16,7 @@ import platform
 import sys
 import threading
 import time
+from collections.abc import Callable
 from types import ModuleType
 from typing import Any, NoReturn, Protocol, cast
 
@@ -181,6 +182,8 @@ BITFIELD_ENUMS = {
 
 # Delay after applying configuration changes (owner, channel, etc.)
 CONFIG_APPLY_DELAY_SECONDS = 0.5
+CONFIG_WRITE_PACE_SECONDS = 0.1
+"""Short inter-write cadence that drains transport queues without stretching transactions."""
 
 # Delay after setURL operations, which write up to 8 channel snapshots
 # plus LoRa config; the device needs extra time to commit all changes
@@ -1571,6 +1574,16 @@ def _handle_set_command(
         printConfig(node.moduleConfig)
 
 
+def _pace_configure_write(
+    remaining_writes: int,
+    *,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> None:
+    """Yield briefly between section writes while keeping transactions short."""
+    if remaining_writes > 0:
+        sleep_fn(CONFIG_WRITE_PACE_SECONDS)
+
+
 def _handle_configure_command(
     interface: MeshInterface,
     args: Any,
@@ -1819,6 +1832,10 @@ def _handle_configure_command(
         interface.getNode(args.dest, False, **getNode_kwargs).beginSettingsTransaction()
         settings_transaction_started = True
 
+    remaining_config_writes = len(validated_config_sections) + len(
+        validated_module_config_sections
+    )
+
     if validated_config_sections:
         localConfig = interface.getNode(args.dest, **getNode_kwargs).localConfig
         for section, section_values in validated_config_sections.items():
@@ -1843,7 +1860,8 @@ def _handle_configure_command(
             interface.getNode(args.dest, **getNode_kwargs).writeConfig(
                 meshtastic.util.camel_to_snake(section)
             )
-            time.sleep(CONFIG_APPLY_DELAY_SECONDS)
+            remaining_config_writes -= 1
+            _pace_configure_write(remaining_config_writes)
 
     if validated_module_config_sections:
         moduleConfig = interface.getNode(args.dest, **getNode_kwargs).moduleConfig
@@ -1869,7 +1887,8 @@ def _handle_configure_command(
             interface.getNode(args.dest, **getNode_kwargs).writeConfig(
                 meshtastic.util.camel_to_snake(section)
             )
-            time.sleep(CONFIG_APPLY_DELAY_SECONDS)
+            remaining_config_writes -= 1
+            _pace_configure_write(remaining_config_writes)
 
     if settings_transaction_started:
         interface.getNode(

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1843,7 +1843,7 @@ def _handle_configure_command(
             interface.getNode(args.dest, **getNode_kwargs).writeConfig(
                 meshtastic.util.camel_to_snake(section)
             )
-        time.sleep(CONFIG_APPLY_DELAY_SECONDS)
+            time.sleep(CONFIG_APPLY_DELAY_SECONDS)
 
     if validated_module_config_sections:
         moduleConfig = interface.getNode(args.dest, **getNode_kwargs).moduleConfig
@@ -1869,7 +1869,7 @@ def _handle_configure_command(
             interface.getNode(args.dest, **getNode_kwargs).writeConfig(
                 meshtastic.util.camel_to_snake(section)
             )
-        time.sleep(CONFIG_APPLY_DELAY_SECONDS)
+            time.sleep(CONFIG_APPLY_DELAY_SECONDS)
 
     if settings_transaction_started:
         interface.getNode(

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -2209,11 +2209,11 @@ def test_main_configure_skips_unknown_config_field(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-def test_configure_paces_each_local_config_write(
+def test_configure_paces_between_section_writes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Avoid filling the firmware TX queue with a burst of section writes."""
+    """Pace a write burst without delaying after the final section."""
     config_path = tmp_path / "paced_config.yaml"
     config_path.write_text(
         yaml.safe_dump(
@@ -2240,27 +2240,39 @@ def test_configure_paces_each_local_config_write(
 
     target_node.writeConfig.side_effect = _write_config
     monkeypatch.setattr(
-        "time.sleep", lambda seconds: events.append(("sleep", seconds))
+        main_module,
+        "_pace_configure_write",
+        lambda remaining: events.append(("pace", remaining)) if remaining else None,
     )
-    monkeypatch.setattr(
-        "meshtastic.__main__._post_configure_reconnect_and_verify",
-        lambda *_args, **_kwargs: main_module._ConfigureReconnectResult.VERIFIED,
+    args = SimpleNamespace(
+        configure=[str(config_path)],
+        dest="!12345678",
     )
-    sys.argv = ["", "--configure", str(config_path)]
-    mt_config.args = cast(Any, sys.argv)
 
-    with patch("meshtastic.serial_interface.SerialInterface", return_value=iface):
-        main()
+    main_module._handle_configure_command(iface, args, {})
 
-    write_indices = [index for index, event in enumerate(events) if event[0] == "write"]
-    assert [events[index][1] for index in write_indices] == [
-        "bluetooth",
-        "display",
-        "ambient_lighting",
-        "mqtt",
+    assert events == [
+        ("write", "bluetooth"),
+        ("pace", 3),
+        ("write", "display"),
+        ("pace", 2),
+        ("write", "ambient_lighting"),
+        ("pace", 1),
+        ("write", "mqtt"),
     ]
-    for index in write_indices:
-        assert events[index + 1] == ("sleep", main_module.CONFIG_APPLY_DELAY_SECONDS)
+    target_node.commitSettingsTransaction.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_configure_write_pacer_uses_short_dedicated_delay() -> None:
+    sleep = MagicMock()
+
+    main_module._pace_configure_write(1, sleep_fn=sleep)
+    main_module._pace_configure_write(0, sleep_fn=sleep)
+
+    sleep.assert_called_once()
+    delay = sleep.call_args.args[0]
+    assert 0 < delay < main_module.CONFIG_APPLY_DELAY_SECONDS
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -2209,6 +2209,62 @@ def test_main_configure_skips_unknown_config_field(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+def test_configure_paces_each_local_config_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Avoid filling the firmware TX queue with a burst of section writes."""
+    config_path = tmp_path / "paced_config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "config": {
+                    "bluetooth": {"enabled": True},
+                    "display": {"screen_on_secs": 30},
+                },
+                "module_config": {
+                    "ambient_lighting": {"current": 5},
+                    "mqtt": {"enabled": True},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    iface, target_node = _build_configure_interface()
+    events: list[tuple[str, object]] = []
+    original_write = target_node.writeConfig.side_effect
+
+    def _write_config(section: str) -> None:
+        events.append(("write", section))
+        original_write(section)
+
+    target_node.writeConfig.side_effect = _write_config
+    monkeypatch.setattr(
+        "time.sleep", lambda seconds: events.append(("sleep", seconds))
+    )
+    monkeypatch.setattr(
+        "meshtastic.__main__._post_configure_reconnect_and_verify",
+        lambda *_args, **_kwargs: main_module._ConfigureReconnectResult.VERIFIED,
+    )
+    sys.argv = ["", "--configure", str(config_path)]
+    mt_config.args = cast(Any, sys.argv)
+
+    with patch("meshtastic.serial_interface.SerialInterface", return_value=iface):
+        main()
+
+    write_indices = [index for index, event in enumerate(events) if event[0] == "write"]
+    assert [events[index][1] for index in write_indices] == [
+        "bluetooth",
+        "display",
+        "ambient_lighting",
+        "mqtt",
+    ]
+    for index in write_indices:
+        assert events[index + 1] == ("sleep", main_module.CONFIG_APPLY_DELAY_SECONDS)
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
 def test_main_configure_rejects_invalid_enum_value(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary by Sourcery

Pace configuration section writes by inserting a delay after each individual config write to prevent firmware TX queue stalls during bulk configuration.

Enhancements:
- Adjust configuration handling to sleep after each section write rather than after the loop, spacing out config updates to the node.

Tests:
- Add a unit test that verifies local configuration writes occur in the expected order and that each write is followed by the configured apply delay.