### PR TITLE
Validate --set Batches Atomically Before Device Mutation

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1211,6 +1211,8 @@ _SECRET_PREF_PATHS: frozenset[str] = frozenset(
         "security.session_passkey",
     }
 )
+_REDACTED_PREF_VALUE = "<redacted>"
+_SET_VALUE_REJECTED_MESSAGE = "value rejected by validation"
 
 
 class _DescriptorLike(Protocol):
@@ -1227,13 +1229,16 @@ class _NamedConfigType(Protocol):
     name: str
 
 
-def _redact_pref_value(name: str, value: str) -> str:
-    """Return a redacted placeholder for secret-bearing preference paths."""
+def _is_secret_pref(name: str) -> bool:
+    """Return whether a preference path is classified as secret-bearing."""
     normalized = _normalize_pref_name(name)
     field_name = normalized.rsplit(".", maxsplit=1)[-1]
-    if normalized in _SECRET_PREF_PATHS or field_name in _SECRET_PREF_FIELDS:
-        return "<redacted>"
-    return value
+    return normalized in _SECRET_PREF_PATHS or field_name in _SECRET_PREF_FIELDS
+
+
+def _redact_pref_value(name: str, value: str) -> str:
+    """Return a redacted placeholder for secret-bearing preference paths."""
+    return _REDACTED_PREF_VALUE if _is_secret_pref(name) else value
 
 
 def getPref(node: Any, comp_name: str, *, allow_secrets: bool = False) -> bool:
@@ -1868,17 +1873,17 @@ def _handle_ota_update(
     _cli_print("\nOTA update completed successfully!")
 
 
-def _print_set_field_choices(node: Any, pref_names: str | Sequence[str]) -> None:
+def _print_set_field_choices(node: Any, pref_names: Sequence[str]) -> None:
     """Print historical field-not-found guidance for one or more --set names.
 
     Parameters
     ----------
     node : Any
         Node whose local and module configuration schemas provide the choices.
-    pref_names : str | Sequence[str]
-        Unknown preference name or names to identify before printing choices.
+    pref_names : Sequence[str]
+        Unknown preference names to identify before printing choices.
     """
-    names = [pref_names] if isinstance(pref_names, str) else list(dict.fromkeys(pref_names))
+    names = list(dict.fromkeys(pref_names))
     for pref_name in names:
         print(
             f"{node.localConfig.__class__.__name__} and "
@@ -1930,9 +1935,76 @@ def _format_set_preflight_exception(pref_name: str, exc: Exception) -> str:
     """
     if isinstance(exc, _PreferenceValueError):
         return str(exc)
-    if _redact_pref_value(pref_name, "value") == "<redacted>":
-        return f"{pref_name}: invalid value <redacted> ({type(exc).__name__})"
+    if _is_secret_pref(pref_name):
+        return (
+            f"{pref_name}: invalid value {_REDACTED_PREF_VALUE} "
+            f"({type(exc).__name__})"
+        )
     return f"{pref_name}: {exc}"
+
+
+def _resolve_set_target(
+    configs: Sequence[Any], pref_name: str
+) -> tuple[Any, FieldDescriptor] | None:
+    """Resolve the owning config message and root field for a normalized preference.
+
+    Parameters
+    ----------
+    configs : Sequence[Any]
+        Configuration wrapper messages to search in resolution order.
+    pref_name : str
+        Normalized dotted preference path.
+
+    Returns
+    -------
+    tuple[Any, FieldDescriptor] | None
+        Owning config wrapper and root field descriptor, or ``None`` when the
+        root field does not exist in any supplied configuration.
+    """
+    root_field = splitCompoundName(pref_name)[0]
+    for config in configs:
+        config_type = config.DESCRIPTOR.fields_by_name.get(root_field)
+        if config_type is not None:
+            return config, config_type
+    return None
+
+
+def _ensure_set_sections_loaded(
+    node: Any, set_entries: Sequence[tuple[str, Any]]
+) -> None:
+    """Request missing config sections before creating preflight snapshots.
+
+    Parameters
+    ----------
+    node : Any
+        Target node whose cached local/module configuration will be validated.
+    set_entries : Sequence[tuple[str, Any]]
+        Parsed ``--set`` name/value entries. Names are normalized before resolution.
+
+    Notes
+    -----
+    Requests are deduplicated by config section. Protobuf message presence, not
+    ``ListFields()``, distinguishes an already-loaded default-valued section from
+    a section that has never been received. Unknown preference paths do not
+    trigger device reads.
+    """
+    configs = (node.localConfig, node.moduleConfig)
+    requested_sections: set[tuple[str, str]] = set()
+    for raw_pref_name, _raw_value in set_entries:
+        pref_name = _normalize_pref_name(raw_pref_name)
+        resolved = _resolve_set_target(configs, pref_name)
+        if resolved is None:
+            continue
+        config, config_type = resolved
+        if not _resolve_pref(config, pref_name):
+            continue
+
+        section_key = (config.DESCRIPTOR.full_name, config_type.name)
+        if section_key in requested_sections:
+            continue
+        requested_sections.add(section_key)
+        if not config.HasField(config_type.name):
+            node.requestConfig(config_type)
 
 
 def _preflight_set_entries(
@@ -1955,7 +2027,7 @@ def _preflight_set_entries(
         semantic rejections remain exit-code compatible with the historical CLI,
         but now cancel the entire batch instead of permitting partial application.
     """
-    candidates = []
+    candidates: list[Any] = []
     for source in (node.localConfig, node.moduleConfig):
         candidate = type(source)()
         candidate.CopyFrom(source)
@@ -1968,16 +2040,12 @@ def _preflight_set_entries(
     try:
         for raw_pref_name, raw_value in set_entries:
             pref_name = _normalize_pref_name(raw_pref_name)
-            root_field = splitCompoundName(pref_name)[0]
-            candidate = next(
-                (
-                    config
-                    for config in candidates
-                    if root_field in config.DESCRIPTOR.fields_by_name
-                ),
-                None,
-            )
-            if candidate is None or not _resolve_pref(candidate, pref_name):
+            resolved = _resolve_set_target(candidates, pref_name)
+            if resolved is None:
+                unknown_fields.append(pref_name)
+                continue
+            candidate, _config_type = resolved
+            if not _resolve_pref(candidate, pref_name):
                 unknown_fields.append(pref_name)
                 continue
 
@@ -2005,7 +2073,9 @@ def _preflight_set_entries(
     if fatal_errors:
         detail_lines = [f"  - {error}" for error in fatal_errors]
         for pref_name, messages in value_rejections:
-            detail_lines.append(f"  - {pref_name}: value rejected by validation")
+            detail_lines.append(
+                f"  - {pref_name}: {_SET_VALUE_REJECTED_MESSAGE}"
+            )
             detail_lines.extend(f"      {message}" for message in messages)
         details = "\n".join(detail_lines)
         _cli_exit(f"ERROR: --set batch rejected before applying changes:\n{details}")
@@ -2013,9 +2083,11 @@ def _preflight_set_entries(
     for pref_name, messages in value_rejections:
         if messages:
             for message in messages:
-                print(message)
+                _report_pref_validation(message)
         else:
-            print(f"{pref_name}: value was rejected by validation.")
+            _report_pref_validation(
+                f"{pref_name}: {_SET_VALUE_REJECTED_MESSAGE}"
+            )
 
     return not (unknown_fields or value_rejections)
 
@@ -2025,45 +2097,56 @@ def _handle_set_command(
     args: Any,
     getNode_kwargs: dict[str, Any],
 ) -> None:
+    """Validate and atomically apply one CLI ``--set`` batch.
+
+    Parameters
+    ----------
+    interface : MeshInterface
+        Active interface used to resolve the target node.
+    args : Any
+        Parsed CLI arguments containing the ``--set`` entries and destination.
+    getNode_kwargs : dict[str, Any]
+        Additional keyword arguments forwarded to ``interface.getNode``.
+
+    Notes
+    -----
+    Required device-backed sections are loaded before preflight snapshots are
+    created. A ``False`` preflight result means diagnostics were already emitted
+    and the entire batch is cancelled without mutation. After a successful
+    preflight, any resolution or validation difference during live application
+    is treated as an invariant violation and exits with an error.
+    """
     node = interface.getNode(args.dest, False, **getNode_kwargs)
     set_entries = _normalize_set_entries(args.set)
+    _ensure_set_sections_loaded(node, set_entries)
     if not _preflight_set_entries(node, set_entries):
         return
 
+    live_configs = (node.localConfig, node.moduleConfig)
     fields: set[str] = set()
     for raw_pref_name, raw_value in set_entries:
         normalized_pref_name = _normalize_pref_name(raw_pref_name)
-        field = splitCompoundName(normalized_pref_name)[0]
-        applied = False
-        for config in [node.localConfig, node.moduleConfig]:
-            config_type = config.DESCRIPTOR.fields_by_name.get(field)
-            if config_type is not None:
-                section = getattr(config, config_type.name)
-                if len(section.ListFields()) == 0:
-                    node.requestConfig(config_type)
-                try:
-                    found = setPref(config, normalized_pref_name, raw_value)
-                except (TypeError, ValueError, OverflowError, binascii.Error) as exc:
-                    detail = _format_set_preflight_exception(
-                        normalized_pref_name, exc
-                    )
-                    _cli_exit(
-                        "ERROR: --set apply diverged after successful preflight:\n"
-                        f"  - {detail}"
-                    )
-                if not found:
-                    _cli_exit(
-                        "ERROR: --set apply diverged after successful preflight for "
-                        f"{normalized_pref_name}."
-                    )
-                fields.add(field)
-                applied = True
-                break
-        if not applied:
+        resolved = _resolve_set_target(live_configs, normalized_pref_name)
+        if resolved is None:
             _cli_exit(
                 "ERROR: --set field no longer resolves after successful preflight: "
                 f"{normalized_pref_name}."
             )
+        config, config_type = resolved
+        try:
+            found = setPref(config, normalized_pref_name, raw_value)
+        except (TypeError, ValueError, OverflowError, binascii.Error) as exc:
+            detail = _format_set_preflight_exception(normalized_pref_name, exc)
+            _cli_exit(
+                "ERROR: --set apply diverged after successful preflight:\n"
+                f"  - {detail}"
+            )
+        if not found:
+            _cli_exit(
+                "ERROR: --set apply diverged after successful preflight for "
+                f"{normalized_pref_name}."
+            )
+        fields.add(config_type.name)
 
     if fields:
         _cli_print("Writing modified preferences to device")

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1856,18 +1856,35 @@ def _handle_ota_update(
     _cli_print("\nOTA update completed successfully!")
 
 
-def _print_set_field_choices(node: Any, pref_name: str) -> None:
-    """Print the historical field-not-found guidance for one --set name."""
-    print(
-        f"{node.localConfig.__class__.__name__} and "
-        f"{node.moduleConfig.__class__.__name__} do not have an attribute {pref_name}."
-    )
+def _print_set_field_choices(
+    node: Any, pref_names: str | Sequence[str]
+) -> None:
+    """Print historical field-not-found guidance for one or more --set names."""
+    names = [pref_names] if isinstance(pref_names, str) else list(dict.fromkeys(pref_names))
+    for pref_name in names:
+        print(
+            f"{node.localConfig.__class__.__name__} and "
+            f"{node.moduleConfig.__class__.__name__} do not have an attribute {pref_name}."
+        )
     print("Choices are...")
     printConfig(node.localConfig)
     printConfig(node.moduleConfig)
 
 
-def _preflight_set_entries(node: Any, set_entries: Sequence[Sequence[Any]]) -> bool:
+def _normalize_set_entries(
+    set_entries: Sequence[Sequence[Any] | None],
+) -> list[tuple[str, Any]]:
+    """Normalize argparse --set entries into explicit name/value pairs."""
+    return [
+        (str(item[0]), item[1])
+        for item in set_entries
+        if item is not None and len(item) >= 2
+    ]
+
+
+def _preflight_set_entries(
+    node: Any, set_entries: Sequence[tuple[str, Any]]
+) -> bool:
     """Validate an entire --set batch on protobuf copies before mutation."""
     candidates = []
     for source in (node.localConfig, node.moduleConfig):
@@ -1876,14 +1893,12 @@ def _preflight_set_entries(node: Any, set_entries: Sequence[Sequence[Any]]) -> b
         candidates.append(candidate)
 
     fatal_errors: list[str] = []
-    rejected_fields: list[str] = []
+    unknown_fields: list[str] = []
+    value_rejections: list[str] = []
     token = _CONFIGURE_PREFLIGHT_MODE.set(True)
     try:
-        for item in set_entries:
-            if item is None or len(item) < 2:
-                continue
-            pref_name = _normalize_pref_name(str(item[0]))
-            raw_value = item[1]
+        for raw_pref_name, raw_value in set_entries:
+            pref_name = _normalize_pref_name(raw_pref_name)
             root_field = meshtastic.util.camel_to_snake(splitCompoundName(pref_name)[0])
             candidate = next(
                 (
@@ -1894,7 +1909,7 @@ def _preflight_set_entries(node: Any, set_entries: Sequence[Sequence[Any]]) -> b
                 None,
             )
             if candidate is None or not _resolve_pref(candidate, pref_name):
-                rejected_fields.append(pref_name)
+                unknown_fields.append(pref_name)
                 continue
 
             try:
@@ -1903,19 +1918,18 @@ def _preflight_set_entries(node: Any, set_entries: Sequence[Sequence[Any]]) -> b
                 fatal_errors.append(f"{pref_name}: {exc}")
                 continue
             if not valid:
-                rejected_fields.append(pref_name)
+                value_rejections.append(pref_name)
     finally:
         _CONFIGURE_PREFLIGHT_MODE.reset(token)
+
+    if unknown_fields:
+        _print_set_field_choices(node, unknown_fields)
 
     if fatal_errors:
         details = "\n".join(f"  - {error}" for error in fatal_errors)
         _cli_exit(f"ERROR: --set batch rejected before applying changes:\n{details}")
 
-    if rejected_fields:
-        _print_set_field_choices(node, rejected_fields[0])
-        return False
-
-    return True
+    return not (unknown_fields or value_rejections)
 
 
 def _handle_set_command(
@@ -1924,29 +1938,24 @@ def _handle_set_command(
     getNode_kwargs: dict[str, Any],
 ) -> None:
     node = interface.getNode(args.dest, False, **getNode_kwargs)
-    if not _preflight_set_entries(node, args.set):
+    set_entries = _normalize_set_entries(args.set)
+    if not _preflight_set_entries(node, set_entries):
         return
 
-    last_pref: list[str] | None = None
+    last_pref: tuple[str, Any] | None = None
     fields: set[str] = set()
     any_found = False
-    for pref_item in args.set:
-        if pref_item is None or len(pref_item) < 2:
-            continue
-        last_pref = pref_item
+    for raw_pref_name, raw_value in set_entries:
+        last_pref = (raw_pref_name, raw_value)
         found = False
-        normalized_pref_name = _normalize_pref_name(pref_item[0])
+        normalized_pref_name = _normalize_pref_name(raw_pref_name)
         field = splitCompoundName(normalized_pref_name)[0]
         for config in [node.localConfig, node.moduleConfig]:
             config_type = config.DESCRIPTOR.fields_by_name.get(field)
             if config_type is not None:
                 if len(config.ListFields()) == 0:
                     node.requestConfig(config_type)
-                try:
-                    with _fatal_preference_value_errors():
-                        found = setPref(config, normalized_pref_name, pref_item[1])
-                except _PreferenceValueError as exc:
-                    _cli_exit(str(exc), 1)
+                found = setPref(config, normalized_pref_name, raw_value)
                 if found:
                     any_found = True
                     fields.add(field)

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -2036,7 +2036,8 @@ def _handle_set_command(
         for config in [node.localConfig, node.moduleConfig]:
             config_type = config.DESCRIPTOR.fields_by_name.get(field)
             if config_type is not None:
-                if len(config.ListFields()) == 0:
+                section = getattr(config, config_type.name)
+                if len(section.ListFields()) == 0:
                     node.requestConfig(config_type)
                 try:
                     found = setPref(config, normalized_pref_name, raw_value)

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -187,11 +187,10 @@ def _fatal_preference_value_errors() -> Iterator[None]:
     finally:
         _SET_PREF_VALUE_ERRORS_FATAL.reset(token)
 
-=======
+
 _PREF_VALIDATION_REPORTER: contextvars.ContextVar[Callable[[str], None] | None] = (
     contextvars.ContextVar("pref_validation_reporter", default=None)
 )
->>>>>>> b4d18df0 (Polish atomic set validation diagnostics)
 
 # Map dotted preference paths to the protobuf enum that defines their flags.
 # These fields are stored as uint32 bitmasks in the protobuf but have an
@@ -1929,6 +1928,8 @@ def _format_set_preflight_exception(pref_name: str, exc: Exception) -> str:
     str
         Safe error detail suitable for the aggregated CLI failure message.
     """
+    if isinstance(exc, _PreferenceValueError):
+        return str(exc)
     if _redact_pref_value(pref_name, "value") == "<redacted>":
         return f"{pref_name}: invalid value <redacted> ({type(exc).__name__})"
     return f"{pref_name}: {exc}"
@@ -1986,7 +1987,8 @@ def _preflight_set_entries(
             )
             try:
                 try:
-                    valid = setPref(candidate, pref_name, raw_value)
+                    with _fatal_preference_value_errors():
+                        valid = setPref(candidate, pref_name, raw_value)
                 finally:
                     _PREF_VALIDATION_REPORTER.reset(reporter_token)
             except (TypeError, ValueError, OverflowError, binascii.Error) as exc:

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1859,7 +1859,15 @@ def _handle_ota_update(
 def _print_set_field_choices(
     node: Any, pref_names: str | Sequence[str]
 ) -> None:
-    """Print historical field-not-found guidance for one or more --set names."""
+    """Print historical field-not-found guidance for one or more --set names.
+
+    Parameters
+    ----------
+    node : Any
+        Node whose local and module configuration schemas provide the choices.
+    pref_names : str | Sequence[str]
+        Unknown preference name or names to identify before printing choices.
+    """
     names = [pref_names] if isinstance(pref_names, str) else list(dict.fromkeys(pref_names))
     for pref_name in names:
         print(
@@ -1874,7 +1882,18 @@ def _print_set_field_choices(
 def _normalize_set_entries(
     set_entries: Sequence[Sequence[Any] | None],
 ) -> list[tuple[str, Any]]:
-    """Normalize argparse --set entries into explicit name/value pairs."""
+    """Normalize argparse --set entries into explicit name/value pairs.
+
+    Parameters
+    ----------
+    set_entries : Sequence[Sequence[Any] | None]
+        Parsed ``--set`` entries, each containing at least a field name and value.
+
+    Returns
+    -------
+    list[tuple[str, Any]]
+        Normalized ``(field_name, value)`` pairs with incomplete entries omitted.
+    """
     return [
         (str(item[0]), item[1])
         for item in set_entries
@@ -1885,7 +1904,21 @@ def _normalize_set_entries(
 def _preflight_set_entries(
     node: Any, set_entries: Sequence[tuple[str, Any]]
 ) -> bool:
-    """Validate an entire --set batch on protobuf copies before mutation."""
+    """Validate an entire --set batch on protobuf copies before mutation.
+
+    Parameters
+    ----------
+    node : Any
+        Node providing the current local and module configuration values.
+    set_entries : Sequence[tuple[str, Any]]
+        Normalized preference names and raw values to validate as one batch.
+
+    Returns
+    -------
+    bool
+        ``True`` when every entry can be applied; ``False`` when an unknown
+        field or non-fatal semantic validation rejects the batch.
+    """
     candidates = []
     for source in (node.localConfig, node.moduleConfig):
         candidate = type(source)()

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -187,6 +187,11 @@ def _fatal_preference_value_errors() -> Iterator[None]:
     finally:
         _SET_PREF_VALUE_ERRORS_FATAL.reset(token)
 
+=======
+_PREF_VALIDATION_REPORTER: contextvars.ContextVar[Callable[[str], None] | None] = (
+    contextvars.ContextVar("pref_validation_reporter", default=None)
+)
+>>>>>>> b4d18df0 (Polish atomic set validation diagnostics)
 
 # Map dotted preference paths to the protobuf enum that defines their flags.
 # These fields are stored as uint32 bitmasks in the protobuf but have an
@@ -336,8 +341,16 @@ def _report_pref_validation(message: str) -> None:
     message : str
         User-facing validation diagnostic.
 
-    Configure preflight intentionally suppresses low-level duplicate diagnostics.
+    Notes
+    -----
+    Outside preflight, validation messages retain their historical direct stdout
+    behavior, including visibility under ``--quiet``. Batch preflight installs a
+    reporter so diagnostics can be emitted coherently after all entries are checked.
     """
+    reporter = _PREF_VALIDATION_REPORTER.get()
+    if reporter is not None:
+        reporter(message)
+        return
     _cli_print(message, force=not _CONFIGURE_PREFLIGHT_MODE.get())
 
 
@@ -1856,9 +1869,7 @@ def _handle_ota_update(
     _cli_print("\nOTA update completed successfully!")
 
 
-def _print_set_field_choices(
-    node: Any, pref_names: str | Sequence[str]
-) -> None:
+def _print_set_field_choices(node: Any, pref_names: str | Sequence[str]) -> None:
     """Print historical field-not-found guidance for one or more --set names.
 
     Parameters
@@ -1888,6 +1899,8 @@ def _normalize_set_entries(
     ----------
     set_entries : Sequence[Sequence[Any] | None]
         Parsed ``--set`` entries, each containing at least a field name and value.
+        Any additional elements are ignored for compatibility with the historical
+        ``item[0]``/``item[1]`` parsing contract.
 
     Returns
     -------
@@ -1899,6 +1912,26 @@ def _normalize_set_entries(
         for item in set_entries
         if item is not None and len(item) >= 2
     ]
+
+
+def _format_set_preflight_exception(pref_name: str, exc: Exception) -> str:
+    """Format a preflight exception without exposing secret preference values.
+
+    Parameters
+    ----------
+    pref_name : str
+        Canonical preference path whose validation raised ``exc``.
+    exc : Exception
+        Validation exception raised by the protobuf/runtime conversion path.
+
+    Returns
+    -------
+    str
+        Safe error detail suitable for the aggregated CLI failure message.
+    """
+    if _redact_pref_value(pref_name, "value") == "<redacted>":
+        return f"{pref_name}: invalid value <redacted> ({type(exc).__name__})"
+    return f"{pref_name}: {exc}"
 
 
 def _preflight_set_entries(
@@ -1917,7 +1950,9 @@ def _preflight_set_entries(
     -------
     bool
         ``True`` when every entry can be applied; ``False`` when an unknown
-        field or non-fatal semantic validation rejects the batch.
+        field or non-fatal semantic validation rejects the batch. Unknown and
+        semantic rejections remain exit-code compatible with the historical CLI,
+        but now cancel the entire batch instead of permitting partial application.
     """
     candidates = []
     for source in (node.localConfig, node.moduleConfig):
@@ -1927,12 +1962,12 @@ def _preflight_set_entries(
 
     fatal_errors: list[str] = []
     unknown_fields: list[str] = []
-    value_rejections: list[str] = []
+    value_rejections: list[tuple[str, tuple[str, ...]]] = []
     token = _CONFIGURE_PREFLIGHT_MODE.set(True)
     try:
         for raw_pref_name, raw_value in set_entries:
             pref_name = _normalize_pref_name(raw_pref_name)
-            root_field = meshtastic.util.camel_to_snake(splitCompoundName(pref_name)[0])
+            root_field = splitCompoundName(pref_name)[0]
             candidate = next(
                 (
                     config
@@ -1945,13 +1980,20 @@ def _preflight_set_entries(
                 unknown_fields.append(pref_name)
                 continue
 
+            validation_messages: list[str] = []
+            reporter_token = _PREF_VALIDATION_REPORTER.set(
+                validation_messages.append
+            )
             try:
-                valid = setPref(candidate, pref_name, raw_value)
+                try:
+                    valid = setPref(candidate, pref_name, raw_value)
+                finally:
+                    _PREF_VALIDATION_REPORTER.reset(reporter_token)
             except (TypeError, ValueError, OverflowError, binascii.Error) as exc:
-                fatal_errors.append(f"{pref_name}: {exc}")
+                fatal_errors.append(_format_set_preflight_exception(pref_name, exc))
                 continue
             if not valid:
-                value_rejections.append(pref_name)
+                value_rejections.append((pref_name, tuple(validation_messages)))
     finally:
         _CONFIGURE_PREFLIGHT_MODE.reset(token)
 
@@ -1959,8 +2001,19 @@ def _preflight_set_entries(
         _print_set_field_choices(node, unknown_fields)
 
     if fatal_errors:
-        details = "\n".join(f"  - {error}" for error in fatal_errors)
+        detail_lines = [f"  - {error}" for error in fatal_errors]
+        for pref_name, messages in value_rejections:
+            detail_lines.append(f"  - {pref_name}: value rejected by validation")
+            detail_lines.extend(f"      {message}" for message in messages)
+        details = "\n".join(detail_lines)
         _cli_exit(f"ERROR: --set batch rejected before applying changes:\n{details}")
+
+    for pref_name, messages in value_rejections:
+        if messages:
+            for message in messages:
+                print(message)
+        else:
+            print(f"{pref_name}: value was rejected by validation.")
 
     return not (unknown_fields or value_rejections)
 
@@ -1975,26 +2028,41 @@ def _handle_set_command(
     if not _preflight_set_entries(node, set_entries):
         return
 
-    last_pref: tuple[str, Any] | None = None
     fields: set[str] = set()
-    any_found = False
     for raw_pref_name, raw_value in set_entries:
-        last_pref = (raw_pref_name, raw_value)
-        found = False
         normalized_pref_name = _normalize_pref_name(raw_pref_name)
         field = splitCompoundName(normalized_pref_name)[0]
+        applied = False
         for config in [node.localConfig, node.moduleConfig]:
             config_type = config.DESCRIPTOR.fields_by_name.get(field)
             if config_type is not None:
                 if len(config.ListFields()) == 0:
                     node.requestConfig(config_type)
-                found = setPref(config, normalized_pref_name, raw_value)
-                if found:
-                    any_found = True
-                    fields.add(field)
-                    break
+                try:
+                    found = setPref(config, normalized_pref_name, raw_value)
+                except (TypeError, ValueError, OverflowError, binascii.Error) as exc:
+                    detail = _format_set_preflight_exception(
+                        normalized_pref_name, exc
+                    )
+                    _cli_exit(
+                        "ERROR: --set apply diverged after successful preflight:\n"
+                        f"  - {detail}"
+                    )
+                if not found:
+                    _cli_exit(
+                        "ERROR: --set apply diverged after successful preflight for "
+                        f"{normalized_pref_name}."
+                    )
+                fields.add(field)
+                applied = True
+                break
+        if not applied:
+            _cli_exit(
+                "ERROR: --set field no longer resolves after successful preflight: "
+                f"{normalized_pref_name}."
+            )
 
-    if any_found:
+    if fields:
         _cli_print("Writing modified preferences to device")
         if len(fields) > 1:
             _cli_print("Using a configuration transaction")
@@ -2004,8 +2072,6 @@ def _handle_set_command(
             node.writeConfig(field)
         if len(fields) > 1:
             node.commitSettingsTransaction()
-    elif last_pref is not None:
-        _print_set_field_choices(node, last_pref[0])
 
 
 def _pace_configure_write(

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1856,12 +1856,76 @@ def _handle_ota_update(
     _cli_print("\nOTA update completed successfully!")
 
 
+def _print_set_field_choices(node: Any, pref_name: str) -> None:
+    """Print the historical field-not-found guidance for one --set name."""
+    print(
+        f"{node.localConfig.__class__.__name__} and "
+        f"{node.moduleConfig.__class__.__name__} do not have an attribute {pref_name}."
+    )
+    print("Choices are...")
+    printConfig(node.localConfig)
+    printConfig(node.moduleConfig)
+
+
+def _preflight_set_entries(node: Any, set_entries: Sequence[Sequence[Any]]) -> bool:
+    """Validate an entire --set batch on protobuf copies before mutation."""
+    candidates = []
+    for source in (node.localConfig, node.moduleConfig):
+        candidate = type(source)()
+        candidate.CopyFrom(source)
+        candidates.append(candidate)
+
+    fatal_errors: list[str] = []
+    rejected_fields: list[str] = []
+    token = _CONFIGURE_PREFLIGHT_MODE.set(True)
+    try:
+        for item in set_entries:
+            if item is None or len(item) < 2:
+                continue
+            pref_name = _normalize_pref_name(str(item[0]))
+            raw_value = item[1]
+            root_field = meshtastic.util.camel_to_snake(splitCompoundName(pref_name)[0])
+            candidate = next(
+                (
+                    config
+                    for config in candidates
+                    if root_field in config.DESCRIPTOR.fields_by_name
+                ),
+                None,
+            )
+            if candidate is None or not _resolve_pref(candidate, pref_name):
+                rejected_fields.append(pref_name)
+                continue
+
+            try:
+                valid = setPref(candidate, pref_name, raw_value)
+            except (TypeError, ValueError, OverflowError, binascii.Error) as exc:
+                fatal_errors.append(f"{pref_name}: {exc}")
+                continue
+            if not valid:
+                rejected_fields.append(pref_name)
+    finally:
+        _CONFIGURE_PREFLIGHT_MODE.reset(token)
+
+    if fatal_errors:
+        details = "\n".join(f"  - {error}" for error in fatal_errors)
+        _cli_exit(f"ERROR: --set batch rejected before applying changes:\n{details}")
+
+    if rejected_fields:
+        _print_set_field_choices(node, rejected_fields[0])
+        return False
+
+    return True
+
+
 def _handle_set_command(
     interface: MeshInterface,
     args: Any,
     getNode_kwargs: dict[str, Any],
 ) -> None:
     node = interface.getNode(args.dest, False, **getNode_kwargs)
+    if not _preflight_set_entries(node, args.set):
+        return
 
     last_pref: list[str] | None = None
     fields: set[str] = set()
@@ -1899,12 +1963,7 @@ def _handle_set_command(
         if len(fields) > 1:
             node.commitSettingsTransaction()
     elif last_pref is not None:
-        print(
-            f"{node.localConfig.__class__.__name__} and {node.moduleConfig.__class__.__name__} do not have an attribute {last_pref[0]}."
-        )
-        print("Choices are...")
-        printConfig(node.localConfig)
-        printConfig(node.moduleConfig)
+        _print_set_field_choices(node, last_pref[0])
 
 
 def _pace_configure_write(

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1242,28 +1242,22 @@ def _redact_pref_value(name: str, value: str) -> str:
 
 
 def getPref(node: Any, comp_name: str, *, allow_secrets: bool = False) -> bool:
-    """Retrieve and display a configuration preference or channel field for a node.
-
-    Given a dot-separated preference name (section.field) or a single name (used for
-    both section and field resolution), print any populated local values for that
-    preference; if the field exists but is not populated locally, request the
-    remote node's configuration so the value can be fetched. When a message/section
-    name is provided (e.g., "channel" or "channel.label"), populated
-    subfields are printed.
+    """Retrieve and display a node configuration preference or populated section fields.
 
     Parameters
     ----------
     node : Any
-        Node object exposing `localConfig` and `moduleConfig`.
+        Node exposing local and module configuration data and configuration requests.
     comp_name : str
-        Dot-separated preference path (e.g., "channel.label" or "label").
-        A single name is used for both section and field resolution.
+        Preference path or configuration section name to retrieve.
+    allow_secrets : bool
+        Whether sensitive preference values may be displayed without redaction.
 
     Returns
     -------
     bool
-        `True` if the preference exists and local values were printed or a remote
-        config request was issued, `False` if the preference was not found.
+        ``True`` if the preference exists and values were displayed or requested,
+        ``False`` if it was not found.
     """
 
     def _print_setting(
@@ -1832,6 +1826,17 @@ def _handle_ota_update(
     args: Any,
     getNode_kwargs: dict[str, Any],
 ) -> None:
+    """Initiate a Wi-Fi OTA update for the directly connected local node.
+
+    Parameters
+    ----------
+    interface : MeshInterface
+        TCP interface connected to the target node.
+    args : Any
+        CLI arguments containing the OTA update path and destination.
+    getNode_kwargs : dict[str, Any]
+        Additional arguments for retrieving the local node.
+    """
     if not isinstance(interface, meshtastic.tcp_interface.TCPInterface):
         _cli_exit(
             "Error: OTA update currently requires a TCP connection to the node (use --host)."
@@ -2010,22 +2015,21 @@ def _ensure_set_sections_loaded(
 def _preflight_set_entries(
     node: Any, set_entries: Sequence[tuple[str, Any]]
 ) -> bool:
-    """Validate an entire --set batch on protobuf copies before mutation.
-
+    """
+    Validate all --set entries against configuration copies before applying changes.
+    
     Parameters
     ----------
     node : Any
-        Node providing the current local and module configuration values.
+        Node providing the current local and module configuration.
     set_entries : Sequence[tuple[str, Any]]
-        Normalized preference names and raw values to validate as one batch.
-
+        Preference names and raw values to validate as one batch.
+    
     Returns
     -------
     bool
-        ``True`` when every entry can be applied; ``False`` when an unknown
-        field or non-fatal semantic validation rejects the batch. Unknown and
-        semantic rejections remain exit-code compatible with the historical CLI,
-        but now cancel the entire batch instead of permitting partial application.
+        ``True`` if every entry is valid; ``False`` if an unknown field or semantic
+        validation failure rejects the batch.
     """
     candidates: list[Any] = []
     for source in (node.localConfig, node.moduleConfig):
@@ -2097,8 +2101,9 @@ def _handle_set_command(
     args: Any,
     getNode_kwargs: dict[str, Any],
 ) -> None:
-    """Validate and atomically apply one CLI ``--set`` batch.
-
+    """
+    Validate and apply a CLI ``--set`` batch without partial updates.
+    
     Parameters
     ----------
     interface : MeshInterface
@@ -2107,14 +2112,12 @@ def _handle_set_command(
         Parsed CLI arguments containing the ``--set`` entries and destination.
     getNode_kwargs : dict[str, Any]
         Additional keyword arguments forwarded to ``interface.getNode``.
-
+    
     Notes
     -----
-    Required device-backed sections are loaded before preflight snapshots are
-    created. A ``False`` preflight result means diagnostics were already emitted
-    and the entire batch is cancelled without mutation. After a successful
-    preflight, any resolution or validation difference during live application
-    is treated as an invariant violation and exits with an error.
+    Invalid batches are rejected before modifying the device. Valid batches write
+    all affected configuration sections and use a transaction when multiple
+    sections are changed.
     """
     node = interface.getNode(args.dest, False, **getNode_kwargs)
     set_entries = _normalize_set_entries(args.set)

--- a/meshtastic/tests/test_cli_set_batch_atomicity.py
+++ b/meshtastic/tests/test_cli_set_batch_atomicity.py
@@ -230,3 +230,32 @@ def test_preflight_surfaces_unknown_fields_alongside_fatal_values(
     assert "lora.not_a_field" in out
     assert "lora.hop_limit" in err
     node.writeConfig.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_camel_case_multiword_section_preflights_and_applies_consistently(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CamelCase multi-word roots should resolve identically in both phases."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--host",
+            "meshtastic.local",
+            "--set",
+            "externalNotification.enabled",
+            "true",
+        ],
+    )
+    interface, node = _interface_with_config_node()
+
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
+        main()
+
+    assert node.moduleConfig.external_notification.enabled is True
+    node.writeConfig.assert_called_once_with("external_notification")
+    node.beginSettingsTransaction.assert_not_called()
+    node.commitSettingsTransaction.assert_not_called()

--- a/meshtastic/tests/test_cli_set_batch_atomicity.py
+++ b/meshtastic/tests/test_cli_set_batch_atomicity.py
@@ -1,0 +1,162 @@
+"""Regression tests for atomic validation of multi-entry --set commands."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from meshtastic.__main__ import main
+from meshtastic.node import Node
+from meshtastic.protobuf import localonly_pb2
+from meshtastic.tcp_interface import TCPInterface
+
+
+def _interface_with_config_node() -> tuple[MagicMock, MagicMock]:
+    interface = MagicMock(autospec=TCPInterface)
+    interface.__enter__ = MagicMock(return_value=interface)
+    interface.__exit__ = MagicMock(return_value=None)
+    node = MagicMock(autospec=Node)
+    node.localConfig = localonly_pb2.LocalConfig()
+    node.moduleConfig = localonly_pb2.LocalModuleConfig()
+    interface.getNode.return_value = node
+    return interface, node
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_invalid_batch_is_rejected_before_any_config_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--host",
+            "meshtastic.local",
+            "--set",
+            "bluetooth.enabled",
+            "true",
+            "--set",
+            "lora.hop_limit",
+            "not_a_number",
+        ],
+    )
+    interface, node = _interface_with_config_node()
+
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+    assert exc_info.value.code == 1
+    assert node.localConfig.bluetooth.enabled is False
+    assert node.localConfig.lora.hop_limit == 0
+    node.beginSettingsTransaction.assert_not_called()
+    node.writeConfig.assert_not_called()
+    node.commitSettingsTransaction.assert_not_called()
+    _out, err = capsys.readouterr()
+    assert "--set batch rejected before applying changes" in err
+    assert "lora.hop_limit" in err
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_preflight_reports_every_invalid_entry(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--host",
+            "meshtastic.local",
+            "--set",
+            "lora.hop_limit",
+            "bad",
+            "--set",
+            "power.ls_secs",
+            "also_bad",
+        ],
+    )
+    interface, node = _interface_with_config_node()
+
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
+        with pytest.raises(SystemExit):
+            main()
+
+    _out, err = capsys.readouterr()
+    assert "lora.hop_limit" in err
+    assert "power.ls_secs" in err
+    node.writeConfig.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_valid_multi_section_batch_still_uses_one_transaction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--host",
+            "meshtastic.local",
+            "--set",
+            "bluetooth.enabled",
+            "true",
+            "--set",
+            "power.ls_secs",
+            "300",
+        ],
+    )
+    interface, node = _interface_with_config_node()
+
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
+        main()
+
+    assert node.localConfig.bluetooth.enabled is True
+    assert node.localConfig.power.ls_secs == 300
+    node.beginSettingsTransaction.assert_called_once_with()
+    assert {call.args[0] for call in node.writeConfig.call_args_list} == {
+        "bluetooth",
+        "power",
+    }
+    node.commitSettingsTransaction.assert_called_once_with()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_nonfatal_validation_rejection_still_prevents_prior_batch_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A validation warning later in a batch must not apply an earlier entry."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--host",
+            "meshtastic.local",
+            "--set",
+            "bluetooth.enabled",
+            "true",
+            "--set",
+            "network.wifi_psk",
+            "short",
+        ],
+    )
+    interface, node = _interface_with_config_node()
+
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
+        main()
+
+    assert node.localConfig.bluetooth.enabled is False
+    node.writeConfig.assert_not_called()
+    out, err = capsys.readouterr()
+    assert "network.wifi_psk must be 8 or more characters" in out
+    assert err == ""

--- a/meshtastic/tests/test_cli_set_batch_atomicity.py
+++ b/meshtastic/tests/test_cli_set_batch_atomicity.py
@@ -12,6 +12,14 @@ from meshtastic.tcp_interface import TCPInterface
 
 
 def _interface_with_config_node() -> tuple[MagicMock, MagicMock]:
+    """
+    Create a mocked interface and node with empty local and module configurations.
+    
+    Returns
+    -------
+    tuple[MagicMock, MagicMock]
+        The configured mock interface and associated mock node.
+    """
     interface = MagicMock(autospec=TCPInterface)
     interface.__enter__ = MagicMock(return_value=interface)
     interface.__exit__ = MagicMock(return_value=None)

--- a/meshtastic/tests/test_cli_set_batch_atomicity.py
+++ b/meshtastic/tests/test_cli_set_batch_atomicity.py
@@ -159,4 +159,74 @@ def test_nonfatal_validation_rejection_still_prevents_prior_batch_mutation(
     node.writeConfig.assert_not_called()
     out, err = capsys.readouterr()
     assert "network.wifi_psk must be 8 or more characters" in out
+    assert "do not have an attribute network.wifi_psk" not in out
     assert err == ""
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_preflight_reports_all_unknown_fields_with_choices_once(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A batch should expose every unknown field without repeating the choice dump."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--host",
+            "meshtastic.local",
+            "--set",
+            "lora.not_a_field",
+            "1",
+            "--set",
+            "power.also_not_a_field",
+            "2",
+        ],
+    )
+    interface, node = _interface_with_config_node()
+
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
+        main()
+
+    out, err = capsys.readouterr()
+    assert "do not have an attribute lora.not_a_field" in out
+    assert "do not have an attribute power.also_not_a_field" in out
+    assert out.count("Choices are...") == 1
+    assert err == ""
+    node.writeConfig.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_preflight_surfaces_unknown_fields_alongside_fatal_values(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Mixed invalid batches should expose all independently actionable failures."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--host",
+            "meshtastic.local",
+            "--set",
+            "lora.not_a_field",
+            "1",
+            "--set",
+            "lora.hop_limit",
+            "not_a_number",
+        ],
+    )
+    interface, node = _interface_with_config_node()
+
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+    assert exc_info.value.code == 1
+    out, err = capsys.readouterr()
+    assert "lora.not_a_field" in out
+    assert "lora.hop_limit" in err
+    node.writeConfig.assert_not_called()

--- a/meshtastic/tests/test_cli_set_batch_atomicity.py
+++ b/meshtastic/tests/test_cli_set_batch_atomicity.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from meshtastic.__main__ import main
+from meshtastic.__main__ import _REDACTED_PREF_VALUE, _is_secret_pref, main
 from meshtastic.node import Node
 from meshtastic.protobuf import localonly_pb2
 from meshtastic.tcp_interface import TCPInterface
@@ -28,6 +28,7 @@ def test_invalid_batch_is_rejected_before_any_config_mutation(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    """A fatal later entry must leave every earlier setting untouched."""
     monkeypatch.setattr(
         sys,
         "argv",
@@ -66,6 +67,7 @@ def test_preflight_reports_every_invalid_entry(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    """Preflight must aggregate every fatal value error in one invocation."""
     monkeypatch.setattr(
         sys,
         "argv",
@@ -164,6 +166,7 @@ def test_nonfatal_validation_rejection_still_prevents_prior_batch_mutation(
     assert "network.wifi_psk must be 8 or more characters" in out
     assert "do not have an attribute network.wifi_psk" not in out
     assert err == ""
+
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
@@ -411,8 +414,12 @@ def test_preflight_exception_redacts_secret_value_across_runtime_messages(
         with pytest.raises(SystemExit) as exc_info:
             main()
 
+    assert _is_secret_pref("bluetooth.fixed_pin")
     assert exc_info.value.code == 1
     node.writeConfig.assert_not_called()
     out, err = capsys.readouterr()
-    assert "bluetooth.fixed_pin: invalid value <redacted> (TypeError)" in err
+    assert (
+        f"bluetooth.fixed_pin: invalid value {_REDACTED_PREF_VALUE} (TypeError)"
+        in err
+    )
     assert secret not in out + err

--- a/meshtastic/tests/test_cli_set_batch_atomicity.py
+++ b/meshtastic/tests/test_cli_set_batch_atomicity.py
@@ -259,3 +259,157 @@ def test_camel_case_multiword_section_preflights_and_applies_consistently(
     node.writeConfig.assert_called_once_with("external_notification")
     node.beginSettingsTransaction.assert_not_called()
     node.commitSettingsTransaction.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_unknown_field_cancels_prior_valid_entry_without_error_exit(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Unknown fields preserve exit-0 guidance while cancelling the whole batch."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--host",
+            "meshtastic.local",
+            "--set",
+            "bluetooth.enabled",
+            "true",
+            "--set",
+            "lora.not_a_field",
+            "1",
+        ],
+    )
+    interface, node = _interface_with_config_node()
+
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
+        main()
+
+    assert node.localConfig.bluetooth.enabled is False
+    node.writeConfig.assert_not_called()
+    out, err = capsys.readouterr()
+    assert "do not have an attribute lora.not_a_field" in out
+    assert err == ""
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+@pytest.mark.parametrize(
+    ("field", "value", "diagnostic"),
+    (
+        ("lora.region", "NOT_A_REGION", "does not have an enum called"),
+        ("network.enabled_protocols", "TCP", "Unknown flag 'TCP'"),
+    ),
+)
+def test_semantic_rejection_cancels_prior_valid_entry_and_reports_reason(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    field: str,
+    value: str,
+    diagnostic: str,
+) -> None:
+    """Enum and bitfield failures remain nonfatal but cannot partially apply a batch."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--host",
+            "meshtastic.local",
+            "--set",
+            "bluetooth.enabled",
+            "true",
+            "--set",
+            field,
+            value,
+        ],
+    )
+    interface, node = _interface_with_config_node()
+
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
+        main()
+
+    assert node.localConfig.bluetooth.enabled is False
+    node.writeConfig.assert_not_called()
+    out, err = capsys.readouterr()
+    assert diagnostic in out
+    assert err == ""
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_semantic_and_fatal_rejections_are_reported_together_on_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A fatal batch reports captured semantic diagnostics in the same error stream."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--host",
+            "meshtastic.local",
+            "--set",
+            "lora.region",
+            "NOT_A_REGION",
+            "--set",
+            "power.ls_secs",
+            "not-a-number",
+        ],
+    )
+    interface, node = _interface_with_config_node()
+
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+    assert exc_info.value.code == 1
+    node.writeConfig.assert_not_called()
+    out, err = capsys.readouterr()
+    assert "does not have an enum called" not in out
+    assert "power.ls_secs" in err
+    assert "lora.region: value rejected by validation" in err
+    assert "does not have an enum called" in err
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_preflight_exception_redacts_secret_value_across_runtime_messages(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Runtime-specific exception wording must never defeat secret redaction."""
+    secret = "SENTINEL_PRIVATE_VALUE"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--host",
+            "meshtastic.local",
+            "--set",
+            "bluetooth.fixed_pin",
+            secret,
+        ],
+    )
+    interface, node = _interface_with_config_node()
+
+    with (
+        patch("meshtastic.tcp_interface.TCPInterface", return_value=interface),
+        patch(
+            "meshtastic.__main__.setPref",
+            side_effect=TypeError(f"{secret!r} has type str"),
+        ),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+    assert exc_info.value.code == 1
+    node.writeConfig.assert_not_called()
+    out, err = capsys.readouterr()
+    assert "bluetooth.fixed_pin: invalid value <redacted> (TypeError)" in err
+    assert secret not in out + err

--- a/meshtastic/tests/test_cli_set_batch_atomicity.py
+++ b/meshtastic/tests/test_cli_set_batch_atomicity.py
@@ -120,6 +120,9 @@ def test_valid_multi_section_batch_still_uses_one_transaction(
 
     assert node.localConfig.bluetooth.enabled is True
     assert node.localConfig.power.ls_secs == 300
+    assert [
+        request.args[0].name for request in node.requestConfig.call_args_list
+    ] == ["bluetooth", "power"]
     node.beginSettingsTransaction.assert_called_once_with()
     assert {call.args[0] for call in node.writeConfig.call_args_list} == {
         "bluetooth",

--- a/meshtastic/tests/test_cli_set_preflight_loading.py
+++ b/meshtastic/tests/test_cli_set_preflight_loading.py
@@ -1,0 +1,158 @@
+"""Regression tests for loading --set config sections before atomic preflight."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from google.protobuf.descriptor import FieldDescriptor
+
+import meshtastic.__main__ as main_module
+from meshtastic.__main__ import (
+    _ensure_set_sections_loaded,
+    _normalize_set_entries,
+    _resolve_set_target,
+)
+from meshtastic.node import Node
+from meshtastic.protobuf import localonly_pb2
+from meshtastic.tcp_interface import TCPInterface
+
+
+def _config_node() -> MagicMock:
+    """Return a node mock with real protobuf config wrappers."""
+    node = MagicMock(autospec=Node)
+    node.localConfig = localonly_pb2.LocalConfig()
+    node.moduleConfig = localonly_pb2.LocalModuleConfig()
+    return node
+
+
+@pytest.mark.unit
+def test_resolve_set_target_uses_one_root_ownership_contract() -> None:
+    """Root resolution should identify local, module, and unknown sections."""
+    node = _config_node()
+    configs = (node.localConfig, node.moduleConfig)
+
+    local_target = _resolve_set_target(configs, "bluetooth.enabled")
+    module_target = _resolve_set_target(configs, "external_notification.enabled")
+
+    assert local_target is not None
+    assert local_target[0] is node.localConfig
+    assert local_target[1].name == "bluetooth"
+    assert module_target is not None
+    assert module_target[0] is node.moduleConfig
+    assert module_target[1].name == "external_notification"
+    assert _resolve_set_target(configs, "not_a_section.value") is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("wrapper_name", "section_name", "pref_name"),
+    (
+        ("localConfig", "bluetooth", "bluetooth.enabled"),
+        ("moduleConfig", "mqtt", "mqtt.enabled"),
+    ),
+)
+def test_loaded_default_section_is_not_requested_again(
+    wrapper_name: str,
+    section_name: str,
+    pref_name: str,
+) -> None:
+    """Message presence, not populated scalar fields, marks a section as loaded."""
+    node = _config_node()
+    wrapper = getattr(node, wrapper_name)
+    section = getattr(wrapper, section_name)
+    section.SetInParent()
+    assert wrapper.HasField(section_name)
+    assert section.ListFields() == []
+
+    _ensure_set_sections_loaded(
+        node,
+        _normalize_set_entries(((pref_name, "true"),)),
+    )
+
+    node.requestConfig.assert_not_called()
+
+
+@pytest.mark.unit
+def test_missing_section_is_requested_once_for_multiple_entries() -> None:
+    """Multiple settings in one missing section should trigger one device read."""
+    node = _config_node()
+
+    _ensure_set_sections_loaded(
+        node,
+        _normalize_set_entries(
+            (
+                ("lora.hop_limit", "3"),
+                ("lora.tx_power", "10"),
+            )
+        ),
+    )
+
+    node.requestConfig.assert_called_once()
+    assert node.requestConfig.call_args.args[0].name == "lora"
+
+
+@pytest.mark.unit
+def test_unknown_nested_field_does_not_trigger_device_read() -> None:
+    """Schema-invalid settings should fail locally without unnecessary requests."""
+    node = _config_node()
+
+    _ensure_set_sections_loaded(
+        node,
+        _normalize_set_entries((("lora.not_a_field", "1"),)),
+    )
+
+    node.requestConfig.assert_not_called()
+
+
+@pytest.mark.unit
+def test_request_can_populate_section_before_preflight_snapshot() -> None:
+    """A synchronous remote-style request should populate state before copying."""
+    node = _config_node()
+
+    def populate_lora(config_type: FieldDescriptor) -> None:
+        assert config_type.name == "lora"
+        node.localConfig.lora.ignore_incoming.append(123)
+
+    node.requestConfig.side_effect = populate_lora
+    _ensure_set_sections_loaded(
+        node,
+        _normalize_set_entries((("lora.ignore_incoming", "456"),)),
+    )
+
+    assert list(node.localConfig.lora.ignore_incoming) == [123]
+
+
+@pytest.mark.unit
+def test_handle_set_loads_sections_before_invoking_preflight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The command must snapshot only after requestConfig has updated live state."""
+    node = _config_node()
+    interface = MagicMock(autospec=TCPInterface)
+    interface.getNode.return_value = node
+    args = SimpleNamespace(
+        dest=None,
+        set=(("lora.ignore_incoming", "456"),),
+    )
+    observed_preflight_values: list[list[int]] = []
+
+    def populate_lora(config_type: FieldDescriptor) -> None:
+        assert config_type.name == "lora"
+        node.localConfig.lora.ignore_incoming.append(123)
+
+    def inspect_preflight(
+        target_node: MagicMock,
+        _entries: list[tuple[str, object]],
+    ) -> bool:
+        observed_preflight_values.append(
+            list(target_node.localConfig.lora.ignore_incoming)
+        )
+        return False
+
+    node.requestConfig.side_effect = populate_lora
+    monkeypatch.setattr(main_module, "_preflight_set_entries", inspect_preflight)
+
+    main_module._handle_set_command(interface, args, {})
+
+    assert observed_preflight_values == [[123]]
+    node.writeConfig.assert_not_called()

--- a/meshtastic/tests/test_cli_set_preflight_loading.py
+++ b/meshtastic/tests/test_cli_set_preflight_loading.py
@@ -144,6 +144,20 @@ def test_handle_set_loads_sections_before_invoking_preflight(
         target_node: MagicMock,
         _entries: list[tuple[str, object]],
     ) -> bool:
+        """Record the current LoRa ignore-incoming values observed during preflight.
+
+        Parameters
+        ----------
+        target_node : MagicMock
+            Node whose configuration is inspected.
+        _entries : list[tuple[str, object]]
+            Settings being preflighted.
+
+        Returns
+        -------
+        bool
+            ``False`` to reject the preflight.
+        """
         observed_preflight_values.append(
             list(target_node.localConfig.lora.ignore_incoming)
         )


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This change adds preflight validation for batched CLI `--set` operations. The command validates all settings on temporary configuration copies before changing the device configuration. Invalid batches do not apply partial changes.

### Key changes

- **Features**
  - Validate all batched settings before mutation.
  - Report all relevant validation diagnostics in one result.
  - Apply valid multi-section batches in one transaction.
  - Resolve section names in camelCase form.
  - Show one consolidated list of available fields for unknown settings.

- **Fixes**
  - Prevent partial configuration updates when validation fails.
  - Reject batches with fatal, nonfatal, semantic, or unknown-field errors.
  - Abort the batch when setting conversion fails.
  - Redact secret values from conversion error messages.
  - Preserve the expected command exit status for rejected batches.

- **Refactors**
  - Normalize `--set` entries before validation and application.
  - Store preference validation diagnostics in a context-local scope.
  - Extract reusable logic for displaying missing-field guidance.
  - Add regression tests for validation failures, atomicity, conversion errors, field resolution, exit status, redaction, and successful multi-section updates.

No breaking changes or migration steps are required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->