### PR TITLE
feat(traceroute): expose structured route results for library callers

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -36,6 +36,8 @@ implementation details that are NOT part of the public stable API.
 1. **Public Stable API** - Guaranteed stable, use for production code:
    - `meshtastic.Node` → from `meshtastic.node`
    - `meshtastic.MeshInterface` → from `meshtastic.mesh_interface`
+   - `MeshInterface.requestTraceRoute()` → structured traceroute results
+   - `meshtastic.traceroute.TraceRouteHop`, `TraceRouteResult`
    - `meshtastic.BROADCAST_ADDR`, `meshtastic.LOCAL_ADDR`
 
 2. **Runtime Modules** - Internal implementation, NOT guaranteed stable:
@@ -76,6 +78,7 @@ If you need to mock or patch Meshtastic internals in your tests:
 ```markdown
 meshtastic.Node STABLE (public API)
 meshtastic.mesh_interface.MeshInterface STABLE (public API)
+meshtastic.traceroute.TraceRouteResult STABLE (public API)
 meshtastic.node_runtime.settings_runtime.toNodeNum COMPAT (testing)
 meshtastic.node_runtime.settings_runtime.\_NodeSettingsRuntime INTERNAL (may change)
 meshtastic.mesh_interface_runtime.\_RequestWaitRuntime INTERNAL (may change)

--- a/README.md
+++ b/README.md
@@ -170,9 +170,9 @@ for hop in result.route_towards:
 
 Each route contains the source and destination plus any intermediate hops.
 `snr_db` describes the link into a hop and is `None` when firmware omits a
-complete SNR sequence. `route_back` is `None` unless the response includes a
-complete reverse route. The historical `sendTraceRoute()` API and its logging
-behavior remain unchanged.
+complete SNR sequence. `route_back` is `None` unless firmware reports a reverse
+route; incomplete reverse SNR data preserves the route with unknown link values.
+The historical `sendTraceRoute()` API and its logging behavior remain unchanged.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,26 @@ interface.sendText("hello mesh")
 interface.close()
 ```
 
+### Structured traceroute results
+
+Library callers can request a traceroute without parsing CLI-oriented log output:
+
+```python
+from meshtastic.serial_interface import SerialInterface
+
+with SerialInterface() as interface:
+    result = interface.requestTraceRoute("!ba4bf9d0", hopLimit=5)
+
+for hop in result.route_towards:
+    print(hop.node_id, hop.snr_db)
+```
+
+Each route contains the source and destination plus any intermediate hops.
+`snr_db` describes the link into a hop and is `None` when firmware omits a
+complete SNR sequence. `route_back` is `None` unless the response includes a
+complete reverse route. The historical `sendTraceRoute()` API and its logging
+behavior remain unchanged.
+
 ## Support
 
 Report `mtjk`-specific issues here:

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -65,6 +65,7 @@ from meshtastic.protobuf import (
     portnums_pb2,
 )
 from meshtastic.region_presets import RegionPresetInfo
+from meshtastic.traceroute import TraceRouteResult
 from meshtastic.util import (
     Acknowledgment,
     Timeout,
@@ -1116,6 +1117,34 @@ class MeshInterface:  # pylint: disable=R0902
             If waiting for traceroute responses times out or the operation fails.
         """
         self._send_pipeline.sendTraceRoute(dest, hopLimit, channelIndex=channelIndex)
+
+    def requestTraceRoute(
+        self, dest: int | str, hopLimit: int, channelIndex: int = 0
+    ) -> TraceRouteResult:
+        """Run a traceroute and return a structured result without CLI output.
+
+        Parameters
+        ----------
+        dest : int | str
+            Destination node (numeric node number or node ID string).
+        hopLimit : int
+            Maximum number of hops to probe.
+        channelIndex : int
+            Channel index to use for transmission. (Default value = 0)
+
+        Returns
+        -------
+        TraceRouteResult
+            Ordered outbound and, when available, return routes with per-link SNR.
+
+        Raises
+        ------
+        MeshInterfaceError
+            If the request fails, times out, or returns an invalid payload.
+        """
+        return self._send_pipeline.requestTraceRoute(
+            dest, hopLimit, channelIndex=channelIndex
+        )
 
     def onResponseTraceRoute(self, p: dict[str, Any]) -> None:
         """Emit human-readable traceroute results from a RouteDiscovery payload.

--- a/meshtastic/mesh_interface_runtime/flows.py
+++ b/meshtastic/mesh_interface_runtime/flows.py
@@ -347,7 +347,7 @@ def sendTraceroute(
     )
 
 
-def requestTraceroute(
+def _request_traceroute(
     interface: "MeshInterface",
     dest: int | str,
     hopLimit: int,

--- a/meshtastic/mesh_interface_runtime/flows.py
+++ b/meshtastic/mesh_interface_runtime/flows.py
@@ -210,8 +210,9 @@ def _on_response_traceroute(
     p: dict[str, Any],
     *,
     emit_summary: bool = True,
+    on_result: Callable[[TraceRouteResult], None] | None = None,
 ) -> TraceRouteResult | None:
-    """Parse a traceroute response, record completion, and optionally log it."""
+    """Parse a traceroute response and publish its result before waking waiters."""
     decoded = p["decoded"]
     request_id = interface._extract_request_id_from_packet(p)
     if decoded.get("portnum") == portnums_pb2.PortNum.Name(
@@ -247,7 +248,6 @@ def _on_response_traceroute(
                 list(route_discovery.snr_back),
             )
             if "hopStart" in p
-            and len(route_discovery.snr_back) == len(route_discovery.route_back) + 1
             else None
         )
     except (
@@ -275,6 +275,8 @@ def _on_response_traceroute(
             _emit_response_summary("Route traced back to us:")
             _emit_response_summary(_format_trace_route(result.route_back))
 
+    if on_result is not None:
+        on_result(result)
     interface._mark_wait_acknowledged(
         WAIT_ATTR_TRACEROUTE,
         request_id=request_id,
@@ -293,10 +295,19 @@ def _send_traceroute(
     """Send one traceroute request and return its structured response when available."""
     result: TraceRouteResult | None = None
 
-    def _capture_response(packet: dict[str, Any]) -> None:
+    def _capture_response(trace_result: TraceRouteResult) -> None:
         nonlocal result
-        result = _on_response_traceroute(
-            interface, packet, emit_summary=emit_summary
+        # Response handlers are normally one-shot; retain the first valid route
+        # if a duplicate packet reaches the callback before handler retirement.
+        if result is None:
+            result = trace_result
+
+    def _handle_response(packet: dict[str, Any]) -> None:
+        _on_response_traceroute(
+            interface,
+            packet,
+            emit_summary=emit_summary,
+            on_result=_capture_response,
         )
 
     packet = interface._send_data_with_wait(
@@ -304,7 +315,7 @@ def _send_traceroute(
         destinationId=dest,
         portNum=portnums_pb2.PortNum.TRACEROUTE_APP,
         wantResponse=True,
-        onResponse=_capture_response,
+        onResponse=_handle_response,
         channelIndex=channelIndex,
         hopLimit=hopLimit,
         response_wait_attr=WAIT_ATTR_TRACEROUTE,

--- a/meshtastic/mesh_interface_runtime/flows.py
+++ b/meshtastic/mesh_interface_runtime/flows.py
@@ -20,6 +20,7 @@ from meshtastic.mesh_interface_runtime.request_wait import (
     WAIT_ATTR_WAYPOINT,
 )
 from meshtastic.protobuf import mesh_pb2, portnums_pb2, telemetry_pb2
+from meshtastic.traceroute import TraceRouteHop, TraceRouteResult
 
 if TYPE_CHECKING:
     from meshtastic.mesh_interface import MeshInterface
@@ -53,15 +54,6 @@ def _emit_response_summary(message: str) -> None:
 def _node_label(interface: "MeshInterface", node_num: int) -> str:
     """Return a human-readable identifier for a numeric node."""
     return interface._node_num_to_id(node_num, False) or f"{node_num:08x}"
-
-
-def _format_snr(snr_value: int | None) -> str:
-    """Format an SNR value encoded in quarter-dB units into a human-readable string."""
-    return (
-        str(snr_value / 4)
-        if snr_value is not None and snr_value != UNKNOWN_SNR_QUARTER_DB
-        else "?"
-    )
 
 
 def _on_response_position(interface: "MeshInterface", p: dict[str, Any]) -> None:
@@ -170,69 +162,162 @@ def sendPosition(
     return d
 
 
-def _on_response_traceroute(interface: "MeshInterface", p: dict[str, Any]) -> None:
-    """Emit human-readable traceroute results from a RouteDiscovery payload."""
+def _snr_db(snr_value: int | None) -> float | None:
+    """Convert firmware quarter-dB SNR values to dB when known."""
+    if snr_value is None or snr_value == UNKNOWN_SNR_QUARTER_DB:
+        return None
+    return snr_value / 4
+
+
+def _build_trace_route_hops(
+    interface: "MeshInterface",
+    start_node: int,
+    intermediate_nodes: list[int],
+    end_node: int,
+    snr_values: list[int],
+) -> tuple[TraceRouteHop, ...]:
+    """Build a full route while preserving incomplete firmware SNR data."""
+    snr_values_valid = len(snr_values) == len(intermediate_nodes) + 1
+    hops = [
+        TraceRouteHop(
+            node_num=start_node,
+            node_id=_node_label(interface, start_node),
+        )
+    ]
+    for index, node_num in enumerate((*intermediate_nodes, end_node)):
+        snr_db = _snr_db(snr_values[index]) if snr_values_valid else None
+        hops.append(
+            TraceRouteHop(
+                node_num=node_num,
+                node_id=_node_label(interface, node_num),
+                snr_db=snr_db,
+            )
+        )
+    return tuple(hops)
+
+
+def _format_trace_route(hops: tuple[TraceRouteHop, ...]) -> str:
+    """Format a structured route using the historical CLI representation."""
+    route_text = hops[0].node_id
+    for hop in hops[1:]:
+        snr_text = "?" if hop.snr_db is None else str(hop.snr_db)
+        route_text = f"{route_text} --> {hop.node_id} ({snr_text}dB)"
+    return route_text
+
+
+def _on_response_traceroute(
+    interface: "MeshInterface",
+    p: dict[str, Any],
+    *,
+    emit_summary: bool = True,
+) -> TraceRouteResult | None:
+    """Parse a traceroute response, record completion, and optionally log it."""
     decoded = p["decoded"]
     request_id = interface._extract_request_id_from_packet(p)
     if decoded.get("portnum") == portnums_pb2.PortNum.Name(
         portnums_pb2.PortNum.ROUTING_APP
     ):
         error_reason = decoded.get("routing", {}).get("errorReason")
-        # Only treat as error if errorReason exists and is not NONE
         if error_reason is not None and error_reason != "NONE":
             interface._record_routing_wait_error(
                 acknowledgment_attr=WAIT_ATTR_TRACEROUTE,
                 routing_error_reason=error_reason,
                 request_id=request_id,
             )
-            return
-        # Otherwise, this is a successful routing ACK, continue to parse payload
+            return None
 
-    routeDiscovery = mesh_pb2.RouteDiscovery()
+    route_discovery = mesh_pb2.RouteDiscovery()
     try:
-        routeDiscovery.ParseFromString(decoded["payload"])
-        asDict = google.protobuf.json_format.MessageToDict(routeDiscovery)
-    except (protobuf_message.DecodeError, KeyError, TypeError) as exc:
+        route_discovery.ParseFromString(decoded["payload"])
+        source_node = int(p["to"])
+        destination_node = int(p["from"])
+        route_towards = _build_trace_route_hops(
+            interface,
+            source_node,
+            list(route_discovery.route),
+            destination_node,
+            list(route_discovery.snr_towards),
+        )
+        route_back = (
+            _build_trace_route_hops(
+                interface,
+                destination_node,
+                list(route_discovery.route_back),
+                source_node,
+                list(route_discovery.snr_back),
+            )
+            if "hopStart" in p
+            and len(route_discovery.snr_back) == len(route_discovery.route_back) + 1
+            else None
+        )
+    except (
+        protobuf_message.DecodeError,
+        KeyError,
+        TypeError,
+        ValueError,
+    ) as exc:
         interface._set_wait_error(
             WAIT_ATTR_TRACEROUTE,
             f"Failed to parse traceroute response payload: {exc}",
             request_id=request_id,
         )
-        return
+        return None
 
-    def _append_hop(route_text: str, node_num: int, snr_text: str) -> str:
-        """Append a hop description to an existing route string."""
-        return f"{route_text} --> {_node_label(interface, node_num)} ({snr_text}dB)"
-
-    route_towards = asDict.get("route", [])
-    snr_towards = asDict.get("snrTowards", [])
-    snr_towards_valid = len(snr_towards) == len(route_towards) + 1
-
-    _emit_response_summary("Route traced towards destination:")
-    routeStr = _node_label(interface, p["to"])
-    for idx, nodeNum in enumerate(route_towards):
-        hop_snr = _format_snr(snr_towards[idx]) if snr_towards_valid else "?"
-        routeStr = _append_hop(routeStr, nodeNum, hop_snr)
-    final_towards_snr = _format_snr(snr_towards[-1]) if snr_towards_valid else "?"
-    routeStr = _append_hop(routeStr, p["from"], final_towards_snr)
-
-    _emit_response_summary(routeStr)
-
-    route_back = asDict.get("routeBack", [])
-    snr_back = asDict.get("snrBack", [])
-    backValid = "hopStart" in p and len(snr_back) == len(route_back) + 1
-    if backValid:
-        _emit_response_summary("Route traced back to us:")
-        routeStr = _node_label(interface, p["from"])
-        for idx, nodeNum in enumerate(route_back):
-            routeStr = _append_hop(routeStr, nodeNum, _format_snr(snr_back[idx]))
-        routeStr = _append_hop(routeStr, p["to"], _format_snr(snr_back[-1]))
-        _emit_response_summary(routeStr)
+    result = TraceRouteResult(
+        route_towards=route_towards,
+        route_back=route_back,
+        request_id=request_id,
+    )
+    if emit_summary:
+        _emit_response_summary("Route traced towards destination:")
+        _emit_response_summary(_format_trace_route(result.route_towards))
+        if result.route_back is not None:
+            _emit_response_summary("Route traced back to us:")
+            _emit_response_summary(_format_trace_route(result.route_back))
 
     interface._mark_wait_acknowledged(
         WAIT_ATTR_TRACEROUTE,
         request_id=request_id,
     )
+    return result
+
+
+def _send_traceroute(
+    interface: "MeshInterface",
+    dest: int | str,
+    hopLimit: int,
+    channelIndex: int,
+    *,
+    emit_summary: bool,
+) -> TraceRouteResult | None:
+    """Send one traceroute request and return its structured response when available."""
+    result: TraceRouteResult | None = None
+
+    def _capture_response(packet: dict[str, Any]) -> None:
+        nonlocal result
+        result = _on_response_traceroute(
+            interface, packet, emit_summary=emit_summary
+        )
+
+    packet = interface._send_data_with_wait(
+        mesh_pb2.RouteDiscovery(),
+        destinationId=dest,
+        portNum=portnums_pb2.PortNum.TRACEROUTE_APP,
+        wantResponse=True,
+        onResponse=_capture_response,
+        channelIndex=channelIndex,
+        hopLimit=hopLimit,
+        response_wait_attr=WAIT_ATTR_TRACEROUTE,
+    )
+    with interface._node_db_lock:
+        node_count = len(interface.nodes) if interface.nodes else 0
+    nodes_based_factor = (node_count - 1) if node_count else (hopLimit + 1)
+    wait_factor = max(1, min(nodes_based_factor, hopLimit + 1))
+    request_id = interface._extract_request_id_from_sent_packet(packet)
+    if request_id is None:
+        raise interface.MeshInterfaceError(RESPONSE_WAIT_REQID_ERROR)
+    interface.waitForTraceRoute(wait_factor, request_id=request_id)
+    return result
 
 
 def sendTraceroute(
@@ -241,26 +326,35 @@ def sendTraceroute(
     hopLimit: int,
     channelIndex: int = 0,
 ) -> None:
-    """Initiate a traceroute request toward a destination node and wait for responses."""
-    r = mesh_pb2.RouteDiscovery()
-    packet = interface._send_data_with_wait(
-        r,
-        destinationId=dest,
-        portNum=portnums_pb2.PortNum.TRACEROUTE_APP,
-        wantResponse=True,
-        onResponse=lambda packet: _on_response_traceroute(interface, packet),
-        channelIndex=channelIndex,
-        hopLimit=hopLimit,
-        response_wait_attr=WAIT_ATTR_TRACEROUTE,
+    """Initiate a traceroute and retain historical human-readable output."""
+    _send_traceroute(
+        interface,
+        dest,
+        hopLimit,
+        channelIndex,
+        emit_summary=True,
     )
-    with interface._node_db_lock:
-        node_count = len(interface.nodes) if interface.nodes else 0
-    nodes_based_factor = (node_count - 1) if node_count else (hopLimit + 1)
-    waitFactor = max(1, min(nodes_based_factor, hopLimit + 1))
-    request_id = interface._extract_request_id_from_sent_packet(packet)
-    if request_id is None:
-        raise interface.MeshInterfaceError(RESPONSE_WAIT_REQID_ERROR)
-    interface.waitForTraceRoute(waitFactor, request_id=request_id)
+
+
+def requestTraceroute(
+    interface: "MeshInterface",
+    dest: int | str,
+    hopLimit: int,
+    channelIndex: int = 0,
+) -> TraceRouteResult:
+    """Initiate a traceroute and return its structured result."""
+    result = _send_traceroute(
+        interface,
+        dest,
+        hopLimit,
+        channelIndex,
+        emit_summary=False,
+    )
+    if result is None:
+        raise interface.MeshInterfaceError(
+            "Traceroute completed without a route result"
+        )
+    return result
 
 
 def _on_response_telemetry(interface: "MeshInterface", p: dict[str, Any]) -> None:

--- a/meshtastic/mesh_interface_runtime/send_pipeline.py
+++ b/meshtastic/mesh_interface_runtime/send_pipeline.py
@@ -16,8 +16,8 @@ from meshtastic.mesh_interface_runtime.flows import (
     _on_response_telemetry,
     _on_response_traceroute,
     _on_response_waypoint,
+    _request_traceroute,
     deleteWaypoint,
-    requestTraceroute,
     sendPosition,
     sendTelemetry,
     sendTraceroute,
@@ -543,7 +543,7 @@ class SendPipeline:
         self, dest: int | str, hopLimit: int, channelIndex: int = 0
     ) -> TraceRouteResult:
         """Initiate a traceroute request and return its structured response."""
-        return requestTraceroute(
+        return _request_traceroute(
             self._interface, dest, hopLimit, channelIndex=channelIndex
         )
 

--- a/meshtastic/mesh_interface_runtime/send_pipeline.py
+++ b/meshtastic/mesh_interface_runtime/send_pipeline.py
@@ -17,6 +17,7 @@ from meshtastic.mesh_interface_runtime.flows import (
     _on_response_traceroute,
     _on_response_waypoint,
     deleteWaypoint,
+    requestTraceroute,
     sendPosition,
     sendTelemetry,
     sendTraceroute,
@@ -32,6 +33,7 @@ from meshtastic.mesh_interface_runtime.request_wait import (
     _RequestWaitRuntime,
 )
 from meshtastic.protobuf import mesh_pb2, portnums_pb2
+from meshtastic.traceroute import TraceRouteResult
 from meshtastic.util import Acknowledgment, Timeout, stripnl
 
 if TYPE_CHECKING:
@@ -534,6 +536,14 @@ class SendPipeline:
     ) -> None:
         """Initiate a traceroute request toward a destination node and wait for responses."""
         return sendTraceroute(
+            self._interface, dest, hopLimit, channelIndex=channelIndex
+        )
+
+    def requestTraceRoute(
+        self, dest: int | str, hopLimit: int, channelIndex: int = 0
+    ) -> TraceRouteResult:
+        """Initiate a traceroute request and return its structured response."""
+        return requestTraceroute(
             self._interface, dest, hopLimit, channelIndex=channelIndex
         )
 

--- a/meshtastic/tests/api_baselines/api_baseline.json
+++ b/meshtastic/tests/api_baselines/api_baseline.json
@@ -30,6 +30,7 @@
     "onResponseTelemetry": "(self, p:dict[str, Any])",
     "onResponseTraceRoute": "(self, p:dict[str, Any])",
     "onResponseWaypoint": "(self, p:dict[str, Any])",
+    "requestTraceRoute": "(self, dest:int | str, hopLimit:int, channelIndex:int=0)",
     "sendAlert": "(self, text:str, destinationId:int | str=BROADCAST_ADDR, onResponse:Callable[[dict[str, Any]], Any] | None=None, channelIndex:int=0, hopLimit:int | None=None)",
     "sendData": "(self, data:'PayloadData', destinationId:int | str=BROADCAST_ADDR, portNum:portnums_pb2.PortNum.ValueType=portnums_pb2.PortNum.PRIVATE_APP, wantAck:bool=False, wantResponse:bool=False, onResponse:Callable[[dict[str, Any]], Any] | None=None, onResponseAckPermitted:bool=False, channelIndex:int=0, hopLimit:int | None=None, pkiEncrypted:bool=False, publicKey:bytes | None=None, priority:mesh_pb2.MeshPacket.Priority.ValueType=mesh_pb2.MeshPacket.Priority.RELIABLE, replyId:int | None=None)",
     "sendHeartbeat": "(self)",

--- a/meshtastic/tests/test_api_baseline_comparison.py
+++ b/meshtastic/tests/test_api_baseline_comparison.py
@@ -397,6 +397,7 @@ class TestMeshInterfaceAPIAgainstBaseline:
             "sendPosition",
             "sendTelemetry",
             "sendTraceRoute",
+            "requestTraceRoute",
             "sendWaypoint",
             "getNode",
             "showNodes",

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -36,6 +36,7 @@ from meshtastic.mesh_interface_runtime.request_wait import (
     WAIT_ATTR_TRACEROUTE,
     WAIT_ATTR_WAYPOINT,
 )
+from meshtastic.traceroute import TraceRouteResult
 
 from .. import BROADCAST_ADDR, LOCAL_ADDR, NODELESS_WANT_CONFIG_ID, ResponseHandler
 from ..mesh_interface import MeshInterface
@@ -2589,6 +2590,141 @@ def test_request_traceroute_preserves_unknown_link_snr() -> None:
     assert result is not None
     assert [hop.snr_db for hop in result.route_towards] == [None, None, None]
     assert result.route_back is None
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_request_traceroute_preserves_reverse_route_with_unknown_snr() -> None:
+    """Reverse topology should survive incomplete firmware SNR arrays."""
+    with MeshInterface(noProto=True) as iface:
+        response = mesh_pb2.RouteDiscovery()
+        response.route_back.extend([12])
+        response.snr_back.extend([16])
+        result = flows_module._on_response_traceroute(  # pylint: disable=protected-access
+            iface,
+            {
+                "decoded": {
+                    "payload": response.SerializeToString(),
+                    "requestId": 90,
+                },
+                "to": 20,
+                "from": 21,
+                "hopStart": 1,
+            },
+            emit_summary=False,
+        )
+
+    assert result is not None
+    assert result.route_back is not None
+    assert [hop.node_num for hop in result.route_back] == [21, 12, 20]
+    assert [hop.snr_db for hop in result.route_back] == [None, None, None]
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_request_traceroute_stores_result_before_releasing_waiter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The response result must be visible before acknowledgment wakes the waiter."""
+    with MeshInterface(noProto=True) as iface:
+        response = mesh_pb2.RouteDiscovery()
+        response.route.extend([11])
+        response.snr_towards.extend([8, 12])
+        sent_packet = mesh_pb2.MeshPacket(id=91)
+        response_callback: Callable[[dict[str, Any]], None] | None = None
+        request_finished = threading.Event()
+        outcome: dict[str, object] = {}
+
+        def _send_data_with_response(
+            _payload: object, **kwargs: Any
+        ) -> mesh_pb2.MeshPacket:
+            nonlocal response_callback
+            response_callback = cast(
+                Callable[[dict[str, Any]], None], kwargs["onResponse"]
+            )
+            iface._clear_wait_error(WAIT_ATTR_TRACEROUTE, request_id=91)
+            return sent_packet
+
+        original_mark_acknowledged = iface._mark_wait_acknowledged
+
+        def _mark_and_hold(*args: Any, **kwargs: Any) -> None:
+            original_mark_acknowledged(*args, **kwargs)
+            assert request_finished.wait(timeout=1.0)
+
+        def _request() -> None:
+            try:
+                outcome["result"] = iface.requestTraceRoute(
+                    dest=21, hopLimit=3, channelIndex=1
+                )
+            except Exception as exc:  # pragma: no cover - asserted below
+                outcome["error"] = exc
+            finally:
+                request_finished.set()
+
+        monkeypatch.setattr(iface, "_send_data_with_wait", _send_data_with_response)
+        monkeypatch.setattr(iface, "_mark_wait_acknowledged", _mark_and_hold)
+        request_thread = threading.Thread(target=_request, daemon=True)
+        request_thread.start()
+        _wait_for_scoped_wait_registration(
+            iface, acknowledgment_attr=WAIT_ATTR_TRACEROUTE, request_id=91
+        )
+        assert response_callback is not None
+        response_callback(
+            {
+                "decoded": {
+                    "payload": response.SerializeToString(),
+                    "requestId": 91,
+                },
+                "to": 20,
+                "from": 21,
+            }
+        )
+        request_thread.join(timeout=1.0)
+
+    assert not request_thread.is_alive()
+    assert "error" not in outcome
+    result = cast(TraceRouteResult, outcome["result"])
+    assert result.request_id == 91
+    assert [hop.node_num for hop in result.route_towards] == [20, 11, 21]
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_request_traceroute_keeps_first_structured_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Duplicate route responses should not replace the first completed result."""
+    with MeshInterface(noProto=True) as iface:
+        first = mesh_pb2.RouteDiscovery()
+        first.route.extend([11])
+        first.snr_towards.extend([8, 12])
+        second = mesh_pb2.RouteDiscovery()
+        second.route.extend([12])
+        second.snr_towards.extend([16, 20])
+        sent_packet = mesh_pb2.MeshPacket(id=92)
+
+        def _send_duplicate_responses(
+            _payload: object, **kwargs: Any
+        ) -> mesh_pb2.MeshPacket:
+            callback = cast(Callable[[dict[str, Any]], None], kwargs["onResponse"])
+            for route in (first, second):
+                callback(
+                    {
+                        "decoded": {
+                            "payload": route.SerializeToString(),
+                            "requestId": 92,
+                        },
+                        "to": 20,
+                        "from": 21,
+                    }
+                )
+            return sent_packet
+
+        monkeypatch.setattr(iface, "_send_data_with_wait", _send_duplicate_responses)
+        monkeypatch.setattr(iface, "waitForTraceRoute", lambda *_args, **_kwargs: None)
+        result = iface.requestTraceRoute(dest=21, hopLimit=3, channelIndex=1)
+
+    assert [hop.node_num for hop in result.route_towards] == [20, 11, 21]
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -2502,6 +2502,97 @@ def test_send_traceroute_and_response_rendering(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
+def test_request_traceroute_returns_structured_routes(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Library traceroutes should return typed paths without CLI-oriented logging."""
+    with MeshInterface(noProto=True) as iface:
+        iface.nodes = {
+            "!0000000b": {"num": 11},
+            "!0000000c": {"num": 12},
+            "!00000014": {"num": 20},
+            "!00000015": {"num": 21},
+        }
+        response = mesh_pb2.RouteDiscovery()
+        response.route.extend([11])
+        response.snr_towards.extend([8, 12])
+        response.route_back.extend([12])
+        response.snr_back.extend([16, 20])
+        sent_packet = mesh_pb2.MeshPacket(id=88)
+        response_callback: Callable[[dict[str, Any]], None] | None = None
+
+        def _send_data_with_response(
+            _payload: object, **kwargs: Any
+        ) -> mesh_pb2.MeshPacket:
+            nonlocal response_callback
+            response_callback = cast(
+                Callable[[dict[str, Any]], None], kwargs["onResponse"]
+            )
+            return sent_packet
+
+        def _wait_for_response(
+            wait_factor: float, request_id: int | None = None
+        ) -> None:
+            assert wait_factor == 3
+            assert request_id == 88
+            assert response_callback is not None
+            response_callback(
+                {
+                    "decoded": {
+                        "payload": response.SerializeToString(),
+                        "requestId": 88,
+                    },
+                    "to": 20,
+                    "from": 21,
+                    "hopStart": 1,
+                }
+            )
+
+        monkeypatch.setattr(iface, "_send_data_with_wait", _send_data_with_response)
+        monkeypatch.setattr(iface, "waitForTraceRoute", _wait_for_response)
+        with caplog.at_level(logging.INFO, logger=flows_module.__name__):
+            result = iface.requestTraceRoute(dest=21, hopLimit=3, channelIndex=1)
+
+    assert result.request_id == 88
+    assert [hop.node_num for hop in result.route_towards] == [20, 11, 21]
+    assert [hop.snr_db for hop in result.route_towards] == [None, 2.0, 3.0]
+    assert result.route_back is not None
+    assert [hop.node_num for hop in result.route_back] == [21, 12, 20]
+    assert [hop.snr_db for hop in result.route_back] == [None, 4.0, 5.0]
+    assert result.source.node_num == 20
+    assert result.destination.node_num == 21
+    assert "Route traced" not in caplog.text
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_request_traceroute_preserves_unknown_link_snr() -> None:
+    """Incomplete firmware SNR arrays should produce unknown links, not bad indexing."""
+    with MeshInterface(noProto=True) as iface:
+        response = mesh_pb2.RouteDiscovery()
+        response.route.extend([11])
+        response.snr_towards.extend([8])
+        result = flows_module._on_response_traceroute(  # pylint: disable=protected-access
+            iface,
+            {
+                "decoded": {
+                    "payload": response.SerializeToString(),
+                    "requestId": 89,
+                },
+                "to": 20,
+                "from": 21,
+            },
+            emit_summary=False,
+        )
+
+    assert result is not None
+    assert [hop.snr_db for hop in result.route_towards] == [None, None, None]
+    assert result.route_back is None
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
 def test_on_response_traceroute_routing_no_response_raises() -> None:
     """Traceroute routing NO_RESPONSE replies should be surfaced by waitForTraceRoute()."""
     with MeshInterface(noProto=True) as iface:

--- a/meshtastic/tests/test_send_pipeline.py
+++ b/meshtastic/tests/test_send_pipeline.py
@@ -781,6 +781,23 @@ class TestSendTraceRoute:
             send_pipeline._interface, "!1234abcd", 3, channelIndex=0
         )
 
+    @pytest.mark.unit
+    def test_request_traceroute_delegates(
+        self, send_pipeline: SendPipeline
+    ) -> None:
+        """Test structured traceroute requests delegate to the flow function."""
+        with patch(
+            "meshtastic.mesh_interface_runtime.send_pipeline.requestTraceroute"
+        ) as mock_flow:
+            result = send_pipeline.requestTraceRoute(
+                "!1234abcd", hopLimit=3, channelIndex=1
+            )
+
+        assert result is mock_flow.return_value
+        mock_flow.assert_called_once_with(
+            send_pipeline._interface, "!1234abcd", 3, channelIndex=1
+        )
+
 
 class TestSendTelemetry:
     """Tests for sendTelemetry method (lines 513-529)."""

--- a/meshtastic/tests/test_send_pipeline.py
+++ b/meshtastic/tests/test_send_pipeline.py
@@ -787,7 +787,7 @@ class TestSendTraceRoute:
     ) -> None:
         """Test structured traceroute requests delegate to the flow function."""
         with patch(
-            "meshtastic.mesh_interface_runtime.send_pipeline.requestTraceroute"
+            "meshtastic.mesh_interface_runtime.send_pipeline._request_traceroute"
         ) as mock_flow:
             result = send_pipeline.requestTraceRoute(
                 "!1234abcd", hopLimit=3, channelIndex=1

--- a/meshtastic/traceroute.py
+++ b/meshtastic/traceroute.py
@@ -1,0 +1,46 @@
+"""Structured traceroute results for Meshtastic library callers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["TraceRouteHop", "TraceRouteResult"]
+
+
+@dataclass(frozen=True, slots=True)
+class TraceRouteHop:
+    """One node in a traced route.
+
+    ``snr_db`` describes the link from the preceding hop to this hop. It is
+    ``None`` for the first hop and whenever the firmware did not provide a
+    complete SNR sequence.
+    """
+
+    node_num: int
+    node_id: str
+    snr_db: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TraceRouteResult:
+    """A completed traceroute in both available directions.
+
+    ``route_towards`` always starts with the local/source node and ends with
+    the destination node. ``route_back`` follows the destination back to the
+    source when the firmware returned a complete reverse route; otherwise it
+    is ``None``.
+    """
+
+    route_towards: tuple[TraceRouteHop, ...]
+    route_back: tuple[TraceRouteHop, ...] | None
+    request_id: int | None = None
+
+    @property
+    def source(self) -> TraceRouteHop:
+        """Return the first hop in the outbound route."""
+        return self.route_towards[0]
+
+    @property
+    def destination(self) -> TraceRouteHop:
+        """Return the final hop in the outbound route."""
+        return self.route_towards[-1]

--- a/meshtastic/traceroute.py
+++ b/meshtastic/traceroute.py
@@ -27,8 +27,8 @@ class TraceRouteResult:
 
     ``route_towards`` always starts with the local/source node and ends with
     the destination node. ``route_back`` follows the destination back to the
-    source when the firmware returned a complete reverse route; otherwise it
-    is ``None``.
+    source when firmware reports a reverse route; otherwise it is ``None``.
+    Incomplete SNR arrays preserve the reported topology with unknown links.
     """
 
     route_towards: tuple[TraceRouteHop, ...]


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Adds structured, immutable traceroute result models and a `requestTraceRoute()` API for callers that need route data without parsing log output. Existing `sendTraceRoute()` behavior and wait semantics are preserved.

## Key changes

### Features
- Added immutable `TraceRouteHop` and `TraceRouteResult` dataclasses.
- Added `MeshInterface.requestTraceRoute()` and corresponding send-pipeline support.
- Added outbound and optional reverse route data, source/destination properties, request IDs, and SNR values in dB.
- Preserved unknown SNR values as `None`.
- Documented the new stable API in the README and compatibility inventory.

### Fixes
- Improved handling of incomplete firmware SNR arrays.
- Added errors for failed requests, timeouts, and invalid response payloads.

### Refactors
- Consolidated traceroute response parsing and sending logic.
- Kept human-readable traceroute logging available through `sendTraceRoute()`, while structured requests avoid CLI-style output.
- Added API baseline coverage and tests for route parsing, delegation, reverse routes, unknown SNR values, and compatibility behavior.

## Breaking changes and migration

No breaking changes are intended. Existing `sendTraceRoute()` callers can continue using the same API. Callers needing structured data can use `requestTraceRoute()` and access `result.route_towards`, `result.route_back`, and each hop’s `node_id` and `snr_db`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->