### PR TITLE
Fix deeply nested protobuf config paths

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1327,21 +1327,30 @@ def traverseConfig(
     return success
 
 
+def _walk_config_path(
+    config: Any, name_parts: list[str]
+) -> tuple[Any, Any | None]:
+    """Return the parent message and descriptor for a dotted config path."""
+    config_part = config
+    config_type = config.DESCRIPTOR.fields_by_name.get(name_parts[0])
+    for name_part in name_parts[1:-1]:
+        if config_type is None or config_type.message_type is None:
+            return config_part, None
+        config_part = getattr(config_part, config_type.name)
+        config_type = config_type.message_type.fields_by_name.get(
+            meshtastic.util.camel_to_snake(name_part)
+        )
+    return config_part, config_type
+
+
 def _resolve_pref(config: Any, comp_name: str) -> bool:
     """Check whether a dotted field path resolves to a valid protobuf field."""
     comp_name = _normalize_pref_name(comp_name)
     name = splitCompoundName(comp_name)
     snake_name = meshtastic.util.camel_to_snake(name[-1])
-    objDesc = config.DESCRIPTOR
-    config_type = objDesc.fields_by_name.get(name[0])
+    _config_part, config_type = _walk_config_path(config, name)
     if config_type and config_type.message_type is not None:
-        config_part = config
-        for name_part in name[1:-1]:
-            part_snake_name = meshtastic.util.camel_to_snake(name_part)
-            config_part = getattr(config_part, config_type.name)
-            config_type = config_type.message_type.fields_by_name.get(part_snake_name)
-        if config_type and config_type.message_type is not None:
-            return config_type.message_type.fields_by_name.get(snake_name) is not None
+        return config_type.message_type.fields_by_name.get(snake_name) is not None
     return config_type is not None
 
 
@@ -1377,14 +1386,7 @@ def setPref(config: Any, comp_name: str, raw_val: Any) -> bool:
     logger.debug("snake_name:%s", snake_name)
     logger.debug("camel_name:%s", camel_name)
 
-    objDesc = config.DESCRIPTOR
-    config_part = config
-    config_type = objDesc.fields_by_name.get(name[0])
-    if config_type and config_type.message_type is not None:
-        for name_part in name[1:-1]:
-            part_snake_name = meshtastic.util.camel_to_snake((name_part))
-            config_part = getattr(config, config_type.name)
-            config_type = config_type.message_type.fields_by_name.get(part_snake_name)
+    config_part, config_type = _walk_config_path(config, name)
     pref = None
     if config_type and config_type.message_type is not None:
         pref = config_type.message_type.fields_by_name.get(snake_name)

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1331,15 +1331,25 @@ def _walk_config_path(
     config: Any, name_parts: list[str]
 ) -> tuple[Any, Any | None]:
     """Return the parent message and descriptor for a dotted config path."""
+    if not name_parts:
+        return config, None
+
+    normalized_parts = [
+        meshtastic.util.camel_to_snake(name_part) for name_part in name_parts
+    ]
     config_part = config
-    config_type = config.DESCRIPTOR.fields_by_name.get(name_parts[0])
-    for name_part in name_parts[1:-1]:
+    config_type = config.DESCRIPTOR.fields_by_name.get(normalized_parts[0])
+    for name_part in normalized_parts[1:-1]:
         if config_type is None or config_type.message_type is None:
             return config_part, None
         config_part = getattr(config_part, config_type.name)
-        config_type = config_type.message_type.fields_by_name.get(
-            meshtastic.util.camel_to_snake(name_part)
-        )
+        config_type = config_type.message_type.fields_by_name.get(name_part)
+    if (
+        len(normalized_parts) > 2
+        and config_type is not None
+        and config_type.message_type is None
+    ):
+        return config_part, None
     return config_part, config_type
 
 

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -6137,3 +6137,38 @@ def test_main_ota_update_file_not_found(
     # Verify no transport was constructed before the file check fired
     tcp_cls.assert_not_called()
     serial_cls.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_setpref_updates_deeply_nested_mesh_beacon_channel_settings() -> None:
+    """Apply valid 2.8 fields nested more than one protobuf message deep."""
+    module_config = localonly_pb2.LocalModuleConfig()
+
+    assert setPref(
+        module_config,
+        "mesh_beacon.broadcast_offer_channel.module_settings.position_precision",
+        12,
+    )
+
+    assert (
+        module_config.mesh_beacon.broadcast_offer_channel.module_settings.position_precision
+        == 12
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_traverse_config_skips_unknown_deep_intermediate_field(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Treat an unknown nested object as a skipped field instead of crashing."""
+    module_config = localonly_pb2.LocalModuleConfig()
+
+    assert traverseConfig(
+        "mesh_beacon",
+        {"broadcast_offer_channel": {"unknown_group": {"value": 1}}},
+        module_config,
+    )
+
+    assert "unknown_group.value" in caplog.text

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -167,6 +167,8 @@ def test_main_init_parser_help_mentions_list_fields(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+
+
 @pytest.mark.parametrize(
     ("flag", "destination"),
     (
@@ -1238,6 +1240,8 @@ def test_main_reboot_ota(capsys: pytest.CaptureFixture[str]) -> None:
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+
+
 @pytest.mark.parametrize(
     ("args", "method_name", "marker"),
     [
@@ -2145,6 +2149,8 @@ def test_main_configure_with_camel_case_keys(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+
+
 @pytest.mark.parametrize(
     ("owner_key", "expected_error"),
     [
@@ -2377,6 +2383,8 @@ def test_main_configure_applies_power_snake_case_keys(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+
+
 @pytest.mark.parametrize(
     "alias_key",
     ["use_12_hour", "use12Hour", "use12hClock", "use12HClock"],
@@ -2486,6 +2494,8 @@ def test_main_configure_rejects_non_dict_module_config(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+
+
 @pytest.mark.parametrize(
     ("top_key", "section_name", "section_value"),
     [
@@ -2918,6 +2928,8 @@ def test_main_ch_longfast_on_non_primary_channel(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+
+
 @pytest.mark.parametrize(
     ("cli_args", "expected_preset"),
     (
@@ -4874,6 +4886,8 @@ def test_main_ch_set_psk_with_ch_index(capsys: pytest.CaptureFixture[str]) -> No
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+
+
 @pytest.mark.parametrize(
     "psk_value",
     [
@@ -5034,6 +5048,8 @@ def test_tunnel_subnet_arg_with_no_devices(
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="on windows is no fcntl module")
+
+
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 @patch("platform.system")
@@ -6024,6 +6040,8 @@ def test_flatten_leaf_paths_empty_nested_dict() -> None:
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+
+
 @pytest.mark.parametrize(
     "field,value,expected,expected_output_substring",
     [
@@ -6093,6 +6111,8 @@ def test_main_setPref_bitfield_invalid_name(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+
+
 @pytest.mark.parametrize("value", ["0xZZ", "0o10"], ids=["invalid_hex", "octal"])
 def test_main_setPref_bitfield_invalid_numeric_string(
     value: str,
@@ -6172,3 +6192,66 @@ def test_traverse_config_skips_unknown_deep_intermediate_field(
     )
 
     assert "unknown_group.value" in caplog.text
+
+@pytest.mark.unit
+def test_walk_config_path_handles_empty_path() -> None:
+    config = localonly_pb2.LocalModuleConfig()
+
+    parent, descriptor = main_module._walk_config_path(config, [])
+
+    assert parent is config
+    assert descriptor is None
+
+
+@pytest.mark.unit
+def test_walk_config_path_normalizes_first_component() -> None:
+    config = localonly_pb2.LocalModuleConfig()
+
+    parent, descriptor = main_module._walk_config_path(
+        config, ["meshBeacon", "broadcastOfferChannel", "psk"]
+    )
+
+    assert parent is config.mesh_beacon
+    assert descriptor is not None
+    assert descriptor.name == "broadcast_offer_channel"
+
+
+@pytest.mark.unit
+def test_walk_config_path_stops_at_scalar_intermediate() -> None:
+    config = localonly_pb2.LocalModuleConfig()
+
+    parent, descriptor = main_module._walk_config_path(
+        config, ["mqtt", "enabled", "value"]
+    )
+
+    assert parent is config.mqtt
+    assert descriptor is None
+
+
+@pytest.mark.unit
+def test_walk_config_path_stops_after_unknown_intermediate() -> None:
+    config = localonly_pb2.LocalModuleConfig()
+
+    parent, descriptor = main_module._walk_config_path(
+        config,
+        [
+            "mesh_beacon",
+            "broadcast_offer_channel",
+            "unknown_group",
+            "child",
+            "value",
+        ],
+    )
+
+    assert parent is config.mesh_beacon.broadcast_offer_channel
+    assert descriptor is None
+
+
+@pytest.mark.unit
+def test_resolve_pref_accepts_nested_message_field() -> None:
+    config = localonly_pb2.LocalModuleConfig()
+
+    assert main_module._resolve_pref(
+        config,
+        "meshBeacon.broadcastOfferChannel.psk",
+    )


### PR DESCRIPTION
## Summary by Sourcery

Fix handling of deeply nested protobuf configuration paths so dotted preference names resolve correctly and unknown intermediate fields are safely skipped.

Bug Fixes:
- Correct resolution of nested protobuf config fields in setPref and preference validation to handle paths spanning multiple message levels without crashing.
- Treat unknown intermediate nested protobuf fields in configuration traversal as skipped entries instead of causing errors.

Tests:
- Add unit tests covering deeply nested mesh_beacon channel module_settings updates via setPref and traversal behavior when encountering unknown nested config groups.