### PR TITLE
Extract Node contact URL at runtime

### DIFF
--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -96,7 +96,7 @@ MAX_SHORT_NAME_LEN = _MAX_SHORT_NAME_LEN
 
 # COMPAT_STABLE_SHIM: private contact helpers remain importable from meshtastic.node.
 _MAX_CONTACT_URL_PAYLOAD = contact_runtime.MAX_CONTACT_URL_PAYLOAD
-_decode_node_bytes_field = contact_runtime.decode_node_bytes_field
+_decode_node_bytes_field = contact_runtime._decode_node_bytes_field
 
 
 class Node:  # pylint: disable=too-many-instance-attributes

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -20,7 +20,7 @@ from meshtastic.node_runtime.channel_presentation_runtime import (
     _NodeChannelPresentationRuntime,
 )
 from meshtastic.node_runtime.channel_request_runtime import _NodeChannelRequestRuntime
-import meshtastic.node_runtime.contact_runtime as contact_runtime
+from meshtastic.node_runtime import contact_runtime
 from meshtastic.node_runtime.settings_runtime import (
     _NodeAdminCommandRuntime,
     _NodeOwnerProfileRuntime,

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -5,15 +5,10 @@ This module provides the Node class which represents a (local or remote) node
 in the mesh, including methods for localConfig, moduleConfig, and channels management.
 """
 
-import base64
-import binascii
 import logging
 import sys
 import threading
 from typing import TYPE_CHECKING, Any, Callable, NoReturn, Sequence, TypeVar
-from urllib.parse import urlparse
-
-import google.protobuf.message
 from google.protobuf.descriptor import FieldDescriptor
 
 from meshtastic.node_runtime.channel_export_runtime import _NodeChannelExportRuntime
@@ -25,6 +20,7 @@ from meshtastic.node_runtime.channel_presentation_runtime import (
     _NodeChannelPresentationRuntime,
 )
 from meshtastic.node_runtime.channel_request_runtime import _NodeChannelRequestRuntime
+import meshtastic.node_runtime.contact_runtime as contact_runtime
 from meshtastic.node_runtime.settings_runtime import (
     _NodeAdminCommandRuntime,
     _NodeOwnerProfileRuntime,
@@ -98,21 +94,9 @@ MAX_LONG_NAME_LEN = _MAX_LONG_NAME_LEN
 MAX_RINGTONE_LENGTH = _MAX_RINGTONE_LENGTH
 MAX_SHORT_NAME_LEN = _MAX_SHORT_NAME_LEN
 
-# Maximum allowed size (in bytes) of the decoded contact URL payload.
-# A legitimate SharedContact protobuf is expected to be <1KB.
-_MAX_CONTACT_URL_PAYLOAD = 4096
-
-
-def _decode_node_bytes_field(value: str | bytes) -> bytes:
-    """Decode a NodeDB byte field that may be stored as base64 string or raw bytes.
-
-    Only base64 syntax is validated here; decoded byte lengths are not checked
-    against nanopb constraints for upstream compatibility — firmware validates
-    field sizes on receipt.
-    """
-    if isinstance(value, bytes):
-        return value
-    return base64.b64decode(value, validate=True)
+# COMPAT_STABLE_SHIM: private contact helpers remain importable from meshtastic.node.
+_MAX_CONTACT_URL_PAYLOAD = contact_runtime.MAX_CONTACT_URL_PAYLOAD
+_decode_node_bytes_field = contact_runtime.decode_node_bytes_field
 
 
 class Node:  # pylint: disable=too-many-instance-attributes
@@ -171,6 +155,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
             self,
             export_runtime=self._channel_export_runtime,
         )
+        self._contact_runtime = contact_runtime._NodeContactRuntime(self)
         self._channel_write_runtime = _NodeChannelWriteRuntime(
             self,
             admin_session_runtime=self._admin_session_runtime,
@@ -934,87 +919,12 @@ class Node:  # pylint: disable=too-many-instance-attributes
             has no usable user ID. Also raised for malformed macaddr or
             publicKey fields in the NodeDB.
         """
-        node_num = toNodeNum(node_id)
-
-        # Reject reserved node numbers so generation/import invariants match
-        if node_num == 0 or node_num >= 0xFFFFFFFF:
-            self._raise_interface_error(f"Invalid node number for contact: {node_num}")
-
-        def _read_user_snapshot() -> dict[str, Any] | None:
-            nodes_by_num = self.iface.nodesByNum
-            node = nodes_by_num.get(node_num) if nodes_by_num else None
-            if not isinstance(node, dict):
-                return None
-            user = node.get("user")
-            if not isinstance(user, dict):
-                return None
-            return dict(user)  # shallow copy under lock
-
-        u = self._execute_with_node_db_lock(_read_user_snapshot)
-        if not u:
-            self._raise_interface_error(f"Node {node_id} not found in NodeDB")
-
-        user_id = u.get("id")
-        if not isinstance(user_id, str) or not user_id:
-            self._raise_interface_error(
-                f"Node {node_id} has no usable user ID in NodeDB"
-            )
-
-        contact = admin_pb2.SharedContact()
-        contact.node_num = node_num
-
-        contact.user.id = user_id
-        if u.get("macaddr"):
-            try:
-                contact.user.macaddr = _decode_node_bytes_field(u["macaddr"])
-            except (binascii.Error, ValueError) as exc:
-                self._raise_interface_error(
-                    f"Invalid macaddr in NodeDB for {node_id}: {exc}"
-                )
-        if u.get("longName"):
-            contact.user.long_name = u["longName"]
-        if u.get("shortName"):
-            contact.user.short_name = u["shortName"]
-        if u.get("hwModel") and u["hwModel"] != "UNSET":
-            hw_model = u["hwModel"]
-            # Unknown enum names from newer firmware are silently omitted to
-            # preserve forward compatibility — core contact fields still work.
-            if isinstance(hw_model, str):
-                try:
-                    contact.user.hw_model = mesh_pb2.HardwareModel.Value(hw_model)
-                except ValueError:
-                    pass
-            elif isinstance(hw_model, int):
-                contact.user.hw_model = hw_model  # type: ignore[assignment]
-        if u.get("role"):
-            role = u["role"]
-            if isinstance(role, str):
-                try:
-                    contact.user.role = config_pb2.Config.DeviceConfig.Role.Value(role)
-                except ValueError:
-                    pass
-            elif isinstance(role, int):
-                contact.user.role = role  # type: ignore[assignment]
-        if u.get("publicKey"):
-            try:
-                contact.user.public_key = _decode_node_bytes_field(u["publicKey"])
-            except (binascii.Error, ValueError) as exc:
-                self._raise_interface_error(
-                    f"Invalid publicKey in NodeDB for {node_id}: {exc}"
-                )
-        if u.get("isLicensed"):
-            contact.user.is_licensed = u["isLicensed"]
-        if u.get("isUnmessagable") is not None:
-            contact.user.is_unmessagable = u["isUnmessagable"]
-        if should_ignore:
-            contact.should_ignore = True
-        if manually_verified:
-            contact.manually_verified = True
-
-        data = contact.SerializeToString()
-        s = base64.urlsafe_b64encode(data).decode("ascii")
-        s = s.rstrip("=")
-        return f"https://meshtastic.org/v/#{s}"
+        return self._contact_runtime.get_contact_url(
+            node_id,
+            should_ignore=should_ignore,
+            manually_verified=manually_verified,
+            decode_bytes_field=_decode_node_bytes_field,
+        )
 
     def addContactURL(self, url: str) -> mesh_pb2.MeshPacket | None:
         """Add a contact (User) to the NodeDB from a shareable contact URL.
@@ -1038,65 +948,9 @@ class Node:  # pylint: disable=too-many-instance-attributes
         MeshInterfaceError
             If the URL is malformed, cannot be parsed, or yields an invalid contact.
         """
-        parsed = urlparse(url)
-        fragment = parsed.fragment
-        if not fragment:
-            self._raise_interface_error(f"Invalid URL '{url}'")
-
-        b64 = fragment
-
-        # Guard against oversized encoded fragments before allocating decode buffers.
-        # base64 encodes 3 bytes per 4 chars, so 4096 decoded bytes ≈ 5462 encoded chars.
-        _MAX_ENCODED_FRAGMENT = (_MAX_CONTACT_URL_PAYLOAD // 3 + 1) * 4 + 4
-        if len(b64) > _MAX_ENCODED_FRAGMENT:
-            self._raise_interface_error(
-                f"Contact URL fragment too large ({len(b64)} chars)"
-            )
-
-        missing_padding = len(b64) % 4
-        if missing_padding:
-            b64 += "=" * (4 - missing_padding)
-
-        try:
-            decoded = base64.b64decode(b64, altchars=b"-_", validate=True)
-        except (binascii.Error, ValueError) as exc:
-            self._raise_interface_error(f"Failed to decode contact URL: {exc}")
-
-        # Cap decoded payload — a legitimate SharedContact is <1KB
-        if len(decoded) > _MAX_CONTACT_URL_PAYLOAD:
-            self._raise_interface_error(
-                f"Contact URL payload too large ({len(decoded)} bytes, "
-                f"max {_MAX_CONTACT_URL_PAYLOAD})"
-            )
-
-        try:
-            contact = admin_pb2.SharedContact()
-            contact.ParseFromString(decoded)
-        except google.protobuf.message.DecodeError as exc:
-            self._raise_interface_error(f"Failed to parse contact URL: {exc}")
-
-        # Validate decoded contact before sending
-        if contact.node_num == 0 or contact.node_num >= 0xFFFFFFFF:
-            self._raise_interface_error(
-                f"Invalid node number in contact: {contact.node_num}"
-            )
-        if not contact.HasField("user"):
-            self._raise_interface_error("Contact URL contains no user data")
-        if not contact.user.id:
-            self._raise_interface_error("Contact URL contains no user ID")
-
-        self.ensureSessionKey()
-
-        p = admin_pb2.AdminMessage()
-        p.add_contact.CopyFrom(contact)
-
-        # Align with _NodeAdminCommandRuntime._send_command: wait for ACK when
-        # sending to a remote node and a packet was actually sent.
-        on_response = self.onAckNak if self != self.iface.localNode else None
-        request = self._send_admin(p, onResponse=on_response)
-        if on_response is not None and request is not None:
-            self.iface.waitForAckNak()
-        return request
+        return self._contact_runtime.add_contact_url(
+            url, max_payload=_MAX_CONTACT_URL_PAYLOAD
+        )
 
     def onResponseRequestRingtone(self, p: dict[str, Any]) -> None:
         """Process an admin response containing a ringtone fragment and cache it on the Node.

--- a/meshtastic/node_runtime/contact_runtime.py
+++ b/meshtastic/node_runtime/contact_runtime.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 MAX_CONTACT_URL_PAYLOAD = 4096
 
 
-def decode_node_bytes_field(value: str | bytes) -> bytes:
+def _decode_node_bytes_field(value: str | bytes) -> bytes:
     """Decode a NodeDB byte field stored as base64 text or raw bytes.
 
     Parameters
@@ -70,7 +70,7 @@ class _NodeContactRuntime:
         *,
         should_ignore: bool = False,
         manually_verified: bool = False,
-        decode_bytes_field: Callable[[str | bytes], bytes] = decode_node_bytes_field,
+        decode_bytes_field: Callable[[str | bytes], bytes] = _decode_node_bytes_field,
     ) -> str:
         """Build a shareable contact URL from the current NodeDB snapshot."""
         node_num = toNodeNum(node_id)

--- a/meshtastic/node_runtime/contact_runtime.py
+++ b/meshtastic/node_runtime/contact_runtime.py
@@ -1,0 +1,221 @@
+"""Contact URL serialization, validation, and import runtime for :class:`Node`."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
+
+import google.protobuf.message
+
+from meshtastic.protobuf import admin_pb2, config_pb2, mesh_pb2
+from meshtastic.util import toNodeNum
+
+if TYPE_CHECKING:
+    from meshtastic.node import Node
+
+
+MAX_CONTACT_URL_PAYLOAD = 4096
+
+
+def decode_node_bytes_field(value: str | bytes) -> bytes:
+    """Decode a NodeDB byte field stored as base64 text or raw bytes.
+
+    Parameters
+    ----------
+    value : str | bytes
+        NodeDB field value to decode.
+
+    Returns
+    -------
+    bytes
+        Raw field bytes.
+
+    Notes
+    -----
+    Only base64 syntax is validated here. Firmware remains responsible for
+    enforcing nanopb field-size limits when imported contact data is applied.
+    """
+    if isinstance(value, bytes):
+        return value
+    return base64.b64decode(value, validate=True)
+
+
+class _NodeContactRuntime:
+    """Own contact URL generation, validation, and admin import orchestration."""
+
+    def __init__(self, node: "Node") -> None:
+        self._node = node
+
+    def _read_user_snapshot(self, node_num: int) -> dict[str, Any] | None:
+        """Return a detached user mapping from the NodeDB under its lock."""
+
+        def _snapshot() -> dict[str, Any] | None:
+            nodes_by_num = self._node.iface.nodesByNum
+            node = nodes_by_num.get(node_num) if nodes_by_num else None
+            if not isinstance(node, dict):
+                return None
+            user = node.get("user")
+            if not isinstance(user, dict):
+                return None
+            return dict(user)
+
+        return self._node._execute_with_node_db_lock(_snapshot)  # noqa: SLF001
+
+    def get_contact_url(
+        self,
+        node_id: int | str,
+        *,
+        should_ignore: bool = False,
+        manually_verified: bool = False,
+        decode_bytes_field: Callable[[str | bytes], bytes] = decode_node_bytes_field,
+    ) -> str:
+        """Build a shareable contact URL from the current NodeDB snapshot."""
+        node_num = toNodeNum(node_id)
+        if node_num == 0 or node_num >= 0xFFFFFFFF:
+            self._node._raise_interface_error(  # noqa: SLF001
+                f"Invalid node number for contact: {node_num}"
+            )
+
+        user = self._read_user_snapshot(node_num)
+        if not user:
+            self._node._raise_interface_error(  # noqa: SLF001
+                f"Node {node_id} not found in NodeDB"
+            )
+
+        user_id = user.get("id")
+        if not isinstance(user_id, str) or not user_id:
+            self._node._raise_interface_error(  # noqa: SLF001
+                f"Node {node_id} has no usable user ID in NodeDB"
+            )
+
+        contact = admin_pb2.SharedContact()
+        contact.node_num = node_num
+        contact.user.id = user_id
+
+        if user.get("macaddr"):
+            try:
+                contact.user.macaddr = decode_bytes_field(user["macaddr"])
+            except (binascii.Error, ValueError) as exc:
+                self._node._raise_interface_error(  # noqa: SLF001
+                    f"Invalid macaddr in NodeDB for {node_id}: {exc}"
+                )
+        if user.get("longName"):
+            contact.user.long_name = user["longName"]
+        if user.get("shortName"):
+            contact.user.short_name = user["shortName"]
+        if user.get("hwModel") and user["hwModel"] != "UNSET":
+            hw_model = user["hwModel"]
+            # Unknown enum names from newer firmware are intentionally omitted so
+            # core contact fields remain forward compatible.
+            if isinstance(hw_model, str):
+                try:
+                    contact.user.hw_model = mesh_pb2.HardwareModel.Value(hw_model)
+                except ValueError:
+                    pass
+            elif isinstance(hw_model, int):
+                contact.user.hw_model = hw_model  # type: ignore[assignment]
+        if user.get("role"):
+            role = user["role"]
+            if isinstance(role, str):
+                try:
+                    contact.user.role = config_pb2.Config.DeviceConfig.Role.Value(role)
+                except ValueError:
+                    pass
+            elif isinstance(role, int):
+                contact.user.role = role  # type: ignore[assignment]
+        if user.get("publicKey"):
+            try:
+                contact.user.public_key = decode_bytes_field(user["publicKey"])
+            except (binascii.Error, ValueError) as exc:
+                self._node._raise_interface_error(  # noqa: SLF001
+                    f"Invalid publicKey in NodeDB for {node_id}: {exc}"
+                )
+        if user.get("isLicensed"):
+            contact.user.is_licensed = user["isLicensed"]
+        if user.get("isUnmessagable") is not None:
+            contact.user.is_unmessagable = user["isUnmessagable"]
+        if should_ignore:
+            contact.should_ignore = True
+        if manually_verified:
+            contact.manually_verified = True
+
+        encoded = base64.urlsafe_b64encode(contact.SerializeToString()).decode("ascii")
+        return f"https://meshtastic.org/v/#{encoded.rstrip('=')}"
+
+    def _decode_contact(
+        self, url: str, *, max_payload: int = MAX_CONTACT_URL_PAYLOAD
+    ) -> admin_pb2.SharedContact:
+        """Decode and validate the SharedContact payload carried by ``url``."""
+        fragment = urlparse(url).fragment
+        if not fragment:
+            self._node._raise_interface_error(f"Invalid URL '{url}'")  # noqa: SLF001
+
+        max_encoded_fragment = (max_payload // 3 + 1) * 4 + 4
+        if len(fragment) > max_encoded_fragment:
+            self._node._raise_interface_error(  # noqa: SLF001
+                f"Contact URL fragment too large ({len(fragment)} chars)"
+            )
+
+        encoded = fragment
+        missing_padding = len(encoded) % 4
+        if missing_padding:
+            encoded += "=" * (4 - missing_padding)
+
+        try:
+            decoded = base64.b64decode(encoded, altchars=b"-_", validate=True)
+        except (binascii.Error, ValueError) as exc:
+            self._node._raise_interface_error(  # noqa: SLF001
+                f"Failed to decode contact URL: {exc}"
+            )
+
+        if len(decoded) > max_payload:
+            self._node._raise_interface_error(  # noqa: SLF001
+                f"Contact URL payload too large ({len(decoded)} bytes, "
+                f"max {max_payload})"
+            )
+
+        try:
+            contact = admin_pb2.SharedContact()
+            contact.ParseFromString(decoded)
+        except google.protobuf.message.DecodeError as exc:
+            self._node._raise_interface_error(  # noqa: SLF001
+                f"Failed to parse contact URL: {exc}"
+            )
+
+        if contact.node_num == 0 or contact.node_num >= 0xFFFFFFFF:
+            self._node._raise_interface_error(  # noqa: SLF001
+                f"Invalid node number in contact: {contact.node_num}"
+            )
+        if not contact.HasField("user"):
+            self._node._raise_interface_error(  # noqa: SLF001
+                "Contact URL contains no user data"
+            )
+        if not contact.user.id:
+            self._node._raise_interface_error(  # noqa: SLF001
+                "Contact URL contains no user ID"
+            )
+        return contact
+
+    def add_contact_url(
+        self, url: str, *, max_payload: int = MAX_CONTACT_URL_PAYLOAD
+    ) -> mesh_pb2.MeshPacket | None:
+        """Decode ``url`` and send its contact through the existing admin path."""
+        contact = self._decode_contact(url, max_payload=max_payload)
+        self._node.ensureSessionKey()
+
+        message = admin_pb2.AdminMessage()
+        message.add_contact.CopyFrom(contact)
+
+        on_response = (
+            self._node.onAckNak if self._node != self._node.iface.localNode else None
+        )
+        request = self._node._send_admin(  # noqa: SLF001
+            message,
+            onResponse=on_response,
+        )
+        if on_response is not None and request is not None:
+            self._node.iface.waitForAckNak()
+        return request

--- a/meshtastic/tests/test_node_contact_runtime_compat.py
+++ b/meshtastic/tests/test_node_contact_runtime_compat.py
@@ -66,7 +66,9 @@ def test_decode_node_bytes_field_preserves_raw_bytes() -> None:
 def test_get_contact_url_rejects_malformed_node_db_byte_fields(field_name: str) -> None:
     """Malformed NodeDB byte fields should fail with field-specific diagnostics."""
     target = _node_with_contact(0x12345678)
-    target.iface.nodesByNum[0x12345678]["user"][field_name] = "not-base64!"
+    nodes_by_num = target.iface.nodesByNum
+    assert nodes_by_num is not None
+    nodes_by_num[0x12345678]["user"][field_name] = "not-base64!"
 
     with pytest.raises(MeshInterface.MeshInterfaceError, match=f"Invalid {field_name}"):
         target.getContactURL(0x12345678)
@@ -76,7 +78,9 @@ def test_get_contact_url_rejects_malformed_node_db_byte_fields(field_name: str) 
 def test_get_contact_url_accepts_numeric_enum_values() -> None:
     """Numeric hardware-model and role values should survive contact export."""
     target = _node_with_contact(0x12345678)
-    user = target.iface.nodesByNum[0x12345678]["user"]
+    nodes_by_num = target.iface.nodesByNum
+    assert nodes_by_num is not None
+    user = nodes_by_num[0x12345678]["user"]
     user["hwModel"] = 1
     user["role"] = 1
 

--- a/meshtastic/tests/test_node_contact_runtime_compat.py
+++ b/meshtastic/tests/test_node_contact_runtime_compat.py
@@ -8,7 +8,7 @@ import pytest
 import meshtastic.node as node_module
 from meshtastic.mesh_interface import MeshInterface
 from meshtastic.node import Node
-from meshtastic.node_runtime.contact_runtime import decode_node_bytes_field
+from meshtastic.node_runtime.contact_runtime import _decode_node_bytes_field
 from meshtastic.protobuf import admin_pb2
 
 
@@ -58,7 +58,7 @@ def test_decode_node_bytes_field_preserves_raw_bytes() -> None:
     """Raw NodeDB bytes should pass through without base64 decoding."""
     raw = b"\x00\x01contact"
 
-    assert decode_node_bytes_field(raw) is raw
+    assert _decode_node_bytes_field(raw) is raw
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_node_contact_runtime_compat.py
+++ b/meshtastic/tests/test_node_contact_runtime_compat.py
@@ -1,5 +1,6 @@
 """Compatibility seams for the extracted Node contact runtime."""
 
+import base64
 from unittest.mock import create_autospec, patch
 
 import pytest
@@ -7,6 +8,8 @@ import pytest
 import meshtastic.node as node_module
 from meshtastic.mesh_interface import MeshInterface
 from meshtastic.node import Node
+from meshtastic.node_runtime.contact_runtime import decode_node_bytes_field
+from meshtastic.protobuf import admin_pb2
 
 
 def _node_with_contact(node_num: int, *, macaddr: str = "AQIDBAUG") -> Node:
@@ -48,3 +51,65 @@ def test_add_contact_url_preserves_node_module_payload_limit_monkeypatch() -> No
     with patch.object(node_module, "_MAX_CONTACT_URL_PAYLOAD", 1):
         with pytest.raises(MeshInterface.MeshInterfaceError, match="Contact URL fragment too large"):
             target.addContactURL(url)
+
+
+@pytest.mark.unit
+def test_decode_node_bytes_field_preserves_raw_bytes() -> None:
+    """Raw NodeDB bytes should pass through without base64 decoding."""
+    raw = b"\x00\x01contact"
+
+    assert decode_node_bytes_field(raw) is raw
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("field_name", ["macaddr", "publicKey"])
+def test_get_contact_url_rejects_malformed_node_db_byte_fields(field_name: str) -> None:
+    """Malformed NodeDB byte fields should fail with field-specific diagnostics."""
+    target = _node_with_contact(0x12345678)
+    target.iface.nodesByNum[0x12345678]["user"][field_name] = "not-base64!"
+
+    with pytest.raises(MeshInterface.MeshInterfaceError, match=f"Invalid {field_name}"):
+        target.getContactURL(0x12345678)
+
+
+@pytest.mark.unit
+def test_get_contact_url_accepts_numeric_enum_values() -> None:
+    """Numeric hardware-model and role values should survive contact export."""
+    target = _node_with_contact(0x12345678)
+    user = target.iface.nodesByNum[0x12345678]["user"]
+    user["hwModel"] = 1
+    user["role"] = 1
+
+    url = target.getContactURL(0x12345678)
+    fragment = url.split("#", maxsplit=1)[1]
+    fragment += "=" * (-len(fragment) % 4)
+    contact = admin_pb2.SharedContact()
+    contact.ParseFromString(base64.urlsafe_b64decode(fragment))
+
+    assert contact.user.hw_model == 1
+    assert contact.user.role == 1
+
+
+@pytest.mark.unit
+def test_decode_contact_rejects_payload_over_decoded_limit() -> None:
+    """Decoded payload size should be checked even when the encoded guard permits it."""
+    target = _node_with_contact(0x12345678)
+    encoded = base64.urlsafe_b64encode(b"1234").decode("ascii").rstrip("=")
+
+    with pytest.raises(MeshInterface.MeshInterfaceError, match="payload too large"):
+        target._contact_runtime._decode_contact(  # noqa: SLF001
+            f"https://meshtastic.org/v/#{encoded}",
+            max_payload=3,
+        )
+
+
+@pytest.mark.unit
+def test_decode_contact_reports_malformed_protobuf_payload() -> None:
+    """Valid base64 containing invalid protobuf wire data should report parse failure."""
+    target = _node_with_contact(0x12345678)
+    encoded = base64.urlsafe_b64encode(b"\xff").decode("ascii").rstrip("=")
+
+    with pytest.raises(MeshInterface.MeshInterfaceError, match="Failed to parse"):
+        target._contact_runtime._decode_contact(  # noqa: SLF001
+            f"https://meshtastic.org/v/#{encoded}"
+        )

--- a/meshtastic/tests/test_node_contact_runtime_compat.py
+++ b/meshtastic/tests/test_node_contact_runtime_compat.py
@@ -1,6 +1,6 @@
 """Compatibility seams for the extracted Node contact runtime."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import create_autospec, patch
 
 import pytest
 
@@ -11,7 +11,7 @@ from meshtastic.node import Node
 
 def _node_with_contact(node_num: int, *, macaddr: str = "AQIDBAUG") -> Node:
     """Build a Node with one contact-shaped NodeDB entry."""
-    iface = MagicMock(autospec=MeshInterface)
+    iface = create_autospec(MeshInterface, instance=True)
     iface.nodesByNum = {
         node_num: {
             "num": node_num,

--- a/meshtastic/tests/test_node_contact_runtime_compat.py
+++ b/meshtastic/tests/test_node_contact_runtime_compat.py
@@ -1,0 +1,50 @@
+"""Compatibility seams for the extracted Node contact runtime."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import meshtastic.node as node_module
+from meshtastic.mesh_interface import MeshInterface
+from meshtastic.node import Node
+
+
+def _node_with_contact(node_num: int, *, macaddr: str = "AQIDBAUG") -> Node:
+    """Build a Node with one contact-shaped NodeDB entry."""
+    iface = MagicMock(autospec=MeshInterface)
+    iface.nodesByNum = {
+        node_num: {
+            "num": node_num,
+            "user": {
+                "id": f"!{node_num:08x}",
+                "longName": "Contact",
+                "shortName": "CT",
+                "macaddr": macaddr,
+            },
+        }
+    }
+    iface.localNode = None
+    return Node(iface, node_num, noProto=True)
+
+
+@pytest.mark.unit
+def test_get_contact_url_preserves_node_module_decoder_monkeypatch() -> None:
+    """The public Node facade must keep the historical private decoder seam."""
+    target = _node_with_contact(0x12345678, macaddr="not-valid-base64")
+
+    with patch.object(node_module, "_decode_node_bytes_field", return_value=b"123456"):
+        url = target.getContactURL(0x12345678)
+
+    assert url.startswith("https://meshtastic.org/v/#")
+
+
+@pytest.mark.unit
+def test_add_contact_url_preserves_node_module_payload_limit_monkeypatch() -> None:
+    """The public Node facade must keep the historical payload-limit seam."""
+    source = _node_with_contact(0x12345678)
+    url = source.getContactURL(0x12345678)
+    target = _node_with_contact(0x87654321)
+
+    with patch.object(node_module, "_MAX_CONTACT_URL_PAYLOAD", 1):
+        with pytest.raises(MeshInterface.MeshInterfaceError, match="Contact URL fragment too large"):
+            target.addContactURL(url)


### PR DESCRIPTION
## Summary by Sourcery

Extract Node contact URL handling into a dedicated runtime while preserving existing public API behavior and compatibility seams.

Enhancements:
- Introduce a _NodeContactRuntime to encapsulate contact URL serialization, validation, and admin import logic for Node instances.
- Expose contact URL payload size and byte-field decoding via a new contact_runtime module while keeping legacy shims in meshtastic.node for backwards compatibility.

Tests:
- Add unit tests to verify that Node still honors monkeypatched contact decoder and payload limit values after extracting the contact runtime.