### PR TITLE
Retry serial bootstrap after malformed frames

### DIFF
--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -323,7 +323,7 @@ class MeshInterface:  # pylint: disable=R0902
         #   + _response_wait_acks + _active_wait_request_ids
         #   + _retired_wait_request_ids
         # - _heartbeat_lock: _closing, heartbeatTimer, _heartbeat_inflight,
-        #   isConnected
+        #   isConnected, _bootstrap_decode_error_count
         # - _packet_id_lock: currentPacketId generation
         # - _queue_lock: queue + queueStatus
         # - _node_db_lock: nodes/nodesByNum/_localChannels plus myInfo/metadata
@@ -352,6 +352,7 @@ class MeshInterface:  # pylint: disable=R0902
         self.failure: BaseException | None = (
             None  # If we've encountered a fatal exception it will be kept here
         )
+        self._bootstrap_decode_error_count = 0
         self._timeout: Timeout = Timeout(maxSecs=timeout)
         self._acknowledgment: Acknowledgment = Acknowledgment()
         self.heartbeatTimer: threading.Timer | None = None
@@ -494,6 +495,20 @@ class MeshInterface:  # pylint: disable=R0902
         """
         with self._heartbeat_lock:
             self._closing = False
+            self._bootstrap_decode_error_count = 0
+
+    def _record_bootstrap_decode_error(self) -> int:
+        """Record one malformed protocol frame observed before connection completes."""
+        with self._heartbeat_lock:
+            if self.isConnected.is_set():
+                return 0
+            self._bootstrap_decode_error_count += 1
+            return self._bootstrap_decode_error_count
+
+    def _bootstrap_decode_error_count_snapshot(self) -> int:
+        """Return the current bootstrap decode-error count under the lifecycle lock."""
+        with self._heartbeat_lock:
+            return self._bootstrap_decode_error_count
 
     def close(self) -> None:
         """Shut down the interface and send a disconnect to the radio.

--- a/meshtastic/mesh_interface_runtime/receive_pipeline.py
+++ b/meshtastic/mesh_interface_runtime/receive_pipeline.py
@@ -237,12 +237,14 @@ class ReceivePipeline:
         try:
             from_radio.ParseFromString(from_radio_bytes)
         except protobuf_message.DecodeError:
-            record_error = getattr(
-                type(self._interface), "_record_bootstrap_decode_error", None
+            recorder_name = "_record_bootstrap_decode_error"
+            has_recorder = recorder_name in vars(self._interface) or hasattr(
+                type(self._interface), recorder_name
             )
-            bootstrap_error_count = (
-                record_error(self._interface) if callable(record_error) else 0
+            record_error = (
+                getattr(self._interface, recorder_name, None) if has_recorder else None
             )
+            bootstrap_error_count = record_error() if callable(record_error) else 0
             if bootstrap_error_count:
                 logger.warning(
                     "Discarding malformed FromRadio frame during connection bootstrap "

--- a/meshtastic/mesh_interface_runtime/receive_pipeline.py
+++ b/meshtastic/mesh_interface_runtime/receive_pipeline.py
@@ -236,6 +236,28 @@ class ReceivePipeline:
         )
         try:
             from_radio.ParseFromString(from_radio_bytes)
+        except protobuf_message.DecodeError:
+            record_error = getattr(
+                type(self._interface), "_record_bootstrap_decode_error", None
+            )
+            bootstrap_error_count = (
+                record_error(self._interface) if callable(record_error) else 0
+            )
+            if bootstrap_error_count:
+                logger.warning(
+                    "Discarding malformed FromRadio frame during connection bootstrap "
+                    "(count=%d, len=%d, sha256=%s)",
+                    bootstrap_error_count,
+                    frame_length,
+                    frame_checksum,
+                )
+            else:
+                logger.exception(
+                    "Error while parsing FromRadio frame len=%d sha256=%s",
+                    frame_length,
+                    frame_checksum,
+                )
+            raise
         except Exception:
             logger.exception(
                 "Error while parsing FromRadio frame len=%d sha256=%s",

--- a/meshtastic/serial_interface.py
+++ b/meshtastic/serial_interface.py
@@ -57,6 +57,9 @@ SERIAL_CONNECT_RETRY_BUDGET_SECONDS = 20.0
 SERIAL_CONNECT_MAX_ATTEMPTS = 12
 """Hard cap on serial connect attempts within the retry window."""
 
+SERIAL_BOOTSTRAP_DECODE_ERROR_RETRY_THRESHOLD = 2
+"""Malformed bootstrap frames tolerated before restarting the serial handshake."""
+
 SERIAL_PORT_PATH_EMPTY_ERROR = (
     "Serial port path cannot be empty; pass None to auto-detect."
 )
@@ -353,6 +356,19 @@ class SerialInterface(StreamInterface):
         if self.stream is None or not getattr(self.stream, "is_open", True):
             self.stream = self._open_serial_stream()
 
+    def _connect_wait_should_abort(self) -> str | None:
+        """Restart bootstrap after repeated malformed protocol frames."""
+        transport_abort = super()._connect_wait_should_abort()
+        if transport_abort is not None:
+            return transport_abort
+        decode_errors = self._bootstrap_decode_error_count_snapshot()
+        if decode_errors >= SERIAL_BOOTSTRAP_DECODE_ERROR_RETRY_THRESHOLD:
+            return (
+                "Corrupt protocol frames during serial connection bootstrap "
+                f"({decode_errors} decode errors)"
+            )
+        return None
+
     def _is_retryable_connect_error(self, exc: Exception) -> bool:
         """Return True when serial connect failures are likely transient."""
         if isinstance(
@@ -371,6 +387,8 @@ class SerialInterface(StreamInterface):
                 or "Connection lost while waiting for connection completion" in message
                 or "No serial Meshtastic device detected for reconnect." in message
                 or "does not exist (device disconnected)" in message
+                or "Corrupt protocol frames during serial connection bootstrap"
+                in message
             )
         return False
 

--- a/meshtastic/serial_interface.py
+++ b/meshtastic/serial_interface.py
@@ -60,6 +60,11 @@ SERIAL_CONNECT_MAX_ATTEMPTS = 12
 SERIAL_BOOTSTRAP_DECODE_ERROR_RETRY_THRESHOLD = 2
 """Malformed bootstrap frames tolerated before restarting the serial handshake."""
 
+SERIAL_BOOTSTRAP_DECODE_ERROR_REASON = (
+    "Corrupt protocol frames during serial connection bootstrap"
+)
+"""Stable error prefix used to classify malformed-frame bootstrap retries."""
+
 SERIAL_PORT_PATH_EMPTY_ERROR = (
     "Serial port path cannot be empty; pass None to auto-detect."
 )
@@ -364,7 +369,7 @@ class SerialInterface(StreamInterface):
         decode_errors = self._bootstrap_decode_error_count_snapshot()
         if decode_errors >= SERIAL_BOOTSTRAP_DECODE_ERROR_RETRY_THRESHOLD:
             return (
-                "Corrupt protocol frames during serial connection bootstrap "
+                f"{SERIAL_BOOTSTRAP_DECODE_ERROR_REASON} "
                 f"({decode_errors} decode errors)"
             )
         return None
@@ -387,8 +392,7 @@ class SerialInterface(StreamInterface):
                 or "Connection lost while waiting for connection completion" in message
                 or "No serial Meshtastic device detected for reconnect." in message
                 or "does not exist (device disconnected)" in message
-                or "Corrupt protocol frames during serial connection bootstrap"
-                in message
+                or SERIAL_BOOTSTRAP_DECODE_ERROR_REASON in message
             )
         return False
 

--- a/meshtastic/stream_interface.py
+++ b/meshtastic/stream_interface.py
@@ -10,6 +10,7 @@ import time
 from typing import IO, Any, BinaryIO, Callable
 
 import serial  # type: ignore[import-untyped]
+from google.protobuf.message import DecodeError
 
 from meshtastic.mesh_interface import MeshInterface
 from meshtastic.protobuf import mesh_pb2
@@ -659,6 +660,10 @@ class StreamInterface(MeshInterface):
                                     bytes(
                                         self._rxBuf[HEADER_LEN : packetlen + HEADER_LEN]
                                     )
+                                )
+                            except DecodeError:
+                                logger.debug(
+                                    "Malformed FromRadio frame was discarded and the reader will resynchronize"
                                 )
                             except Exception:
                                 logger.exception(

--- a/meshtastic/tests/test_serial_bootstrap_recovery.py
+++ b/meshtastic/tests/test_serial_bootstrap_recovery.py
@@ -10,6 +10,7 @@ from google.protobuf.message import DecodeError
 from meshtastic.mesh_interface import MeshInterface
 from meshtastic.mesh_interface_runtime.receive_pipeline import ReceivePipeline
 from meshtastic.serial_interface import (
+    SERIAL_BOOTSTRAP_DECODE_ERROR_REASON,
     SERIAL_BOOTSTRAP_DECODE_ERROR_RETRY_THRESHOLD,
     SerialInterface,
 )
@@ -28,38 +29,57 @@ def test_receive_pipeline_records_malformed_bootstrap_frame() -> None:
 
 
 @pytest.mark.unit
-def test_serial_wait_aborts_after_repeated_bootstrap_decode_errors() -> None:
+def test_receive_pipeline_honors_instance_bootstrap_error_recorder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed-frame accounting should respect per-instance overrides."""
+    with MeshInterface(noProto=True) as interface:
+        recorder = MagicMock(return_value=3)
+        monkeypatch.setattr(interface, "_record_bootstrap_decode_error", recorder)
+        pipeline = ReceivePipeline(interface)
+
+        with pytest.raises(DecodeError):
+            pipeline._parse_from_radio_bytes(b"\x80")  # noqa: SLF001
+
+        recorder.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_serial_wait_aborts_after_repeated_bootstrap_decode_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     interface = object.__new__(SerialInterface)
     interface._wantExit = False
     interface.stream = SimpleNamespace(is_open=True)
     interface._rxThread = MagicMock()
     interface._rxThread.is_alive.return_value = True
-    interface._bootstrap_decode_error_count_snapshot = MagicMock(
-        return_value=SERIAL_BOOTSTRAP_DECODE_ERROR_RETRY_THRESHOLD
-    )
+    snapshot = MagicMock(return_value=SERIAL_BOOTSTRAP_DECODE_ERROR_RETRY_THRESHOLD)
+    monkeypatch.setattr(interface, "_bootstrap_decode_error_count_snapshot", snapshot)
 
     reason = interface._connect_wait_should_abort()
 
     assert reason is not None
-    assert "Corrupt protocol frames during serial connection bootstrap" in reason
+    assert SERIAL_BOOTSTRAP_DECODE_ERROR_REASON in reason
+    snapshot.assert_called_once_with()
 
 
 @pytest.mark.unit
-def test_serial_wait_prioritizes_transport_shutdown_over_decode_retry() -> None:
+def test_serial_wait_prioritizes_transport_shutdown_over_decode_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     interface = object.__new__(SerialInterface)
     interface._wantExit = True
     interface.stream = SimpleNamespace(is_open=True)
     interface._rxThread = MagicMock()
     interface._rxThread.is_alive.return_value = True
-    interface._bootstrap_decode_error_count_snapshot = MagicMock(
-        return_value=SERIAL_BOOTSTRAP_DECODE_ERROR_RETRY_THRESHOLD
-    )
+    snapshot = MagicMock(return_value=SERIAL_BOOTSTRAP_DECODE_ERROR_RETRY_THRESHOLD)
+    monkeypatch.setattr(interface, "_bootstrap_decode_error_count_snapshot", snapshot)
 
     assert (
         interface._connect_wait_should_abort()
         == "Connection cancelled while waiting for completion"
     )
-    interface._bootstrap_decode_error_count_snapshot.assert_not_called()
+    snapshot.assert_not_called()
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_serial_bootstrap_recovery.py
+++ b/meshtastic/tests/test_serial_bootstrap_recovery.py
@@ -1,0 +1,100 @@
+"""Regression tests for serial recovery from malformed bootstrap frames."""
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from google.protobuf.message import DecodeError
+
+from meshtastic.mesh_interface import MeshInterface
+from meshtastic.mesh_interface_runtime.receive_pipeline import ReceivePipeline
+from meshtastic.serial_interface import (
+    SERIAL_BOOTSTRAP_DECODE_ERROR_RETRY_THRESHOLD,
+    SerialInterface,
+)
+from meshtastic.stream_interface import StreamInterface
+
+
+@pytest.mark.unit
+def test_receive_pipeline_records_malformed_bootstrap_frame() -> None:
+    with MeshInterface(noProto=True) as interface:
+        pipeline = ReceivePipeline(interface)
+
+        with pytest.raises(DecodeError):
+            pipeline._parse_from_radio_bytes(b"\x80")  # noqa: SLF001
+
+        assert interface._bootstrap_decode_error_count_snapshot() == 1  # noqa: SLF001
+
+
+@pytest.mark.unit
+def test_serial_wait_aborts_after_repeated_bootstrap_decode_errors() -> None:
+    interface = object.__new__(SerialInterface)
+    interface._wantExit = False
+    interface.stream = SimpleNamespace(is_open=True)
+    interface._rxThread = MagicMock()
+    interface._rxThread.is_alive.return_value = True
+    interface._bootstrap_decode_error_count_snapshot = MagicMock(
+        return_value=SERIAL_BOOTSTRAP_DECODE_ERROR_RETRY_THRESHOLD
+    )
+
+    reason = interface._connect_wait_should_abort()
+
+    assert reason is not None
+    assert "Corrupt protocol frames during serial connection bootstrap" in reason
+
+
+@pytest.mark.unit
+def test_serial_wait_prioritizes_transport_shutdown_over_decode_retry() -> None:
+    interface = object.__new__(SerialInterface)
+    interface._wantExit = True
+    interface.stream = SimpleNamespace(is_open=True)
+    interface._rxThread = MagicMock()
+    interface._rxThread.is_alive.return_value = True
+    interface._bootstrap_decode_error_count_snapshot = MagicMock(
+        return_value=SERIAL_BOOTSTRAP_DECODE_ERROR_RETRY_THRESHOLD
+    )
+
+    assert (
+        interface._connect_wait_should_abort()
+        == "Connection cancelled while waiting for completion"
+    )
+    interface._bootstrap_decode_error_count_snapshot.assert_not_called()
+
+
+@pytest.mark.unit
+def test_serial_connect_retries_bootstrap_decode_failure() -> None:
+    interface = object.__new__(SerialInterface)
+    interface.devPath = "/dev/ttyUSB0"
+    interface._dev_path_auto_detected = False
+    interface._connect_lock = threading.Lock()
+    stream = MagicMock()
+    stream.is_open = True
+    interface.stream = stream
+    transient_error = MeshInterface.MeshInterfaceError(
+        "Corrupt protocol frames during serial connection bootstrap (2 decode errors)"
+    )
+
+    with (
+        patch.object(
+            StreamInterface, "connect", side_effect=[transient_error, None]
+        ) as connect,
+        patch.object(interface, "_open_serial_stream", return_value=stream),
+        patch("meshtastic.serial_interface.time.sleep") as sleep,
+    ):
+        interface.connect()
+
+    assert connect.call_count == 2
+    stream.close.assert_called_once_with()
+    sleep.assert_called_once()
+
+
+@pytest.mark.unit
+def test_prepare_for_connect_clears_previous_decode_failures() -> None:
+    with MeshInterface(noProto=True) as interface:
+        for _ in range(4):
+            interface._record_bootstrap_decode_error()  # noqa: SLF001
+
+        interface._prepare_for_connect()  # noqa: SLF001
+
+        assert interface._bootstrap_decode_error_count_snapshot() == 0  # noqa: SLF001


### PR DESCRIPTION
## Summary by Sourcery

Add tracking of malformed protocol frames during connection bootstrap and restart serial handshakes when repeated decode errors occur.

New Features:
- Introduce automatic retry of serial connection bootstrap when protocol frames are repeatedly malformed.

Enhancements:
- Track a bootstrap decode-error counter on MeshInterface to inform serial connection abort decisions.
- Improve FromRadio frame parsing and stream reader logging to distinguish malformed frames from other failures.

Tests:
- Add unit regression tests covering bootstrap decode error tracking, serial abort/retry behaviour, and clearing state before new connects.