### PR TITLE
Bound transmit queue waits and abort on disconnect

### DIFF
--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -11,7 +11,7 @@ import threading
 import time
 import traceback
 from types import MappingProxyType, TracebackType
-from typing import IO, Any, Callable, Mapping, TypeAlias, cast
+from typing import IO, Any, Callable, ClassVar, Mapping, TypeAlias, cast
 
 try:
     import print_color  # type: ignore[import-untyped]
@@ -33,6 +33,7 @@ from meshtastic.mesh_interface_runtime.flows import (
 )
 from meshtastic.mesh_interface_runtime.node_view import NodeView
 from meshtastic.mesh_interface_runtime.queue_send import (
+    QUEUE_WAIT_TIMEOUT_SECONDS,
     QueueWaitError,
     _QueueSendRuntime,
 )
@@ -255,6 +256,9 @@ class MeshInterface:  # pylint: disable=R0902
     debugOut
     """
 
+    _queue_wait_timeout_seconds: ClassVar[float] = QUEUE_WAIT_TIMEOUT_SECONDS
+    _last_disconnect_source: str | None
+
     class MeshInterfaceError(Exception):
         """An exception class for general mesh interface errors."""
 
@@ -385,6 +389,7 @@ class MeshInterface:  # pylint: disable=R0902
             get_queue_status=lambda: self.queueStatus,
             set_queue_status=self._set_queue_status,
             queue_wait_delay_seconds=QUEUE_WAIT_DELAY_SECONDS,
+            queue_wait_timeout_seconds=self._queue_wait_timeout_seconds,
             abort_wait=self._queue_wait_abort_reason,
         )
         self._from_radio_dispatch_map_cache: (

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -32,7 +32,10 @@ from meshtastic.mesh_interface_runtime.flows import (
     TelemetryType,
 )
 from meshtastic.mesh_interface_runtime.node_view import NodeView
-from meshtastic.mesh_interface_runtime.queue_send import _QueueSendRuntime
+from meshtastic.mesh_interface_runtime.queue_send import (
+    QueueWaitError,
+    _QueueSendRuntime,
+)
 from meshtastic.mesh_interface_runtime.receive_pipeline import (
     ReceivePipeline,
     _FromRadioContext,
@@ -382,6 +385,7 @@ class MeshInterface:  # pylint: disable=R0902
             get_queue_status=lambda: self.queueStatus,
             set_queue_status=self._set_queue_status,
             queue_wait_delay_seconds=QUEUE_WAIT_DELAY_SECONDS,
+            abort_wait=self._queue_wait_abort_reason,
         )
         self._from_radio_dispatch_map_cache: (
             dict[str, Callable[[_FromRadioContext], list[_PublicationIntent]]] | None
@@ -395,6 +399,17 @@ class MeshInterface:  # pylint: disable=R0902
         # for any external consumers of the library.
         if debugOut:
             pub.subscribe(MeshInterface._print_log_line, "meshtastic.log.line")
+
+    def _queue_wait_abort_reason(self) -> str | None:
+        """Return why a blocked TX-queue wait can no longer make progress."""
+        if self.failure is not None:
+            return f"interface failure: {self.failure}"
+        if self._closing:
+            return "interface is closing"
+        disconnect_source = getattr(self, "_last_disconnect_source", None)
+        if disconnect_source and not self.isConnected.is_set():
+            return f"interface disconnected ({disconnect_source})"
+        return None
 
     def _set_queue_status(self, queue_status: mesh_pb2.QueueStatus | None) -> None:
         """Set the queueStatus attribute directly."""
@@ -1685,11 +1700,14 @@ class MeshInterface:  # pylint: disable=R0902
             )
             return
 
-        self._queue_send_runtime._send_to_radio(
-            toRadio,
-            send_impl=self._send_to_radio_impl,
-            sleep_fn=time.sleep,
-        )
+        try:
+            self._queue_send_runtime._send_to_radio(
+                toRadio,
+                send_impl=self._send_to_radio_impl,
+                sleep_fn=time.sleep,
+            )
+        except QueueWaitError as exc:
+            raise MeshInterface.MeshInterfaceError(str(exc)) from exc
 
     def _send_to_radio_impl(self, toRadio: mesh_pb2.ToRadio) -> None:
         """Transport hook that delivers a ToRadio protobuf to the radio device.

--- a/meshtastic/mesh_interface_runtime/queue_send.py
+++ b/meshtastic/mesh_interface_runtime/queue_send.py
@@ -113,13 +113,11 @@ class _QueueSendRuntime:
 
         resent_queue: OrderedDict[int, mesh_pb2.ToRadio | bool] = OrderedDict()
         sent_packet_ids: set[int] = set()
-        wait_started: float | None = None
+        wait_deadline: float | None = None
 
         def _drop_unsent_incoming() -> None:
             with self._lock:
-                queue = self._get_queue()
-                if queue.get(to_radio.packet.id) is to_radio:
-                    queue.pop(to_radio.packet.id, None)
+                self._get_queue().pop(to_radio.packet.id, None)
 
         try:
             while True:
@@ -138,9 +136,9 @@ class _QueueSendRuntime:
                         )
 
                     now = time.monotonic()
-                    if wait_started is None:
-                        wait_started = now
-                    elif now - wait_started >= self._queue_wait_timeout_seconds:
+                    if wait_deadline is None:
+                        wait_deadline = now + self._queue_wait_timeout_seconds
+                    if now >= wait_deadline:
                         _drop_unsent_incoming()
                         raise QueueWaitError(
                             "Timed out waiting for free space in TX queue "
@@ -151,7 +149,7 @@ class _QueueSendRuntime:
                     sleep_fn(self._queue_wait_delay_seconds)
                     continue
 
-                wait_started = None
+                wait_deadline = None
 
                 packet_id, packet = to_resend
                 resent_queue[packet_id] = packet

--- a/meshtastic/mesh_interface_runtime/queue_send.py
+++ b/meshtastic/mesh_interface_runtime/queue_send.py
@@ -16,7 +16,12 @@ from meshtastic.protobuf import mesh_pb2
 logger = logging.getLogger(__name__)
 
 QUEUE_WAIT_DELAY_SECONDS: float = 0.5
+QUEUE_WAIT_TIMEOUT_SECONDS: float = 30.0
 AWAITING_QUEUE_STATUS_TTL_SECONDS: float = 300.0
+
+
+class QueueWaitError(TimeoutError):
+    """Raised when a packet cannot make progress through the firmware TX queue."""
 
 
 class _QueueSendRuntime:
@@ -30,12 +35,16 @@ class _QueueSendRuntime:
         get_queue_status: Callable[[], mesh_pb2.QueueStatus | None],
         set_queue_status: Callable[[mesh_pb2.QueueStatus], None],
         queue_wait_delay_seconds: float,
+        queue_wait_timeout_seconds: float = QUEUE_WAIT_TIMEOUT_SECONDS,
+        abort_wait: Callable[[], str | None] | None = None,
     ) -> None:
         self._lock = lock
         self._get_queue = get_queue
         self._get_queue_status = get_queue_status
         self._set_queue_status = set_queue_status
         self._queue_wait_delay_seconds = queue_wait_delay_seconds
+        self._queue_wait_timeout_seconds = max(0.0, queue_wait_timeout_seconds)
+        self._abort_wait = abort_wait
         self._awaiting_queue_status_ids: dict[int, float] = {}
         self._queue_status_seen = False
 
@@ -104,6 +113,14 @@ class _QueueSendRuntime:
 
         resent_queue: OrderedDict[int, mesh_pb2.ToRadio | bool] = OrderedDict()
         sent_packet_ids: set[int] = set()
+        wait_started: float | None = None
+
+        def _drop_unsent_incoming() -> None:
+            with self._lock:
+                queue = self._get_queue()
+                if queue.get(to_radio.packet.id) is to_radio:
+                    queue.pop(to_radio.packet.id, None)
+
         try:
             while True:
                 to_resend = self._pop_for_send()
@@ -112,9 +129,29 @@ class _QueueSendRuntime:
                         queue_has_items = bool(self._get_queue())
                     if not queue_has_items:
                         break
+
+                    abort_reason = self._abort_wait() if self._abort_wait else None
+                    if abort_reason:
+                        _drop_unsent_incoming()
+                        raise QueueWaitError(
+                            f"Stopped waiting for free space in TX queue: {abort_reason}"
+                        )
+
+                    now = time.monotonic()
+                    if wait_started is None:
+                        wait_started = now
+                    elif now - wait_started >= self._queue_wait_timeout_seconds:
+                        _drop_unsent_incoming()
+                        raise QueueWaitError(
+                            "Timed out waiting for free space in TX queue "
+                            f"after {self._queue_wait_timeout_seconds:.1f}s"
+                        )
+
                     logger.debug("Waiting for free space in TX Queue")
                     sleep_fn(self._queue_wait_delay_seconds)
                     continue
+
+                wait_started = None
 
                 packet_id, packet = to_resend
                 resent_queue[packet_id] = packet

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -4776,3 +4776,22 @@ def test_mesh_interface_mqtt_proxy_delegates_to_send_pipeline() -> None:
             {},
         )
     ]
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_send_to_radio_reports_disconnected_queue_wait_as_interface_error() -> None:
+    """A stale full queue after disconnect must fail rather than sleep forever."""
+    with MeshInterface(noProto=True) as iface:
+        iface.noProto = False
+        iface.queueStatus = mesh_pb2.QueueStatus(free=0, maxlen=16)
+        iface._last_disconnect_source = "stream.closed"
+        packet = mesh_pb2.ToRadio()
+        packet.packet.id = 903
+
+        with pytest.raises(
+            MeshInterface.MeshInterfaceError,
+            match=r"interface disconnected \(stream.closed\)",
+        ):
+            iface._send_to_radio(packet)
+
+        assert 903 not in iface.queue

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -497,6 +497,8 @@ def test_getNode_not_local(caplog: pytest.LogCaptureFixture) -> None:
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+
+
 @pytest.mark.parametrize("request_channel_attempts", [None, 2])
 def test_getNode_not_local_timeout(
     caplog: pytest.LogCaptureFixture,
@@ -633,6 +635,8 @@ def test_close_waits_for_inflight_heartbeat_send(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+
+
 @pytest.mark.parametrize(
     "disconnect_error",
     [
@@ -1229,6 +1233,8 @@ def test_sendPacket_uses_numeric_num_from_node_record(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+
+
 @pytest.mark.parametrize(
     ("destination_id", "expected_num"),
     [
@@ -1252,6 +1258,8 @@ def test_sendPacket_parses_supported_hex_node_id_forms(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+
+
 @pytest.mark.parametrize("destination_id", ["nothexid", "nothexid1"])
 def test_sendPacket_with_non_hex_long_destination_falls_back_to_db_lookup(
     iface_with_nodes: MeshInterface,
@@ -2788,6 +2796,8 @@ def test_on_response_waypoint_paths(caplog: pytest.LogCaptureFixture) -> None:
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+
+
 @pytest.mark.parametrize(
     ("handler_name", "waiter_name", "port_name", "error_prefix"),
     [
@@ -4795,3 +4805,31 @@ def test_send_to_radio_reports_disconnected_queue_wait_as_interface_error() -> N
             iface._send_to_radio(packet)
 
         assert 903 not in iface.queue
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_queue_wait_abort_reason_reports_failure_and_closing() -> None:
+    with MeshInterface(noProto=True) as iface:
+        iface.failure = RuntimeError("serial failed")
+        assert iface._queue_wait_abort_reason() == "interface failure: serial failed"
+        iface.failure = None
+        iface._closing = True
+        assert iface._queue_wait_abort_reason() == "interface is closing"
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_queue_wait_timeout_can_be_overridden_by_transport_subclass() -> None:
+    class FastFailInterface(MeshInterface):
+        _queue_wait_timeout_seconds = 1.25
+
+    with FastFailInterface(noProto=True) as iface:
+        assert iface._queue_send_runtime._queue_wait_timeout_seconds == 1.25
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_queue_wait_abort_reason_allows_connected_interface() -> None:
+    with MeshInterface(noProto=True) as iface:
+        iface.isConnected.set()
+        assert iface._queue_wait_abort_reason() is None

--- a/meshtastic/tests/test_mesh_interface_queue_send_runtime.py
+++ b/meshtastic/tests/test_mesh_interface_queue_send_runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import collections
 import threading
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -477,3 +478,87 @@ def test_send_to_radio_aborts_queue_wait_when_transport_is_gone() -> None:
         )
 
     assert 902 not in harness.queue
+
+
+@pytest.mark.unit
+def test_queue_wait_timeout_zero_fails_without_sleep() -> None:
+    harness = _QueueHarness()
+    harness.queue_status = mesh_pb2.QueueStatus(free=0, maxlen=16)
+    runtime = _QueueSendRuntime(
+        lock=harness.lock,
+        get_queue=lambda: harness.queue,
+        get_queue_status=lambda: harness.queue_status,
+        set_queue_status=harness.set_queue_status,
+        queue_wait_delay_seconds=1.0,
+        queue_wait_timeout_seconds=0.0,
+    )
+    packet = mesh_pb2.ToRadio()
+    packet.packet.id = 904
+    sleep = MagicMock()
+
+    with pytest.raises(queue_send_module.QueueWaitError, match="after 0.0s"):
+        runtime._send_to_radio(packet, send_impl=MagicMock(), sleep_fn=sleep)
+
+    sleep.assert_not_called()
+    assert 904 not in harness.queue
+
+
+@pytest.mark.unit
+def test_queue_wait_failure_drops_equivalent_packet_instance_by_id() -> None:
+    harness = _QueueHarness()
+    harness.queue_status = mesh_pb2.QueueStatus(free=0, maxlen=16)
+    packet = mesh_pb2.ToRadio()
+    packet.packet.id = 905
+
+    def replace_then_abort() -> str:
+        replacement = mesh_pb2.ToRadio()
+        replacement.CopyFrom(packet)
+        harness.queue[packet.packet.id] = replacement
+        return "closed"
+
+    runtime = _QueueSendRuntime(
+        lock=harness.lock,
+        get_queue=lambda: harness.queue,
+        get_queue_status=lambda: harness.queue_status,
+        set_queue_status=harness.set_queue_status,
+        queue_wait_delay_seconds=0.0,
+        abort_wait=replace_then_abort,
+    )
+
+    with pytest.raises(queue_send_module.QueueWaitError, match="closed"):
+        runtime._send_to_radio(
+            packet,
+            send_impl=MagicMock(),
+            sleep_fn=MagicMock(),
+        )
+
+    assert 905 not in harness.queue
+
+
+@pytest.mark.unit
+def test_queue_wait_resumes_when_firmware_reports_space() -> None:
+    harness = _QueueHarness()
+    harness.queue_status = mesh_pb2.QueueStatus(free=0, maxlen=16)
+    runtime = _QueueSendRuntime(
+        lock=harness.lock,
+        get_queue=lambda: harness.queue,
+        get_queue_status=lambda: harness.queue_status,
+        set_queue_status=harness.set_queue_status,
+        queue_wait_delay_seconds=0.0,
+        queue_wait_timeout_seconds=1.0,
+    )
+    packet = mesh_pb2.ToRadio()
+    packet.packet.id = 906
+    sent: list[int] = []
+
+    def release_queue(_seconds: float) -> None:
+        assert harness.queue_status is not None
+        harness.queue_status.free = 1
+
+    runtime._send_to_radio(
+        packet,
+        send_impl=lambda message: sent.append(message.packet.id),
+        sleep_fn=release_queue,
+    )
+
+    assert sent == [906]

--- a/meshtastic/tests/test_mesh_interface_queue_send_runtime.py
+++ b/meshtastic/tests/test_mesh_interface_queue_send_runtime.py
@@ -413,3 +413,67 @@ def test_send_to_radio_uses_runtime_pop_method(
     )
 
     assert sent == [123, 456]
+
+@pytest.mark.unit
+def test_send_to_radio_times_out_when_queue_status_never_recovers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    harness = _QueueHarness()
+    status = mesh_pb2.QueueStatus(free=0, maxlen=16)
+    harness.queue_status = status
+    runtime = _QueueSendRuntime(
+        lock=harness.lock,
+        get_queue=lambda: harness.queue,
+        get_queue_status=lambda: harness.queue_status,
+        set_queue_status=harness.set_queue_status,
+        queue_wait_delay_seconds=0.0,
+        queue_wait_timeout_seconds=1.0,
+    )
+    packet = mesh_pb2.ToRadio()
+    packet.packet.id = 901
+    monotonic_values = iter((10.0, 11.1))
+    monkeypatch.setattr(
+        queue_send_module.time,
+        "monotonic",
+        lambda: next(monotonic_values),
+    )
+
+    with pytest.raises(
+        queue_send_module.QueueWaitError,
+        match="Timed out waiting for free space in TX queue after 1.0s",
+    ):
+        runtime._send_to_radio(
+            packet,
+            send_impl=lambda _message: None,
+            sleep_fn=lambda _seconds: None,
+        )
+
+    assert 901 not in harness.queue
+
+
+@pytest.mark.unit
+def test_send_to_radio_aborts_queue_wait_when_transport_is_gone() -> None:
+    harness = _QueueHarness()
+    harness.queue_status = mesh_pb2.QueueStatus(free=0, maxlen=16)
+    runtime = _QueueSendRuntime(
+        lock=harness.lock,
+        get_queue=lambda: harness.queue,
+        get_queue_status=lambda: harness.queue_status,
+        set_queue_status=harness.set_queue_status,
+        queue_wait_delay_seconds=0.0,
+        abort_wait=lambda: "interface disconnected (stream.closed)",
+    )
+    packet = mesh_pb2.ToRadio()
+    packet.packet.id = 902
+
+    with pytest.raises(
+        queue_send_module.QueueWaitError,
+        match=r"Stopped waiting.*interface disconnected \(stream.closed\)",
+    ):
+        runtime._send_to_radio(
+            packet,
+            send_impl=lambda _message: None,
+            sleep_fn=lambda _seconds: None,
+        )
+
+    assert 902 not in harness.queue


### PR DESCRIPTION
## Summary by Sourcery

Bound TX queue waits so they time out and abort cleanly when the interface is disconnected or failing, and propagate a clear error to callers.

Bug Fixes:
- Prevent send operations from sleeping indefinitely when the firmware TX queue remains full after a disconnect or interface failure.

Enhancements:
- Introduce a configurable TX queue wait timeout and an abort hook that drops the unsent packet and raises a specific QueueWaitError when progress is no longer possible.
- Translate QueueWaitError from the queue runtime into MeshInterfaceError in MeshInterface._send_to_radio for clearer, user-facing error reporting.

Tests:
- Add unit tests covering TX queue wait timeout behavior, abort-on-disconnect behavior in the queue runtime, and propagation of the error through MeshInterface._send_to_radio.