### PR TITLE
fix(ble): classify closed D-Bus streams as transport failures

### DIFF
--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -68,6 +68,12 @@ _CONNECT_TIMEOUT_INVALID_MSG: str = (
 )
 _CONNECT_TIMEOUT_FALLBACK_SECONDS: float = 10.0
 _DISPATCH_MISSING: object = object()
+_DIRECT_CONNECT_DBUS_TRANSPORT_ERROR_MESSAGE: str = (
+    "BLE DBus transport error during direct connect."
+)
+_RETRY_CONNECT_DBUS_TRANSPORT_ERROR_MESSAGE: str = (
+    "BLE DBus transport error during retry connect."
+)
 _STALE_BLUEZ_DBUS_ERROR_NAMES: frozenset[str] = frozenset(
     {
         "org.bluez.error.alreadyconnected",
@@ -1718,7 +1724,7 @@ class ConnectionOrchestrator:
                         )
                         raise _normalize_dbus_transport_error(
                             retry_dbus_err,
-                            message="BLE DBus transport error during direct connect.",
+                            message=_DIRECT_CONNECT_DBUS_TRANSPORT_ERROR_MESSAGE,
                             requested_identifier=target_address,
                             address=target_address,
                         ) from retry_dbus_err
@@ -1738,7 +1744,7 @@ class ConnectionOrchestrator:
             if isinstance(error_for_fallback, (BleakDBusError, EOFError)):
                 raise _normalize_dbus_transport_error(
                     error_for_fallback,
-                    message="BLE DBus transport error during direct connect.",
+                    message=_DIRECT_CONNECT_DBUS_TRANSPORT_ERROR_MESSAGE,
                     requested_identifier=target_address,
                     address=target_address,
                 ) from error_for_fallback
@@ -1900,7 +1906,7 @@ class ConnectionOrchestrator:
             self._client_manager_safe_close_client(client)
             raise _normalize_dbus_transport_error(
                 dbus_err,
-                message="BLE DBus transport error during retry connect.",
+                message=_RETRY_CONNECT_DBUS_TRANSPORT_ERROR_MESSAGE,
                 requested_identifier=target_address or resolved_address,
                 address=resolved_address,
             ) from dbus_err

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -1613,8 +1613,9 @@ class ConnectionOrchestrator:
 
         Raises
         ------
-        BleakDBusError
-            Propagated for DBus-level failures to allow upstream backoff.
+        BLEDBusTransportError
+            Raised for BlueZ/DBus failures, including an unexpectedly closed
+            dbus-fast transport.
         BleakError
             Propagated for non-recoverable direct-connect errors.
         BLEError
@@ -1635,7 +1636,12 @@ class ConnectionOrchestrator:
             connect_timeout=direct_connect_timeout,
         )
         error_for_fallback: (
-            BleakError | BLEClient.BLEError | OSError | TimeoutError | BleakDBusError
+            BleakError
+            | BLEClient.BLEError
+            | OSError
+            | TimeoutError
+            | BleakDBusError
+            | EOFError
         ) | None = None
         try:
             self._raise_if_interface_closing()
@@ -1645,6 +1651,7 @@ class ConnectionOrchestrator:
             raise
         except (
             BleakDBusError,
+            EOFError,
             BleakError,
             BLEClient.BLEError,
             OSError,
@@ -1686,7 +1693,7 @@ class ConnectionOrchestrator:
                         return retried_client, False
                     except BLEAddressMismatchError:
                         raise
-                    except BleakDBusError as retry_dbus_err:
+                    except (BleakDBusError, EOFError) as retry_dbus_err:
                         logger.debug(
                             "Direct reconnect after stale BlueZ cleanup failed for %s: %s",
                             normalized_target,
@@ -1712,7 +1719,7 @@ class ConnectionOrchestrator:
                             exc_info=True,
                         )
                         raise
-            if isinstance(error_for_fallback, BleakDBusError):
+            if isinstance(error_for_fallback, (BleakDBusError, EOFError)):
                 raise BLEDBusTransportError.from_exception(
                     error_for_fallback,
                     message="BLE DBus transport error during direct connect.",
@@ -1848,8 +1855,9 @@ class ConnectionOrchestrator:
 
         Raises
         ------
-        BleakDBusError
-            Propagated for DBus-level failures.
+        BLEDBusTransportError
+            Raised for BlueZ/DBus failures, including an unexpectedly closed
+            dbus-fast transport.
         BleakError
             Propagated when retry connect fails without eligible fallback.
         BLEError
@@ -1872,7 +1880,7 @@ class ConnectionOrchestrator:
         except (SystemExit, KeyboardInterrupt):  # pylint: disable=W0706
             self._client_manager_safe_close_client(client)
             raise
-        except BleakDBusError as dbus_err:
+        except (BleakDBusError, EOFError) as dbus_err:
             self._client_manager_safe_close_client(client)
             raise BLEDBusTransportError.from_exception(
                 dbus_err,

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -91,6 +91,22 @@ _STALE_BLUEZ_FALLBACK_MESSAGE_TOKENS: tuple[str, ...] = (
 )
 
 
+def _normalize_dbus_transport_error(
+    error: BleakDBusError | EOFError,
+    *,
+    message: str,
+    requested_identifier: str | None,
+    address: str | None,
+) -> BLEDBusTransportError:
+    """Return the canonical typed error for BlueZ and closed D-Bus streams."""
+    return BLEDBusTransportError.from_exception(
+        error,
+        message=message,
+        requested_identifier=requested_identifier,
+        address=address,
+    )
+
+
 def _is_device_not_found_error(err: Exception) -> bool:
     """Return True when an exception indicates the target BLE device was not found."""
     if isinstance(err, BleakDeviceNotFoundError):
@@ -1700,7 +1716,7 @@ class ConnectionOrchestrator:
                             retry_dbus_err,
                             exc_info=True,
                         )
-                        raise BLEDBusTransportError.from_exception(
+                        raise _normalize_dbus_transport_error(
                             retry_dbus_err,
                             message="BLE DBus transport error during direct connect.",
                             requested_identifier=target_address,
@@ -1720,7 +1736,7 @@ class ConnectionOrchestrator:
                         )
                         raise
             if isinstance(error_for_fallback, (BleakDBusError, EOFError)):
-                raise BLEDBusTransportError.from_exception(
+                raise _normalize_dbus_transport_error(
                     error_for_fallback,
                     message="BLE DBus transport error during direct connect.",
                     requested_identifier=target_address,
@@ -1882,7 +1898,7 @@ class ConnectionOrchestrator:
             raise
         except (BleakDBusError, EOFError) as dbus_err:
             self._client_manager_safe_close_client(client)
-            raise BLEDBusTransportError.from_exception(
+            raise _normalize_dbus_transport_error(
                 dbus_err,
                 message="BLE DBus transport error during retry connect.",
                 requested_identifier=target_address or resolved_address,

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -857,6 +857,73 @@ def test_orchestrator_attempt_direct_connect_maps_dbus_error_to_typed_error(
         assert isinstance(exc_info.value, iface.BLEError)
 
 
+def test_orchestrator_attempt_direct_connect_maps_dbus_eof_to_typed_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A closed dbus-fast transport should use the typed DBus error path."""
+    with _make_orchestrator(monkeypatch) as (iface, orchestrator):
+        direct_client = DummyClient()
+        orchestrator._client_manager_create_client = (
+            lambda *_args, **_kwargs: direct_client
+        )
+        orchestrator._client_manager_connect_client = lambda *_args, **_kwargs: (
+            _ for _ in ()
+        ).throw(EOFError())
+        orchestrator._should_attempt_stale_bluez_cleanup = lambda **_kwargs: False
+        orchestrator._client_manager_safe_close_client = lambda *_args, **_kwargs: None
+
+        with pytest.raises(BLEDBusTransportError) as exc_info:
+            orchestrator._attempt_direct_connect(
+                target_address=TEST_BLE_ADDRESS,
+                explicit_address=True,
+                normalized_target="aabbccddeeff",
+                on_disconnect_func=lambda _client: None,
+                pair_on_connect=False,
+                direct_connect_timeout=1.0,
+                register_notifications_func=lambda _client: None,
+                on_connected_func=lambda: None,
+                emit_connected_side_effects=True,
+            )
+
+        assert exc_info.value.requested_identifier == TEST_BLE_ADDRESS
+        assert exc_info.value.dbus_error == "org.bluez.Error.Failed"
+        assert exc_info.value.dbus_error_body == ()
+        assert isinstance(exc_info.value.cause, EOFError)
+        assert isinstance(exc_info.value, iface.BLEError)
+
+
+def test_orchestrator_retry_connect_maps_dbus_eof_to_typed_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Retry connects should classify a closed D-Bus stream consistently."""
+    with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
+        retry_client = DummyClient()
+        closed_clients: list[DummyClient] = []
+        orchestrator._client_manager_create_client = (
+            lambda *_args, **_kwargs: retry_client
+        )
+        orchestrator._client_manager_connect_client = lambda *_args, **_kwargs: (
+            _ for _ in ()
+        ).throw(EOFError())
+        orchestrator._client_manager_safe_close_client = (
+            lambda client: closed_clients.append(client)
+        )
+
+        with pytest.raises(BLEDBusTransportError) as exc_info:
+            orchestrator._connect_retry_target(
+                connection_target=TEST_BLE_ADDRESS,
+                resolved_address=TEST_BLE_ADDRESS,
+                target_address=TEST_BLE_ADDRESS,
+                skip_discovery_scan=True,
+                on_disconnect_func=lambda _client: None,
+                pair_on_connect=False,
+                retry_connect_timeout=1.0,
+            )
+
+        assert closed_clients == [retry_client]
+        assert isinstance(exc_info.value.cause, EOFError)
+
+
 def test_orchestrator_attempt_direct_connect_uses_stale_cleanup_retry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -930,6 +930,56 @@ def test_orchestrator_retry_connect_maps_dbus_eof_to_typed_error(
         assert isinstance(exc_info.value, iface.BLEError)
 
 
+def test_orchestrator_stale_cleanup_retry_maps_dbus_eof_to_typed_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A post-cleanup direct retry should normalize and clean up D-Bus EOF."""
+    with _make_orchestrator(monkeypatch) as (iface, orchestrator):
+        direct_client = DummyClient()
+        retry_client = DummyClient()
+        clients = iter((direct_client, retry_client))
+        closed_clients: list[DummyClient] = []
+        orchestrator._client_manager_create_client = (
+            lambda *_args, **_kwargs: next(clients)
+        )
+
+        def _connect_client(client: DummyClient, **_kwargs: object) -> None:
+            if client is direct_client:
+                raise BleakDBusError(
+                    "org.bluez.Error.InProgress",
+                    ["Device or resource busy"],
+                )
+            raise EOFError()
+
+        orchestrator._client_manager_connect_client = _connect_client
+        orchestrator._client_manager_safe_close_client = (
+            lambda client: closed_clients.append(client)
+        )
+        orchestrator._should_attempt_stale_bluez_cleanup = lambda **_kwargs: True
+        orchestrator._attempt_stale_bluez_cleanup = lambda **_kwargs: True
+
+        with pytest.raises(BLEDBusTransportError) as exc_info:
+            orchestrator._attempt_direct_connect(
+                target_address=TEST_BLE_ADDRESS,
+                explicit_address=True,
+                normalized_target="aabbccddeeff",
+                on_disconnect_func=lambda _client: None,
+                pair_on_connect=False,
+                direct_connect_timeout=1.0,
+                register_notifications_func=lambda _client: None,
+                on_connected_func=lambda: None,
+                emit_connected_side_effects=True,
+            )
+
+        assert closed_clients == [direct_client, retry_client]
+        assert exc_info.value.requested_identifier == TEST_BLE_ADDRESS
+        assert isinstance(exc_info.value.dbus_error, str)
+        assert exc_info.value.dbus_error
+        assert exc_info.value.dbus_error_body == ()
+        assert isinstance(exc_info.value.cause, EOFError)
+        assert isinstance(exc_info.value, iface.BLEError)
+
+
 def test_orchestrator_attempt_direct_connect_uses_stale_cleanup_retry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -886,7 +886,8 @@ def test_orchestrator_attempt_direct_connect_maps_dbus_eof_to_typed_error(
             )
 
         assert exc_info.value.requested_identifier == TEST_BLE_ADDRESS
-        assert exc_info.value.dbus_error == "org.bluez.Error.Failed"
+        assert isinstance(exc_info.value.dbus_error, str)
+        assert exc_info.value.dbus_error
         assert exc_info.value.dbus_error_body == ()
         assert isinstance(exc_info.value.cause, EOFError)
         assert isinstance(exc_info.value, iface.BLEError)
@@ -896,7 +897,7 @@ def test_orchestrator_retry_connect_maps_dbus_eof_to_typed_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Retry connects should classify a closed D-Bus stream consistently."""
-    with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
+    with _make_orchestrator(monkeypatch) as (iface, orchestrator):
         retry_client = DummyClient()
         closed_clients: list[DummyClient] = []
         orchestrator._client_manager_create_client = (
@@ -921,7 +922,12 @@ def test_orchestrator_retry_connect_maps_dbus_eof_to_typed_error(
             )
 
         assert closed_clients == [retry_client]
+        assert exc_info.value.requested_identifier == TEST_BLE_ADDRESS
+        assert isinstance(exc_info.value.dbus_error, str)
+        assert exc_info.value.dbus_error
+        assert exc_info.value.dbus_error_body == ()
         assert isinstance(exc_info.value.cause, EOFError)
+        assert isinstance(exc_info.value, iface.BLEError)
 
 
 def test_orchestrator_attempt_direct_connect_uses_stale_cleanup_retry(


### PR DESCRIPTION
Normalize EOFError from dbus-fast during direct and retry connects into BLEDBusTransportError. Preserve the original cause and structured address context so library callers can apply D-Bus-specific diagnostics and retry policy instead of treating a closed BlueZ transport as an unknown exception.

## Summary by Sourcery

Classify closed dbus-fast D-Bus streams as BLE D-Bus transport errors and ensure both direct and retry BLE connections surface these failures via the typed BLEDBusTransportError.

Bug Fixes:
- Normalize EOFError from dbus-fast during BLE direct and retry connects into BLEDBusTransportError so closed BlueZ transports are handled consistently.
- Preserve D-Bus error context, including requested identifier and cause, when mapping transport EOF conditions into typed BLE errors.

Tests:
- Add coverage to verify EOFError from direct and retry BLE connection attempts is converted into BLEDBusTransportError with the expected metadata.