### PR TITLE
Pin cleanup action, update linting, reformat code, and bump version to 2.7.11.post2

### DIFF
--- a/.github/workflows/cleanup_artifacts.yml
+++ b/.github/workflows/cleanup_artifacts.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Remove old artifacts
         # v1.4.0
-        uses: c-hive/gha-remove-artifacts@44fc7acaf1b3d0987da0e8d4707a989d80e9554b
+        uses: c-hive/gha-remove-artifacts@44fc7acaf1b3d0987da0e8d4707a989d80e9554b # v1.4.0
         with:
           age: 1 month
           skip-tags: true

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -18,10 +18,13 @@ lint:
     - pylint
     - pyright
     - renovate
-    # actionlint's --fix mangles pinned action `uses:` references (concatenates
-    # the resolved version onto the existing line, breaking the YAML). Disable
-    # until upstream fixes the autofix; pinact already covers action currency.
+    # actionlint and pinact both have broken --fix paths that mangle pinned
+    # GitHub Actions `uses:` references (concatenating the resolved version tag
+    # onto the existing line and duplicating the `uses:` key, producing invalid
+    # YAML). Disable both until upstream fixes the autofix; CI relies on the
+    # SHA-pinned references renovate/pinact-manual already maintain.
     - actionlint
+    - pinact
   ignore:
     - linters: [ALL]
       paths:
@@ -89,7 +92,6 @@ lint:
           batch: true
           stdin: false
   enabled:
-    - pinact@4.0.0
     - grype@0.116.0
     - black@26.5.1
     - checkov@3.3.8

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -90,7 +90,7 @@ lint:
           stdin: false
   enabled:
     - pinact@4.0.0
-    - grype@0.110.0
+    - grype@0.116.0
     - black@26.5.1
     - checkov@3.3.8
     - git-diff-check

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -7,10 +7,10 @@
 import argparse
 import binascii
 import contextlib
+import contextvars
 import enum
 import getpass
 import importlib
-import contextvars
 import logging
 import os
 import platform
@@ -23,8 +23,8 @@ from typing import Any, NoReturn, Protocol, cast
 
 import yaml
 from google.protobuf.descriptor import FieldDescriptor
-from google.protobuf.message import Message
 from google.protobuf.json_format import MessageToDict
+from google.protobuf.message import Message
 from pubsub import pub
 
 import meshtastic.cli.runtime as cli_runtime
@@ -745,9 +745,7 @@ def _temporary_instance_attributes(
     """Temporarily override instance attributes and restore their exact prior state."""
     missing = object()
     instance_values = vars(instance)
-    previous_values = {
-        name: instance_values.get(name, missing) for name in overrides
-    }
+    previous_values = {name: instance_values.get(name, missing) for name in overrides}
     try:
         for name, value in overrides.items():
             setattr(instance, name, value)
@@ -1429,9 +1427,7 @@ def traverseConfig(
     return success
 
 
-def _walk_config_path(
-    config: Any, name_parts: list[str]
-) -> tuple[Any, Any | None]:
+def _walk_config_path(config: Any, name_parts: list[str]) -> tuple[Any, Any | None]:
     """Return the parent message and descriptor for a dotted config path."""
     if not name_parts:
         return config, None
@@ -1891,9 +1887,7 @@ def _handle_configure_command(
         target_node.set_ringtone(configuration["ringtone"])
         time.sleep(CONFIG_APPLY_DELAY_SECONDS)
 
-    channel_url_key = (
-        "channel_url" if "channel_url" in configuration else "channelUrl"
-    )
+    channel_url_key = "channel_url" if "channel_url" in configuration else "channelUrl"
     if channel_url_key in configuration:
         if not phase1_started:
             _cli_print(CONFIGURE_PHASE1_HEADER)
@@ -3147,16 +3141,13 @@ def _set_missing_flags_false(
             d[path[-1]] = False
 
 
-def _prefix_base64_bytes_fields(
-    message: Message, values: dict[str, Any]
-) -> None:
+def _prefix_base64_bytes_fields(message: Message, values: dict[str, Any]) -> None:
     """Mark every protobuf bytes field in a ``MessageToDict`` mapping as base64."""
 
-    def _field_key(
-        field: FieldDescriptor, mapping: dict[str, Any]
-    ) -> str | None:
-        json_name = getattr(field, "json_name", field.name)
-        for candidate in (json_name, field.name):
+    def _field_key(field: FieldDescriptor, mapping: dict[str, Any]) -> str | None:
+        json_name: str = getattr(field, "json_name", field.name)
+        name: str = field.name
+        for candidate in (json_name, name):
             if candidate in mapping:
                 return candidate
         return None
@@ -3194,7 +3185,9 @@ def _prefix_base64_bytes_fields(
             if message_type.GetOptions().map_entry:
                 value_field = message_type.fields_by_name["value"]
                 if not isinstance(value, dict):
-                    raise TypeError(f"Expected mapping for protobuf map field {field_path}")
+                    raise TypeError(
+                        f"Expected mapping for protobuf map field {field_path}"
+                    )
                 if value_field.type == FieldDescriptor.TYPE_BYTES:
                     for map_key, map_value in value.items():
                         value[map_key] = _prefix_bytes(
@@ -3221,9 +3214,7 @@ def _prefix_base64_bytes_fields(
                     )
                 for index, item in enumerate(value):
                     if not isinstance(item, dict):
-                        raise TypeError(
-                            f"Expected mapping for {field_path}[{index}]"
-                        )
+                        raise TypeError(f"Expected mapping for {field_path}[{index}]")
                     _walk(message_type, item, path=f"{field_path}[{index}]")
             else:
                 if not isinstance(value, dict):

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -170,8 +170,6 @@ def test_main_init_parser_help_mentions_list_fields(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-
-
 @pytest.mark.parametrize(
     ("flag", "destination"),
     (
@@ -1243,8 +1241,6 @@ def test_main_reboot_ota(capsys: pytest.CaptureFixture[str]) -> None:
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-
-
 @pytest.mark.parametrize(
     ("args", "method_name", "marker"),
     [
@@ -2152,8 +2148,6 @@ def test_main_configure_with_camel_case_keys(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-
-
 @pytest.mark.parametrize(
     ("owner_key", "expected_error"),
     [
@@ -2454,8 +2448,6 @@ def test_main_configure_applies_power_snake_case_keys(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-
-
 @pytest.mark.parametrize(
     "alias_key",
     ["use_12_hour", "use12Hour", "use12hClock", "use12HClock"],
@@ -2565,8 +2557,6 @@ def test_main_configure_rejects_non_dict_module_config(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-
-
 @pytest.mark.parametrize(
     ("top_key", "section_name", "section_value"),
     [
@@ -2999,8 +2989,6 @@ def test_main_ch_longfast_on_non_primary_channel(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-
-
 @pytest.mark.parametrize(
     ("cli_args", "expected_preset"),
     (
@@ -4957,8 +4945,6 @@ def test_main_ch_set_psk_with_ch_index(capsys: pytest.CaptureFixture[str]) -> No
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-
-
 @pytest.mark.parametrize(
     "psk_value",
     [
@@ -5119,8 +5105,6 @@ def test_tunnel_subnet_arg_with_no_devices(
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="on windows is no fcntl module")
-
-
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 @patch("platform.system")
@@ -6111,8 +6095,6 @@ def test_flatten_leaf_paths_empty_nested_dict() -> None:
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-
-
 @pytest.mark.parametrize(
     "field,value,expected,expected_output_substring",
     [
@@ -6182,8 +6164,6 @@ def test_main_setPref_bitfield_invalid_name(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-
-
 @pytest.mark.parametrize("value", ["0xZZ", "0o10"], ids=["invalid_hex", "octal"])
 def test_main_setPref_bitfield_invalid_numeric_string(
     value: str,
@@ -6263,6 +6243,7 @@ def test_traverse_config_skips_unknown_deep_intermediate_field(
     )
 
     assert "unknown_group.value" in caplog.text
+
 
 @pytest.mark.unit
 def test_walk_config_path_handles_empty_path() -> None:
@@ -6368,7 +6349,6 @@ def test_secret_redaction_is_scoped_to_sensitive_preference_paths() -> None:
     assert main_module._redact_pref_value("unrelated.password", "visible") == "visible"
 
 
-
 @pytest.mark.unit
 @pytest.mark.parametrize(
     ("value", "message"),
@@ -6393,7 +6373,6 @@ def test_apply_configure_channel_url_rejects_invalid_values(
     target_node.setURL.assert_not_called()
 
 
-
 @pytest.mark.unit
 def test_apply_configure_channel_url_skips_matching_state(
     monkeypatch: pytest.MonkeyPatch,
@@ -6415,7 +6394,6 @@ def test_apply_configure_channel_url_skips_matching_state(
     assert applied is False
     target_node.setURL.assert_not_called()
     assert "already matches" in capsys.readouterr().out
-
 
 
 @pytest.mark.unit
@@ -6497,7 +6475,6 @@ def test_configure_preflight_reuses_target_node_and_preserves_logger(
     assert target_node.writeConfig.call_args_list == [call("bluetooth")]
     target_node.commitSettingsTransaction.assert_called_once_with()
     assert main_module.logger.disabled is False
-
 
 
 @pytest.mark.unit
@@ -6604,7 +6581,6 @@ def test_prefix_base64_bytes_fields_handles_bytes_map_values() -> None:
     assert values == {"values": {"primary": "base64:AQI="}}
 
 
-
 @pytest.mark.unit
 def test_prefix_base64_bytes_fields_rejects_invalid_repeated_values() -> None:
     message = localonly_pb2.LocalConfig()
@@ -6612,7 +6588,6 @@ def test_prefix_base64_bytes_fields_rejects_invalid_repeated_values() -> None:
 
     with pytest.raises(TypeError, match="repeated bytes field security.admin_key"):
         _prefix_base64_bytes_fields(message, values)
-
 
 
 def _build_nested_bytes_test_message() -> Any:
@@ -6687,7 +6662,6 @@ def _build_nested_bytes_test_message() -> Any:
     return message_class()
 
 
-
 @pytest.mark.unit
 def test_prefix_base64_bytes_fields_walks_nested_message_shapes() -> None:
     message = _build_nested_bytes_test_message()
@@ -6707,7 +6681,6 @@ def test_prefix_base64_bytes_fields_walks_nested_message_shapes() -> None:
         "blobs": ["base64:BA==", "base64:BQ=="],
         "scalarBlob": "base64:Bg==",
     }
-
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_main_configure_reconnect.py
+++ b/meshtastic/tests/test_main_configure_reconnect.py
@@ -395,6 +395,7 @@ def test_post_seturl_stability_check_triggers_reconnect_when_disconnected(
     iface.connect.assert_called()
     iface.waitForConfig.assert_called_once()
 
+
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_configure_redacts_channel_url_progress_output(
@@ -405,7 +406,9 @@ def test_configure_redacts_channel_url_progress_output(
     """Channel URLs contain channel keys and must not be echoed while applying YAML."""
     secret_url = "https://meshtastic.org/e/#distinctive-channel-key"
     config_path = tmp_path / "channel.yaml"
-    config_path.write_text(yaml.safe_dump({"channel_url": secret_url}), encoding="utf-8")
+    config_path.write_text(
+        yaml.safe_dump({"channel_url": secret_url}), encoding="utf-8"
+    )
     target_node = MagicMock()
     target_node.getURL.return_value = "https://meshtastic.org/e/#old-key"
     iface = MagicMock()

--- a/meshtastic/tests/test_main_factory_reset.py
+++ b/meshtastic/tests/test_main_factory_reset.py
@@ -55,8 +55,6 @@ def _mock_newer_version_check(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-
-
 @pytest.mark.parametrize(
     ("reset_flag", "expected_full"),
     [("--factory-reset", False), ("--factory-reset-device", True)],
@@ -403,6 +401,7 @@ def test_post_factory_reset_ready_probe_closes_and_probes_reconnect() -> None:
     iface.connect.assert_called_once()
     assert iface.close.call_count >= 2
 
+
 @pytest.mark.unit
 def test_post_factory_reset_ready_probe_bounds_and_quiets_expected_failure(
     caplog: pytest.LogCaptureFixture,
@@ -432,6 +431,7 @@ def test_post_factory_reset_ready_probe_bounds_and_quiets_expected_failure(
     assert not hasattr(iface, "_connect_retry_budget_seconds")
     assert not hasattr(iface, "_suppress_connect_failure_logging")
     assert iface.close.call_count >= 2
+
 
 @pytest.mark.unit
 def test_temporary_instance_attributes_restores_existing_and_missing_values() -> None:

--- a/meshtastic/tests/test_mesh_interface.py
+++ b/meshtastic/tests/test_mesh_interface.py
@@ -498,8 +498,6 @@ def test_getNode_not_local(caplog: pytest.LogCaptureFixture) -> None:
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-
-
 @pytest.mark.parametrize("request_channel_attempts", [None, 2])
 def test_getNode_not_local_timeout(
     caplog: pytest.LogCaptureFixture,
@@ -636,8 +634,6 @@ def test_close_waits_for_inflight_heartbeat_send(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-
-
 @pytest.mark.parametrize(
     "disconnect_error",
     [
@@ -1234,8 +1230,6 @@ def test_sendPacket_uses_numeric_num_from_node_record(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-
-
 @pytest.mark.parametrize(
     ("destination_id", "expected_num"),
     [
@@ -1259,8 +1253,6 @@ def test_sendPacket_parses_supported_hex_node_id_forms(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-
-
 @pytest.mark.parametrize("destination_id", ["nothexid", "nothexid1"])
 def test_sendPacket_with_non_hex_long_destination_falls_back_to_db_lookup(
     iface_with_nodes: MeshInterface,
@@ -2574,17 +2566,19 @@ def test_request_traceroute_preserves_unknown_link_snr() -> None:
         response = mesh_pb2.RouteDiscovery()
         response.route.extend([11])
         response.snr_towards.extend([8])
-        result = flows_module._on_response_traceroute(  # pylint: disable=protected-access
-            iface,
-            {
-                "decoded": {
-                    "payload": response.SerializeToString(),
-                    "requestId": 89,
+        result = (
+            flows_module._on_response_traceroute(  # pylint: disable=protected-access
+                iface,
+                {
+                    "decoded": {
+                        "payload": response.SerializeToString(),
+                        "requestId": 89,
+                    },
+                    "to": 20,
+                    "from": 21,
                 },
-                "to": 20,
-                "from": 21,
-            },
-            emit_summary=False,
+                emit_summary=False,
+            )
         )
 
     assert result is not None
@@ -2600,18 +2594,20 @@ def test_request_traceroute_preserves_reverse_route_with_unknown_snr() -> None:
         response = mesh_pb2.RouteDiscovery()
         response.route_back.extend([12])
         response.snr_back.extend([16])
-        result = flows_module._on_response_traceroute(  # pylint: disable=protected-access
-            iface,
-            {
-                "decoded": {
-                    "payload": response.SerializeToString(),
-                    "requestId": 90,
+        result = (
+            flows_module._on_response_traceroute(  # pylint: disable=protected-access
+                iface,
+                {
+                    "decoded": {
+                        "payload": response.SerializeToString(),
+                        "requestId": 90,
+                    },
+                    "to": 20,
+                    "from": 21,
+                    "hopStart": 1,
                 },
-                "to": 20,
-                "from": 21,
-                "hopStart": 1,
-            },
-            emit_summary=False,
+                emit_summary=False,
+            )
         )
 
     assert result is not None
@@ -3023,8 +3019,6 @@ def test_on_response_waypoint_paths(caplog: pytest.LogCaptureFixture) -> None:
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-
-
 @pytest.mark.parametrize(
     ("handler_name", "waiter_name", "port_name", "error_prefix"),
     [
@@ -5014,6 +5008,7 @@ def test_mesh_interface_mqtt_proxy_delegates_to_send_pipeline() -> None:
         )
     ]
 
+
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_send_to_radio_reports_disconnected_queue_wait_as_interface_error() -> None:
@@ -5032,6 +5027,7 @@ def test_send_to_radio_reports_disconnected_queue_wait_as_interface_error() -> N
             iface._send_to_radio(packet)
 
         assert 903 not in iface.queue
+
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
@@ -5071,7 +5067,6 @@ def test_connection_probe_overrides_are_normalized() -> None:
     assert iface._connection_timeout_override("_probe_timeout", 3.0) == 3.0
     iface.__dict__["_probe_timeout"] = "invalid"
     assert iface._connection_timeout_override("_probe_timeout") is None
-
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_mesh_interface_queue_send_runtime.py
+++ b/meshtastic/tests/test_mesh_interface_queue_send_runtime.py
@@ -415,6 +415,7 @@ def test_send_to_radio_uses_runtime_pop_method(
 
     assert sent == [123, 456]
 
+
 @pytest.mark.unit
 def test_send_to_radio_times_out_when_queue_status_never_recovers(
     monkeypatch: pytest.MonkeyPatch,

--- a/meshtastic/tests/test_send_pipeline.py
+++ b/meshtastic/tests/test_send_pipeline.py
@@ -782,9 +782,7 @@ class TestSendTraceRoute:
         )
 
     @pytest.mark.unit
-    def test_request_traceroute_delegates(
-        self, send_pipeline: SendPipeline
-    ) -> None:
+    def test_request_traceroute_delegates(self, send_pipeline: SendPipeline) -> None:
         """Test structured traceroute requests delegate to the flow function."""
         with patch(
             "meshtastic.mesh_interface_runtime.send_pipeline._request_traceroute"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Includes PEP 561 py.typed marker for type checker support
 [tool.poetry]
 name = "mtjk"
-version = "2.7.11.post1"
+version = "2.7.11.post2"
 description = "Python API & client shell for talking to Meshtastic devices"
 authors = ["Meshtastic Developers (upstream project authors)"]
 maintainers = ["Jeremiah K. <jeremiahk@gmx.com>"]

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -939,8 +939,8 @@ def test_orchestrator_stale_cleanup_retry_maps_dbus_eof_to_typed_error(
         retry_client = DummyClient()
         clients = iter((direct_client, retry_client))
         closed_clients: list[DummyClient] = []
-        orchestrator._client_manager_create_client = (
-            lambda *_args, **_kwargs: next(clients)
+        orchestrator._client_manager_create_client = lambda *_args, **_kwargs: next(
+            clients
         )
 
         def _connect_client(client: DummyClient, **_kwargs: object) -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR updates project tooling and metadata while resolving lint-related issues. It pins a GitHub Actions dependency to a commit SHA, upgrades Grype, adjusts Trunk lint configuration, bumps the project version, and applies formatting-only changes across implementation and test files.

### Key changes

**Features**
- Pinned `c-hive/gha-remove-artifacts` to a specific commit SHA for reproducible workflow execution.
- Upgraded Grype from `0.110.0` to `0.116.0`.

**Fixes**
- Disabled `pinact` autofixes alongside `actionlint` because they can corrupt SHA-pinned workflow references.
- Updated related Trunk configuration and documentation.
- Refined `TypeError` message formatting in protobuf-to-dictionary conversion paths.

**Refactors**
- Bumped the project version from `2.7.11.post1` to `2.7.11.post2`.
- Applied formatting, type-annotation, import-order, and whitespace cleanup across source and test files.
- Reformatted several test calls and function definitions without changing test behavior.

No breaking changes or migration steps are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->