### PR TITLE
Improve channel CLI field validation and guidance

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -28,6 +28,7 @@ from google.protobuf.message import Message
 from pubsub import pub
 
 import meshtastic.cli.runtime as cli_runtime
+from meshtastic.mesh_interface_runtime import node_data
 import meshtastic.ota
 import meshtastic.serial_interface
 import meshtastic.tcp_interface
@@ -2041,6 +2042,22 @@ def _handle_configure_command(
     )
 
 
+def _validate_cli_show_fields(interface: MeshInterface, show_fields: list[str]) -> None:
+    """Reject unavailable --show-fields values with a concrete choice list."""
+    nodes_by_num = getattr(interface, "nodesByNum", None)
+    if not isinstance(nodes_by_num, dict) or not nodes_by_num:
+        return
+    available = node_data.getKnownFieldPaths(list(nodes_by_num.values()))
+    available_set = set(available)
+    invalid = [field for field in show_fields if field not in available_set]
+    if invalid:
+        _cli_exit(
+            "Unknown --show-fields value(s): "
+            f"{', '.join(invalid)}. Available fields: {', '.join(available)}",
+            1,
+        )
+
+
 def onConnected(interface: MeshInterface) -> None:
     """Execute CLI actions specified by parsed command-line arguments using the provided MeshInterface.
 
@@ -2545,7 +2562,9 @@ def onConnected(interface: MeshInterface) -> None:
             if ch_add_idx is not None:
                 # Since we set the channel index after adding a channel, don't allow --ch-index
                 _cli_exit(
-                    "Warning: '--ch-add' and '--ch-index' are incompatible. Channel not added."
+                    "Warning: --ch-add chooses the next free channel index automatically; "
+                    "remove --ch-index and retry. Use --ch-set, --ch-del, --ch-enable, "
+                    "or --ch-disable when targeting a specific index."
                 )
             closeNow = True
             if len(args.ch_add) > 10:
@@ -2911,6 +2930,8 @@ def onConnected(interface: MeshInterface) -> None:
             if args.dest != BROADCAST_ADDR:
                 print("Showing node list of a remote node is not supported.")
                 return
+            if args.show_fields:
+                _validate_cli_show_fields(interface, args.show_fields)
             interface.showNodes(True, args.show_fields)
 
         if args.show_fields and not args.nodes:

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -15,6 +15,7 @@ import logging
 import os
 import platform
 import sys
+import textwrap
 import threading
 import time
 from collections.abc import Callable, Iterator, Sequence
@@ -2045,15 +2046,24 @@ def _handle_configure_command(
 def _validate_cli_show_fields(interface: MeshInterface, show_fields: list[str]) -> None:
     """Reject unavailable --show-fields values with a concrete choice list."""
     nodes_by_num = getattr(interface, "nodesByNum", None)
-    if not isinstance(nodes_by_num, dict) or not nodes_by_num:
-        return
-    available = node_data.getKnownFieldPaths(list(nodes_by_num.values()))
+    observed_nodes = (
+        list(nodes_by_num.values()) if isinstance(nodes_by_num, dict) else []
+    )
+    available = node_data.getKnownFieldPaths(observed_nodes)
     available_set = set(available)
     invalid = [field for field in show_fields if field not in available_set]
     if invalid:
+        choices = textwrap.fill(
+            ", ".join(available),
+            width=100,
+            initial_indent="  ",
+            subsequent_indent="  ",
+            break_long_words=False,
+            break_on_hyphens=False,
+        )
         _cli_exit(
             "Unknown --show-fields value(s): "
-            f"{', '.join(invalid)}. Available fields: {', '.join(available)}",
+            f"{', '.join(invalid)}.\nAvailable fields:\n{choices}",
             1,
         )
 

--- a/meshtastic/mesh_interface_runtime/node_data.py
+++ b/meshtastic/mesh_interface_runtime/node_data.py
@@ -2,6 +2,10 @@
 
 from typing import Any
 
+from google.protobuf.descriptor import Descriptor
+
+from meshtastic.protobuf import mesh_pb2, telemetry_pb2
+
 
 def extractNodeFieldValue(node_dict: dict[str, Any], field_path: str) -> Any:
     """Retrieve a nested value from a dictionary using a dotted key path.
@@ -106,3 +110,51 @@ def sortNodes(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
         key=lambda r: r.get("lastHeard") or 0,
         reverse=True,
     )
+
+
+def _descriptor_field_paths(descriptor: Descriptor, prefix: str = "") -> set[str]:
+    """Return JSON-style dotted paths reachable from one protobuf descriptor."""
+    paths: set[str] = set()
+    for field in descriptor.fields:
+        path = f"{prefix}.{field.json_name}" if prefix else field.json_name
+        paths.add(path)
+        if (
+            field.message_type is not None
+            and not field.message_type.GetOptions().map_entry
+        ):
+            paths.update(_descriptor_field_paths(field.message_type, path))
+    return paths
+
+
+def getKnownFieldPaths(nodes: list[dict[str, Any]] | None = None) -> list[str]:
+    """Return known CLI node-table field paths from schema plus observed node data."""
+    paths: set[str] = set(DEFAULT_SHOW_FIELDS)
+    paths.update(_descriptor_field_paths(mesh_pb2.NodeInfo.DESCRIPTOR))
+
+    for telemetry_field in telemetry_pb2.Telemetry.DESCRIPTOR.fields:
+        if telemetry_field.message_type is None:
+            continue
+        paths.add(telemetry_field.json_name)
+        paths.update(
+            _descriptor_field_paths(
+                telemetry_field.message_type,
+                telemetry_field.json_name,
+            )
+        )
+
+    # These are synthesized by presentation/runtime logic rather than represented
+    # directly in NodeInfo's protobuf descriptor.
+    paths.update({"N", "since", "position.latitude", "position.longitude"})
+
+    def _walk_observed(value: Any, prefix: str = "") -> None:
+        if not isinstance(value, dict):
+            return
+        for key, child in value.items():
+            path = f"{prefix}.{key}" if prefix else str(key)
+            paths.add(path)
+            _walk_observed(child, path)
+
+    for node in nodes or []:
+        _walk_observed(node)
+
+    return sorted(paths)

--- a/meshtastic/tests/test_cli_channel_ux.py
+++ b/meshtastic/tests/test_cli_channel_ux.py
@@ -107,3 +107,71 @@ def test_nodes_show_fields_accepts_schema_fields_absent_from_node_database(
     interface.showNodes.assert_called_once_with(
         True, ["user.id", "environmentMetrics.temperature"]
     )
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+@pytest.mark.parametrize("nodes_by_num", [None, {}])
+def test_nodes_show_fields_rejects_unknown_field_without_node_database(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    nodes_by_num: object,
+) -> None:
+    """Schema validation must still run before any nodes have been synchronized."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--host",
+            "meshtastic.local",
+            "--nodes",
+            "--show-fields",
+            "definitely.notAField",
+        ],
+    )
+    interface = MagicMock(autospec=TCPInterface)
+    interface.__enter__ = MagicMock(return_value=interface)
+    interface.__exit__ = MagicMock(return_value=None)
+    interface.nodesByNum = nodes_by_num
+
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+    assert exc_info.value.code == 1
+    interface.showNodes.assert_not_called()
+    _out, err = capsys.readouterr()
+    assert "Unknown --show-fields value(s): definitely.notAField" in err
+    assert "Available fields:\n" in err
+    assert "user.id" in err
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_nodes_show_fields_accepts_schema_field_without_node_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Known schema fields should remain usable before NodeDB population."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--host",
+            "meshtastic.local",
+            "--nodes",
+            "--show-fields",
+            "environmentMetrics.temperature",
+        ],
+    )
+    interface = MagicMock(autospec=TCPInterface)
+    interface.__enter__ = MagicMock(return_value=interface)
+    interface.__exit__ = MagicMock(return_value=None)
+    interface.nodesByNum = {}
+
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
+        main()
+
+    interface.showNodes.assert_called_once_with(
+        True, ["environmentMetrics.temperature"]
+    )

--- a/meshtastic/tests/test_cli_channel_ux.py
+++ b/meshtastic/tests/test_cli_channel_ux.py
@@ -1,0 +1,109 @@
+"""Focused CLI validation tests for channel and node-list options."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from meshtastic.__main__ import main
+from meshtastic.tcp_interface import TCPInterface
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_ch_add_with_index_explains_how_to_target_channels(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--host",
+            "meshtastic.local",
+            "--ch-add",
+            "test",
+            "--ch-index",
+            "1",
+        ],
+    )
+    interface = MagicMock(autospec=TCPInterface)
+    interface.__enter__ = MagicMock(return_value=interface)
+    interface.__exit__ = MagicMock(return_value=None)
+
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+    assert exc_info.value.code == 1
+    _out, err = capsys.readouterr()
+    assert "--ch-add chooses the next free channel index automatically" in err
+    assert "remove --ch-index and retry" in err
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_nodes_show_fields_rejects_unknown_field_with_choices(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--host",
+            "meshtastic.local",
+            "--nodes",
+            "--show-fields",
+            "user.id,channel_aeros index",
+        ],
+    )
+    interface = MagicMock(autospec=TCPInterface)
+    interface.__enter__ = MagicMock(return_value=interface)
+    interface.__exit__ = MagicMock(return_value=None)
+    interface.nodesByNum = {
+        1: {"num": 1, "user": {"id": "!00000001", "longName": "Node"}, "channel": 0}
+    }
+
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+    assert exc_info.value.code == 1
+    interface.showNodes.assert_not_called()
+    _out, err = capsys.readouterr()
+    assert "Unknown --show-fields value(s): channel_aeros index" in err
+    assert "user.id" in err
+    assert "channel" in err
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_nodes_show_fields_accepts_schema_fields_absent_from_node_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--host",
+            "meshtastic.local",
+            "--nodes",
+            "--show-fields",
+            "user.id,environmentMetrics.temperature",
+        ],
+    )
+    interface = MagicMock(autospec=TCPInterface)
+    interface.__enter__ = MagicMock(return_value=interface)
+    interface.__exit__ = MagicMock(return_value=None)
+    interface.nodesByNum = {1: {"num": 1, "user": {"id": "!00000001"}, "channel": 0}}
+
+    with patch("meshtastic.tcp_interface.TCPInterface", return_value=interface):
+        main()
+
+    interface.showNodes.assert_called_once_with(
+        True, ["user.id", "environmentMetrics.temperature"]
+    )

--- a/meshtastic/tests/test_node_data_field_paths.py
+++ b/meshtastic/tests/test_node_data_field_paths.py
@@ -1,0 +1,28 @@
+"""Tests for maintainable schema-driven node-table field discovery."""
+
+import pytest
+
+from meshtastic.mesh_interface_runtime import node_data
+
+
+@pytest.mark.unit
+def test_known_field_paths_include_node_and_telemetry_schema() -> None:
+    fields = set(node_data.getKnownFieldPaths())
+
+    assert "user.id" in fields
+    assert "position.latitude" in fields
+    assert "deviceMetrics.batteryLevel" in fields
+    assert "environmentMetrics.temperature" in fields
+    assert "healthMetrics.heartBpm" in fields
+
+
+@pytest.mark.unit
+def test_known_field_paths_include_observed_extension_fields() -> None:
+    fields = set(
+        node_data.getKnownFieldPaths(
+            [{"num": 1, "vendorExtension": {"sampleValue": 7}}]
+        )
+    )
+
+    assert "vendorExtension" in fields
+    assert "vendorExtension.sampleValue" in fields


### PR DESCRIPTION
## Summary by Sourcery

Improve CLI validation and guidance for channel operations and node list field selection.

New Features:
- Add schema-driven discovery of available node-table field paths combining protobuf descriptors and observed node data.
- Validate --show-fields values against known node fields and present concrete choices when invalid.

Enhancements:
- Clarify error messaging when using --ch-add together with --ch-index to explain automatic index selection and how to target specific channels.

Tests:
- Add CLI tests covering channel index guidance and show-fields validation behavior.
- Add tests verifying schema-driven node field path discovery, including telemetry and vendor extension fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change improves CLI validation and guidance for channel operations and node field selection. It discovers valid node field paths from protobuf schemas and observed node data, validates `--show-fields`, and provides clearer guidance for channel index usage.

- **Features**
  - Added `getKnownFieldPaths()` to discover standard, telemetry, health, runtime, and vendor-extension fields.
  - Added validation for `--show-fields`.
  - Invalid fields now show the available field paths.
  - Schema-defined fields are accepted even when they are absent from the node database.

- **Fixes**
  - Improved `--ch-add` and `--ch-index` error guidance.
  - Explained automatic channel index assignment.
  - Explained how to target a specific channel.

- **Refactors**
  - Added recursive protobuf descriptor field discovery.
  - Added support for observed nested node-dictionary fields.
  - Added tests for channel guidance, field validation, schema fields, telemetry fields, and vendor extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->