### PR TITLE
Validate CLI preference values without tracebacks

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -172,9 +172,6 @@ _CONFIGURE_PREFLIGHT_MODE: contextvars.ContextVar[bool] = contextvars.ContextVar
 _SET_PREF_VALUE_ERRORS_FATAL: contextvars.ContextVar[bool] = contextvars.ContextVar(
     "set_pref_value_errors_fatal", default=False
 )
-_PREF_VALIDATION_REPORTER: contextvars.ContextVar[Callable[[str], None] | None] = (
-    contextvars.ContextVar("pref_validation_reporter", default=None)
-)
 
 
 class _PreferenceValueError(ValueError):
@@ -332,23 +329,15 @@ def _cli_print(message: str, *, force: bool = False) -> None:
 
 
 def _report_pref_validation(message: str) -> None:
-    """Route preference validation output through the active validation context.
+    """Print preference validation output through the shared CLI path.
 
     Parameters
     ----------
     message : str
         User-facing validation diagnostic.
 
-    Notes
-    -----
     Configure preflight intentionally suppresses low-level duplicate diagnostics.
-    Other preflight callers may install a context-local reporter to aggregate the
-    messages and surface them after the full batch has been validated.
     """
-    reporter = _PREF_VALIDATION_REPORTER.get()
-    if reporter is not None:
-        reporter(message)
-        return
     _cli_print(message, force=not _CONFIGURE_PREFLIGHT_MODE.get())
 
 
@@ -2989,6 +2978,11 @@ def onConnected(interface: MeshInterface) -> None:
 
                 _cli_print("Writing modified channels to device")
                 node.writeChannel(_idx)
+            else:
+                _cli_exit(
+                    "Warning: Unknown channel setting name. No changes were made.",
+                    1,
+                )
 
         if args.get_canned_message:
             closeNow = True

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -172,6 +172,9 @@ _CONFIGURE_PREFLIGHT_MODE: contextvars.ContextVar[bool] = contextvars.ContextVar
 _SET_PREF_VALUE_ERRORS_FATAL: contextvars.ContextVar[bool] = contextvars.ContextVar(
     "set_pref_value_errors_fatal", default=False
 )
+_PREF_VALIDATION_REPORTER: contextvars.ContextVar[Callable[[str], None] | None] = (
+    contextvars.ContextVar("pref_validation_reporter", default=None)
+)
 
 
 class _PreferenceValueError(ValueError):
@@ -326,6 +329,27 @@ def _cli_print(message: str, *, force: bool = False) -> None:
     if not force and args and getattr(args, "quiet", False):
         return
     print(message)
+
+
+def _report_pref_validation(message: str) -> None:
+    """Route preference validation output through the active validation context.
+
+    Parameters
+    ----------
+    message : str
+        User-facing validation diagnostic.
+
+    Notes
+    -----
+    Configure preflight intentionally suppresses low-level duplicate diagnostics.
+    Other preflight callers may install a context-local reporter to aggregate the
+    messages and surface them after the full batch has been validated.
+    """
+    reporter = _PREF_VALIDATION_REPORTER.get()
+    if reporter is not None:
+        reporter(message)
+        return
+    _cli_print(message, force=not _CONFIGURE_PREFLIGHT_MODE.get())
 
 
 def supportInfo() -> None:
@@ -1499,7 +1523,7 @@ def _protobuf_field_type_label(field: FieldDescriptor) -> str:
     str
         Concise user-facing label for the field type.
     """
-    if field.type in {
+    integer_types = {
         FieldDescriptor.TYPE_INT32,
         FieldDescriptor.TYPE_INT64,
         FieldDescriptor.TYPE_UINT32,
@@ -1510,18 +1534,19 @@ def _protobuf_field_type_label(field: FieldDescriptor) -> str:
         FieldDescriptor.TYPE_FIXED64,
         FieldDescriptor.TYPE_SFIXED32,
         FieldDescriptor.TYPE_SFIXED64,
-    }:
+    }
+    if field.type in integer_types:
         return "integer"
-    if field.type in {FieldDescriptor.TYPE_FLOAT, FieldDescriptor.TYPE_DOUBLE}:
-        return "number"
-    if field.type == FieldDescriptor.TYPE_BOOL:
-        return "boolean"
-    if field.type == FieldDescriptor.TYPE_BYTES:
-        return "bytes (hex/base64)"
-    if field.type == FieldDescriptor.TYPE_STRING:
-        return "string"
-    return "compatible value"
 
+    type_labels = {
+        FieldDescriptor.TYPE_ENUM: "enum name or integer",
+        FieldDescriptor.TYPE_FLOAT: "number",
+        FieldDescriptor.TYPE_DOUBLE: "number",
+        FieldDescriptor.TYPE_BOOL: "boolean",
+        FieldDescriptor.TYPE_BYTES: "bytes (hex/base64)",
+        FieldDescriptor.TYPE_STRING: "string",
+    }
+    return type_labels.get(field.type, "compatible value")
 
 
 def _print_channel_field_choices(settings: Any, pref_name: str) -> None:
@@ -1546,6 +1571,45 @@ def _print_channel_field_choices(settings: Any, pref_name: str) -> None:
             continue
         for sub_field in sorted(field.message_type.fields, key=lambda item: item.name):
             print(f"    {field.name}.{sub_field.name}")
+
+
+def _reject_pref_value(
+    field: FieldDescriptor,
+    *,
+    field_path: str,
+    raw_value: Any,
+) -> bool:
+    """Report one invalid preference value without exposing secret input.
+
+    Parameters
+    ----------
+    field : FieldDescriptor
+        Descriptor for the field whose value was rejected.
+    field_path : str
+        Canonical dotted preference path used in diagnostics and redaction.
+    raw_value : Any
+        Original caller-supplied value used for safe diagnostic rendering.
+
+    Returns
+    -------
+    bool
+        Always ``False`` for convenient use from validation branches.
+
+    Raises
+    ------
+    _PreferenceValueError
+        If fatal preference-value handling is active.
+    """
+    display_value = _redact_pref_value(field_path, repr(raw_value))
+    message = (
+        f"Invalid value {display_value} for {field_path}; "
+        f"expected {_protobuf_field_type_label(field)}."
+    )
+    if _SET_PREF_VALUE_ERRORS_FATAL.get():
+        raise _PreferenceValueError(message)
+    _report_pref_validation(message)
+    return False
+
 
 def _assign_scalar_pref_value(
     target: Any,
@@ -1591,15 +1655,7 @@ def _assign_scalar_pref_value(
                 return True
             except (TypeError, ValueError, OverflowError):
                 pass
-    display_value = _redact_pref_value(field_path, repr(raw_value))
-    message = (
-        f"Invalid value {display_value} for {field_path}; "
-        f"expected {_protobuf_field_type_label(field)}."
-    )
-    if _SET_PREF_VALUE_ERRORS_FATAL.get():
-        raise _PreferenceValueError(message)
-    _cli_print(message, force=not _CONFIGURE_PREFLIGHT_MODE.get())
-    return False
+    return _reject_pref_value(field, field_path=field_path, raw_value=raw_value)
 
 
 def setPref(config: Any, comp_name: str, raw_val: Any) -> bool:
@@ -1655,16 +1711,25 @@ def setPref(config: Any, comp_name: str, raw_val: Any) -> bool:
         try:
             val = _parse_bitfield_value(bitfield_enum, raw_val)
         except ValueError as e:
-            print(f"ERROR: {e}")
+            _report_pref_validation(f"ERROR: {e}")
             return False
     elif isinstance(raw_val, str):
-        val = meshtastic.util.fromStr(raw_val)
+        try:
+            val = meshtastic.util.fromStr(raw_val)
+        except (ValueError, binascii.Error):
+            return _reject_pref_value(
+                pref,
+                field_path=comp_name,
+                raw_value=raw_val,
+            )
     else:
         val = raw_val
     logger.debug("val:%s", _redact_pref_value(comp_name, meshtastic.util.toStr(val)))
 
     if snake_name == "wifi_psk" and len(str(raw_val)) < 8:
-        print("Warning: network.wifi_psk must be 8 or more characters.")
+        _report_pref_validation(
+            "Warning: network.wifi_psk must be 8 or more characters."
+        )
         return False
 
     enumType = pref.enum_type
@@ -1674,16 +1739,16 @@ def setPref(config: Any, comp_name: str, raw_val: Any) -> bool:
         if ev:
             val = ev.number
         else:
-            print(
+            _report_pref_validation(
                 f"{name[0]}.{uni_name} does not have an enum called {val}, so you can not set it."
             )
-            print("Choices in sorted order are:")
+            _report_pref_validation("Choices in sorted order are:")
             names = []
             for f in enumType.values:
                 # Note: We must use the value of the enum (regardless if camel or snake case)
                 names.append(f"{f.name}")
             for temp_name in sorted(names):
-                print(f"    {temp_name}")
+                _report_pref_validation(f"    {temp_name}")
             return False
 
     # repeating fields need to be handled with append, not setattr
@@ -1702,30 +1767,48 @@ def setPref(config: Any, comp_name: str, raw_val: Any) -> bool:
             field_path=comp_name,
             raw_value=raw_val,
         )
-    elif isinstance(val, list):
-        new_vals = [meshtastic.util.fromStr(x) for x in val]
-        config_values = getattr(config, config_type.name)
-        getattr(config_values, pref.name)[:] = new_vals
     else:
-        config_values = getattr(config, config_type.name)
-        if val == 0:
-            # clear values
-            if not _CONFIGURE_PREFLIGHT_MODE.get():
-                _cli_print(f"Clearing {pref.name} list")
-            del getattr(config_values, pref.name)[:]
-        else:
-            display_value = _redact_pref_value(
-                comp_name, meshtastic.util.toStr(raw_val)
+        target = (
+            getattr(config_part, config_type.name)
+            if config_type.message_type is not None
+            else config_part
+        )
+        candidate = type(target)()
+        candidate.CopyFrom(target)
+        candidate_values = getattr(candidate, pref.name)
+        try:
+            if isinstance(val, list):
+                new_vals = [
+                    meshtastic.util.fromStr(item) if isinstance(item, str) else item
+                    for item in val
+                ]
+                candidate_values[:] = new_vals
+            elif val == 0:
+                del candidate_values[:]
+            else:
+                cur_vals = [x for x in candidate_values if x not in [0, "", b""]]
+                if val not in cur_vals:
+                    cur_vals.append(val)
+                candidate_values[:] = cur_vals
+        except (TypeError, ValueError, OverflowError, binascii.Error):
+            assignment_ok = _reject_pref_value(
+                pref,
+                field_path=comp_name,
+                raw_value=raw_val,
             )
-            if not _CONFIGURE_PREFLIGHT_MODE.get():
-                _cli_print(f"Adding '{display_value}' to the {pref.name} list")
-            cur_vals = [
-                x for x in getattr(config_values, pref.name) if x not in [0, "", b""]
-            ]
-            if val not in cur_vals:
-                cur_vals.append(val)
-            getattr(config_values, pref.name)[:] = cur_vals
-        print_assignment = False
+        else:
+            target.CopyFrom(candidate)
+            if not isinstance(val, list):
+                if val == 0:
+                    if not _CONFIGURE_PREFLIGHT_MODE.get():
+                        _cli_print(f"Clearing {pref.name} list")
+                else:
+                    display_value = _redact_pref_value(
+                        comp_name, meshtastic.util.toStr(raw_val)
+                    )
+                    if not _CONFIGURE_PREFLIGHT_MODE.get():
+                        _cli_print(f"Adding '{display_value}' to the {pref.name} list")
+                print_assignment = False
 
     if assignment_ok and print_assignment:
         prefix = (
@@ -2880,7 +2963,7 @@ def onConnected(interface: MeshInterface) -> None:
                     if not _resolve_pref(pending_settings, pref[0]):
                         _print_channel_field_choices(pending_settings, pref[0])
                         channel_update_valid = False
-                        break
+                        continue
                     try:
                         with _fatal_preference_value_errors():
                             found = setPref(pending_settings, pref[0], pref[1])

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -2869,6 +2869,7 @@ def onConnected(interface: MeshInterface) -> None:
             # leave earlier values partially mutated in the local cache.
             pending_settings = type(ch.settings)()
             pending_settings.CopyFrom(ch.settings)
+            channel_update_valid = True
             for pref in args.ch_set or []:
                 if pref[0] == "psk":
                     try:
@@ -2878,7 +2879,8 @@ def onConnected(interface: MeshInterface) -> None:
                 else:
                     if not _resolve_pref(pending_settings, pref[0]):
                         _print_channel_field_choices(pending_settings, pref[0])
-                        _cli_exit("Channel setting was not applied.", 1)
+                        channel_update_valid = False
+                        break
                     try:
                         with _fatal_preference_value_errors():
                             found = setPref(pending_settings, pref[0], pref[1])
@@ -2889,20 +2891,21 @@ def onConnected(interface: MeshInterface) -> None:
 
                 enable = True  # If we set any pref, assume the user wants to enable the channel
 
-            if args.ch_set:
-                ch.settings.CopyFrom(pending_settings)
+            if channel_update_valid:
+                if args.ch_set:
+                    ch.settings.CopyFrom(pending_settings)
 
-            if enable:
-                ch.role = (
-                    channel_pb2.Channel.Role.PRIMARY
-                    if (_idx == 0)
-                    else channel_pb2.Channel.Role.SECONDARY
-                )
-            else:
-                ch.role = channel_pb2.Channel.Role.DISABLED
+                if enable:
+                    ch.role = (
+                        channel_pb2.Channel.Role.PRIMARY
+                        if (_idx == 0)
+                        else channel_pb2.Channel.Role.SECONDARY
+                    )
+                else:
+                    ch.role = channel_pb2.Channel.Role.DISABLED
 
-            _cli_print("Writing modified channels to device")
-            node.writeChannel(_idx)
+                _cli_print("Writing modified channels to device")
+                node.writeChannel(_idx)
 
         if args.get_canned_message:
             closeNow = True

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -178,6 +178,16 @@ class _PreferenceValueError(ValueError):
     """Raised internally when CLI preference assignment has an invalid scalar value."""
 
 
+@contextlib.contextmanager
+def _fatal_preference_value_errors() -> Iterator[None]:
+    """Temporarily make scalar preference validation failures fatal to the CLI."""
+    token = _SET_PREF_VALUE_ERRORS_FATAL.set(True)
+    try:
+        yield
+    finally:
+        _SET_PREF_VALUE_ERRORS_FATAL.reset(token)
+
+
 # Map dotted preference paths to the protobuf enum that defines their flags.
 # These fields are stored as uint32 bitmasks in the protobuf but have an
 # associated enum that names the individual flags. Add new bitfield-enum
@@ -1517,8 +1527,9 @@ def _assign_scalar_pref_value(
                 return True
             except (TypeError, ValueError, OverflowError):
                 pass
+    display_value = _redact_pref_value(field_path, repr(raw_value))
     message = (
-        f"Invalid value {raw_value!r} for {field_path}; "
+        f"Invalid value {display_value} for {field_path}; "
         f"expected {_protobuf_field_type_label(field)}."
     )
     if _SET_PREF_VALUE_ERRORS_FATAL.get():
@@ -1731,13 +1742,11 @@ def _handle_set_command(
             if config_type is not None:
                 if len(config.ListFields()) == 0:
                     node.requestConfig(config_type)
-                token = _SET_PREF_VALUE_ERRORS_FATAL.set(True)
                 try:
-                    found = setPref(config, normalized_pref_name, pref_item[1])
+                    with _fatal_preference_value_errors():
+                        found = setPref(config, normalized_pref_name, pref_item[1])
                 except _PreferenceValueError as exc:
                     _cli_exit(str(exc), 1)
-                finally:
-                    _SET_PREF_VALUE_ERRORS_FATAL.reset(token)
                 if found:
                     any_found = True
                     fields.add(field)

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -311,15 +311,19 @@ def _cli_exit(message: str, return_value: int = 1) -> NoReturn:
     meshtastic.util.our_exit(message, return_value)
 
 
-def _cli_print(message: str) -> None:
-    """Print a message to stdout unless --quiet is active.
+def _cli_print(message: str, *, force: bool = False) -> None:
+    """Print a CLI message, optionally bypassing ``--quiet`` suppression.
 
-    This helper gates non-essential informational output so that --quiet
-    suppresses ordinary print() calls in addition to lowering the logging
-    level.
+    Parameters
+    ----------
+    message : str
+        User-facing message to print to stdout.
+    force : bool
+        When ``True``, print even if ``--quiet`` is active. Use this for
+        validation output that must remain visible to the user.
     """
     args = mt_config.args
-    if args and getattr(args, "quiet", False):
+    if not force and args and getattr(args, "quiet", False):
         return
     print(message)
 
@@ -1483,7 +1487,18 @@ def _resolve_pref(config: Any, comp_name: str) -> bool:
 
 
 def _protobuf_field_type_label(field: FieldDescriptor) -> str:
-    """Return a concise user-facing type label for a protobuf field."""
+    """Return a concise user-facing type label for a protobuf field.
+
+    Parameters
+    ----------
+    field : FieldDescriptor
+        Protobuf field whose expected CLI value type should be described.
+
+    Returns
+    -------
+    str
+        Concise user-facing label for the field type.
+    """
     if field.type in {
         FieldDescriptor.TYPE_INT32,
         FieldDescriptor.TYPE_INT64,
@@ -1508,6 +1523,30 @@ def _protobuf_field_type_label(field: FieldDescriptor) -> str:
     return "compatible value"
 
 
+
+def _print_channel_field_choices(settings: Any, pref_name: str) -> None:
+    """Print available channel-setting fields after an unknown --ch-set name.
+
+    Parameters
+    ----------
+    settings : Any
+        Channel settings protobuf whose fields should be listed.
+    pref_name : str
+        Unknown preference name supplied to ``--ch-set``.
+    """
+    print(f"{settings.__class__.__name__} does not have an attribute {pref_name}.")
+    print("Choices are...")
+    for field in settings.DESCRIPTOR.fields:
+        if field.name != "module_settings":
+            print(field.name)
+            continue
+
+        print(f"{field.name}:")
+        if field.message_type is None:
+            continue
+        for sub_field in sorted(field.message_type.fields, key=lambda item: item.name):
+            print(f"    {field.name}.{sub_field.name}")
+
 def _assign_scalar_pref_value(
     target: Any,
     field: FieldDescriptor,
@@ -1516,7 +1555,32 @@ def _assign_scalar_pref_value(
     field_path: str,
     raw_value: Any,
 ) -> bool:
-    """Assign one non-repeated protobuf field without leaking conversion errors."""
+    """Assign one non-repeated protobuf field without leaking conversion errors.
+
+    Parameters
+    ----------
+    target : Any
+        Protobuf message instance that owns ``field``.
+    field : FieldDescriptor
+        Descriptor for the scalar field being assigned.
+    value : Any
+        Converted value to assign to the protobuf field.
+    field_path : str
+        Canonical dotted preference path used in diagnostics and redaction.
+    raw_value : Any
+        Original caller-supplied value used for safe diagnostic rendering.
+
+    Returns
+    -------
+    bool
+        ``True`` when assignment succeeds; ``False`` when a non-fatal
+        validation failure is reported.
+
+    Raises
+    ------
+    _PreferenceValueError
+        If assignment fails while fatal preference-value handling is active.
+    """
     try:
         setattr(target, field.name, value)
         return True
@@ -1534,7 +1598,7 @@ def _assign_scalar_pref_value(
     )
     if _SET_PREF_VALUE_ERRORS_FATAL.get():
         raise _PreferenceValueError(message)
-    print(message)
+    _cli_print(message, force=not _CONFIGURE_PREFLIGHT_MODE.get())
     return False
 
 
@@ -2801,39 +2865,32 @@ def onConnected(interface: MeshInterface) -> None:
                 if args.ch_disable:
                     enable = False
 
-            # Handle the channel settings
+            # Validate channel settings on a copy so a later invalid entry cannot
+            # leave earlier values partially mutated in the local cache.
+            pending_settings = type(ch.settings)()
+            pending_settings.CopyFrom(ch.settings)
             for pref in args.ch_set or []:
                 if pref[0] == "psk":
-                    found = True
                     try:
-                        ch.settings.psk = meshtastic.util.fromPSK(pref[1])
+                        pending_settings.psk = meshtastic.util.fromPSK(pref[1])
                     except ValueError as exc:
                         _cli_exit(f"Invalid channel PSK: {exc}", 1)
                 else:
-                    found = setPref(ch.settings, pref[0], pref[1])
-                if not found:
-                    category_settings = ["module_settings"]
-                    print(
-                        f"{ch.settings.__class__.__name__} does not have an attribute {pref[0]}."
-                    )
-                    print("Choices are...")
-                    for field in ch.settings.DESCRIPTOR.fields:
-                        if field.name not in category_settings:
-                            print(f"{field.name}")
-                        else:
-                            print(f"{field.name}:")
-                            config = ch.settings.DESCRIPTOR.fields_by_name.get(
-                                field.name
-                            )
-                            names = []
-                            if config is not None and config.message_type is not None:
-                                for sub_field in config.message_type.fields:
-                                    tmp_name = f"{field.name}.{sub_field.name}"
-                                    names.append(tmp_name)
-                            for temp_name in sorted(names):
-                                print(f"    {temp_name}")
+                    if not _resolve_pref(pending_settings, pref[0]):
+                        _print_channel_field_choices(pending_settings, pref[0])
+                        _cli_exit("Channel setting was not applied.", 1)
+                    try:
+                        with _fatal_preference_value_errors():
+                            found = setPref(pending_settings, pref[0], pref[1])
+                    except _PreferenceValueError as exc:
+                        _cli_exit(str(exc), 1)
+                    if not found:
+                        _cli_exit(f"Invalid value for channel setting {pref[0]}.", 1)
 
                 enable = True  # If we set any pref, assume the user wants to enable the channel
+
+            if args.ch_set:
+                ch.settings.CopyFrom(pending_settings)
 
             if enable:
                 ch.role = (

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -169,6 +169,14 @@ logger = logging.getLogger(__name__)
 _CONFIGURE_PREFLIGHT_MODE: contextvars.ContextVar[bool] = contextvars.ContextVar(
     "configure_preflight_mode", default=False
 )
+_SET_PREF_VALUE_ERRORS_FATAL: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "set_pref_value_errors_fatal", default=False
+)
+
+
+class _PreferenceValueError(ValueError):
+    """Raised internally when CLI preference assignment has an invalid scalar value."""
+
 
 # Map dotted preference paths to the protobuf enum that defines their flags.
 # These fields are stored as uint32 bitmasks in the protobuf but have an
@@ -1464,6 +1472,61 @@ def _resolve_pref(config: Any, comp_name: str) -> bool:
     return config_type is not None
 
 
+def _protobuf_field_type_label(field: FieldDescriptor) -> str:
+    """Return a concise user-facing type label for a protobuf field."""
+    if field.type in {
+        FieldDescriptor.TYPE_INT32,
+        FieldDescriptor.TYPE_INT64,
+        FieldDescriptor.TYPE_UINT32,
+        FieldDescriptor.TYPE_UINT64,
+        FieldDescriptor.TYPE_SINT32,
+        FieldDescriptor.TYPE_SINT64,
+        FieldDescriptor.TYPE_FIXED32,
+        FieldDescriptor.TYPE_FIXED64,
+        FieldDescriptor.TYPE_SFIXED32,
+        FieldDescriptor.TYPE_SFIXED64,
+    }:
+        return "integer"
+    if field.type in {FieldDescriptor.TYPE_FLOAT, FieldDescriptor.TYPE_DOUBLE}:
+        return "number"
+    if field.type == FieldDescriptor.TYPE_BOOL:
+        return "boolean"
+    if field.type == FieldDescriptor.TYPE_BYTES:
+        return "bytes (hex/base64)"
+    if field.type == FieldDescriptor.TYPE_STRING:
+        return "string"
+    return "compatible value"
+
+
+def _assign_scalar_pref_value(
+    target: Any,
+    field: FieldDescriptor,
+    value: Any,
+    *,
+    field_path: str,
+    raw_value: Any,
+) -> bool:
+    """Assign one non-repeated protobuf field without leaking conversion errors."""
+    try:
+        setattr(target, field.name, value)
+        return True
+    except (TypeError, ValueError, OverflowError):
+        if field.type == FieldDescriptor.TYPE_STRING and not isinstance(value, str):
+            try:
+                setattr(target, field.name, str(value))
+                return True
+            except (TypeError, ValueError, OverflowError):
+                pass
+    message = (
+        f"Invalid value {raw_value!r} for {field_path}; "
+        f"expected {_protobuf_field_type_label(field)}."
+    )
+    if _SET_PREF_VALUE_ERRORS_FATAL.get():
+        raise _PreferenceValueError(message)
+    print(message)
+    return False
+
+
 def setPref(config: Any, comp_name: str, raw_val: Any) -> bool:
     """Set a protobuf configuration or channel field identified by a dot-separated path.
 
@@ -1549,17 +1612,21 @@ def setPref(config: Any, comp_name: str, raw_val: Any) -> bool:
             return False
 
     # repeating fields need to be handled with append, not setattr
+    assignment_ok = True
+    print_assignment = True
     if not _is_repeated_field(pref):
-        try:
-            if config_type.message_type is not None:
-                config_values = getattr(config_part, config_type.name)
-                setattr(config_values, pref.name, val)
-            else:
-                setattr(config_part, snake_name, val)
-        except TypeError:
-            # The setter didn't like our arg type guess try again as a string
-            config_values = getattr(config_part, config_type.name)
-            setattr(config_values, pref.name, str(val))
+        target = (
+            getattr(config_part, config_type.name)
+            if config_type.message_type is not None
+            else config_part
+        )
+        assignment_ok = _assign_scalar_pref_value(
+            target,
+            pref,
+            val,
+            field_path=comp_name,
+            raw_value=raw_val,
+        )
     elif isinstance(val, list):
         new_vals = [meshtastic.util.fromStr(x) for x in val]
         config_values = getattr(config, config_type.name)
@@ -1583,14 +1650,17 @@ def setPref(config: Any, comp_name: str, raw_val: Any) -> bool:
             if val not in cur_vals:
                 cur_vals.append(val)
             getattr(config_values, pref.name)[:] = cur_vals
-        return True
+        print_assignment = False
 
-    prefix = f"{'.'.join(name[0:-1])}." if config_type.message_type is not None else ""
-    display_value = _redact_pref_value(comp_name, meshtastic.util.toStr(raw_val))
-    if not _CONFIGURE_PREFLIGHT_MODE.get():
-        _cli_print(f"Set {prefix}{uni_name} to {display_value}")
+    if assignment_ok and print_assignment:
+        prefix = (
+            f"{'.'.join(name[0:-1])}." if config_type.message_type is not None else ""
+        )
+        display_value = _redact_pref_value(comp_name, meshtastic.util.toStr(raw_val))
+        if not _CONFIGURE_PREFLIGHT_MODE.get():
+            _cli_print(f"Set {prefix}{uni_name} to {display_value}")
 
-    return True
+    return assignment_ok
 
 
 def _handle_ota_update(
@@ -1661,7 +1731,13 @@ def _handle_set_command(
             if config_type is not None:
                 if len(config.ListFields()) == 0:
                     node.requestConfig(config_type)
-                found = setPref(config, normalized_pref_name, pref_item[1])
+                token = _SET_PREF_VALUE_ERRORS_FATAL.set(True)
+                try:
+                    found = setPref(config, normalized_pref_name, pref_item[1])
+                except _PreferenceValueError as exc:
+                    _cli_exit(str(exc), 1)
+                finally:
+                    _SET_PREF_VALUE_ERRORS_FATAL.reset(token)
                 if found:
                     any_found = True
                     fields.add(field)
@@ -2720,7 +2796,10 @@ def onConnected(interface: MeshInterface) -> None:
             for pref in args.ch_set or []:
                 if pref[0] == "psk":
                     found = True
-                    ch.settings.psk = meshtastic.util.fromPSK(pref[1])
+                    try:
+                        ch.settings.psk = meshtastic.util.fromPSK(pref[1])
+                    except ValueError as exc:
+                        _cli_exit(f"Invalid channel PSK: {exc}", 1)
                 else:
                     found = setPref(ch.settings, pref[0], pref[1])
                 if not found:

--- a/meshtastic/tests/cli_validation_test_helpers.py
+++ b/meshtastic/tests/cli_validation_test_helpers.py
@@ -1,0 +1,20 @@
+"""Shared builders for focused CLI validation tests."""
+
+from unittest.mock import MagicMock
+
+from meshtastic.node import Node
+from meshtastic.protobuf import channel_pb2, localonly_pb2
+from meshtastic.tcp_interface import TCPInterface
+
+
+def _mock_tcp_interface_with_channels() -> tuple[MagicMock, MagicMock]:
+    """Return a mocked TCP interface with a minimally configured node."""
+    interface = MagicMock(autospec=TCPInterface)
+    interface.__enter__ = MagicMock(return_value=interface)
+    interface.__exit__ = MagicMock(return_value=None)
+    node = MagicMock(autospec=Node)
+    node.localConfig = localonly_pb2.LocalConfig()
+    node.moduleConfig = localonly_pb2.LocalModuleConfig()
+    node.channels = [channel_pb2.Channel(index=0), channel_pb2.Channel(index=1)]
+    interface.getNode.return_value = node
+    return interface, node

--- a/meshtastic/tests/test_cli_channel_set_validation.py
+++ b/meshtastic/tests/test_cli_channel_set_validation.py
@@ -1,0 +1,130 @@
+"""Regression tests for channel-setting CLI validation."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from meshtastic.__main__ import main
+from meshtastic.node import Node
+from meshtastic.protobuf import channel_pb2, localonly_pb2
+from meshtastic.tcp_interface import TCPInterface
+
+
+def _interface_with_channels() -> tuple[MagicMock, MagicMock]:
+    interface = MagicMock(autospec=TCPInterface)
+    interface.__enter__ = MagicMock(return_value=interface)
+    interface.__exit__ = MagicMock(return_value=None)
+    node = MagicMock(autospec=Node)
+    node.localConfig = localonly_pb2.LocalConfig()
+    node.moduleConfig = localonly_pb2.LocalModuleConfig()
+    node.channels = [channel_pb2.Channel(index=0), channel_pb2.Channel(index=1)]
+    interface.getNode.return_value = node
+    return interface, node
+
+
+def _run_channel_set(
+    monkeypatch: pytest.MonkeyPatch,
+    interface: MagicMock,
+    *setting: str,
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--host",
+            "meshtastic.local",
+            "--ch-index",
+            "1",
+            "--ch-set",
+            *setting,
+        ],
+    )
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
+        main()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_invalid_non_psk_channel_value_exits_without_writing(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    interface, node = _interface_with_channels()
+
+    with pytest.raises(SystemExit) as exc_info:
+        _run_channel_set(monkeypatch, interface, "uplink_enabled", "not-a-boolean")
+
+    assert exc_info.value.code == 1
+    node.writeChannel.assert_not_called()
+    out, err = capsys.readouterr()
+    assert "expected boolean" in err
+    assert "does not have an attribute uplink_enabled" not in out
+    assert "Traceback" not in out + err
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_unknown_channel_field_exits_without_writing(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    interface, node = _interface_with_channels()
+
+    with pytest.raises(SystemExit) as exc_info:
+        _run_channel_set(monkeypatch, interface, "not_a_channel_field", "1")
+
+    assert exc_info.value.code == 1
+    node.writeChannel.assert_not_called()
+    out, err = capsys.readouterr()
+    assert "does not have an attribute not_a_channel_field" in out
+    assert "Choices are..." in out
+    assert "Channel setting was not applied." in err
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_valid_non_psk_channel_value_still_writes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    interface, node = _interface_with_channels()
+
+    _run_channel_set(monkeypatch, interface, "uplink_enabled", "true")
+
+    assert node.channels[1].settings.uplink_enabled is True
+    node.writeChannel.assert_called_once_with(1)
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_channel_set_batch_does_not_partially_mutate_on_later_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rejected later entry must leave earlier channel values untouched."""
+    interface, node = _interface_with_channels()
+    original = node.channels[1].settings.uplink_enabled
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--host",
+            "meshtastic.local",
+            "--ch-index",
+            "1",
+            "--ch-set",
+            "uplink_enabled",
+            "true",
+            "--ch-set",
+            "downlink_enabled",
+            "not-a-boolean",
+        ],
+    )
+
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
+        with pytest.raises(SystemExit):
+            main()
+
+    assert node.channels[1].settings.uplink_enabled is original
+    node.writeChannel.assert_not_called()

--- a/meshtastic/tests/test_cli_channel_set_validation.py
+++ b/meshtastic/tests/test_cli_channel_set_validation.py
@@ -66,21 +66,24 @@ def test_invalid_non_psk_channel_value_exits_without_writing(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-def test_unknown_channel_field_exits_without_writing(
+def test_unknown_channel_field_reports_choices_without_writing(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    """Unknown fields preserve the historical nonfatal choices-only contract."""
     interface, node = _interface_with_channels()
+    original_channel = channel_pb2.Channel()
+    original_channel.CopyFrom(node.channels[1])
 
-    with pytest.raises(SystemExit) as exc_info:
-        _run_channel_set(monkeypatch, interface, "not_a_channel_field", "1")
+    _run_channel_set(monkeypatch, interface, "not_a_channel_field", "1")
 
-    assert exc_info.value.code == 1
     node.writeChannel.assert_not_called()
+    assert node.channels[1] == original_channel
     out, err = capsys.readouterr()
     assert "does not have an attribute not_a_channel_field" in out
     assert "Choices are..." in out
-    assert "Channel setting was not applied." in err
+    assert "Writing modified channels to device" not in out
+    assert err == ""
 
 
 @pytest.mark.unit
@@ -128,3 +131,43 @@ def test_channel_set_batch_does_not_partially_mutate_on_later_failure(
 
     assert node.channels[1].settings.uplink_enabled is original
     node.writeChannel.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_channel_set_batch_does_not_mutate_on_later_unknown_field(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A later unknown field cancels an otherwise valid channel update atomically."""
+    interface, node = _interface_with_channels()
+    original_channel = channel_pb2.Channel()
+    original_channel.CopyFrom(node.channels[1])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--host",
+            "meshtastic.local",
+            "--ch-index",
+            "1",
+            "--ch-set",
+            "uplink_enabled",
+            "true",
+            "--ch-set",
+            "not_a_channel_field",
+            "1",
+        ],
+    )
+
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
+        main()
+
+    node.writeChannel.assert_not_called()
+    assert node.channels[1] == original_channel
+    out, err = capsys.readouterr()
+    assert "does not have an attribute not_a_channel_field" in out
+    assert "Choices are..." in out
+    assert "Writing modified channels to device" not in out
+    assert err == ""

--- a/meshtastic/tests/test_cli_channel_set_validation.py
+++ b/meshtastic/tests/test_cli_channel_set_validation.py
@@ -6,21 +6,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from meshtastic.__main__ import main
-from meshtastic.node import Node
-from meshtastic.protobuf import channel_pb2, localonly_pb2
-from meshtastic.tcp_interface import TCPInterface
+from meshtastic.protobuf import channel_pb2
 
-
-def _interface_with_channels() -> tuple[MagicMock, MagicMock]:
-    interface = MagicMock(autospec=TCPInterface)
-    interface.__enter__ = MagicMock(return_value=interface)
-    interface.__exit__ = MagicMock(return_value=None)
-    node = MagicMock(autospec=Node)
-    node.localConfig = localonly_pb2.LocalConfig()
-    node.moduleConfig = localonly_pb2.LocalModuleConfig()
-    node.channels = [channel_pb2.Channel(index=0), channel_pb2.Channel(index=1)]
-    interface.getNode.return_value = node
-    return interface, node
+from .cli_validation_test_helpers import _mock_tcp_interface_with_channels
 
 
 def _run_channel_set(
@@ -51,7 +39,7 @@ def test_invalid_non_psk_channel_value_exits_without_writing(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    interface, node = _interface_with_channels()
+    interface, node = _mock_tcp_interface_with_channels()
 
     with pytest.raises(SystemExit) as exc_info:
         _run_channel_set(monkeypatch, interface, "uplink_enabled", "not-a-boolean")
@@ -70,20 +58,22 @@ def test_unknown_channel_field_reports_choices_without_writing(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Unknown fields preserve the historical nonfatal choices-only contract."""
-    interface, node = _interface_with_channels()
+    """Unknown fields report choices and fail without writing."""
+    interface, node = _mock_tcp_interface_with_channels()
     original_channel = channel_pb2.Channel()
     original_channel.CopyFrom(node.channels[1])
 
-    _run_channel_set(monkeypatch, interface, "not_a_channel_field", "1")
+    with pytest.raises(SystemExit) as exc_info:
+        _run_channel_set(monkeypatch, interface, "not_a_channel_field", "1")
 
+    assert exc_info.value.code == 1
     node.writeChannel.assert_not_called()
     assert node.channels[1] == original_channel
     out, err = capsys.readouterr()
     assert "does not have an attribute not_a_channel_field" in out
     assert "Choices are..." in out
     assert "Writing modified channels to device" not in out
-    assert err == ""
+    assert "Unknown channel setting name. No changes were made." in err
 
 
 @pytest.mark.unit
@@ -91,7 +81,7 @@ def test_unknown_channel_field_reports_choices_without_writing(
 def test_valid_non_psk_channel_value_still_writes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    interface, node = _interface_with_channels()
+    interface, node = _mock_tcp_interface_with_channels()
 
     _run_channel_set(monkeypatch, interface, "uplink_enabled", "true")
 
@@ -105,7 +95,7 @@ def test_channel_set_batch_does_not_partially_mutate_on_later_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A rejected later entry must leave earlier channel values untouched."""
-    interface, node = _interface_with_channels()
+    interface, node = _mock_tcp_interface_with_channels()
     original = node.channels[1].settings.uplink_enabled
     monkeypatch.setattr(
         sys,
@@ -140,7 +130,7 @@ def test_channel_set_batch_does_not_mutate_on_later_unknown_field(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """A later unknown field cancels an otherwise valid channel update atomically."""
-    interface, node = _interface_with_channels()
+    interface, node = _mock_tcp_interface_with_channels()
     original_channel = channel_pb2.Channel()
     original_channel.CopyFrom(node.channels[1])
     monkeypatch.setattr(
@@ -162,15 +152,17 @@ def test_channel_set_batch_does_not_mutate_on_later_unknown_field(
     )
 
     with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
-        main()
+        with pytest.raises(SystemExit) as exc_info:
+            main()
 
+    assert exc_info.value.code == 1
     node.writeChannel.assert_not_called()
     assert node.channels[1] == original_channel
     out, err = capsys.readouterr()
     assert "does not have an attribute not_a_channel_field" in out
     assert "Choices are..." in out
     assert "Writing modified channels to device" not in out
-    assert err == ""
+    assert "Unknown channel setting name. No changes were made." in err
 
 
 @pytest.mark.unit
@@ -180,7 +172,7 @@ def test_unknown_channel_field_does_not_hide_later_invalid_value(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """Validation continues after an unknown field while the whole batch stays atomic."""
-    interface, node = _interface_with_channels()
+    interface, node = _mock_tcp_interface_with_channels()
     original_channel = channel_pb2.Channel()
     original_channel.CopyFrom(node.channels[1])
     monkeypatch.setattr(

--- a/meshtastic/tests/test_cli_channel_set_validation.py
+++ b/meshtastic/tests/test_cli_channel_set_validation.py
@@ -171,3 +171,44 @@ def test_channel_set_batch_does_not_mutate_on_later_unknown_field(
     assert "Choices are..." in out
     assert "Writing modified channels to device" not in out
     assert err == ""
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_unknown_channel_field_does_not_hide_later_invalid_value(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Validation continues after an unknown field while the whole batch stays atomic."""
+    interface, node = _interface_with_channels()
+    original_channel = channel_pb2.Channel()
+    original_channel.CopyFrom(node.channels[1])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--host",
+            "meshtastic.local",
+            "--ch-index",
+            "1",
+            "--ch-set",
+            "not_a_channel_field",
+            "1",
+            "--ch-set",
+            "uplink_enabled",
+            "not-a-boolean",
+        ],
+    )
+
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+    assert exc_info.value.code == 1
+    node.writeChannel.assert_not_called()
+    assert node.channels[1] == original_channel
+    out, err = capsys.readouterr()
+    assert "does not have an attribute not_a_channel_field" in out
+    assert "expected boolean" in err
+    assert "Traceback" not in out + err

--- a/meshtastic/tests/test_cli_pref_validation_output.py
+++ b/meshtastic/tests/test_cli_pref_validation_output.py
@@ -1,0 +1,45 @@
+"""Regression tests for preference-validation CLI output routing."""
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from meshtastic import mt_config
+from meshtastic.__main__ import _CONFIGURE_PREFLIGHT_MODE, setPref
+from meshtastic.protobuf import localonly_pb2
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_direct_validation_error_remains_visible_in_quiet_mode(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Quiet mode must not hide a direct user-facing validation failure."""
+    mt_config.args = cast(Any, SimpleNamespace(quiet=True))
+    config = localonly_pb2.LocalConfig()
+
+    assert setPref(config, "lora.hop_limit", "bad") is False
+
+    out, err = capsys.readouterr()
+    assert "expected integer" in out
+    assert err == ""
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_configure_preflight_validation_respects_quiet_mode(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Configure preflight may suppress its duplicate low-level diagnostic."""
+    mt_config.args = cast(Any, SimpleNamespace(quiet=True))
+    config = localonly_pb2.LocalConfig()
+    token = _CONFIGURE_PREFLIGHT_MODE.set(True)
+    try:
+        assert setPref(config, "lora.hop_limit", "bad") is False
+    finally:
+        _CONFIGURE_PREFLIGHT_MODE.reset(token)
+
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert err == ""

--- a/meshtastic/tests/test_cli_pref_validation_output.py
+++ b/meshtastic/tests/test_cli_pref_validation_output.py
@@ -43,3 +43,32 @@ def test_configure_preflight_validation_respects_quiet_mode(
     out, err = capsys.readouterr()
     assert out == ""
     assert err == ""
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("lora.region", "NOT_A_REGION"),
+        ("network.enabled_protocols", "TCP"),
+        ("network.wifi_psk", "short"),
+    ),
+)
+def test_configure_preflight_semantic_diagnostics_respect_quiet_mode(
+    field: str,
+    value: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Configure preflight keeps historical diagnostics but honors ``--quiet``."""
+    mt_config.args = cast(Any, SimpleNamespace(quiet=True))
+    config = localonly_pb2.LocalConfig()
+    token = _CONFIGURE_PREFLIGHT_MODE.set(True)
+    try:
+        assert setPref(config, field, value) is False
+    finally:
+        _CONFIGURE_PREFLIGHT_MODE.reset(token)
+
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert err == ""

--- a/meshtastic/tests/test_cli_set_type_validation.py
+++ b/meshtastic/tests/test_cli_set_type_validation.py
@@ -107,9 +107,9 @@ def test_cli_invalid_channel_psk_exits_without_writing(
 
     assert exc_info.value.code == 1
     node.writeChannel.assert_not_called()
-    _out, err = capsys.readouterr()
+    out, err = capsys.readouterr()
     assert "Invalid channel PSK: Invalid hex PSK" in err
-    assert "Traceback" not in err
+    assert "Traceback" not in out + err
 
 
 @pytest.mark.unit
@@ -156,3 +156,17 @@ def test_set_pref_valid_enum_still_uses_symbolic_name() -> None:
 
     assert setPref(config, "lora.region", "US") is True
     assert config.lora.region == config_pb2.Config.LoRaConfig.RegionCode.US
+
+@pytest.mark.unit
+def test_set_pref_redacts_secret_values_in_validation_errors(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Invalid secret-bearing values must not be echoed in diagnostics."""
+    config = localonly_pb2.LocalConfig()
+    secret = "definitely-secret-not-bytes"
+
+    assert setPref(config, "security.private_key", secret) is False
+
+    out, err = capsys.readouterr()
+    assert "Invalid value <redacted> for security.private_key" in out
+    assert secret not in out + err

--- a/meshtastic/tests/test_cli_set_type_validation.py
+++ b/meshtastic/tests/test_cli_set_type_validation.py
@@ -170,3 +170,129 @@ def test_set_pref_redacts_secret_values_in_validation_errors(
     out, err = capsys.readouterr()
     assert "Invalid value <redacted> for security.private_key" in out
     assert secret not in out + err
+
+
+@pytest.mark.unit
+def test_set_pref_rejects_malformed_encoded_value_without_exception(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Malformed encoded input is rejected through the normal validation path."""
+    config = localonly_pb2.LocalConfig()
+    malformed = "0xNOTHEX"
+
+    assert setPref(config, "security.private_key", malformed) is False
+
+    out, err = capsys.readouterr()
+    assert "Invalid value <redacted> for security.private_key" in out
+    assert malformed not in out + err
+    assert config.security.private_key == b""
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_cli_malformed_encoded_value_exits_without_writing(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    malformed = "0xNOTHEX"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--host",
+            "meshtastic.local",
+            "--set",
+            "security.private_key",
+            malformed,
+        ],
+    )
+    interface, node = _tcp_interface_with_node()
+
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+    assert exc_info.value.code == 1
+    node.writeConfig.assert_not_called()
+    out, err = capsys.readouterr()
+    assert "Invalid value <redacted> for security.private_key" in err
+    assert malformed not in out + err
+    assert "Traceback" not in out + err
+
+
+@pytest.mark.unit
+def test_set_pref_repeated_failure_does_not_partially_mutate(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Repeated scalar validation must complete on a copy before mutation."""
+    config = localonly_pb2.LocalConfig()
+    config.lora.ignore_incoming.append(123)
+
+    assert setPref(config, "lora.ignore_incoming", "not-a-number") is False
+
+    assert list(config.lora.ignore_incoming) == [123]
+    out, err = capsys.readouterr()
+    assert "expected integer" in out
+    assert "Adding 'not-a-number'" not in out
+    assert err == ""
+
+
+@pytest.mark.unit
+def test_set_pref_repeated_list_preserves_historical_string_conversion() -> None:
+    """Repeated list entries retain historical per-item ``fromStr`` conversion."""
+    config = localonly_pb2.LocalConfig()
+    config.lora.ignore_incoming.append(123)
+
+    assert setPref(config, "lora.ignore_incoming", ["456"]) is True
+
+    assert list(config.lora.ignore_incoming) == [456]
+
+
+@pytest.mark.unit
+def test_set_pref_invalid_repeated_list_is_atomic(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A bad converted list element must not partially replace the live container."""
+    config = localonly_pb2.LocalConfig()
+    config.lora.ignore_incoming.append(123)
+
+    assert setPref(config, "lora.ignore_incoming", ["456", "not-a-number"]) is False
+
+    assert list(config.lora.ignore_incoming) == [123]
+    out, err = capsys.readouterr()
+    assert "expected integer" in out
+    assert err == ""
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_cli_invalid_repeated_value_exits_without_mutation_or_write(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--host",
+            "meshtastic.local",
+            "--set",
+            "lora.ignore_incoming",
+            "not-a-number",
+        ],
+    )
+    interface, node = _tcp_interface_with_node()
+    node.localConfig.lora.ignore_incoming.append(123)
+
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+    assert exc_info.value.code == 1
+    assert list(node.localConfig.lora.ignore_incoming) == [123]
+    node.writeConfig.assert_not_called()
+    out, err = capsys.readouterr()
+    assert "expected integer" in err
+    assert "Traceback" not in out + err

--- a/meshtastic/tests/test_cli_set_type_validation.py
+++ b/meshtastic/tests/test_cli_set_type_validation.py
@@ -1,26 +1,14 @@
 """CLI regression tests for invalid preference and channel value types."""
 
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 from meshtastic.__main__ import main, setPref
-from meshtastic.node import Node
-from meshtastic.protobuf import channel_pb2, config_pb2, localonly_pb2
-from meshtastic.tcp_interface import TCPInterface
+from meshtastic.protobuf import config_pb2, localonly_pb2
 
-
-def _tcp_interface_with_node() -> tuple[MagicMock, MagicMock]:
-    interface = MagicMock(autospec=TCPInterface)
-    interface.__enter__ = MagicMock(return_value=interface)
-    interface.__exit__ = MagicMock(return_value=None)
-    node = MagicMock(autospec=Node)
-    node.localConfig = localonly_pb2.LocalConfig()
-    node.moduleConfig = localonly_pb2.LocalModuleConfig()
-    node.channels = [channel_pb2.Channel(index=0), channel_pb2.Channel(index=1)]
-    interface.getNode.return_value = node
-    return interface, node
+from .cli_validation_test_helpers import _mock_tcp_interface_with_channels
 
 
 @pytest.mark.unit
@@ -66,7 +54,7 @@ def test_cli_invalid_integer_set_exits_without_writing(
             "not_a_number",
         ],
     )
-    interface, node = _tcp_interface_with_node()
+    interface, node = _mock_tcp_interface_with_channels()
 
     with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
         with pytest.raises(SystemExit) as exc_info:
@@ -99,7 +87,7 @@ def test_cli_invalid_channel_psk_exits_without_writing(
             "0xNOTHEX",
         ],
     )
-    interface, node = _tcp_interface_with_node()
+    interface, node = _mock_tcp_interface_with_channels()
 
     with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
         with pytest.raises(SystemExit) as exc_info:
@@ -141,7 +129,7 @@ def test_cli_valid_hex_channel_psk_still_writes(
             "0x1a1a",
         ],
     )
-    interface, node = _tcp_interface_with_node()
+    interface, node = _mock_tcp_interface_with_channels()
 
     with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
         main()
@@ -207,7 +195,7 @@ def test_cli_malformed_encoded_value_exits_without_writing(
             malformed,
         ],
     )
-    interface, node = _tcp_interface_with_node()
+    interface, node = _mock_tcp_interface_with_channels()
 
     with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
         with pytest.raises(SystemExit) as exc_info:
@@ -283,7 +271,7 @@ def test_cli_invalid_repeated_value_exits_without_mutation_or_write(
             "not-a-number",
         ],
     )
-    interface, node = _tcp_interface_with_node()
+    interface, node = _mock_tcp_interface_with_channels()
     node.localConfig.lora.ignore_incoming.append(123)
 
     with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):

--- a/meshtastic/tests/test_cli_set_type_validation.py
+++ b/meshtastic/tests/test_cli_set_type_validation.py
@@ -1,0 +1,158 @@
+"""CLI regression tests for invalid preference and channel value types."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from meshtastic.__main__ import main, setPref
+from meshtastic.node import Node
+from meshtastic.protobuf import channel_pb2, config_pb2, localonly_pb2
+from meshtastic.tcp_interface import TCPInterface
+
+
+def _tcp_interface_with_node() -> tuple[MagicMock, MagicMock]:
+    interface = MagicMock(autospec=TCPInterface)
+    interface.__enter__ = MagicMock(return_value=interface)
+    interface.__exit__ = MagicMock(return_value=None)
+    node = MagicMock(autospec=Node)
+    node.localConfig = localonly_pb2.LocalConfig()
+    node.moduleConfig = localonly_pb2.LocalModuleConfig()
+    node.channels = [channel_pb2.Channel(index=0), channel_pb2.Channel(index=1)]
+    interface.getNode.return_value = node
+    return interface, node
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("field", "value", "expected_type"),
+    (
+        ("lora.hop_limit", "not_a_number", "integer"),
+        ("bluetooth.enabled", "not_a_boolean", "boolean"),
+        ("power.adc_multiplier_override", "not_a_number", "number"),
+        ("power.ls_secs", str(1 << 40), "integer"),
+    ),
+)
+def test_set_pref_rejects_invalid_scalar_types_without_exception(
+    field: str,
+    value: str,
+    expected_type: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    config = localonly_pb2.LocalConfig()
+
+    assert setPref(config, field, value) is False
+
+    out, err = capsys.readouterr()
+    assert f"Invalid value {value!r} for {field}; expected {expected_type}." in out
+    assert err == ""
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_cli_invalid_integer_set_exits_without_writing(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--host",
+            "meshtastic.local",
+            "--set",
+            "lora.hop_limit",
+            "not_a_number",
+        ],
+    )
+    interface, node = _tcp_interface_with_node()
+
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+    assert exc_info.value.code == 1
+    node.writeConfig.assert_not_called()
+    out, err = capsys.readouterr()
+    assert "expected integer" in err
+    assert "Traceback" not in out + err
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_cli_invalid_channel_psk_exits_without_writing(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--host",
+            "meshtastic.local",
+            "--ch-index",
+            "1",
+            "--ch-set",
+            "psk",
+            "0xNOTHEX",
+        ],
+    )
+    interface, node = _tcp_interface_with_node()
+
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+    assert exc_info.value.code == 1
+    node.writeChannel.assert_not_called()
+    _out, err = capsys.readouterr()
+    assert "Invalid channel PSK: Invalid hex PSK" in err
+    assert "Traceback" not in err
+
+
+@pytest.mark.unit
+def test_set_pref_preserves_numeric_and_numeric_string_behavior() -> None:
+    config = localonly_pb2.LocalConfig()
+
+    assert setPref(config, "lora.hop_limit", "5") is True
+    assert config.lora.hop_limit == 5
+    assert setPref(config, "network.ntp_server", "123") is True
+    assert config.network.ntp_server == "123"
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_cli_valid_hex_channel_psk_still_writes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--host",
+            "meshtastic.local",
+            "--ch-index",
+            "1",
+            "--ch-set",
+            "psk",
+            "0x1a1a",
+        ],
+    )
+    interface, node = _tcp_interface_with_node()
+
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
+        main()
+
+    assert node.channels[1].settings.psk == b"\x1a\x1a"
+    node.writeChannel.assert_called_once_with(1)
+
+
+@pytest.mark.unit
+def test_set_pref_valid_enum_still_uses_symbolic_name() -> None:
+    config = localonly_pb2.LocalConfig()
+
+    assert setPref(config, "lora.region", "US") is True
+    assert config.lora.region == config_pb2.Config.LoRaConfig.RegionCode.US

--- a/meshtastic/tests/test_main_coverage.py
+++ b/meshtastic/tests/test_main_coverage.py
@@ -903,11 +903,14 @@ def test_main_ch_set_unknown_pref_prints_module_settings_subfields(
     mt_config.dest = "^local"
 
     with patch("meshtastic.serial_interface.SerialInterface", return_value=iface):
-        main()
-        out, _err = capsys.readouterr()
-        assert "module_settings:" in out
-        assert "module_settings.position_precision" in out
-        assert "module_settings.is_muted" in out
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+    assert exc_info.value.code == 1
+    out, _err = capsys.readouterr()
+    assert "module_settings:" in out
+    assert "module_settings.position_precision" in out
+    assert "module_settings.is_muted" in out
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_simradio_cli.py
+++ b/meshtastic/tests/test_simradio_cli.py
@@ -153,13 +153,13 @@ def test_simradio_cli_invalid_settings_report_choices(
 ) -> None:
     """Invalid schema paths should report choices without mutating firmware."""
     cases = (
-        ("--get", "not_a_setting"),
-        ("--set", "not_a_setting", "value"),
-        ("--ch-set", "not_a_setting", "value", "--ch-index", "0"),
+        (("--get", "not_a_setting"), 0),
+        (("--set", "not_a_setting", "value"), 0),
+        (("--ch-set", "not_a_setting", "value", "--ch-index", "0"), 1),
     )
-    for arguments in cases:
+    for arguments, expected_returncode in cases:
         result = run_cli(firmware_node.port, *arguments)
-        assert result.returncode == 0, result.output
+        assert result.returncode == expected_returncode, result.output
         assert "Choices" in result.output
 
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This change improves CLI validation and error handling for preferences and channel settings. Invalid values now produce clear errors and clean exits without tracebacks or unintended writes. Existing valid numeric, string, enum, and hexadecimal PSK behavior remains supported.

## Key changes

### Features
- Added validation for scalar preference values before assignment.
- Added string fallback conversion where applicable.
- Added user-facing errors for invalid channel PSK values.
- Added validation output that remains visible when `--quiet` is active.
- Added regression tests for valid and invalid preference and channel values.
- Added tests for quiet-mode output and secret-value redaction.
- Added atomicity tests for repeated preference fields and channel-setting batches.

### Fixes
- Reject oversized integers with user-facing errors.
- Validate channel settings on a copy before applying changes.
- Prevent preference and channel writes when validation fails.
- Preserve configuration state after failed validation.
- Ensure failed `--set` and `--ch-set` commands exit cleanly without tracebacks.
- Suppress duplicate diagnostics during configure preflight validation.
- Prevent partial mutation when repeated-field conversion fails.

### Refactors
- Added context-controlled fatal handling for preference assignment failures.
- Moved scalar protobuf assignment into a helper.
- Added type-specific, redacted diagnostic messages for invalid preference values.

## Breaking changes and migration

No breaking changes or migration steps are required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->