### PR TITLE
Bypass TX Queue Capacity Waits for Local Loopback Packets

### DIFF
--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -397,6 +397,7 @@ class MeshInterface:  # pylint: disable=R0902
             queue_wait_delay_seconds=QUEUE_WAIT_DELAY_SECONDS,
             queue_wait_timeout_seconds=self._queue_wait_timeout_seconds,
             abort_wait=self._queue_wait_abort_reason,
+            uses_tx_queue_capacity=self._packet_uses_tx_queue_capacity,
         )
         self._from_radio_dispatch_map_cache: (
             dict[str, Callable[[_FromRadioContext], list[_PublicationIntent]]] | None
@@ -410,6 +411,22 @@ class MeshInterface:  # pylint: disable=R0902
         # for any external consumers of the library.
         if debugOut:
             pub.subscribe(MeshInterface._print_log_line, "meshtastic.log.line")
+
+    def _packet_uses_tx_queue_capacity(self, to_radio: mesh_pb2.ToRadio) -> bool:
+        """Return whether ``to_radio`` consumes firmware RF TX-queue capacity.
+
+        Firmware loopback-delivers packets addressed to the local node without
+        enqueueing them for RF transmission. QueueStatus therefore describes an
+        unrelated resource for those packets and must not block their delivery.
+        Until the local node number is known, retain the conservative historical
+        behavior and treat packets as RF-queue consumers.
+        """
+        if not to_radio.HasField("packet"):
+            return True
+        my_info = self.myInfo
+        if my_info is None:
+            return True
+        return to_radio.packet.to != my_info.my_node_num
 
     def _queue_wait_abort_reason(self) -> str | None:
         """Return why a blocked TX-queue wait can no longer make progress."""

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -423,6 +423,9 @@ class MeshInterface:  # pylint: disable=R0902
         """
         if not to_radio.HasField("packet"):
             return True
+        # Read myInfo without _node_db_lock on purpose. Queue classification can
+        # run while _queue_lock is held, and the lock contract forbids nested
+        # MeshInterface lock acquisition. One attribute snapshot is sufficient.
         my_info = self.myInfo
         if my_info is None:
             return True

--- a/meshtastic/mesh_interface_runtime/queue_send.py
+++ b/meshtastic/mesh_interface_runtime/queue_send.py
@@ -37,6 +37,7 @@ class _QueueSendRuntime:
         queue_wait_delay_seconds: float,
         queue_wait_timeout_seconds: float = QUEUE_WAIT_TIMEOUT_SECONDS,
         abort_wait: Callable[[], str | None] | None = None,
+        uses_tx_queue_capacity: Callable[[mesh_pb2.ToRadio], bool] | None = None,
     ) -> None:
         self._lock = lock
         self._get_queue = get_queue
@@ -45,6 +46,7 @@ class _QueueSendRuntime:
         self._queue_wait_delay_seconds = queue_wait_delay_seconds
         self._queue_wait_timeout_seconds = max(0.0, queue_wait_timeout_seconds)
         self._abort_wait = abort_wait
+        self._uses_tx_queue_capacity = uses_tx_queue_capacity
         self._awaiting_queue_status_ids: dict[int, float] = {}
         self._queue_status_seen = False
 
@@ -74,27 +76,88 @@ class _QueueSendRuntime:
         """Claim one queue slot when queue status is available."""
         self._claim()
 
+    def _packet_uses_tx_queue_capacity(self, packet: mesh_pb2.ToRadio) -> bool:
+        """Return whether a packet consumes one firmware RF TX-queue slot."""
+        if self._uses_tx_queue_capacity is None:
+            return True
+        return self._uses_tx_queue_capacity(packet)
+
     def _pop_for_send(self) -> tuple[int, mesh_pb2.ToRadio | bool] | None:
-        """Pop the next sendable queue entry while honoring queue free-space state."""
+        """Pop the next sendable entry while honoring firmware RF queue capacity."""
         with self._lock:
             queue = self._get_queue()
             if not queue:
                 return None
+
             queue_status = self._get_queue_status()
             if queue_status is not None and queue_status.free <= 0:
-                packet_id, packet = next(iter(queue.items()))
-                if not isinstance(packet, mesh_pb2.ToRadio):
-                    queue.pop(packet_id, None)
-                    return packet_id, packet
+                first_packet_id, first_packet = next(iter(queue.items()))
+                if not isinstance(first_packet, mesh_pb2.ToRadio):
+                    queue.pop(first_packet_id, None)
+                    return first_packet_id, first_packet
+                for packet_id, packet in tuple(queue.items()):
+                    if (
+                        isinstance(packet, mesh_pb2.ToRadio)
+                        and not self._packet_uses_tx_queue_capacity(packet)
+                    ):
+                        queue.pop(packet_id, None)
+                        return packet_id, packet
                 return None
+
             to_resend = queue.popitem(last=False)
-            if queue_status is not None and isinstance(to_resend[1], mesh_pb2.ToRadio):
+            packet = to_resend[1]
+            if (
+                queue_status is not None
+                and isinstance(packet, mesh_pb2.ToRadio)
+                and self._packet_uses_tx_queue_capacity(packet)
+            ):
                 queue_status.free -= 1
             return to_resend
 
     def pop_for_send(self) -> tuple[int, mesh_pb2.ToRadio | bool] | None:
         """Pop the next sendable queue entry while honoring queue free-space state."""
         return self._pop_for_send()
+
+    def _pop_capacity_exempt_for_send(
+        self,
+    ) -> tuple[int, mesh_pb2.ToRadio] | None:
+        """Pop the next entry that can progress without firmware RF capacity."""
+        with self._lock:
+            queue = self._get_queue()
+            for packet_id, packet in tuple(queue.items()):
+                if isinstance(
+                    packet, mesh_pb2.ToRadio
+                ) and not self._packet_uses_tx_queue_capacity(packet):
+                    queue.pop(packet_id, None)
+                    return packet_id, packet
+        return None
+
+    def _send_capacity_exempt_packets(
+        self,
+        to_radio: mesh_pb2.ToRadio,
+        *,
+        send_impl: Callable[[mesh_pb2.ToRadio], None],
+    ) -> None:
+        """Send local-loopback backlog without waiting on firmware RF capacity."""
+        with self._lock:
+            self._get_queue()[to_radio.packet.id] = to_radio
+
+        resent_queue: OrderedDict[int, mesh_pb2.ToRadio | bool] = OrderedDict()
+        sent_packet_ids: set[int] = set()
+        try:
+            while True:
+                to_resend = self._pop_capacity_exempt_for_send()
+                if to_resend is None:
+                    break
+                packet_id, packet = to_resend
+                resent_queue[packet_id] = packet
+                send_impl(packet)
+                sent_packet_ids.add(packet_id)
+        finally:
+            self._reconcile_resent_queue(
+                resent_queue=resent_queue,
+                sent_packet_ids=sent_packet_ids,
+            )
 
     def _send_to_radio(
         self,
@@ -107,9 +170,12 @@ class _QueueSendRuntime:
         if not to_radio.HasField("packet"):
             send_impl(to_radio)
             return
-        else:
-            with self._lock:
-                self._get_queue()[to_radio.packet.id] = to_radio
+        if not self._packet_uses_tx_queue_capacity(to_radio):
+            self._send_capacity_exempt_packets(to_radio, send_impl=send_impl)
+            return
+
+        with self._lock:
+            self._get_queue()[to_radio.packet.id] = to_radio
 
         resent_queue: OrderedDict[int, mesh_pb2.ToRadio | bool] = OrderedDict()
         sent_packet_ids: set[int] = set()
@@ -179,6 +245,28 @@ class _QueueSendRuntime:
             sleep_fn=sleep_fn,
         )
 
+    def _requeue_capacity_exempt_packet_locked(
+        self,
+        packet_id: int,
+        packet: mesh_pb2.ToRadio,
+    ) -> None:
+        """Requeue a failed local packet ahead of newer local-loopback work."""
+        queue = self._get_queue()
+        queued_items = tuple(queue.items())
+        queue.clear()
+        inserted = False
+        for queued_id, queued_packet in queued_items:
+            if (
+                not inserted
+                and isinstance(queued_packet, mesh_pb2.ToRadio)
+                and not self._packet_uses_tx_queue_capacity(queued_packet)
+            ):
+                queue[packet_id] = packet
+                inserted = True
+            queue[queued_id] = queued_packet
+        if not inserted:
+            queue[packet_id] = packet
+
     def _reconcile_resent_queue(
         self,
         *,
@@ -201,7 +289,10 @@ class _QueueSendRuntime:
             if queued_value is missing and packet_id in sent_packet_ids:
                 with self._lock:
                     self._prune_awaiting_queue_status_ids_locked(time.monotonic())
-                    if self._queue_status_seen:
+                    packet_uses_capacity = isinstance(
+                        packet, mesh_pb2.ToRadio
+                    ) and self._packet_uses_tx_queue_capacity(packet)
+                    if self._queue_status_seen or not packet_uses_capacity:
                         self._awaiting_queue_status_ids[packet_id] = time.monotonic()
                 logger.debug(
                     "packet %08x sent and awaiting queue-status correlation",
@@ -213,7 +304,10 @@ class _QueueSendRuntime:
                 packet_to_requeue = queued_value
             elif isinstance(packet, mesh_pb2.ToRadio):
                 packet_to_requeue = packet
-                restore_queue_slot = packet_id not in sent_packet_ids
+                restore_queue_slot = (
+                    packet_id not in sent_packet_ids
+                    and self._packet_uses_tx_queue_capacity(packet)
+                )
             elif queued_value is not missing and isinstance(queued_value, bool):
                 packet_to_requeue = queued_value
             if packet_to_requeue is not None:
@@ -225,7 +319,16 @@ class _QueueSendRuntime:
                                 queue_status.maxlen,
                                 queue_status.free + 1,
                             )
-                    self._get_queue()[packet_id] = packet_to_requeue
+                    if (
+                        isinstance(packet_to_requeue, mesh_pb2.ToRadio)
+                        and not self._packet_uses_tx_queue_capacity(packet_to_requeue)
+                    ):
+                        self._requeue_capacity_exempt_packet_locked(
+                            packet_id,
+                            packet_to_requeue,
+                        )
+                    else:
+                        self._get_queue()[packet_id] = packet_to_requeue
 
     def reconcile_resent_queue(
         self,

--- a/meshtastic/mesh_interface_runtime/queue_send.py
+++ b/meshtastic/mesh_interface_runtime/queue_send.py
@@ -47,6 +47,11 @@ class _QueueSendRuntime:
         self._queue_wait_timeout_seconds = max(0.0, queue_wait_timeout_seconds)
         self._abort_wait = abort_wait
         self._uses_tx_queue_capacity = uses_tx_queue_capacity
+        self._packet_uses_capacity_by_id: dict[int, bool] = {}
+        # Remember the exact QueueStatus snapshot decremented for each in-flight
+        # packet. A newer firmware report supersedes that local claim and must not
+        # be incremented if transport I/O later fails.
+        self._claimed_queue_status_by_id: dict[int, mesh_pb2.QueueStatus] = {}
         self._awaiting_queue_status_ids: dict[int, float] = {}
         self._queue_status_seen = False
 
@@ -82,6 +87,55 @@ class _QueueSendRuntime:
             return True
         return self._uses_tx_queue_capacity(packet)
 
+    def _queued_packet_uses_capacity_locked(
+        self,
+        packet_id: int,
+        packet: mesh_pb2.ToRadio,
+    ) -> bool:
+        """Return stable capacity ownership for a queued packet.
+
+        The caller must hold ``_lock``. Queue entries that predate the runtime's
+        own enqueue path are classified lazily once and then retain that decision
+        through send, retry, and queue-status reconciliation.
+        """
+        existing = self._packet_uses_capacity_by_id.get(packet_id)
+        if existing is not None:
+            return existing
+        uses_capacity = self._packet_uses_tx_queue_capacity(packet)
+        self._packet_uses_capacity_by_id[packet_id] = uses_capacity
+        return uses_capacity
+
+    def _forget_capacity_state_locked(self, packet_id: int) -> None:
+        """Forget completed packet capacity state. Caller must hold ``_lock``."""
+        self._packet_uses_capacity_by_id.pop(packet_id, None)
+        self._claimed_queue_status_by_id.pop(packet_id, None)
+
+    def _enqueue_packet_locked(
+        self,
+        packet: mesh_pb2.ToRadio,
+        *,
+        uses_capacity: bool,
+    ) -> None:
+        """Queue one incoming packet with its snapshotted capacity class."""
+        packet_id = packet.packet.id
+        self._get_queue()[packet_id] = packet
+        self._packet_uses_capacity_by_id[packet_id] = uses_capacity
+        self._claimed_queue_status_by_id.pop(packet_id, None)
+
+    def _pop_capacity_exempt_locked(
+        self,
+    ) -> tuple[int, mesh_pb2.ToRadio] | None:
+        """Pop the next RF-capacity-exempt packet. Caller must hold ``_lock``."""
+        queue = self._get_queue()
+        for packet_id, packet in tuple(queue.items()):
+            if not isinstance(packet, mesh_pb2.ToRadio):
+                continue
+            if self._queued_packet_uses_capacity_locked(packet_id, packet):
+                continue
+            queue.pop(packet_id, None)
+            return packet_id, packet
+        return None
+
     def _pop_for_send(self) -> tuple[int, mesh_pb2.ToRadio | bool] | None:
         """Pop the next sendable entry while honoring firmware RF queue capacity."""
         with self._lock:
@@ -95,24 +149,14 @@ class _QueueSendRuntime:
                 if not isinstance(first_packet, mesh_pb2.ToRadio):
                     queue.pop(first_packet_id, None)
                     return first_packet_id, first_packet
-                for packet_id, packet in tuple(queue.items()):
-                    if (
-                        isinstance(packet, mesh_pb2.ToRadio)
-                        and not self._packet_uses_tx_queue_capacity(packet)
-                    ):
-                        queue.pop(packet_id, None)
-                        return packet_id, packet
-                return None
+                return self._pop_capacity_exempt_locked()
 
-            to_resend = queue.popitem(last=False)
-            packet = to_resend[1]
-            if (
-                queue_status is not None
-                and isinstance(packet, mesh_pb2.ToRadio)
-                and self._packet_uses_tx_queue_capacity(packet)
-            ):
-                queue_status.free -= 1
-            return to_resend
+            packet_id, packet = queue.popitem(last=False)
+            if queue_status is not None and isinstance(packet, mesh_pb2.ToRadio):
+                if self._queued_packet_uses_capacity_locked(packet_id, packet):
+                    queue_status.free -= 1
+                    self._claimed_queue_status_by_id[packet_id] = queue_status
+            return packet_id, packet
 
     def pop_for_send(self) -> tuple[int, mesh_pb2.ToRadio | bool] | None:
         """Pop the next sendable queue entry while honoring queue free-space state."""
@@ -123,25 +167,14 @@ class _QueueSendRuntime:
     ) -> tuple[int, mesh_pb2.ToRadio] | None:
         """Pop the next entry that can progress without firmware RF capacity."""
         with self._lock:
-            queue = self._get_queue()
-            for packet_id, packet in tuple(queue.items()):
-                if isinstance(
-                    packet, mesh_pb2.ToRadio
-                ) and not self._packet_uses_tx_queue_capacity(packet):
-                    queue.pop(packet_id, None)
-                    return packet_id, packet
-        return None
+            return self._pop_capacity_exempt_locked()
 
     def _send_capacity_exempt_packets(
         self,
-        to_radio: mesh_pb2.ToRadio,
         *,
         send_impl: Callable[[mesh_pb2.ToRadio], None],
     ) -> None:
-        """Send local-loopback backlog without waiting on firmware RF capacity."""
-        with self._lock:
-            self._get_queue()[to_radio.packet.id] = to_radio
-
+        """Send RF-capacity-exempt backlog without waiting on firmware RF capacity."""
         resent_queue: OrderedDict[int, mesh_pb2.ToRadio | bool] = OrderedDict()
         sent_packet_ids: set[int] = set()
         try:
@@ -170,12 +203,16 @@ class _QueueSendRuntime:
         if not to_radio.HasField("packet"):
             send_impl(to_radio)
             return
-        if not self._packet_uses_tx_queue_capacity(to_radio):
-            self._send_capacity_exempt_packets(to_radio, send_impl=send_impl)
-            return
 
+        uses_capacity = self._packet_uses_tx_queue_capacity(to_radio)
         with self._lock:
-            self._get_queue()[to_radio.packet.id] = to_radio
+            self._enqueue_packet_locked(
+                to_radio,
+                uses_capacity=uses_capacity,
+            )
+        if not uses_capacity:
+            self._send_capacity_exempt_packets(send_impl=send_impl)
+            return
 
         resent_queue: OrderedDict[int, mesh_pb2.ToRadio | bool] = OrderedDict()
         sent_packet_ids: set[int] = set()
@@ -183,7 +220,9 @@ class _QueueSendRuntime:
 
         def _drop_unsent_incoming() -> None:
             with self._lock:
-                self._get_queue().pop(to_radio.packet.id, None)
+                packet_id = to_radio.packet.id
+                self._get_queue().pop(packet_id, None)
+                self._forget_capacity_state_locked(packet_id)
 
         try:
             while True:
@@ -218,6 +257,13 @@ class _QueueSendRuntime:
                 wait_deadline = None
 
                 packet_id, packet = to_resend
+                if packet is False and packet_id in sent_packet_ids:
+                    logger.debug("packet %08x got acked during send", packet_id)
+                    resent_queue.pop(packet_id, None)
+                    sent_packet_ids.remove(packet_id)
+                    with self._lock:
+                        self._forget_capacity_state_locked(packet_id)
+                    continue
                 resent_queue[packet_id] = packet
                 if not isinstance(packet, mesh_pb2.ToRadio):
                     continue
@@ -250,19 +296,19 @@ class _QueueSendRuntime:
         packet_id: int,
         packet: mesh_pb2.ToRadio,
     ) -> None:
-        """Requeue a failed local packet ahead of newer local-loopback work."""
+        """Requeue a failed local packet ahead of newer capacity-exempt work."""
         queue = self._get_queue()
         queued_items = tuple(queue.items())
         queue.clear()
         inserted = False
         for queued_id, queued_packet in queued_items:
-            if (
-                not inserted
-                and isinstance(queued_packet, mesh_pb2.ToRadio)
-                and not self._packet_uses_tx_queue_capacity(queued_packet)
-            ):
-                queue[packet_id] = packet
-                inserted = True
+            if not inserted and isinstance(queued_packet, mesh_pb2.ToRadio):
+                if not self._queued_packet_uses_capacity_locked(
+                    queued_id,
+                    queued_packet,
+                ):
+                    queue[packet_id] = packet
+                    inserted = True
             queue[queued_id] = queued_packet
         if not inserted:
             queue[packet_id] = packet
@@ -276,59 +322,87 @@ class _QueueSendRuntime:
         """Reconcile resent packets against ACK-under-us and requeue semantics."""
         missing = object()
         for packet_id, packet in resent_queue.items():
-            restore_queue_slot = False
             with self._lock:
+                uses_capacity = (
+                    self._queued_packet_uses_capacity_locked(packet_id, packet)
+                    if isinstance(packet, mesh_pb2.ToRadio)
+                    else None
+                )
                 queued_value: mesh_pb2.ToRadio | bool | object = self._get_queue().pop(
                     packet_id,
                     missing,
                 )
                 acked = queued_value is False
+
             if acked:
                 logger.debug("packet %08x got acked under us", packet_id)
+                with self._lock:
+                    self._forget_capacity_state_locked(packet_id)
                 continue
+
             if queued_value is missing and packet_id in sent_packet_ids:
                 with self._lock:
                     self._prune_awaiting_queue_status_ids_locked(time.monotonic())
-                    packet_uses_capacity = isinstance(
-                        packet, mesh_pb2.ToRadio
-                    ) and self._packet_uses_tx_queue_capacity(packet)
-                    if self._queue_status_seen or not packet_uses_capacity:
+                    self._claimed_queue_status_by_id.pop(packet_id, None)
+                    should_track_reply = self._queue_status_seen or uses_capacity is False
+                    if should_track_reply:
                         self._awaiting_queue_status_ids[packet_id] = time.monotonic()
-                logger.debug(
-                    "packet %08x sent and awaiting queue-status correlation",
-                    packet_id,
-                )
+                    else:
+                        self._forget_capacity_state_locked(packet_id)
+                if should_track_reply:
+                    logger.debug(
+                        "packet %08x sent and awaiting queue-status correlation",
+                        packet_id,
+                    )
+                else:
+                    logger.debug(
+                        "packet %08x sent without queue-status correlation",
+                        packet_id,
+                    )
                 continue
+
             packet_to_requeue: mesh_pb2.ToRadio | bool | None = None
             if isinstance(queued_value, mesh_pb2.ToRadio):
                 packet_to_requeue = queued_value
             elif isinstance(packet, mesh_pb2.ToRadio):
                 packet_to_requeue = packet
-                restore_queue_slot = (
-                    packet_id not in sent_packet_ids
-                    and self._packet_uses_tx_queue_capacity(packet)
-                )
             elif queued_value is not missing and isinstance(queued_value, bool):
                 packet_to_requeue = queued_value
-            if packet_to_requeue is not None:
+
+            if packet_to_requeue is None:
                 with self._lock:
-                    if restore_queue_slot:
-                        queue_status = self._get_queue_status()
-                        if queue_status is not None:
-                            queue_status.free = min(
-                                queue_status.maxlen,
-                                queue_status.free + 1,
-                            )
-                    if (
-                        isinstance(packet_to_requeue, mesh_pb2.ToRadio)
-                        and not self._packet_uses_tx_queue_capacity(packet_to_requeue)
-                    ):
+                    self._forget_capacity_state_locked(packet_id)
+                continue
+
+            with self._lock:
+                claimed_status = self._claimed_queue_status_by_id.pop(
+                    packet_id,
+                    None,
+                )
+                if claimed_status is not None and packet_id not in sent_packet_ids:
+                    current_status = self._get_queue_status()
+                    if current_status is claimed_status:
+                        current_status.free = min(
+                            current_status.maxlen,
+                            current_status.free + 1,
+                        )
+
+                if isinstance(packet_to_requeue, mesh_pb2.ToRadio):
+                    if uses_capacity is None:
+                        uses_capacity = self._queued_packet_uses_capacity_locked(
+                            packet_id,
+                            packet_to_requeue,
+                        )
+                    if not uses_capacity:
                         self._requeue_capacity_exempt_packet_locked(
                             packet_id,
                             packet_to_requeue,
                         )
                     else:
                         self._get_queue()[packet_id] = packet_to_requeue
+                else:
+                    self._get_queue()[packet_id] = packet_to_requeue
+                    self._forget_capacity_state_locked(packet_id)
 
     def reconcile_resent_queue(
         self,
@@ -371,6 +445,8 @@ class _QueueSendRuntime:
             was_awaiting = packet_id in self._awaiting_queue_status_ids
             if packet_id != 0:
                 self._awaiting_queue_status_ids.pop(packet_id, None)
+                if just_queued is not None or was_awaiting:
+                    self._forget_capacity_state_locked(packet_id)
         if debug_enabled:
             logger.debug(
                 "queue: %s",
@@ -403,7 +479,18 @@ class _QueueSendRuntime:
             packet_id = queue_status.mesh_packet_id
             if packet_id != 0:
                 with self._lock:
-                    self._awaiting_queue_status_ids.pop(packet_id, None)
+                    was_awaiting = (
+                        self._awaiting_queue_status_ids.pop(packet_id, None) is not None
+                    )
+                    if was_awaiting:
+                        self._forget_capacity_state_locked(packet_id)
+                    elif (
+                        packet_id in self._packet_uses_capacity_by_id
+                        and packet_id not in self._get_queue()
+                    ):
+                        # A response can arrive during send_impl(), before
+                        # reconciliation registers the packet as awaiting it.
+                        self._get_queue()[packet_id] = False
             return
         self._correlate_queue_status_reply(queue_status)
 
@@ -419,3 +506,4 @@ class _QueueSendRuntime:
         for packet_id, tracked_at in list(self._awaiting_queue_status_ids.items()):
             if tracked_at < expired_before:
                 self._awaiting_queue_status_ids.pop(packet_id, None)
+                self._forget_capacity_state_locked(packet_id)

--- a/meshtastic/tests/test_mesh_interface_local_queue_capacity.py
+++ b/meshtastic/tests/test_mesh_interface_local_queue_capacity.py
@@ -63,8 +63,10 @@ def _runtime(
             queue_wait_delay_seconds=queue_wait_delay_seconds,
             queue_wait_timeout_seconds=queue_wait_timeout_seconds,
         )
-    if classifier is None:
-        def classifier(message: mesh_pb2.ToRadio) -> bool:
+    if classifier is not None:
+        _selected_classifier = classifier
+    else:
+        def _selected_classifier(message: mesh_pb2.ToRadio) -> bool:
             return message.packet.to != local_num
 
     return _QueueSendRuntime(
@@ -74,7 +76,7 @@ def _runtime(
         set_queue_status=harness.set_queue_status,
         queue_wait_delay_seconds=queue_wait_delay_seconds,
         queue_wait_timeout_seconds=queue_wait_timeout_seconds,
-        uses_tx_queue_capacity=classifier,
+        uses_tx_queue_capacity=_selected_classifier,
     )
 
 

--- a/meshtastic/tests/test_mesh_interface_local_queue_capacity.py
+++ b/meshtastic/tests/test_mesh_interface_local_queue_capacity.py
@@ -1,14 +1,23 @@
 """Regression coverage for local-loopback TX queue capacity handling."""
 
 from collections import OrderedDict
+from collections.abc import Callable
 from threading import RLock
 from unittest.mock import MagicMock
 
 import pytest
 
 from meshtastic.mesh_interface import MeshInterface
-from meshtastic.mesh_interface_runtime.queue_send import _QueueSendRuntime
+from meshtastic.mesh_interface_runtime.queue_send import (
+    QUEUE_WAIT_TIMEOUT_SECONDS,
+    QueueWaitError,
+    _QueueSendRuntime,
+)
 from meshtastic.protobuf import mesh_pb2
+
+
+LOCAL_NUM = 0x12345678
+REMOTE_NUM = 0x87654321
 
 
 class _QueueHarness:
@@ -17,7 +26,10 @@ class _QueueHarness:
     def __init__(self, *, free: int) -> None:
         self.lock = RLock()
         self.queue: OrderedDict[int, mesh_pb2.ToRadio | bool] = OrderedDict()
-        self.queue_status = mesh_pb2.QueueStatus(free=free, maxlen=16)
+        self.queue_status: mesh_pb2.QueueStatus | None = mesh_pb2.QueueStatus(
+            free=free,
+            maxlen=16,
+        )
 
     def set_queue_status(self, status: mesh_pb2.QueueStatus) -> None:
         """Replace the cached queue status."""
@@ -32,21 +44,51 @@ def _packet(packet_id: int, destination: int) -> mesh_pb2.ToRadio:
     return message
 
 
-@pytest.mark.unit
-def test_local_loopback_sends_when_firmware_rf_queue_is_full() -> None:
-    """Local loopback must not wait for unrelated firmware RF queue capacity."""
-    local_num = 0x12345678
-    harness = _QueueHarness(free=0)
-    sent: list[int] = []
-    sleep = MagicMock()
-    runtime = _QueueSendRuntime(
+def _runtime(
+    harness: _QueueHarness,
+    *,
+    local_num: int = LOCAL_NUM,
+    queue_wait_delay_seconds: float = 0.0,
+    queue_wait_timeout_seconds: float = QUEUE_WAIT_TIMEOUT_SECONDS,
+    classifier: Callable[[mesh_pb2.ToRadio], bool] | None = None,
+    omit_classifier: bool = False,
+) -> _QueueSendRuntime:
+    """Build a queue runtime with the local-loopback classifier used by tests."""
+    if omit_classifier:
+        return _QueueSendRuntime(
+            lock=harness.lock,
+            get_queue=lambda: harness.queue,
+            get_queue_status=lambda: harness.queue_status,
+            set_queue_status=harness.set_queue_status,
+            queue_wait_delay_seconds=queue_wait_delay_seconds,
+            queue_wait_timeout_seconds=queue_wait_timeout_seconds,
+        )
+    if classifier is None:
+        def classifier(message: mesh_pb2.ToRadio) -> bool:
+            return message.packet.to != local_num
+
+    return _QueueSendRuntime(
         lock=harness.lock,
         get_queue=lambda: harness.queue,
         get_queue_status=lambda: harness.queue_status,
         set_queue_status=harness.set_queue_status,
+        queue_wait_delay_seconds=queue_wait_delay_seconds,
+        queue_wait_timeout_seconds=queue_wait_timeout_seconds,
+        uses_tx_queue_capacity=classifier,
+    )
+
+
+@pytest.mark.unit
+def test_local_loopback_sends_when_firmware_rf_queue_is_full() -> None:
+    """Local loopback must not wait for unrelated firmware RF queue capacity."""
+    local_num = LOCAL_NUM
+    harness = _QueueHarness(free=0)
+    sent: list[int] = []
+    sleep = MagicMock()
+    runtime = _runtime(
+        harness,
         queue_wait_delay_seconds=0.5,
         queue_wait_timeout_seconds=0.0,
-        uses_tx_queue_capacity=lambda message: message.packet.to != local_num,
     )
 
     runtime.send_to_radio(
@@ -56,6 +98,7 @@ def test_local_loopback_sends_when_firmware_rf_queue_is_full() -> None:
     )
 
     assert sent == [101]
+    assert harness.queue_status is not None
     assert harness.queue_status.free == 0
     assert list(harness.queue) == []
     sleep.assert_not_called()
@@ -64,8 +107,8 @@ def test_local_loopback_sends_when_firmware_rf_queue_is_full() -> None:
 @pytest.mark.unit
 def test_local_loopback_returns_without_draining_blocked_rf_backlog() -> None:
     """A local send must not inherit waiting responsibility for RF backlog."""
-    local_num = 0x12345678
-    remote_num = 0x87654321
+    local_num = LOCAL_NUM
+    remote_num = REMOTE_NUM
     harness = _QueueHarness(free=0)
     remote = _packet(201, remote_num)
     local = _packet(202, local_num)
@@ -73,14 +116,10 @@ def test_local_loopback_returns_without_draining_blocked_rf_backlog() -> None:
     sent: list[int] = []
     sleep = MagicMock()
 
-    runtime = _QueueSendRuntime(
-        lock=harness.lock,
-        get_queue=lambda: harness.queue,
-        get_queue_status=lambda: harness.queue_status,
-        set_queue_status=harness.set_queue_status,
+    runtime = _runtime(
+        harness,
         queue_wait_delay_seconds=0.5,
         queue_wait_timeout_seconds=0.0,
-        uses_tx_queue_capacity=lambda message: message.packet.to != local_num,
     )
 
     runtime.send_to_radio(
@@ -97,16 +136,9 @@ def test_local_loopback_returns_without_draining_blocked_rf_backlog() -> None:
 @pytest.mark.unit
 def test_local_loopback_does_not_claim_available_rf_capacity() -> None:
     """Sending locally must leave cached RF queue free-space unchanged."""
-    local_num = 0x12345678
+    local_num = LOCAL_NUM
     harness = _QueueHarness(free=3)
-    runtime = _QueueSendRuntime(
-        lock=harness.lock,
-        get_queue=lambda: harness.queue,
-        get_queue_status=lambda: harness.queue_status,
-        set_queue_status=harness.set_queue_status,
-        queue_wait_delay_seconds=0.0,
-        uses_tx_queue_capacity=lambda message: message.packet.to != local_num,
-    )
+    runtime = _runtime(harness)
 
     runtime.send_to_radio(
         _packet(301, local_num),
@@ -114,23 +146,17 @@ def test_local_loopback_does_not_claim_available_rf_capacity() -> None:
         sleep_fn=lambda _seconds: None,
     )
 
+    assert harness.queue_status is not None
     assert harness.queue_status.free == 3
 
 
 @pytest.mark.unit
 def test_failed_local_loopback_send_does_not_restore_rf_capacity() -> None:
     """A failed local transport send must not fabricate a free RF queue slot."""
-    local_num = 0x12345678
+    local_num = LOCAL_NUM
     harness = _QueueHarness(free=0)
     packet = _packet(350, local_num)
-    runtime = _QueueSendRuntime(
-        lock=harness.lock,
-        get_queue=lambda: harness.queue,
-        get_queue_status=lambda: harness.queue_status,
-        set_queue_status=harness.set_queue_status,
-        queue_wait_delay_seconds=0.0,
-        uses_tx_queue_capacity=lambda message: message.packet.to != local_num,
-    )
+    runtime = _runtime(harness)
 
     with pytest.raises(RuntimeError, match="transport failed"):
         runtime.send_to_radio(
@@ -141,6 +167,7 @@ def test_failed_local_loopback_send_does_not_restore_rf_capacity() -> None:
             sleep_fn=lambda _seconds: None,
         )
 
+    assert harness.queue_status is not None
     assert harness.queue_status.free == 0
     assert list(harness.queue) == [350]
     assert 350 not in runtime._awaiting_queue_status_ids
@@ -149,20 +176,13 @@ def test_failed_local_loopback_send_does_not_restore_rf_capacity() -> None:
 @pytest.mark.unit
 def test_failed_older_local_retry_stays_ahead_of_newer_local_work() -> None:
     """A failed local retry must retain its order ahead of newer local packets."""
-    local_num = 0x12345678
-    remote_num = 0x87654321
+    local_num = LOCAL_NUM
+    remote_num = REMOTE_NUM
     harness = _QueueHarness(free=0)
     harness.queue[360] = _packet(360, remote_num)
     harness.queue[361] = _packet(361, local_num)
     attempted: list[int] = []
-    runtime = _QueueSendRuntime(
-        lock=harness.lock,
-        get_queue=lambda: harness.queue,
-        get_queue_status=lambda: harness.queue_status,
-        set_queue_status=harness.set_queue_status,
-        queue_wait_delay_seconds=0.0,
-        uses_tx_queue_capacity=lambda message: message.packet.to != local_num,
-    )
+    runtime = _runtime(harness)
 
     def fail_send(message: mesh_pb2.ToRadio) -> None:
         attempted.append(message.packet.id)
@@ -190,20 +210,13 @@ def test_failed_older_local_retry_stays_ahead_of_newer_local_work() -> None:
 @pytest.mark.unit
 def test_next_local_send_retries_older_local_backlog_without_rf_wait() -> None:
     """A later local send should retry older local backlog without touching RF work."""
-    local_num = 0x12345678
-    remote_num = 0x87654321
+    local_num = LOCAL_NUM
+    remote_num = REMOTE_NUM
     harness = _QueueHarness(free=0)
     harness.queue[330] = _packet(330, remote_num)
     harness.queue[331] = _packet(331, local_num)
     sent: list[int] = []
-    runtime = _QueueSendRuntime(
-        lock=harness.lock,
-        get_queue=lambda: harness.queue,
-        get_queue_status=lambda: harness.queue_status,
-        set_queue_status=harness.set_queue_status,
-        queue_wait_delay_seconds=0.0,
-        uses_tx_queue_capacity=lambda message: message.packet.to != local_num,
-    )
+    runtime = _runtime(harness)
 
     runtime.send_to_radio(
         _packet(332, local_num),
@@ -213,22 +226,16 @@ def test_next_local_send_retries_older_local_backlog_without_rf_wait() -> None:
 
     assert sent == [331, 332]
     assert list(harness.queue) == [330]
+    assert harness.queue_status is not None
     assert harness.queue_status.free == 0
 
 
 @pytest.mark.unit
 def test_delayed_local_queue_status_does_not_leave_ack_sentinel() -> None:
     """Delayed QueueStatus replies should retire local correlation cleanly."""
-    local_num = 0x12345678
+    local_num = LOCAL_NUM
     harness = _QueueHarness(free=0)
-    runtime = _QueueSendRuntime(
-        lock=harness.lock,
-        get_queue=lambda: harness.queue,
-        get_queue_status=lambda: harness.queue_status,
-        set_queue_status=harness.set_queue_status,
-        queue_wait_delay_seconds=0.0,
-        uses_tx_queue_capacity=lambda message: message.packet.to != local_num,
-    )
+    runtime = _runtime(harness)
 
     runtime.send_to_radio(
         _packet(375, local_num),
@@ -243,21 +250,15 @@ def test_delayed_local_queue_status_does_not_leave_ack_sentinel() -> None:
 
     assert list(harness.queue) == []
     assert 375 not in runtime._awaiting_queue_status_ids
+    assert 375 not in runtime._packet_uses_capacity_by_id
 
 
 @pytest.mark.unit
 def test_synchronous_local_queue_status_correlates_during_send() -> None:
     """A QueueStatus delivered during transport I/O must not be re-registered."""
-    local_num = 0x12345678
+    local_num = LOCAL_NUM
     harness = _QueueHarness(free=0)
-    runtime = _QueueSendRuntime(
-        lock=harness.lock,
-        get_queue=lambda: harness.queue,
-        get_queue_status=lambda: harness.queue_status,
-        set_queue_status=harness.set_queue_status,
-        queue_wait_delay_seconds=0.0,
-        uses_tx_queue_capacity=lambda message: message.packet.to != local_num,
-    )
+    runtime = _runtime(harness)
 
     def send_and_reply(message: mesh_pb2.ToRadio) -> None:
         runtime.handle_queue_status_from_radio(
@@ -276,6 +277,184 @@ def test_synchronous_local_queue_status_correlates_during_send() -> None:
 
     assert list(harness.queue) == []
     assert 376 not in runtime._awaiting_queue_status_ids
+    assert 376 not in runtime._packet_uses_capacity_by_id
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("result", (0, 1))
+def test_synchronous_remote_queue_status_cleans_capacity_state(result: int) -> None:
+    """A synchronous remote status must terminate ownership correlation cleanly."""
+    harness = _QueueHarness(free=1)
+    runtime = _runtime(harness)
+
+    def send_and_reply(message: mesh_pb2.ToRadio) -> None:
+        runtime.handle_queue_status_from_radio(
+            mesh_pb2.QueueStatus(
+                free=1,
+                maxlen=16,
+                res=result,
+                mesh_packet_id=message.packet.id,
+            )
+        )
+
+    runtime.send_to_radio(
+        _packet(377, REMOTE_NUM),
+        send_impl=send_and_reply,
+        sleep_fn=lambda _seconds: None,
+    )
+
+    assert list(harness.queue) == []
+    assert 377 not in runtime._awaiting_queue_status_ids
+    assert 377 not in runtime._packet_uses_capacity_by_id
+    assert 377 not in runtime._claimed_queue_status_by_id
+
+
+@pytest.mark.unit
+def test_runtime_without_classifier_keeps_historical_backpressure() -> None:
+    """Omitting the classifier must preserve RF-capacity waits for every packet."""
+    harness = _QueueHarness(free=0)
+    send_impl = MagicMock()
+    runtime = _runtime(
+        harness,
+        queue_wait_timeout_seconds=0.0,
+        omit_classifier=True,
+    )
+
+    with pytest.raises(QueueWaitError, match="free space in TX queue"):
+        runtime.send_to_radio(
+            _packet(601, LOCAL_NUM),
+            send_impl=send_impl,
+            sleep_fn=lambda _seconds: None,
+        )
+
+    send_impl.assert_not_called()
+    assert list(harness.queue) == []
+
+
+@pytest.mark.unit
+def test_incoming_capacity_classification_is_snapshotted_once() -> None:
+    """Reconnect-time classifier changes must not strand an accepted local packet."""
+    harness = _QueueHarness(free=0)
+    calls = 0
+
+    def changing_classifier(_message: mesh_pb2.ToRadio) -> bool:
+        nonlocal calls
+        calls += 1
+        return calls > 1
+
+    runtime = _runtime(harness, classifier=changing_classifier)
+    sent: list[int] = []
+
+    runtime.send_to_radio(
+        _packet(602, LOCAL_NUM),
+        send_impl=lambda message: sent.append(message.packet.id),
+        sleep_fn=lambda _seconds: None,
+    )
+
+    assert sent == [602]
+    assert calls == 1
+    assert list(harness.queue) == []
+
+
+@pytest.mark.unit
+def test_failed_local_retry_keeps_snapshotted_exemption() -> None:
+    """A failed local packet must remain exempt after classifier state changes."""
+    harness = _QueueHarness(free=0)
+    uses_capacity = False
+    runtime = _runtime(
+        harness,
+        classifier=lambda _message: uses_capacity,
+        queue_wait_timeout_seconds=0.0,
+    )
+
+    with pytest.raises(RuntimeError, match="transport failed"):
+        runtime.send_to_radio(
+            _packet(603, LOCAL_NUM),
+            send_impl=lambda _message: (_ for _ in ()).throw(
+                RuntimeError("transport failed")
+            ),
+            sleep_fn=lambda _seconds: None,
+        )
+
+    uses_capacity = True
+    sent: list[int] = []
+    with pytest.raises(QueueWaitError, match="free space in TX queue"):
+        runtime.send_to_radio(
+            _packet(604, REMOTE_NUM),
+            send_impl=lambda message: sent.append(message.packet.id),
+            sleep_fn=lambda _seconds: None,
+        )
+
+    assert sent == [603]
+    assert list(harness.queue) == []
+
+
+@pytest.mark.unit
+def test_failed_send_restores_only_an_actually_claimed_slot() -> None:
+    """A late QueueStatus must not fabricate capacity after an unclaimed send."""
+    harness = _QueueHarness(free=0)
+    harness.queue_status = None
+    runtime = _runtime(harness)
+
+    def fail_after_status_arrives(_message: mesh_pb2.ToRadio) -> None:
+        harness.queue_status = mesh_pb2.QueueStatus(free=0, maxlen=16)
+        raise RuntimeError("transport failed")
+
+    with pytest.raises(RuntimeError, match="transport failed"):
+        runtime.send_to_radio(
+            _packet(605, REMOTE_NUM),
+            send_impl=fail_after_status_arrives,
+            sleep_fn=lambda _seconds: None,
+        )
+
+    assert harness.queue_status is not None
+    assert harness.queue_status.free == 0
+    assert list(harness.queue) == [605]
+    assert 605 not in runtime._claimed_queue_status_by_id
+
+
+@pytest.mark.unit
+def test_failed_send_restores_a_slot_that_was_claimed() -> None:
+    """A transport failure must restore RF capacity claimed for that attempt."""
+    harness = _QueueHarness(free=1)
+    runtime = _runtime(harness)
+
+    with pytest.raises(RuntimeError, match="transport failed"):
+        runtime.send_to_radio(
+            _packet(606, REMOTE_NUM),
+            send_impl=lambda _message: (_ for _ in ()).throw(
+                RuntimeError("transport failed")
+            ),
+            sleep_fn=lambda _seconds: None,
+        )
+
+    assert harness.queue_status is not None
+    assert harness.queue_status.free == 1
+    assert list(harness.queue) == [606]
+    assert 606 not in runtime._claimed_queue_status_by_id
+
+
+@pytest.mark.unit
+def test_failed_send_does_not_restore_into_newer_queue_status() -> None:
+    """A newer firmware QueueStatus snapshot must supersede a local slot claim."""
+    harness = _QueueHarness(free=1)
+    runtime = _runtime(harness)
+
+    def fail_after_new_status(_message: mesh_pb2.ToRadio) -> None:
+        harness.queue_status = mesh_pb2.QueueStatus(free=4, maxlen=16)
+        raise RuntimeError("transport failed")
+
+    with pytest.raises(RuntimeError, match="transport failed"):
+        runtime.send_to_radio(
+            _packet(607, REMOTE_NUM),
+            send_impl=fail_after_new_status,
+            sleep_fn=lambda _seconds: None,
+        )
+
+    assert harness.queue_status is not None
+    assert harness.queue_status.free == 4
+    assert list(harness.queue) == [607]
+    assert 607 not in runtime._claimed_queue_status_by_id
 
 
 @pytest.mark.unit
@@ -283,7 +462,7 @@ def test_mesh_interface_classifies_only_known_local_destination_as_exempt() -> N
     """MeshInterface should conservatively gate packets until local identity is known."""
     iface = object.__new__(MeshInterface)
     iface.myInfo = None
-    local_num = 0x12345678
+    local_num = LOCAL_NUM
     local = _packet(401, local_num)
 
     assert iface._packet_uses_tx_queue_capacity(local) is True
@@ -291,7 +470,7 @@ def test_mesh_interface_classifies_only_known_local_destination_as_exempt() -> N
     iface.myInfo = mesh_pb2.MyNodeInfo(my_node_num=local_num)
 
     assert iface._packet_uses_tx_queue_capacity(local) is False
-    assert iface._packet_uses_tx_queue_capacity(_packet(402, 0x87654321)) is True
+    assert iface._packet_uses_tx_queue_capacity(_packet(402, REMOTE_NUM)) is True
     assert iface._packet_uses_tx_queue_capacity(mesh_pb2.ToRadio()) is True
 
 
@@ -302,7 +481,7 @@ def test_mesh_interface_sends_known_local_packet_with_full_rf_queue(
     """MeshInterface should bypass RF backpressure for a known local destination."""
     monkeypatch.setattr(MeshInterface, "_queue_wait_timeout_seconds", 0.0)
     iface = MeshInterface()
-    local_num = 0x12345678
+    local_num = LOCAL_NUM
     iface.myInfo = mesh_pb2.MyNodeInfo(my_node_num=local_num)
     iface.queueStatus = mesh_pb2.QueueStatus(free=0, maxlen=16)
     send_impl = MagicMock()
@@ -330,6 +509,8 @@ def test_mesh_interface_still_blocks_remote_packet_when_rf_queue_is_full(
     with pytest.raises(
         MeshInterface.MeshInterfaceError, match="free space in TX queue"
     ):
-        iface._send_to_radio(_packet(502, 0x87654321))
+        iface._send_to_radio(_packet(502, REMOTE_NUM))
 
     send_impl.assert_not_called()
+    assert list(iface.queue) == []
+    assert 502 not in iface._queue_send_runtime._packet_uses_capacity_by_id

--- a/meshtastic/tests/test_mesh_interface_local_queue_capacity.py
+++ b/meshtastic/tests/test_mesh_interface_local_queue_capacity.py
@@ -1,0 +1,335 @@
+"""Regression coverage for local-loopback TX queue capacity handling."""
+
+from collections import OrderedDict
+from threading import RLock
+from unittest.mock import MagicMock
+
+import pytest
+
+from meshtastic.mesh_interface import MeshInterface
+from meshtastic.mesh_interface_runtime.queue_send import _QueueSendRuntime
+from meshtastic.protobuf import mesh_pb2
+
+
+class _QueueHarness:
+    """Minimal queue state used by queue-runtime capacity tests."""
+
+    def __init__(self, *, free: int) -> None:
+        self.lock = RLock()
+        self.queue: OrderedDict[int, mesh_pb2.ToRadio | bool] = OrderedDict()
+        self.queue_status = mesh_pb2.QueueStatus(free=free, maxlen=16)
+
+    def set_queue_status(self, status: mesh_pb2.QueueStatus) -> None:
+        """Replace the cached queue status."""
+        self.queue_status = status
+
+
+def _packet(packet_id: int, destination: int) -> mesh_pb2.ToRadio:
+    """Build one packet-bearing ToRadio message."""
+    message = mesh_pb2.ToRadio()
+    message.packet.id = packet_id
+    message.packet.to = destination
+    return message
+
+
+@pytest.mark.unit
+def test_local_loopback_sends_when_firmware_rf_queue_is_full() -> None:
+    """Local loopback must not wait for unrelated firmware RF queue capacity."""
+    local_num = 0x12345678
+    harness = _QueueHarness(free=0)
+    sent: list[int] = []
+    sleep = MagicMock()
+    runtime = _QueueSendRuntime(
+        lock=harness.lock,
+        get_queue=lambda: harness.queue,
+        get_queue_status=lambda: harness.queue_status,
+        set_queue_status=harness.set_queue_status,
+        queue_wait_delay_seconds=0.5,
+        queue_wait_timeout_seconds=0.0,
+        uses_tx_queue_capacity=lambda message: message.packet.to != local_num,
+    )
+
+    runtime.send_to_radio(
+        _packet(101, local_num),
+        send_impl=lambda message: sent.append(message.packet.id),
+        sleep_fn=sleep,
+    )
+
+    assert sent == [101]
+    assert harness.queue_status.free == 0
+    assert list(harness.queue) == []
+    sleep.assert_not_called()
+
+
+@pytest.mark.unit
+def test_local_loopback_returns_without_draining_blocked_rf_backlog() -> None:
+    """A local send must not inherit waiting responsibility for RF backlog."""
+    local_num = 0x12345678
+    remote_num = 0x87654321
+    harness = _QueueHarness(free=0)
+    remote = _packet(201, remote_num)
+    local = _packet(202, local_num)
+    harness.queue[remote.packet.id] = remote
+    sent: list[int] = []
+    sleep = MagicMock()
+
+    runtime = _QueueSendRuntime(
+        lock=harness.lock,
+        get_queue=lambda: harness.queue,
+        get_queue_status=lambda: harness.queue_status,
+        set_queue_status=harness.set_queue_status,
+        queue_wait_delay_seconds=0.5,
+        queue_wait_timeout_seconds=0.0,
+        uses_tx_queue_capacity=lambda message: message.packet.to != local_num,
+    )
+
+    runtime.send_to_radio(
+        local,
+        send_impl=lambda message: sent.append(message.packet.id),
+        sleep_fn=sleep,
+    )
+
+    assert sent == [202]
+    assert list(harness.queue) == [201]
+    sleep.assert_not_called()
+
+
+@pytest.mark.unit
+def test_local_loopback_does_not_claim_available_rf_capacity() -> None:
+    """Sending locally must leave cached RF queue free-space unchanged."""
+    local_num = 0x12345678
+    harness = _QueueHarness(free=3)
+    runtime = _QueueSendRuntime(
+        lock=harness.lock,
+        get_queue=lambda: harness.queue,
+        get_queue_status=lambda: harness.queue_status,
+        set_queue_status=harness.set_queue_status,
+        queue_wait_delay_seconds=0.0,
+        uses_tx_queue_capacity=lambda message: message.packet.to != local_num,
+    )
+
+    runtime.send_to_radio(
+        _packet(301, local_num),
+        send_impl=lambda _message: None,
+        sleep_fn=lambda _seconds: None,
+    )
+
+    assert harness.queue_status.free == 3
+
+
+@pytest.mark.unit
+def test_failed_local_loopback_send_does_not_restore_rf_capacity() -> None:
+    """A failed local transport send must not fabricate a free RF queue slot."""
+    local_num = 0x12345678
+    harness = _QueueHarness(free=0)
+    packet = _packet(350, local_num)
+    runtime = _QueueSendRuntime(
+        lock=harness.lock,
+        get_queue=lambda: harness.queue,
+        get_queue_status=lambda: harness.queue_status,
+        set_queue_status=harness.set_queue_status,
+        queue_wait_delay_seconds=0.0,
+        uses_tx_queue_capacity=lambda message: message.packet.to != local_num,
+    )
+
+    with pytest.raises(RuntimeError, match="transport failed"):
+        runtime.send_to_radio(
+            packet,
+            send_impl=lambda _message: (_ for _ in ()).throw(
+                RuntimeError("transport failed")
+            ),
+            sleep_fn=lambda _seconds: None,
+        )
+
+    assert harness.queue_status.free == 0
+    assert list(harness.queue) == [350]
+    assert 350 not in runtime._awaiting_queue_status_ids
+
+
+@pytest.mark.unit
+def test_failed_older_local_retry_stays_ahead_of_newer_local_work() -> None:
+    """A failed local retry must retain its order ahead of newer local packets."""
+    local_num = 0x12345678
+    remote_num = 0x87654321
+    harness = _QueueHarness(free=0)
+    harness.queue[360] = _packet(360, remote_num)
+    harness.queue[361] = _packet(361, local_num)
+    attempted: list[int] = []
+    runtime = _QueueSendRuntime(
+        lock=harness.lock,
+        get_queue=lambda: harness.queue,
+        get_queue_status=lambda: harness.queue_status,
+        set_queue_status=harness.set_queue_status,
+        queue_wait_delay_seconds=0.0,
+        uses_tx_queue_capacity=lambda message: message.packet.to != local_num,
+    )
+
+    def fail_send(message: mesh_pb2.ToRadio) -> None:
+        attempted.append(message.packet.id)
+        raise RuntimeError("transport failed")
+
+    with pytest.raises(RuntimeError, match="transport failed"):
+        runtime.send_to_radio(
+            _packet(362, local_num),
+            send_impl=fail_send,
+            sleep_fn=lambda _seconds: None,
+        )
+
+    assert attempted == [361]
+    sent: list[int] = []
+    runtime.send_to_radio(
+        _packet(363, local_num),
+        send_impl=lambda message: sent.append(message.packet.id),
+        sleep_fn=lambda _seconds: None,
+    )
+
+    assert sent == [361, 362, 363]
+    assert list(harness.queue) == [360]
+
+
+@pytest.mark.unit
+def test_next_local_send_retries_older_local_backlog_without_rf_wait() -> None:
+    """A later local send should retry older local backlog without touching RF work."""
+    local_num = 0x12345678
+    remote_num = 0x87654321
+    harness = _QueueHarness(free=0)
+    harness.queue[330] = _packet(330, remote_num)
+    harness.queue[331] = _packet(331, local_num)
+    sent: list[int] = []
+    runtime = _QueueSendRuntime(
+        lock=harness.lock,
+        get_queue=lambda: harness.queue,
+        get_queue_status=lambda: harness.queue_status,
+        set_queue_status=harness.set_queue_status,
+        queue_wait_delay_seconds=0.0,
+        uses_tx_queue_capacity=lambda message: message.packet.to != local_num,
+    )
+
+    runtime.send_to_radio(
+        _packet(332, local_num),
+        send_impl=lambda message: sent.append(message.packet.id),
+        sleep_fn=lambda _seconds: None,
+    )
+
+    assert sent == [331, 332]
+    assert list(harness.queue) == [330]
+    assert harness.queue_status.free == 0
+
+
+@pytest.mark.unit
+def test_delayed_local_queue_status_does_not_leave_ack_sentinel() -> None:
+    """Delayed QueueStatus replies should retire local correlation cleanly."""
+    local_num = 0x12345678
+    harness = _QueueHarness(free=0)
+    runtime = _QueueSendRuntime(
+        lock=harness.lock,
+        get_queue=lambda: harness.queue,
+        get_queue_status=lambda: harness.queue_status,
+        set_queue_status=harness.set_queue_status,
+        queue_wait_delay_seconds=0.0,
+        uses_tx_queue_capacity=lambda message: message.packet.to != local_num,
+    )
+
+    runtime.send_to_radio(
+        _packet(375, local_num),
+        send_impl=lambda _message: None,
+        sleep_fn=lambda _seconds: None,
+    )
+    assert 375 in runtime._awaiting_queue_status_ids
+
+    runtime.handle_queue_status_from_radio(
+        mesh_pb2.QueueStatus(free=0, maxlen=16, mesh_packet_id=375)
+    )
+
+    assert list(harness.queue) == []
+    assert 375 not in runtime._awaiting_queue_status_ids
+
+
+@pytest.mark.unit
+def test_synchronous_local_queue_status_correlates_during_send() -> None:
+    """A QueueStatus delivered during transport I/O must not be re-registered."""
+    local_num = 0x12345678
+    harness = _QueueHarness(free=0)
+    runtime = _QueueSendRuntime(
+        lock=harness.lock,
+        get_queue=lambda: harness.queue,
+        get_queue_status=lambda: harness.queue_status,
+        set_queue_status=harness.set_queue_status,
+        queue_wait_delay_seconds=0.0,
+        uses_tx_queue_capacity=lambda message: message.packet.to != local_num,
+    )
+
+    def send_and_reply(message: mesh_pb2.ToRadio) -> None:
+        runtime.handle_queue_status_from_radio(
+            mesh_pb2.QueueStatus(
+                free=0,
+                maxlen=16,
+                mesh_packet_id=message.packet.id,
+            )
+        )
+
+    runtime.send_to_radio(
+        _packet(376, local_num),
+        send_impl=send_and_reply,
+        sleep_fn=lambda _seconds: None,
+    )
+
+    assert list(harness.queue) == []
+    assert 376 not in runtime._awaiting_queue_status_ids
+
+
+@pytest.mark.unit
+def test_mesh_interface_classifies_only_known_local_destination_as_exempt() -> None:
+    """MeshInterface should conservatively gate packets until local identity is known."""
+    iface = object.__new__(MeshInterface)
+    iface.myInfo = None
+    local_num = 0x12345678
+    local = _packet(401, local_num)
+
+    assert iface._packet_uses_tx_queue_capacity(local) is True
+
+    iface.myInfo = mesh_pb2.MyNodeInfo(my_node_num=local_num)
+
+    assert iface._packet_uses_tx_queue_capacity(local) is False
+    assert iface._packet_uses_tx_queue_capacity(_packet(402, 0x87654321)) is True
+    assert iface._packet_uses_tx_queue_capacity(mesh_pb2.ToRadio()) is True
+
+
+@pytest.mark.unit
+def test_mesh_interface_sends_known_local_packet_with_full_rf_queue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MeshInterface should bypass RF backpressure for a known local destination."""
+    monkeypatch.setattr(MeshInterface, "_queue_wait_timeout_seconds", 0.0)
+    iface = MeshInterface()
+    local_num = 0x12345678
+    iface.myInfo = mesh_pb2.MyNodeInfo(my_node_num=local_num)
+    iface.queueStatus = mesh_pb2.QueueStatus(free=0, maxlen=16)
+    send_impl = MagicMock()
+    monkeypatch.setattr(iface, "_send_to_radio_impl", send_impl)
+    local = _packet(501, local_num)
+
+    iface._send_to_radio(local)
+
+    send_impl.assert_called_once_with(local)
+    assert iface.queueStatus.free == 0
+
+
+@pytest.mark.unit
+def test_mesh_interface_still_blocks_remote_packet_when_rf_queue_is_full(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Remote packets must retain bounded firmware RF queue backpressure."""
+    monkeypatch.setattr(MeshInterface, "_queue_wait_timeout_seconds", 0.0)
+    iface = MeshInterface()
+    iface.myInfo = mesh_pb2.MyNodeInfo(my_node_num=0x12345678)
+    iface.queueStatus = mesh_pb2.QueueStatus(free=0, maxlen=16)
+    send_impl = MagicMock()
+    monkeypatch.setattr(iface, "_send_to_radio_impl", send_impl)
+
+    with pytest.raises(
+        MeshInterface.MeshInterfaceError, match="free space in TX queue"
+    ):
+        iface._send_to_radio(_packet(502, 0x87654321))
+
+    send_impl.assert_not_called()

--- a/meshtastic/tests/test_mesh_interface_queue_send_runtime.py
+++ b/meshtastic/tests/test_mesh_interface_queue_send_runtime.py
@@ -265,6 +265,7 @@ def test_sent_packet_without_queue_status_does_not_track_awaiting_correlation() 
     )
 
     assert runtime._awaiting_queue_status_ids == {}
+    assert 654 not in runtime._packet_uses_capacity_by_id
 
 
 @pytest.mark.unit
@@ -336,6 +337,7 @@ def test_expired_awaiting_queue_status_id_is_treated_as_unexpected(
     runtime._correlate_queue_status_reply(queue_status_reply)
 
     assert 777 not in runtime._awaiting_queue_status_ids
+    assert 777 not in runtime._packet_uses_capacity_by_id
     assert harness.queue[777] is False
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This change lets known local loopback packets bypass firmware transmit-queue capacity waits. Remote packets and packets sent before local node information is available continue to use queue backpressure.

## Key changes

### Features
- Added packet classification through `_packet_uses_tx_queue_capacity`.
- Allowed local loopback packets to bypass full-queue waits.
- Preserved ordering for local packets during backlog processing, failures, and retries.
- Added queue-status correlation and resend handling for capacity-consuming and capacity-exempt packets.

### Fixes
- Prevented local loopback packets from changing RF queue state.
- Prevented local packets from draining the remote packet backlog.
- Preserved remote packet backpressure when the RF queue is full.
- Used conservative classification before local node identity is available.
- Cleaned up capacity tracking for delayed and synchronous queue-status responses.
- Restored queue capacity only for slots that the packet actually claimed.

### Refactors
- Added the optional `uses_tx_queue_capacity` callback to `_QueueSendRuntime`.
- Updated queue popping, slot accounting, requeueing, resend reconciliation, and capacity-state cleanup to use packet classification.
- Added regression tests for local loopback handling and queue-send runtime state cleanup.

## Breaking changes and migration

`_QueueSendRuntime.__init__` has a new optional `uses_tx_queue_capacity` parameter. Existing callers do not need changes. Callers that construct `_QueueSendRuntime` directly can provide this callback to customize packet classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->