### PR TITLE
Derive inbound config fields from protobuf descriptors

### DIFF
--- a/meshtastic/mesh_interface_runtime/receive_pipeline.py
+++ b/meshtastic/mesh_interface_runtime/receive_pipeline.py
@@ -68,34 +68,11 @@ _FROM_RADIO_BRANCHES: tuple[
 )
 
 # Module-level constants
-LOCAL_CONFIG_FROM_RADIO_FIELDS: tuple[str, ...] = (
-    "device",
-    "position",
-    "power",
-    "network",
-    "display",
-    "lora",
-    "bluetooth",
-    "security",
-    "sessionkey",
-    "device_ui",
+LOCAL_CONFIG_FROM_RADIO_FIELDS: tuple[str, ...] = tuple(
+    field.name for field in config_pb2.Config.DESCRIPTOR.fields
 )
-MODULE_CONFIG_FROM_RADIO_FIELDS: tuple[str, ...] = (
-    "mqtt",
-    "serial",
-    "external_notification",
-    "store_forward",
-    "range_test",
-    "telemetry",
-    "canned_message",
-    "audio",
-    "remote_hardware",
-    "neighbor_info",
-    "detection_sensor",
-    "ambient_lighting",
-    "paxcounter",
-    "statusmessage",
-    "traffic_management",
+MODULE_CONFIG_FROM_RADIO_FIELDS: tuple[str, ...] = tuple(
+    field.name for field in module_config_pb2.ModuleConfig.DESCRIPTOR.fields
 )
 DECODE_FAILED_PREFIX = "decode-failed: "
 

--- a/meshtastic/node_runtime/settings_runtime/message.py
+++ b/meshtastic/node_runtime/settings_runtime/message.py
@@ -4,6 +4,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from google.protobuf.descriptor import FieldDescriptor
+from google.protobuf.message import Message
 
 from meshtastic.protobuf import admin_pb2
 
@@ -46,54 +47,29 @@ class _NodeSettingsMessageBuilder:
             f"Unsupported config descriptor: {config_type.name} in {config_type.containing_type.name}"
         )
 
-    def _write_config_dispatch(self) -> dict[str, tuple[str, Any]]:
-        """Return config-name mapping to (setter oneof, source config message)."""
-        node = self._node
-        dispatch = {
-            "device": ("set_config", node.localConfig.device),
-            "position": ("set_config", node.localConfig.position),
-            "power": ("set_config", node.localConfig.power),
-            "network": ("set_config", node.localConfig.network),
-            "display": ("set_config", node.localConfig.display),
-            "lora": ("set_config", node.localConfig.lora),
-            "bluetooth": ("set_config", node.localConfig.bluetooth),
-            "security": ("set_config", node.localConfig.security),
-            "mqtt": ("set_module_config", node.moduleConfig.mqtt),
-            "serial": ("set_module_config", node.moduleConfig.serial),
-            "external_notification": (
-                "set_module_config",
-                node.moduleConfig.external_notification,
-            ),
-            "store_forward": ("set_module_config", node.moduleConfig.store_forward),
-            "range_test": ("set_module_config", node.moduleConfig.range_test),
-            "telemetry": ("set_module_config", node.moduleConfig.telemetry),
-            "canned_message": ("set_module_config", node.moduleConfig.canned_message),
-            "audio": ("set_module_config", node.moduleConfig.audio),
-            "remote_hardware": (
-                "set_module_config",
-                node.moduleConfig.remote_hardware,
-            ),
-            "neighbor_info": ("set_module_config", node.moduleConfig.neighbor_info),
-            "detection_sensor": (
-                "set_module_config",
-                node.moduleConfig.detection_sensor,
-            ),
-            "ambient_lighting": (
-                "set_module_config",
-                node.moduleConfig.ambient_lighting,
-            ),
-            "paxcounter": ("set_module_config", node.moduleConfig.paxcounter),
-            "statusmessage": ("set_module_config", node.moduleConfig.statusmessage),
-            "traffic_management": (
-                "set_module_config",
-                node.moduleConfig.traffic_management,
-            ),
+    @staticmethod
+    def _write_entries_for(
+        setter_name: str, source_config: Message
+    ) -> dict[str, tuple[str, Any]]:
+        """Return writable fields shared by an admin setter and local cache."""
+        setter_field = admin_pb2.AdminMessage.DESCRIPTOR.fields_by_name[setter_name]
+        setter_message = setter_field.message_type
+        if setter_message is None:
+            raise ValueError(f"Admin setter {setter_name!r} is not a message field")
+
+        source_fields = source_config.DESCRIPTOR.fields_by_name
+        return {
+            field.name: (setter_name, getattr(source_config, field.name))
+            for field in setter_message.fields
+            if field.name in source_fields
         }
-        # Optional fields may appear in some protobuf schema revisions.
-        if hasattr(node.localConfig, "sessionkey"):
-            dispatch["sessionkey"] = ("set_config", node.localConfig.sessionkey)
-        if hasattr(node.localConfig, "device_ui"):
-            dispatch["device_ui"] = ("set_config", node.localConfig.device_ui)
+
+    def _write_config_dispatch(self) -> dict[str, tuple[str, Any]]:
+        """Return schema-driven config-name to admin setter/source mapping."""
+        dispatch = self._write_entries_for("set_config", self._node.localConfig)
+        dispatch.update(
+            self._write_entries_for("set_module_config", self._node.moduleConfig)
+        )
         return dispatch
 
     def get_write_config_entry(self, config_name: str) -> tuple[str, Any] | None:

--- a/meshtastic/tests/test_node_settings_write_dispatch.py
+++ b/meshtastic/tests/test_node_settings_write_dispatch.py
@@ -1,0 +1,67 @@
+"""Focused tests for schema-driven settings write dispatch."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from google.protobuf.message import Message
+
+from meshtastic.node_runtime.settings_runtime.message import _NodeSettingsMessageBuilder
+from meshtastic.protobuf import admin_pb2, atak_pb2, localonly_pb2
+
+
+def _builder() -> tuple[_NodeSettingsMessageBuilder, MagicMock]:
+    node = MagicMock(spec=["localConfig", "moduleConfig", "_raise_interface_error"])
+    node.localConfig = localonly_pb2.LocalConfig()
+    node.moduleConfig = localonly_pb2.LocalModuleConfig()
+    return _NodeSettingsMessageBuilder(node), node
+
+
+def _shared_field_names(setter_name: str, source: Message) -> set[str]:
+    setter = admin_pb2.AdminMessage.DESCRIPTOR.fields_by_name[setter_name]
+    assert setter.message_type is not None
+    return set(setter.message_type.fields_by_name) & set(source.DESCRIPTOR.fields_by_name)
+
+
+@pytest.mark.unit
+def test_write_dispatch_matches_admin_and_local_config_schema_intersection() -> None:
+    """Writable sections should follow both admin wire schema and local cache schema."""
+    builder, node = _builder()
+
+    dispatch = builder._write_config_dispatch()  # noqa: SLF001
+
+    expected_local = _shared_field_names("set_config", node.localConfig)
+    expected_module = _shared_field_names("set_module_config", node.moduleConfig)
+    assert set(dispatch) == expected_local | expected_module
+    assert all(dispatch[name][0] == "set_config" for name in expected_local)
+    assert all(dispatch[name][0] == "set_module_config" for name in expected_module)
+    assert "version" not in dispatch
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("config_name", "field_name", "value"),
+    [("tak", "team", atak_pb2.Team.Red), ("mesh_beacon", "flags", 5)],
+)
+def test_new_module_sections_build_write_messages(
+    config_name: str, field_name: str, value: int
+) -> None:
+    """New module sections received/exported by the client must also be writable."""
+    builder, node = _builder()
+    source_config = getattr(node.moduleConfig, config_name)
+    setattr(source_config, field_name, value)
+
+    message = builder.build_write_message(config_name)
+
+    assert message.HasField("set_module_config")
+    assert message.set_module_config.HasField(config_name)
+    assert getattr(message.set_module_config, config_name) == source_config
+
+
+@pytest.mark.unit
+def test_unknown_write_section_remains_invalid() -> None:
+    """Descriptor-driven dispatch must not make arbitrary names writable."""
+    builder, node = _builder()
+    node._raise_interface_error.side_effect = RuntimeError
+
+    with pytest.raises(RuntimeError):
+        builder.validate_config_name("not_a_config_section")

--- a/meshtastic/tests/test_node_settings_write_dispatch.py
+++ b/meshtastic/tests/test_node_settings_write_dispatch.py
@@ -53,7 +53,8 @@ def test_new_module_sections_build_write_messages(
     message = builder.build_write_message(config_name)
 
     assert message.HasField("set_module_config")
-    assert message.set_module_config.HasField(config_name)
+    populated = {field.name for field, _ in message.set_module_config.ListFields()}
+    assert config_name in populated
     assert getattr(message.set_module_config, config_name) == source_config
 
 

--- a/meshtastic/tests/test_receive_pipeline_config_fields.py
+++ b/meshtastic/tests/test_receive_pipeline_config_fields.py
@@ -4,13 +4,14 @@ import threading
 from types import SimpleNamespace
 
 import pytest
+from google.protobuf.descriptor import Descriptor
 
 from meshtastic.mesh_interface_runtime.receive_pipeline import (
     LOCAL_CONFIG_FROM_RADIO_FIELDS,
     MODULE_CONFIG_FROM_RADIO_FIELDS,
     ReceivePipeline,
 )
-from meshtastic.protobuf import atak_pb2, config_pb2, localonly_pb2, module_config_pb2
+from meshtastic.protobuf import config_pb2, localonly_pb2, module_config_pb2
 
 
 @pytest.mark.unit
@@ -25,21 +26,74 @@ def test_receive_field_lists_follow_active_protobuf_descriptors() -> None:
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("field_name", ["tak", "mesh_beacon"])
-def test_new_module_config_fields_update_local_cache(field_name: str) -> None:
-    """Recently added module config sections must not be silently dropped."""
-    local_node = SimpleNamespace(moduleConfig=localonly_pb2.LocalModuleConfig())
+@pytest.mark.parametrize(
+    "descriptor",
+    [config_pb2.Config.DESCRIPTOR, module_config_pb2.ModuleConfig.DESCRIPTOR],
+)
+def test_inbound_config_wrappers_remain_singular_messages(descriptor: Descriptor) -> None:
+    """Receive-copy logic relies on wrapper fields being singular submessages."""
+    fields = descriptor.fields
+    assert fields
+    assert all(field.message_type is not None for field in fields)
+    assert all(not field.is_repeated for field in fields)
+
+
+def _pipeline_with_local_node() -> tuple[ReceivePipeline, SimpleNamespace]:
+    local_node = SimpleNamespace(
+        localConfig=localonly_pb2.LocalConfig(),
+        moduleConfig=localonly_pb2.LocalModuleConfig(),
+    )
     interface = SimpleNamespace(
         _node_db_lock=threading.RLock(),
         localNode=local_node,
     )
-    pipeline = ReceivePipeline(interface)  # type: ignore[arg-type]
-    incoming = module_config_pb2.ModuleConfig()
+    return ReceivePipeline(interface), local_node  # type: ignore[arg-type]
 
-    if field_name == "tak":
-        incoming.tak.team = atak_pb2.Team.Red
-    else:
-        incoming.mesh_beacon.broadcast_message = "schema-driven"
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "field_name",
+    sorted(
+        set(config_pb2.Config.DESCRIPTOR.fields_by_name)
+        & set(localonly_pb2.LocalConfig.DESCRIPTOR.fields_by_name)
+    ),
+)
+def test_every_supported_local_config_field_updates_local_cache(field_name: str) -> None:
+    """Every wire config field supported by LocalConfig should be copied."""
+    pipeline, local_node = _pipeline_with_local_node()
+    incoming = config_pb2.Config()
+    getattr(incoming, field_name).SetInParent()
+
+    assert pipeline._apply_local_config_from_radio(incoming)  # noqa: SLF001
+    assert local_node.localConfig.HasField(field_name)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "field_name",
+    sorted(
+        set(config_pb2.Config.DESCRIPTOR.fields_by_name)
+        - set(localonly_pb2.LocalConfig.DESCRIPTOR.fields_by_name)
+    ),
+)
+def test_wire_only_local_config_fields_are_ignored_safely(field_name: str) -> None:
+    """Wire-only config sections should not be treated as cache updates."""
+    pipeline, _local_node = _pipeline_with_local_node()
+    incoming = config_pb2.Config()
+    getattr(incoming, field_name).SetInParent()
+
+    assert not pipeline._apply_local_config_from_radio(incoming)  # noqa: SLF001
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "field_name", [field.name for field in module_config_pb2.ModuleConfig.DESCRIPTOR.fields]
+)
+def test_every_module_config_field_updates_local_cache(field_name: str) -> None:
+    """Every module config wrapper field should copy into the local cache."""
+    pipeline, local_node = _pipeline_with_local_node()
+    incoming = module_config_pb2.ModuleConfig()
+    getattr(incoming, field_name).SetInParent()
 
     assert pipeline._apply_module_config_from_radio(incoming)  # noqa: SLF001
-    assert getattr(local_node.moduleConfig, field_name) == getattr(incoming, field_name)
+    assert local_node.moduleConfig.HasField(field_name)

--- a/meshtastic/tests/test_receive_pipeline_config_fields.py
+++ b/meshtastic/tests/test_receive_pipeline_config_fields.py
@@ -1,0 +1,45 @@
+"""Regression tests for descriptor-driven configuration receive fields."""
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from meshtastic.mesh_interface_runtime.receive_pipeline import (
+    LOCAL_CONFIG_FROM_RADIO_FIELDS,
+    MODULE_CONFIG_FROM_RADIO_FIELDS,
+    ReceivePipeline,
+)
+from meshtastic.protobuf import atak_pb2, config_pb2, localonly_pb2, module_config_pb2
+
+
+@pytest.mark.unit
+def test_receive_field_lists_follow_active_protobuf_descriptors() -> None:
+    """Every inbound config field in the active schema should be considered."""
+    assert LOCAL_CONFIG_FROM_RADIO_FIELDS == tuple(
+        field.name for field in config_pb2.Config.DESCRIPTOR.fields
+    )
+    assert MODULE_CONFIG_FROM_RADIO_FIELDS == tuple(
+        field.name for field in module_config_pb2.ModuleConfig.DESCRIPTOR.fields
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("field_name", ["tak", "mesh_beacon"])
+def test_new_module_config_fields_update_local_cache(field_name: str) -> None:
+    """Recently added module config sections must not be silently dropped."""
+    local_node = SimpleNamespace(moduleConfig=localonly_pb2.LocalModuleConfig())
+    interface = SimpleNamespace(
+        _node_db_lock=threading.RLock(),
+        localNode=local_node,
+    )
+    pipeline = ReceivePipeline(interface)  # type: ignore[arg-type]
+    incoming = module_config_pb2.ModuleConfig()
+
+    if field_name == "tak":
+        incoming.tak.team = atak_pb2.Team.Red
+    else:
+        incoming.mesh_beacon.broadcast_message = "schema-driven"
+
+    assert pipeline._apply_module_config_from_radio(incoming)  # noqa: SLF001
+    assert getattr(local_node.moduleConfig, field_name) == getattr(incoming, field_name)


### PR DESCRIPTION
## Summary by Sourcery

Derive inbound configuration field lists from protobuf descriptors to keep them in sync with the active schema and ensure newly added module config sections are correctly applied to the local cache.

Enhancements:
- Replace hard-coded inbound config field lists with values derived from the Config and ModuleConfig protobuf descriptors to automatically track schema changes.

Tests:
- Add regression tests to verify descriptor-driven config field lists and ensure new module config sections like TAK and mesh_beacon update the local node cache correctly.