### PR TITLE
Upgrade trunk plugin to v1.11.0 and apply formatting fixes

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -9,7 +9,7 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.10.2
+      ref: v1.11.0
       uri: https://github.com/trunk-io/plugins
 lint:
   disabled:
@@ -94,16 +94,16 @@ lint:
   enabled:
     - grype@0.116.0
     - black@26.5.1
-    - checkov@3.3.8
+    - checkov@3.3.9
     - git-diff-check
     - gitleaks@8.30.1
     - isort@8.0.1
     - markdownlint@0.49.1
     - osv-scanner@2.3.5
-    - prettier@3.9.5
-    - ruff@0.15.22
+    - prettier@3.9.6
+    - ruff@0.16.1
     - shellcheck@0.11.0
-    - shfmt@3.6.0
+    - shfmt@3.13.1
     - taplo@0.10.0
     - trivy@0.70.0
     - trufflehog@3.95.2

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -29,7 +29,6 @@ from google.protobuf.message import Message
 from pubsub import pub
 
 import meshtastic.cli.runtime as cli_runtime
-from meshtastic.mesh_interface_runtime import node_data
 import meshtastic.ota
 import meshtastic.serial_interface
 import meshtastic.tcp_interface
@@ -75,6 +74,7 @@ from meshtastic.lockdown import (
     validate_lockdown_passphrase,
 )
 from meshtastic.mesh_interface import MeshInterface
+from meshtastic.mesh_interface_runtime import node_data
 from meshtastic.protobuf import (
     admin_pb2,
     channel_pb2,
@@ -2012,19 +2012,17 @@ def _ensure_set_sections_loaded(
             node.requestConfig(config_type)
 
 
-def _preflight_set_entries(
-    node: Any, set_entries: Sequence[tuple[str, Any]]
-) -> bool:
+def _preflight_set_entries(node: Any, set_entries: Sequence[tuple[str, Any]]) -> bool:
     """
     Validate all --set entries against configuration copies before applying changes.
-    
+
     Parameters
     ----------
     node : Any
         Node providing the current local and module configuration.
     set_entries : Sequence[tuple[str, Any]]
         Preference names and raw values to validate as one batch.
-    
+
     Returns
     -------
     bool
@@ -2054,9 +2052,7 @@ def _preflight_set_entries(
                 continue
 
             validation_messages: list[str] = []
-            reporter_token = _PREF_VALIDATION_REPORTER.set(
-                validation_messages.append
-            )
+            reporter_token = _PREF_VALIDATION_REPORTER.set(validation_messages.append)
             try:
                 try:
                     with _fatal_preference_value_errors():
@@ -2077,9 +2073,7 @@ def _preflight_set_entries(
     if fatal_errors:
         detail_lines = [f"  - {error}" for error in fatal_errors]
         for pref_name, messages in value_rejections:
-            detail_lines.append(
-                f"  - {pref_name}: {_SET_VALUE_REJECTED_MESSAGE}"
-            )
+            detail_lines.append(f"  - {pref_name}: {_SET_VALUE_REJECTED_MESSAGE}")
             detail_lines.extend(f"      {message}" for message in messages)
         details = "\n".join(detail_lines)
         _cli_exit(f"ERROR: --set batch rejected before applying changes:\n{details}")
@@ -2089,9 +2083,7 @@ def _preflight_set_entries(
             for message in messages:
                 _report_pref_validation(message)
         else:
-            _report_pref_validation(
-                f"{pref_name}: {_SET_VALUE_REJECTED_MESSAGE}"
-            )
+            _report_pref_validation(f"{pref_name}: {_SET_VALUE_REJECTED_MESSAGE}")
 
     return not (unknown_fields or value_rejections)
 
@@ -2103,7 +2095,7 @@ def _handle_set_command(
 ) -> None:
     """
     Validate and apply a CLI ``--set`` batch without partial updates.
-    
+
     Parameters
     ----------
     interface : MeshInterface
@@ -2112,7 +2104,7 @@ def _handle_set_command(
         Parsed CLI arguments containing the ``--set`` entries and destination.
     getNode_kwargs : dict[str, Any]
         Additional keyword arguments forwarded to ``interface.getNode``.
-    
+
     Notes
     -----
     Invalid batches are rejected before modifying the device. Valid batches write

--- a/meshtastic/mesh_interface_runtime/queue_send.py
+++ b/meshtastic/mesh_interface_runtime/queue_send.py
@@ -344,7 +344,9 @@ class _QueueSendRuntime:
                 with self._lock:
                     self._prune_awaiting_queue_status_ids_locked(time.monotonic())
                     self._claimed_queue_status_by_id.pop(packet_id, None)
-                    should_track_reply = self._queue_status_seen or uses_capacity is False
+                    should_track_reply = (
+                        self._queue_status_seen or uses_capacity is False
+                    )
                     if should_track_reply:
                         self._awaiting_queue_status_ids[packet_id] = time.monotonic()
                     else:

--- a/meshtastic/tests/test_cli_channel_ux.py
+++ b/meshtastic/tests/test_cli_channel_ux.py
@@ -108,6 +108,7 @@ def test_nodes_show_fields_accepts_schema_fields_absent_from_node_database(
         True, ["user.id", "environmentMetrics.temperature"]
     )
 
+
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 @pytest.mark.parametrize("nodes_by_num", [None, {}])

--- a/meshtastic/tests/test_cli_set_batch_atomicity.py
+++ b/meshtastic/tests/test_cli_set_batch_atomicity.py
@@ -14,7 +14,7 @@ from meshtastic.tcp_interface import TCPInterface
 def _interface_with_config_node() -> tuple[MagicMock, MagicMock]:
     """
     Create a mocked interface and node with empty local and module configurations.
-    
+
     Returns
     -------
     tuple[MagicMock, MagicMock]
@@ -130,9 +130,10 @@ def test_valid_multi_section_batch_still_uses_one_transaction(
 
     assert node.localConfig.bluetooth.enabled is True
     assert node.localConfig.power.ls_secs == 300
-    assert [
-        request.args[0].name for request in node.requestConfig.call_args_list
-    ] == ["bluetooth", "power"]
+    assert [request.args[0].name for request in node.requestConfig.call_args_list] == [
+        "bluetooth",
+        "power",
+    ]
     node.beginSettingsTransaction.assert_called_once_with()
     assert {call.args[0] for call in node.writeConfig.call_args_list} == {
         "bluetooth",
@@ -427,7 +428,6 @@ def test_preflight_exception_redacts_secret_value_across_runtime_messages(
     node.writeConfig.assert_not_called()
     out, err = capsys.readouterr()
     assert (
-        f"bluetooth.fixed_pin: invalid value {_REDACTED_PREF_VALUE} (TypeError)"
-        in err
+        f"bluetooth.fixed_pin: invalid value {_REDACTED_PREF_VALUE} (TypeError)" in err
     )
     assert secret not in out + err

--- a/meshtastic/tests/test_cli_set_type_validation.py
+++ b/meshtastic/tests/test_cli_set_type_validation.py
@@ -145,6 +145,7 @@ def test_set_pref_valid_enum_still_uses_symbolic_name() -> None:
     assert setPref(config, "lora.region", "US") is True
     assert config.lora.region == config_pb2.Config.LoRaConfig.RegionCode.US
 
+
 @pytest.mark.unit
 def test_set_pref_redacts_secret_values_in_validation_errors(
     capsys: pytest.CaptureFixture[str],

--- a/meshtastic/tests/test_mesh_interface_local_queue_capacity.py
+++ b/meshtastic/tests/test_mesh_interface_local_queue_capacity.py
@@ -15,7 +15,6 @@ from meshtastic.mesh_interface_runtime.queue_send import (
 )
 from meshtastic.protobuf import mesh_pb2
 
-
 LOCAL_NUM = 0x12345678
 REMOTE_NUM = 0x87654321
 
@@ -66,6 +65,7 @@ def _runtime(
     if classifier is not None:
         _selected_classifier = classifier
     else:
+
         def _selected_classifier(message: mesh_pb2.ToRadio) -> bool:
             return message.packet.to != local_num
 

--- a/meshtastic/tests/test_node_settings_write_dispatch.py
+++ b/meshtastic/tests/test_node_settings_write_dispatch.py
@@ -19,7 +19,9 @@ def _builder() -> tuple[_NodeSettingsMessageBuilder, MagicMock]:
 def _shared_field_names(setter_name: str, source: Message) -> set[str]:
     setter = admin_pb2.AdminMessage.DESCRIPTOR.fields_by_name[setter_name]
     assert setter.message_type is not None
-    return set(setter.message_type.fields_by_name) & set(source.DESCRIPTOR.fields_by_name)
+    return set(setter.message_type.fields_by_name) & set(
+        source.DESCRIPTOR.fields_by_name
+    )
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_receive_pipeline_config_fields.py
+++ b/meshtastic/tests/test_receive_pipeline_config_fields.py
@@ -30,7 +30,9 @@ def test_receive_field_lists_follow_active_protobuf_descriptors() -> None:
     "descriptor",
     [config_pb2.Config.DESCRIPTOR, module_config_pb2.ModuleConfig.DESCRIPTOR],
 )
-def test_inbound_config_wrappers_remain_singular_messages(descriptor: Descriptor) -> None:
+def test_inbound_config_wrappers_remain_singular_messages(
+    descriptor: Descriptor,
+) -> None:
     """Receive-copy logic relies on wrapper fields being singular submessages."""
     fields = descriptor.fields
     assert fields
@@ -58,7 +60,9 @@ def _pipeline_with_local_node() -> tuple[ReceivePipeline, SimpleNamespace]:
         & set(localonly_pb2.LocalConfig.DESCRIPTOR.fields_by_name)
     ),
 )
-def test_every_supported_local_config_field_updates_local_cache(field_name: str) -> None:
+def test_every_supported_local_config_field_updates_local_cache(
+    field_name: str,
+) -> None:
     """Every wire config field supported by LocalConfig should be copied."""
     pipeline, local_node = _pipeline_with_local_node()
     incoming = config_pb2.Config()
@@ -87,7 +91,8 @@ def test_wire_only_local_config_fields_are_ignored_safely(field_name: str) -> No
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
-    "field_name", [field.name for field in module_config_pb2.ModuleConfig.DESCRIPTOR.fields]
+    "field_name",
+    [field.name for field in module_config_pb2.ModuleConfig.DESCRIPTOR.fields],
 )
 def test_every_module_config_field_updates_local_cache(field_name: str) -> None:
     """Every module config wrapper field should copy into the local cache."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Includes PEP 561 py.typed marker for type checker support
 [tool.poetry]
 name = "mtjk"
-version = "2.7.11.post2"
+version = "2.7.11.post3"
 description = "Python API & client shell for talking to Meshtastic devices"
 authors = ["Meshtastic Developers (upstream project authors)"]
 maintainers = ["Jeremiah K. <jeremiahk@gmx.com>"]


### PR DESCRIPTION
## Summary by Sourcery

Upgrade tooling configuration and apply formatting-only cleanups across the CLI, runtime, and tests.

Enhancements:
- Reformat CLI implementation and runtime helper code to comply with updated style rules.
- Tidy test modules with consistent parameterization, assertions, and whitespace.

Build:
- Update Trunk plugin reference and bundled lint tool versions in .trunk/trunk.yaml.
- Bump project version in pyproject.toml for the new tooling-compatible release.

Tests:
- Adjust test code structure and expectations to align with new formatting and import order changes without altering test behavior.