### PR TITLE
Round-trip all protobuf bytes fields in config exports

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -17,12 +17,13 @@ import platform
 import sys
 import threading
 import time
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Sequence
 from types import ModuleType
 from typing import Any, NoReturn, Protocol, cast
 
 import yaml
 from google.protobuf.descriptor import FieldDescriptor
+from google.protobuf.message import Message
 from google.protobuf.json_format import MessageToDict
 from pubsub import pub
 
@@ -1163,6 +1164,14 @@ _SECRET_PREF_PATHS: frozenset[str] = frozenset(
         "security.session_passkey",
     }
 )
+
+
+class _DescriptorLike(Protocol):
+    """Structural descriptor type shared by pure-Python and upb protobuf runtimes."""
+
+    @property
+    def fields(self) -> Sequence[FieldDescriptor]:
+        """Return fields declared by this message descriptor."""
 
 
 class _NamedConfigType(Protocol):
@@ -3138,47 +3147,88 @@ def _set_missing_flags_false(
             d[path[-1]] = False
 
 
-def _prefix_base64_bytes_fields(message: Any, values: dict[str, Any]) -> None:
-    """Mark every protobuf bytes field in a MessageToDict mapping as base64.
+def _prefix_base64_bytes_fields(
+    message: Message, values: dict[str, Any]
+) -> None:
+    """Mark every protobuf bytes field in a ``MessageToDict`` mapping as base64."""
 
-    ``MessageToDict`` emits bytes as unmarked base64 strings.  ``setPref`` only
-    decodes strings with the explicit ``base64:`` prefix, so exported nested
-    bytes fields must be marked generically rather than special-casing security
-    keys.  This also covers repeated bytes and future protobuf additions.
-    """
+    def _field_key(
+        field: FieldDescriptor, mapping: dict[str, Any]
+    ) -> str | None:
+        json_name = getattr(field, "json_name", field.name)
+        for candidate in (json_name, field.name):
+            if candidate in mapping:
+                return candidate
+        return None
 
-    def _walk(descriptor: Any, mapping: dict[str, Any]) -> None:
-        normalized_key_map = {
-            meshtastic.util.camel_to_snake(key): key
-            for key in mapping
-            if isinstance(key, str)
-        }
+    def _prefix_bytes(value: Any, *, field_path: str) -> Any:
+        if isinstance(value, str):
+            return value if value.startswith("base64:") else f"base64:{value}"
+        if isinstance(value, list):
+            if not all(isinstance(item, str) for item in value):
+                raise TypeError(
+                    f"Expected base64 strings for repeated bytes field {field_path}"
+                )
+            return [
+                item if item.startswith("base64:") else f"base64:{item}"
+                for item in value
+            ]
+        raise TypeError(f"Expected base64 string for bytes field {field_path}")
+
+    def _walk(
+        descriptor: _DescriptorLike, mapping: dict[str, Any], *, path: str = ""
+    ) -> None:
         for field in descriptor.fields:
-            key = normalized_key_map.get(field.name)
+            key = _field_key(field, mapping)
             if key is None:
                 continue
-            value = mapping.get(key)
+            value = mapping[key]
+            field_path = f"{path}.{field.name}" if path else field.name
             if field.type == FieldDescriptor.TYPE_BYTES:
-                if isinstance(value, str):
-                    if not value.startswith("base64:"):
-                        mapping[key] = f"base64:{value}"
-                elif isinstance(value, list):
-                    mapping[key] = [
-                        f"base64:{item}"
-                        if isinstance(item, str)
-                        and not item.startswith("base64:")
-                        else item
-                        for item in value
-                    ]
+                mapping[key] = _prefix_bytes(value, field_path=field_path)
                 continue
             if field.type != FieldDescriptor.TYPE_MESSAGE:
                 continue
-            if isinstance(value, dict):
-                _walk(field.message_type, value)
-            elif isinstance(value, list):
-                for item in value:
-                    if isinstance(item, dict):
-                        _walk(field.message_type, item)
+
+            message_type = field.message_type
+            if message_type.GetOptions().map_entry:
+                value_field = message_type.fields_by_name["value"]
+                if not isinstance(value, dict):
+                    raise TypeError(f"Expected mapping for protobuf map field {field_path}")
+                if value_field.type == FieldDescriptor.TYPE_BYTES:
+                    for map_key, map_value in value.items():
+                        value[map_key] = _prefix_bytes(
+                            map_value, field_path=f"{field_path}[{map_key!r}]"
+                        )
+                elif value_field.type == FieldDescriptor.TYPE_MESSAGE:
+                    for map_key, map_value in value.items():
+                        if not isinstance(map_value, dict):
+                            raise TypeError(
+                                "Expected mapping for protobuf message map value "
+                                f"{field_path}[{map_key!r}]"
+                            )
+                        _walk(
+                            value_field.message_type,
+                            map_value,
+                            path=f"{field_path}[{map_key!r}]",
+                        )
+                continue
+
+            if _is_repeated_field(field):
+                if not isinstance(value, list):
+                    raise TypeError(
+                        f"Expected list for repeated message field {field_path}"
+                    )
+                for index, item in enumerate(value):
+                    if not isinstance(item, dict):
+                        raise TypeError(
+                            f"Expected mapping for {field_path}[{index}]"
+                        )
+                    _walk(message_type, item, path=f"{field_path}[{index}]")
+            else:
+                if not isinstance(value, dict):
+                    raise TypeError(f"Expected mapping for message field {field_path}")
+                _walk(message_type, value, path=field_path)
 
     _walk(message.DESCRIPTOR, values)
 

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -22,6 +22,7 @@ from types import ModuleType
 from typing import Any, NoReturn, Protocol, cast
 
 import yaml
+from google.protobuf.descriptor import FieldDescriptor
 from google.protobuf.json_format import MessageToDict
 from pubsub import pub
 
@@ -3137,6 +3138,51 @@ def _set_missing_flags_false(
             d[path[-1]] = False
 
 
+def _prefix_base64_bytes_fields(message: Any, values: dict[str, Any]) -> None:
+    """Mark every protobuf bytes field in a MessageToDict mapping as base64.
+
+    ``MessageToDict`` emits bytes as unmarked base64 strings.  ``setPref`` only
+    decodes strings with the explicit ``base64:`` prefix, so exported nested
+    bytes fields must be marked generically rather than special-casing security
+    keys.  This also covers repeated bytes and future protobuf additions.
+    """
+
+    def _walk(descriptor: Any, mapping: dict[str, Any]) -> None:
+        normalized_key_map = {
+            meshtastic.util.camel_to_snake(key): key
+            for key in mapping
+            if isinstance(key, str)
+        }
+        for field in descriptor.fields:
+            key = normalized_key_map.get(field.name)
+            if key is None:
+                continue
+            value = mapping.get(key)
+            if field.type == FieldDescriptor.TYPE_BYTES:
+                if isinstance(value, str):
+                    if not value.startswith("base64:"):
+                        mapping[key] = f"base64:{value}"
+                elif isinstance(value, list):
+                    mapping[key] = [
+                        f"base64:{item}"
+                        if isinstance(item, str)
+                        and not item.startswith("base64:")
+                        else item
+                        for item in value
+                    ]
+                continue
+            if field.type != FieldDescriptor.TYPE_MESSAGE:
+                continue
+            if isinstance(value, dict):
+                _walk(field.message_type, value)
+            elif isinstance(value, list):
+                for item in value:
+                    if isinstance(item, dict):
+                        _walk(field.message_type, item)
+
+    _walk(message.DESCRIPTOR, values)
+
+
 def _prefix_base64_key(
     security: dict[str, Any], normalized_key_map: dict[str, str], camel_name: str
 ) -> None:
@@ -3245,6 +3291,7 @@ def exportConfig(interface: MeshInterface) -> str:
 
     config = MessageToDict(interface.localNode.localConfig)
     if config:
+        _prefix_base64_bytes_fields(interface.localNode.localConfig, config)
         # Ensure explicit false values are present before key conversion.
         _set_missing_flags_false(config, CONFIG_TRUE_DEFAULTS)
 
@@ -3257,26 +3304,11 @@ def exportConfig(interface: MeshInterface) -> str:
                 else meshtastic.util.camel_to_snake(pref)
             )
             prefs[pref_key] = value
-            # mark base64 encoded fields as such
-            if pref == "security" and isinstance(prefs[pref_key], dict):
-                security = prefs[pref_key]
-                # Normalize keys to canonical camelCase for reliable lookup,
-                # since MessageToDict may produce inconsistent casing
-                normalized_key_map = {
-                    meshtastic.util.snake_to_camel(
-                        meshtastic.util.camel_to_snake(key)
-                    ): key
-                    for key in security
-                    if isinstance(key, str)
-                }
-
-                _prefix_base64_key(security, normalized_key_map, "privateKey")
-                _prefix_base64_key(security, normalized_key_map, "publicKey")
-                _prefix_base64_key(security, normalized_key_map, "adminKey")
         configObj["config"] = prefs
 
     module_config = MessageToDict(interface.localNode.moduleConfig)
     if module_config:
+        _prefix_base64_bytes_fields(interface.localNode.moduleConfig, module_config)
         # Ensure explicit false values are present before key conversion.
         _set_missing_flags_false(module_config, MODULE_TRUE_DEFAULTS)
 

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -6536,3 +6536,26 @@ def test_set_pref_repeated_field_progress_outside_preflight(
     assert "Clearing ignore_incoming list" in out
     assert list(config.lora.ignore_incoming) == []
     assert err == ""
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_export_config_round_trips_nested_module_bytes_fields() -> None:
+    """Firmware 2.8 Mesh Beacon channel PSKs must remain bytes after restore."""
+    source_local = localonly_pb2.LocalConfig()
+    source_module = localonly_pb2.LocalModuleConfig()
+    source_module.mesh_beacon.broadcast_interval_secs = 60
+    source_module.mesh_beacon.broadcast_offer_channel.psk = b"\x01\x02\x03\x04"
+    source_module.mesh_beacon.broadcast_on_channel.psk = b"\xaa\xbb\xcc\xdd"
+
+    exported_yaml = export_config(_build_export_interface(source_local, source_module))
+    exported = yaml.safe_load(exported_yaml)
+    mesh_beacon = exported["module_config"]["mesh_beacon"]
+    assert mesh_beacon["broadcastOfferChannel"]["psk"].startswith("base64:")
+    assert mesh_beacon["broadcastOnChannel"]["psk"].startswith("base64:")
+
+    restored = localonly_pb2.LocalModuleConfig()
+    assert traverseConfig("mesh_beacon", mesh_beacon, restored) is True
+    assert restored.mesh_beacon.broadcast_offer_channel.psk == b"\x01\x02\x03\x04"
+    assert restored.mesh_beacon.broadcast_on_channel.psk == b"\xaa\xbb\xcc\xdd"
+

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -16,6 +16,8 @@ from unittest.mock import MagicMock, call, mock_open, patch
 
 import pytest
 import yaml
+from google.protobuf import descriptor_pb2, descriptor_pool, message_factory
+from google.protobuf.json_format import MessageToDict
 
 import meshtastic.__main__ as main_module
 from meshtastic import mt_config
@@ -23,6 +25,7 @@ from meshtastic.__main__ import (
     _create_power_meter,
     _normalize_pref_name,
     _parse_host_port,
+    _prefix_base64_bytes_fields,
     _prefix_base64_key,
     _set_missing_flags_false,
     export_config,
@@ -6559,3 +6562,174 @@ def test_export_config_round_trips_nested_module_bytes_fields() -> None:
     assert restored.mesh_beacon.broadcast_offer_channel.psk == b"\x01\x02\x03\x04"
     assert restored.mesh_beacon.broadcast_on_channel.psk == b"\xaa\xbb\xcc\xdd"
 
+
+@pytest.mark.unit
+def test_prefix_base64_bytes_fields_handles_bytes_map_values() -> None:
+    file_proto = descriptor_pb2.FileDescriptorProto(
+        name="bytes_map_test.proto", package="mtjk.tests", syntax="proto3"
+    )
+    container = file_proto.message_type.add(name="BytesMap")
+    entry = container.nested_type.add(name="ValuesEntry")
+    entry.options.map_entry = True
+    entry.field.add(
+        name="key",
+        number=1,
+        label=descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL,
+        type=descriptor_pb2.FieldDescriptorProto.TYPE_STRING,
+    )
+    entry.field.add(
+        name="value",
+        number=2,
+        label=descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL,
+        type=descriptor_pb2.FieldDescriptorProto.TYPE_BYTES,
+    )
+    container.field.add(
+        name="values",
+        number=1,
+        label=descriptor_pb2.FieldDescriptorProto.LABEL_REPEATED,
+        type=descriptor_pb2.FieldDescriptorProto.TYPE_MESSAGE,
+        type_name=".mtjk.tests.BytesMap.ValuesEntry",
+    )
+    pool = descriptor_pool.DescriptorPool()
+    pool.Add(file_proto)
+    message_class = message_factory.GetMessageClass(
+        pool.FindMessageTypeByName("mtjk.tests.BytesMap")
+    )
+    message = cast(Any, message_class())
+    message.values["primary"] = b"\x01\x02"
+    values = MessageToDict(message)
+
+    _prefix_base64_bytes_fields(message, values)
+
+    assert values == {"values": {"primary": "base64:AQI="}}
+
+
+
+@pytest.mark.unit
+def test_prefix_base64_bytes_fields_rejects_invalid_repeated_values() -> None:
+    message = localonly_pb2.LocalConfig()
+    values: dict[str, Any] = {"security": {"adminKey": ["AQI=", 7]}}
+
+    with pytest.raises(TypeError, match="repeated bytes field security.admin_key"):
+        _prefix_base64_bytes_fields(message, values)
+
+
+
+def _build_nested_bytes_test_message() -> Any:
+    file_proto = descriptor_pb2.FileDescriptorProto(
+        name="nested_bytes_test.proto",
+        package="mtjk.tests.nested",
+        syntax="proto3",
+    )
+    child = file_proto.message_type.add(name="Child")
+    child.field.add(
+        name="payload",
+        number=1,
+        label=descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL,
+        type=descriptor_pb2.FieldDescriptorProto.TYPE_BYTES,
+    )
+    container = file_proto.message_type.add(name="Container")
+
+    child_map_entry = container.nested_type.add(name="ChildMapEntry")
+    child_map_entry.options.map_entry = True
+    child_map_entry.field.add(
+        name="key",
+        number=1,
+        label=descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL,
+        type=descriptor_pb2.FieldDescriptorProto.TYPE_STRING,
+    )
+    child_map_entry.field.add(
+        name="value",
+        number=2,
+        label=descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL,
+        type=descriptor_pb2.FieldDescriptorProto.TYPE_MESSAGE,
+        type_name=".mtjk.tests.nested.Child",
+    )
+    container.field.add(
+        name="child_map",
+        number=1,
+        label=descriptor_pb2.FieldDescriptorProto.LABEL_REPEATED,
+        type=descriptor_pb2.FieldDescriptorProto.TYPE_MESSAGE,
+        type_name=".mtjk.tests.nested.Container.ChildMapEntry",
+    )
+    container.field.add(
+        name="children",
+        number=2,
+        label=descriptor_pb2.FieldDescriptorProto.LABEL_REPEATED,
+        type=descriptor_pb2.FieldDescriptorProto.TYPE_MESSAGE,
+        type_name=".mtjk.tests.nested.Child",
+    )
+    container.field.add(
+        name="child",
+        number=3,
+        label=descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL,
+        type=descriptor_pb2.FieldDescriptorProto.TYPE_MESSAGE,
+        type_name=".mtjk.tests.nested.Child",
+    )
+    container.field.add(
+        name="blobs",
+        number=4,
+        label=descriptor_pb2.FieldDescriptorProto.LABEL_REPEATED,
+        type=descriptor_pb2.FieldDescriptorProto.TYPE_BYTES,
+    )
+    container.field.add(
+        name="scalar_blob",
+        number=5,
+        label=descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL,
+        type=descriptor_pb2.FieldDescriptorProto.TYPE_BYTES,
+    )
+
+    pool = descriptor_pool.DescriptorPool()
+    pool.Add(file_proto)
+    message_class = message_factory.GetMessageClass(
+        pool.FindMessageTypeByName("mtjk.tests.nested.Container")
+    )
+    return message_class()
+
+
+
+@pytest.mark.unit
+def test_prefix_base64_bytes_fields_walks_nested_message_shapes() -> None:
+    message = _build_nested_bytes_test_message()
+    message.child_map["primary"].payload = b"\x01"
+    message.children.add().payload = b"\x02"
+    message.child.payload = b"\x03"
+    message.blobs.extend([b"\x04", b"\x05"])
+    message.scalar_blob = b"\x06"
+    values = MessageToDict(message)
+
+    _prefix_base64_bytes_fields(message, values)
+
+    assert values == {
+        "childMap": {"primary": {"payload": "base64:AQ=="}},
+        "children": [{"payload": "base64:Ag=="}],
+        "child": {"payload": "base64:Aw=="},
+        "blobs": ["base64:BA==", "base64:BQ=="],
+        "scalarBlob": "base64:Bg==",
+    }
+
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("values", "message"),
+    [
+        ({"scalarBlob": 7}, "bytes field scalar_blob"),
+        ({"childMap": []}, "protobuf map field child_map"),
+        (
+            {"childMap": {"primary": "not-a-mapping"}},
+            "protobuf message map value child_map",
+        ),
+        ({"children": {}}, "repeated message field children"),
+        ({"children": ["not-a-mapping"]}, "children\\[0\\]"),
+        ({"child": []}, "message field child"),
+    ],
+)
+def test_prefix_base64_bytes_fields_rejects_invalid_message_shapes(
+    values: dict[str, Any],
+    message: str,
+) -> None:
+    proto = _build_nested_bytes_test_message()
+
+    with pytest.raises(TypeError, match=message):
+        _prefix_base64_bytes_fields(proto, values)


### PR DESCRIPTION
## Summary by Sourcery

Ensure protobuf bytes fields in exported configs are consistently marked and round-trip correctly through YAML export and restore.

New Features:
- Support automatic base64 prefixing for all protobuf bytes fields in config exports, including nested messages and map entries.

Enhancements:
- Generalize bytes-field handling in exportConfig by introducing a descriptor-driven walker that works across protobuf runtimes, replacing ad hoc security key logic.

Tests:
- Add unit tests covering round-trip of Mesh Beacon channel PSKs through export/restore and validation of base64 prefixing for nested messages, maps, repeated bytes fields, and error handling for invalid shapes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This updates configuration export and restore handling so all protobuf `bytes` fields survive YAML round trips, including nested, repeated, and map values in local and module configuration. Byte values are exported with a `base64:` prefix and decoded during restoration, with coverage for nested module fields such as Mesh Beacon PSKs.

### Key changes

**Features**
- Added descriptor-driven traversal for protobuf `bytes` fields.
- Supports nested messages, repeated fields, and protobuf maps.
- Preserves Mesh Beacon channel PSK values through export and restore.
- Added round-trip tests using `traverseConfig`.

**Fixes**
- Configuration exports now preserve bytes fields beyond security keys.
- Added validation for unexpected message shapes, raising `TypeError` where appropriate.

**Refactors**
- Centralized byte prefixing in `_prefix_base64_bytes_fields`.
- Updated `exportConfig()` to apply the helper to local and module configuration mappings.
- Added unit tests for nested messages, map values, invalid inputs, and restoration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->