### PR TITLE
Extract CLI configuration I/O runtime

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -25,9 +25,9 @@ from typing import Any, NoReturn, Protocol, cast
 import yaml
 from google.protobuf.descriptor import FieldDescriptor
 from google.protobuf.json_format import MessageToDict
-from google.protobuf.message import Message
 from pubsub import pub
 
+import meshtastic.cli.config_io as cli_config_io
 import meshtastic.cli.runtime as cli_runtime
 import meshtastic.ota
 import meshtastic.serial_interface
@@ -3533,48 +3533,19 @@ def onConnected(interface: MeshInterface) -> None:
 
 
 def printConfig(config: Any) -> None:
-    """Print the top-level configuration sections and their fields.
-
-    Skips the "version" section. For each other top-level section, prints the section name
-    followed by its fields in the form "section.field"; field names are converted to
-    camelCase when mt_config.camel_case is true.
-
-    Parameters
-    ----------
-    config : Any
-        A protobuf-like configuration message exposing a DESCRIPTOR with top-level fields.
-    """
-    objDesc = config.DESCRIPTOR
-    for config_section in objDesc.fields:
-        if config_section.name != "version":
-            section_field = objDesc.fields_by_name.get(config_section.name)
-            if section_field is None or section_field.message_type is None:
-                continue
-            print(f"{config_section.name}:")
-            names = []
-            for field in section_field.message_type.fields:
-                tmp_name = f"{config_section.name}.{field.name}"
-                if mt_config.camel_case:
-                    tmp_name = meshtastic.util.snake_to_camel(tmp_name)
-                names.append(tmp_name)
-            for temp_name in sorted(names):
-                print(f"    {temp_name}")
+    """COMPAT_STABLE_SHIM: print config fields through the CLI config I/O runtime."""
+    cli_config_io.print_config(config, camel_case=mt_config.camel_case)
 
 
 def printAvailableConfigFields() -> None:
-    """Print all current config fields from protobuf descriptors plus aliases."""
-    print("Local config fields:")
-    printConfig(localonly_pb2.LocalConfig())
-    print("")
-    print("Module config fields:")
-    printConfig(localonly_pb2.LocalModuleConfig())
-    if _PREFERENCE_FIELD_ALIASES:
-        print("")
-        print("Compatibility aliases:")
-        for alias_name, canonical_name in sorted(_PREFERENCE_FIELD_ALIASES.items()):
-            print(
-                f"    {_display_pref_name(alias_name)} -> {_display_pref_name(canonical_name)}"
-            )
+    """COMPAT_STABLE_SHIM: print config fields and aliases through the runtime."""
+    cli_config_io.print_available_config_fields(
+        camel_case=mt_config.camel_case,
+        aliases=_PREFERENCE_FIELD_ALIASES,
+        display_pref_name=_display_pref_name,
+        local_config_factory=localonly_pb2.LocalConfig,
+        module_config_factory=localonly_pb2.LocalModuleConfig,
+    )
 
 
 def onNode(node: Any) -> None:
@@ -3604,274 +3575,26 @@ def subscribe() -> None:
     # pub.subscribe(onNode, "meshtastic.node")
 
 
-def _is_repeated_field(field_desc: Any) -> bool:
-    """Return True if the protobuf field is repeated.
-
-    Newer protobuf runtimes expose a boolean ``is_repeated`` property, while
-    older generated descriptors require comparing ``label`` to
-    ``LABEL_REPEATED``.
-    """
-    is_repeated = getattr(field_desc, "is_repeated", None)
-    if isinstance(is_repeated, bool):
-        return is_repeated
-
-    label = getattr(field_desc, "label", None)
-    label_repeated = getattr(field_desc, "LABEL_REPEATED", None)
-    return label is not None and label == label_repeated
-
-
-def _set_missing_flags_false(
-    config_dict: dict[str, Any], true_defaults: set[tuple[str, ...]]
-) -> None:
-    """Ensure specific boolean flags exist in a nested configuration dictionary by creating any.
-
-    missing path components and setting missing final keys to False.
-
-    Parameters
-    ----------
-    config_dict : dict[str, Any]
-        Nested configuration dictionary to modify in place.
-    true_defaults : set[tuple[str, ...]]
-        Set of key paths (tuples of keys) whose final key should exist;
-        if a path is missing, intermediate dictionaries are created and the final key is added with value False.
-    """
-    for path in true_defaults:
-        d = config_dict
-        for key in path[:-1]:
-            if key not in d or not isinstance(d[key], dict):
-                d[key] = {}
-            d = d[key]
-        if path[-1] not in d:
-            d[path[-1]] = False
-
-
-def _prefix_base64_bytes_fields(message: Message, values: dict[str, Any]) -> None:
-    """Mark every protobuf bytes field in a ``MessageToDict`` mapping as base64."""
-
-    def _field_key(field: FieldDescriptor, mapping: dict[str, Any]) -> str | None:
-        json_name: str = getattr(field, "json_name", field.name)
-        name: str = field.name
-        for candidate in (json_name, name):
-            if candidate in mapping:
-                return candidate
-        return None
-
-    def _prefix_bytes(value: Any, *, field_path: str) -> Any:
-        if isinstance(value, str):
-            return value if value.startswith("base64:") else f"base64:{value}"
-        if isinstance(value, list):
-            if not all(isinstance(item, str) for item in value):
-                raise TypeError(
-                    f"Expected base64 strings for repeated bytes field {field_path}"
-                )
-            return [
-                item if item.startswith("base64:") else f"base64:{item}"
-                for item in value
-            ]
-        raise TypeError(f"Expected base64 string for bytes field {field_path}")
-
-    def _walk(
-        descriptor: _DescriptorLike, mapping: dict[str, Any], *, path: str = ""
-    ) -> None:
-        for field in descriptor.fields:
-            key = _field_key(field, mapping)
-            if key is None:
-                continue
-            value = mapping[key]
-            field_path = f"{path}.{field.name}" if path else field.name
-            if field.type == FieldDescriptor.TYPE_BYTES:
-                mapping[key] = _prefix_bytes(value, field_path=field_path)
-                continue
-            if field.type != FieldDescriptor.TYPE_MESSAGE:
-                continue
-
-            message_type = field.message_type
-            if message_type.GetOptions().map_entry:
-                value_field = message_type.fields_by_name["value"]
-                if not isinstance(value, dict):
-                    raise TypeError(
-                        f"Expected mapping for protobuf map field {field_path}"
-                    )
-                if value_field.type == FieldDescriptor.TYPE_BYTES:
-                    for map_key, map_value in value.items():
-                        value[map_key] = _prefix_bytes(
-                            map_value, field_path=f"{field_path}[{map_key!r}]"
-                        )
-                elif value_field.type == FieldDescriptor.TYPE_MESSAGE:
-                    for map_key, map_value in value.items():
-                        if not isinstance(map_value, dict):
-                            raise TypeError(
-                                "Expected mapping for protobuf message map value "
-                                f"{field_path}[{map_key!r}]"
-                            )
-                        _walk(
-                            value_field.message_type,
-                            map_value,
-                            path=f"{field_path}[{map_key!r}]",
-                        )
-                continue
-
-            if _is_repeated_field(field):
-                if not isinstance(value, list):
-                    raise TypeError(
-                        f"Expected list for repeated message field {field_path}"
-                    )
-                for index, item in enumerate(value):
-                    if not isinstance(item, dict):
-                        raise TypeError(f"Expected mapping for {field_path}[{index}]")
-                    _walk(message_type, item, path=f"{field_path}[{index}]")
-            else:
-                if not isinstance(value, dict):
-                    raise TypeError(f"Expected mapping for message field {field_path}")
-                _walk(message_type, value, path=field_path)
-
-    _walk(message.DESCRIPTOR, values)
-
-
-def _prefix_base64_key(
-    security: dict[str, Any], normalized_key_map: dict[str, str], camel_name: str
-) -> None:
-    """Prefix a security key value with 'base64:' if it is a string or list of strings.
-
-    This helper normalizes base64-encoded security keys (privateKey, publicKey, adminKey)
-    so they are clearly marked as base64-encoded in exported configuration.
-
-    Parameters
-    ----------
-    security : dict[str, Any]
-        The security configuration dictionary to modify in-place.
-    normalized_key_map : dict[str, str]
-        Mapping from canonical camelCase names to actual keys in security dict.
-    camel_name : str
-        The canonical camelCase name of the key to process (e.g., "privateKey").
-    """
-    key = normalized_key_map.get(camel_name)
-    if not key:
-        return
-    val = security.get(key)
-    if isinstance(val, str):
-        if not val.startswith("base64:"):
-            security[key] = "base64:" + val
-    elif isinstance(val, list):
-        security[key] = [
-            ("base64:" + v if isinstance(v, str) and not v.startswith("base64:") else v)
-            for v in val
-        ]
-
-
-# Boolean flags that default to True in firmware but may be absent from
-# MessageToDict output; set missing values to False to preserve round-trip intent.
-CONFIG_TRUE_DEFAULTS: set[tuple[str, ...]] = {
-    ("bluetooth", "enabled"),
-    ("lora", "sx126xRxBoostedGain"),
-    ("lora", "txEnabled"),
-    ("lora", "usePreset"),
-    ("position", "positionBroadcastSmartEnabled"),
-    ("security", "serialEnabled"),
-}
-
-MODULE_TRUE_DEFAULTS: set[tuple[str, ...]] = {
-    ("mqtt", "encryptionEnabled"),
-}
+# COMPAT_STABLE_SHIM: preserve historical private helper imports.
+_is_repeated_field = cli_config_io.is_repeated_field
+_set_missing_flags_false = cli_config_io.set_missing_flags_false
+_prefix_base64_bytes_fields = cli_config_io.prefix_base64_bytes_fields
+_prefix_base64_key = cli_config_io.prefix_base64_key
+CONFIG_TRUE_DEFAULTS = cli_config_io.CONFIG_TRUE_DEFAULTS
+MODULE_TRUE_DEFAULTS = cli_config_io.MODULE_TRUE_DEFAULTS
 
 
 def exportConfig(interface: MeshInterface) -> str:
-    """Export local node and module configuration as a YAML-formatted Meshtastic configuration string.
-
-    Produces a YAML document containing selected top-level metadata (owner, owner_short, channel
-    URL, canned messages, ringtone, and location) plus `config` and `module_config` sections
-    derived from node's protobuf-backed settings. Key casing in the exported `config` and
-    `module_config` follows mt_config.camel_case. Certain boolean flags are explicitly set to
-    false if missing, and security key fields are normalized to include a "base64:" prefix when
-    appropriate.
-
-    Parameters
-    ----------
-    interface : MeshInterface
-        The connected interface whose local node and module configuration will be exported.
-
-    Returns
-    -------
-    str
-        A YAML string (prefixed with a header comment) representing exported configuration.
-    """
-    configObj: dict[str, Any] = {}
-
-    owner = interface.getLongName()
-    owner_short = interface.getShortName()
-    channel_url = interface.localNode.getURL()
-    myinfo = interface.getMyNodeInfo()
-    canned_messages = interface.getCannedMessage()
-    ringtone = interface.getRingtone()
-    pos = myinfo.get("position") if myinfo else None
-    lat = None
-    lon = None
-    alt = None
-    if pos:
-        lat = pos.get("latitude")
-        lon = pos.get("longitude")
-        alt = pos.get("altitude")
-
-    if owner:
-        configObj["owner"] = owner
-    if owner_short:
-        configObj["owner_short"] = owner_short
-    if channel_url:
-        if mt_config.camel_case:
-            configObj["channelUrl"] = channel_url
-        else:
-            configObj["channel_url"] = channel_url
-    if canned_messages:
-        configObj["canned_messages"] = canned_messages
-    if ringtone:
-        configObj["ringtone"] = ringtone
-    # lat and lon don't make much sense without the other (so fill with 0s), and alt isn't meaningful without both
-    if lat is not None or lon is not None:
-        configObj["location"] = {
-            "lat": lat if lat is not None else 0.0,
-            "lon": lon if lon is not None else 0.0,
-        }
-        if alt is not None:
-            configObj["location"]["alt"] = alt
-
-    config = MessageToDict(interface.localNode.localConfig)
-    if config:
-        _prefix_base64_bytes_fields(interface.localNode.localConfig, config)
-        # Ensure explicit false values are present before key conversion.
-        _set_missing_flags_false(config, CONFIG_TRUE_DEFAULTS)
-
-        # Convert inner keys to correct snake/camelCase.
-        prefs = {}
-        for pref, value in config.items():
-            pref_key = (
-                meshtastic.util.snake_to_camel(pref)
-                if mt_config.camel_case
-                else meshtastic.util.camel_to_snake(pref)
-            )
-            prefs[pref_key] = value
-        configObj["config"] = prefs
-
-    module_config = MessageToDict(interface.localNode.moduleConfig)
-    if module_config:
-        _prefix_base64_bytes_fields(interface.localNode.moduleConfig, module_config)
-        # Ensure explicit false values are present before key conversion.
-        _set_missing_flags_false(module_config, MODULE_TRUE_DEFAULTS)
-
-        # Convert inner keys to correct snake/camelCase.
-        prefs = {}
-        for pref, value in module_config.items():
-            pref_key = (
-                meshtastic.util.snake_to_camel(pref)
-                if mt_config.camel_case
-                else meshtastic.util.camel_to_snake(pref)
-            )
-            prefs[pref_key] = value
-        configObj["module_config"] = prefs
-
-    config_txt = "# start of Meshtastic configure yaml\n"
-    # was used as a string here and a Dictionary above
-    config_txt += yaml.dump(configObj)
-    return config_txt
+    """COMPAT_STABLE_SHIM: export configuration through the CLI config I/O runtime."""
+    return cli_config_io.export_config(
+        interface,
+        camel_case=mt_config.camel_case,
+        message_to_dict=MessageToDict,
+        prefix_base64_bytes_fields_fn=_prefix_base64_bytes_fields,
+        set_missing_flags_false_fn=_set_missing_flags_false,
+        config_true_defaults=CONFIG_TRUE_DEFAULTS,
+        module_true_defaults=MODULE_TRUE_DEFAULTS,
+    )
 
 
 # COMPAT_STABLE_SHIM: snake_case alias for exportConfig

--- a/meshtastic/cli/config_io.py
+++ b/meshtastic/cli/config_io.py
@@ -343,15 +343,15 @@ def export_config(
             config_obj["location"]["alt"] = altitude
 
     config = message_to_dict(interface.localNode.localConfig)
+    prefix_base64_bytes_fields_fn(interface.localNode.localConfig, config)
+    set_missing_flags_false_fn(config, config_true_defaults)
     if config:
-        prefix_base64_bytes_fields_fn(interface.localNode.localConfig, config)
-        set_missing_flags_false_fn(config, config_true_defaults)
         config_obj["config"] = _converted_section_keys(config, camel_case=camel_case)
 
     module_config = message_to_dict(interface.localNode.moduleConfig)
+    prefix_base64_bytes_fields_fn(interface.localNode.moduleConfig, module_config)
+    set_missing_flags_false_fn(module_config, module_true_defaults)
     if module_config:
-        prefix_base64_bytes_fields_fn(interface.localNode.moduleConfig, module_config)
-        set_missing_flags_false_fn(module_config, module_true_defaults)
         config_obj["module_config"] = _converted_section_keys(
             module_config, camel_case=camel_case
         )

--- a/meshtastic/cli/config_io.py
+++ b/meshtastic/cli/config_io.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from typing import Any, Protocol
 
 import yaml
@@ -118,31 +118,35 @@ def is_repeated_field(field_desc: Any) -> bool:
 
 
 def set_missing_flags_false(
-    config_dict: dict[str, Any], true_defaults: set[tuple[str, ...]]
+    config_dict: MutableMapping[str, Any], true_defaults: set[tuple[str, ...]]
 ) -> None:
     """Materialize omitted firmware-true boolean defaults as explicit ``False``.
 
     Parameters
     ----------
-    config_dict : dict[str, Any]
-        Nested configuration dictionary modified in place.
+    config_dict : MutableMapping[str, Any]
+        Nested configuration mapping modified in place.
     true_defaults : set[tuple[str, ...]]
         Key paths whose missing final key should be created with ``False``.
     """
     for path in true_defaults:
         current = config_dict
         for key in path[:-1]:
-            if key not in current or not isinstance(current[key], dict):
+            if key not in current or not isinstance(current[key], MutableMapping):
                 current[key] = {}
             current = current[key]
         if path[-1] not in current:
             current[path[-1]] = False
 
 
-def prefix_base64_bytes_fields(message: Message, values: dict[str, Any]) -> None:
+def prefix_base64_bytes_fields(
+    message: Message, values: MutableMapping[str, Any]
+) -> None:
     """Mark every protobuf bytes field in a ``MessageToDict`` mapping as base64."""
 
-    def _field_key(field: FieldDescriptor, mapping: dict[str, Any]) -> str | None:
+    def _field_key(
+        field: FieldDescriptor, mapping: MutableMapping[str, Any]
+    ) -> str | None:
         json_name: str = getattr(field, "json_name", field.name)
         for candidate in (json_name, field.name):
             if candidate in mapping:
@@ -164,7 +168,7 @@ def prefix_base64_bytes_fields(message: Message, values: dict[str, Any]) -> None
         raise TypeError(f"Expected base64 string for bytes field {field_path}")
 
     def _walk(
-        descriptor: DescriptorLike, mapping: dict[str, Any], *, path: str = ""
+        descriptor: DescriptorLike, mapping: MutableMapping[str, Any], *, path: str = ""
     ) -> None:
         for field in descriptor.fields:
             key = _field_key(field, mapping)
@@ -181,7 +185,7 @@ def prefix_base64_bytes_fields(message: Message, values: dict[str, Any]) -> None
             message_type = field.message_type
             if message_type.GetOptions().map_entry:
                 value_field = message_type.fields_by_name["value"]
-                if not isinstance(value, dict):
+                if not isinstance(value, MutableMapping):
                     raise TypeError(
                         f"Expected mapping for protobuf map field {field_path}"
                     )
@@ -192,7 +196,7 @@ def prefix_base64_bytes_fields(message: Message, values: dict[str, Any]) -> None
                         )
                 elif value_field.type == FieldDescriptor.TYPE_MESSAGE:
                     for map_key, map_value in value.items():
-                        if not isinstance(map_value, dict):
+                        if not isinstance(map_value, MutableMapping):
                             raise TypeError(
                                 "Expected mapping for protobuf message map value "
                                 f"{field_path}[{map_key!r}]"
@@ -210,17 +214,18 @@ def prefix_base64_bytes_fields(message: Message, values: dict[str, Any]) -> None
                         f"Expected list for repeated message field {field_path}"
                     )
                 for index, item in enumerate(value):
-                    if not isinstance(item, dict):
+                    if not isinstance(item, MutableMapping):
                         raise TypeError(f"Expected mapping for {field_path}[{index}]")
                     _walk(message_type, item, path=f"{field_path}[{index}]")
             else:
-                if not isinstance(value, dict):
+                if not isinstance(value, MutableMapping):
                     raise TypeError(f"Expected mapping for message field {field_path}")
                 _walk(message_type, value, path=field_path)
 
     _walk(message.DESCRIPTOR, values)
 
 
+# COMPAT_STABLE_SHIM: implementation backing meshtastic.__main__._prefix_base64_key.
 def prefix_base64_key(
     security: dict[str, Any], normalized_key_map: dict[str, str], camel_name: str
 ) -> None:
@@ -244,7 +249,7 @@ def prefix_base64_key(
 
 
 def _converted_section_keys(
-    values: dict[str, Any], *, camel_case: bool
+    values: Mapping[str, Any], *, camel_case: bool
 ) -> dict[str, Any]:
     """Return a shallow copy with top-level section names in requested casing."""
     converted: dict[str, Any] = {}
@@ -262,15 +267,15 @@ def export_config(
     interface: MeshInterface,
     *,
     camel_case: bool,
-    message_to_dict: Callable[[Message], dict[str, Any]] = MessageToDict,
+    message_to_dict: Callable[[Message], MutableMapping[str, Any]] = MessageToDict,
     prefix_base64_bytes_fields_fn: Callable[
-        [Message, dict[str, Any]], None
+        [Message, MutableMapping[str, Any]], None
     ] = prefix_base64_bytes_fields,
     set_missing_flags_false_fn: Callable[
-        [dict[str, Any], set[tuple[str, ...]]], None
+        [MutableMapping[str, Any], set[tuple[str, ...]]], None
     ] = set_missing_flags_false,
-    config_true_defaults: set[tuple[str, ...]] = CONFIG_TRUE_DEFAULTS,
-    module_true_defaults: set[tuple[str, ...]] = MODULE_TRUE_DEFAULTS,
+    config_true_defaults: set[tuple[str, ...]] | None = None,
+    module_true_defaults: set[tuple[str, ...]] | None = None,
 ) -> str:
     """Export local node and module configuration as Meshtastic YAML.
 
@@ -280,25 +285,32 @@ def export_config(
         Connected interface whose local node state should be exported.
     camel_case : bool
         Whether exported configuration section keys use camelCase.
-    message_to_dict : Callable[[Message], dict[str, Any]]
+    message_to_dict : Callable[[Message], MutableMapping[str, Any]]
         Protobuf-to-dictionary converter. The compatibility facade injects its
         current module-level symbol so monkeypatches continue to take effect.
-    prefix_base64_bytes_fields_fn : Callable[[Message, dict[str, Any]], None]
+    prefix_base64_bytes_fields_fn : Callable[[Message, MutableMapping[str, Any]], None]
         Bytes-field normalizer injected by the compatibility facade.
-    set_missing_flags_false_fn : Callable[[dict[str, Any], set[tuple[str, ...]]], None]
+    set_missing_flags_false_fn : Callable[[MutableMapping[str, Any], set[tuple[str, ...]]], None]
         Missing-default materializer injected by the compatibility facade.
-    config_true_defaults : set[tuple[str, ...]]
-        Local-config paths whose omitted firmware-true defaults are exported as
-        explicit ``False`` values.
-    module_true_defaults : set[tuple[str, ...]]
-        Module-config paths whose omitted firmware-true defaults are exported as
-        explicit ``False`` values.
+    config_true_defaults : set[tuple[str, ...]] | None
+        Optional local-config paths whose omitted firmware-true defaults are
+        exported as explicit ``False`` values.
+    module_true_defaults : set[tuple[str, ...]] | None
+        Optional module-config paths whose omitted firmware-true defaults are
+        exported as explicit ``False`` values.
 
     Returns
     -------
     str
         YAML text prefixed with the historical configure-file header.
     """
+    config_true_defaults = (
+        CONFIG_TRUE_DEFAULTS if config_true_defaults is None else config_true_defaults
+    )
+    module_true_defaults = (
+        MODULE_TRUE_DEFAULTS if module_true_defaults is None else module_true_defaults
+    )
+
     config_obj: dict[str, Any] = {}
 
     owner = interface.getLongName()

--- a/meshtastic/cli/config_io.py
+++ b/meshtastic/cli/config_io.py
@@ -1,0 +1,347 @@
+"""Configuration presentation and YAML export helpers for the Meshtastic CLI."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any, Protocol
+
+import yaml
+from google.protobuf.descriptor import FieldDescriptor
+from google.protobuf.json_format import MessageToDict
+from google.protobuf.message import Message
+
+import meshtastic.util
+from meshtastic.mesh_interface import MeshInterface
+from meshtastic.protobuf import localonly_pb2
+
+
+class DescriptorLike(Protocol):
+    """Structural descriptor type shared by pure-Python and upb protobuf runtimes."""
+
+    @property
+    def fields(self) -> Sequence[FieldDescriptor]:
+        """Return fields declared by this message descriptor."""
+
+
+CONFIG_TRUE_DEFAULTS: set[tuple[str, ...]] = {
+    ("bluetooth", "enabled"),
+    ("lora", "sx126xRxBoostedGain"),
+    ("lora", "txEnabled"),
+    ("lora", "usePreset"),
+    ("position", "positionBroadcastSmartEnabled"),
+    ("security", "serialEnabled"),
+}
+
+MODULE_TRUE_DEFAULTS: set[tuple[str, ...]] = {
+    ("mqtt", "encryptionEnabled"),
+}
+
+
+def print_config(config: Any, *, camel_case: bool) -> None:
+    """Print top-level configuration sections and their writable fields.
+
+    Parameters
+    ----------
+    config : Any
+        Protobuf-like configuration message exposing a ``DESCRIPTOR``.
+    camel_case : bool
+        Whether field paths should be rendered in camelCase.
+    """
+    descriptor = config.DESCRIPTOR
+    for config_section in descriptor.fields:
+        if config_section.name == "version":
+            continue
+        section_field = descriptor.fields_by_name.get(config_section.name)
+        if section_field is None or section_field.message_type is None:
+            continue
+        print(f"{config_section.name}:")
+        names = []
+        for field in section_field.message_type.fields:
+            field_name = f"{config_section.name}.{field.name}"
+            if camel_case:
+                field_name = meshtastic.util.snake_to_camel(field_name)
+            names.append(field_name)
+        for field_name in sorted(names):
+            print(f"    {field_name}")
+
+
+def print_available_config_fields(
+    *,
+    camel_case: bool,
+    aliases: Mapping[str, str],
+    display_pref_name: Callable[[str], str],
+    local_config_factory: Callable[[], Any] = localonly_pb2.LocalConfig,
+    module_config_factory: Callable[[], Any] = localonly_pb2.LocalModuleConfig,
+) -> None:
+    """Print current local/module fields and compatibility aliases.
+
+    Parameters
+    ----------
+    camel_case : bool
+        Whether config fields should be rendered in camelCase.
+    aliases : Mapping[str, str]
+        Compatibility aliases mapped to canonical preference paths.
+    display_pref_name : Callable[[str], str]
+        Formatter used for alias names so legacy CLI casing is preserved.
+    local_config_factory : Callable[[], Any]
+        Factory for the local-configuration wrapper. This is injectable so the
+        historical ``meshtastic.__main__.localonly_pb2`` monkeypatch seam is
+        preserved by the compatibility facade.
+    module_config_factory : Callable[[], Any]
+        Factory for the module-configuration wrapper, with the same compatibility
+        injection semantics as ``local_config_factory``.
+    """
+    print("Local config fields:")
+    print_config(local_config_factory(), camel_case=camel_case)
+    print("")
+    print("Module config fields:")
+    print_config(module_config_factory(), camel_case=camel_case)
+    if aliases:
+        print("")
+        print("Compatibility aliases:")
+        for alias_name, canonical_name in sorted(aliases.items()):
+            print(
+                f"    {display_pref_name(alias_name)} -> "
+                f"{display_pref_name(canonical_name)}"
+            )
+
+
+def is_repeated_field(field_desc: Any) -> bool:
+    """Return whether a protobuf descriptor represents a repeated field."""
+    is_repeated = getattr(field_desc, "is_repeated", None)
+    if isinstance(is_repeated, bool):
+        return is_repeated
+
+    label = getattr(field_desc, "label", None)
+    label_repeated = getattr(field_desc, "LABEL_REPEATED", None)
+    return label is not None and label == label_repeated
+
+
+def set_missing_flags_false(
+    config_dict: dict[str, Any], true_defaults: set[tuple[str, ...]]
+) -> None:
+    """Materialize omitted firmware-true boolean defaults as explicit ``False``.
+
+    Parameters
+    ----------
+    config_dict : dict[str, Any]
+        Nested configuration dictionary modified in place.
+    true_defaults : set[tuple[str, ...]]
+        Key paths whose missing final key should be created with ``False``.
+    """
+    for path in true_defaults:
+        current = config_dict
+        for key in path[:-1]:
+            if key not in current or not isinstance(current[key], dict):
+                current[key] = {}
+            current = current[key]
+        if path[-1] not in current:
+            current[path[-1]] = False
+
+
+def prefix_base64_bytes_fields(message: Message, values: dict[str, Any]) -> None:
+    """Mark every protobuf bytes field in a ``MessageToDict`` mapping as base64."""
+
+    def _field_key(field: FieldDescriptor, mapping: dict[str, Any]) -> str | None:
+        json_name: str = getattr(field, "json_name", field.name)
+        for candidate in (json_name, field.name):
+            if candidate in mapping:
+                return candidate
+        return None
+
+    def _prefix_bytes(value: Any, *, field_path: str) -> Any:
+        if isinstance(value, str):
+            return value if value.startswith("base64:") else f"base64:{value}"
+        if isinstance(value, list):
+            if not all(isinstance(item, str) for item in value):
+                raise TypeError(
+                    f"Expected base64 strings for repeated bytes field {field_path}"
+                )
+            return [
+                item if item.startswith("base64:") else f"base64:{item}"
+                for item in value
+            ]
+        raise TypeError(f"Expected base64 string for bytes field {field_path}")
+
+    def _walk(
+        descriptor: DescriptorLike, mapping: dict[str, Any], *, path: str = ""
+    ) -> None:
+        for field in descriptor.fields:
+            key = _field_key(field, mapping)
+            if key is None:
+                continue
+            value = mapping[key]
+            field_path = f"{path}.{field.name}" if path else field.name
+            if field.type == FieldDescriptor.TYPE_BYTES:
+                mapping[key] = _prefix_bytes(value, field_path=field_path)
+                continue
+            if field.type != FieldDescriptor.TYPE_MESSAGE:
+                continue
+
+            message_type = field.message_type
+            if message_type.GetOptions().map_entry:
+                value_field = message_type.fields_by_name["value"]
+                if not isinstance(value, dict):
+                    raise TypeError(
+                        f"Expected mapping for protobuf map field {field_path}"
+                    )
+                if value_field.type == FieldDescriptor.TYPE_BYTES:
+                    for map_key, map_value in value.items():
+                        value[map_key] = _prefix_bytes(
+                            map_value, field_path=f"{field_path}[{map_key!r}]"
+                        )
+                elif value_field.type == FieldDescriptor.TYPE_MESSAGE:
+                    for map_key, map_value in value.items():
+                        if not isinstance(map_value, dict):
+                            raise TypeError(
+                                "Expected mapping for protobuf message map value "
+                                f"{field_path}[{map_key!r}]"
+                            )
+                        _walk(
+                            value_field.message_type,
+                            map_value,
+                            path=f"{field_path}[{map_key!r}]",
+                        )
+                continue
+
+            if is_repeated_field(field):
+                if not isinstance(value, list):
+                    raise TypeError(
+                        f"Expected list for repeated message field {field_path}"
+                    )
+                for index, item in enumerate(value):
+                    if not isinstance(item, dict):
+                        raise TypeError(f"Expected mapping for {field_path}[{index}]")
+                    _walk(message_type, item, path=f"{field_path}[{index}]")
+            else:
+                if not isinstance(value, dict):
+                    raise TypeError(f"Expected mapping for message field {field_path}")
+                _walk(message_type, value, path=field_path)
+
+    _walk(message.DESCRIPTOR, values)
+
+
+def prefix_base64_key(
+    security: dict[str, Any], normalized_key_map: dict[str, str], camel_name: str
+) -> None:
+    """Prefix a security key value with ``base64:`` when needed."""
+    key = normalized_key_map.get(camel_name)
+    if not key:
+        return
+    value = security.get(key)
+    if isinstance(value, str):
+        if not value.startswith("base64:"):
+            security[key] = "base64:" + value
+    elif isinstance(value, list):
+        security[key] = [
+            (
+                "base64:" + item
+                if isinstance(item, str) and not item.startswith("base64:")
+                else item
+            )
+            for item in value
+        ]
+
+
+def _converted_section_keys(
+    values: dict[str, Any], *, camel_case: bool
+) -> dict[str, Any]:
+    """Return a shallow copy with top-level section names in requested casing."""
+    converted: dict[str, Any] = {}
+    for preference, value in values.items():
+        key = (
+            meshtastic.util.snake_to_camel(preference)
+            if camel_case
+            else meshtastic.util.camel_to_snake(preference)
+        )
+        converted[key] = value
+    return converted
+
+
+def export_config(
+    interface: MeshInterface,
+    *,
+    camel_case: bool,
+    message_to_dict: Callable[[Message], dict[str, Any]] = MessageToDict,
+    prefix_base64_bytes_fields_fn: Callable[
+        [Message, dict[str, Any]], None
+    ] = prefix_base64_bytes_fields,
+    set_missing_flags_false_fn: Callable[
+        [dict[str, Any], set[tuple[str, ...]]], None
+    ] = set_missing_flags_false,
+    config_true_defaults: set[tuple[str, ...]] = CONFIG_TRUE_DEFAULTS,
+    module_true_defaults: set[tuple[str, ...]] = MODULE_TRUE_DEFAULTS,
+) -> str:
+    """Export local node and module configuration as Meshtastic YAML.
+
+    Parameters
+    ----------
+    interface : MeshInterface
+        Connected interface whose local node state should be exported.
+    camel_case : bool
+        Whether exported configuration section keys use camelCase.
+    message_to_dict : Callable[[Message], dict[str, Any]]
+        Protobuf-to-dictionary converter. The compatibility facade injects its
+        current module-level symbol so monkeypatches continue to take effect.
+    prefix_base64_bytes_fields_fn : Callable[[Message, dict[str, Any]], None]
+        Bytes-field normalizer injected by the compatibility facade.
+    set_missing_flags_false_fn : Callable[[dict[str, Any], set[tuple[str, ...]]], None]
+        Missing-default materializer injected by the compatibility facade.
+    config_true_defaults : set[tuple[str, ...]]
+        Local-config paths whose omitted firmware-true defaults are exported as
+        explicit ``False`` values.
+    module_true_defaults : set[tuple[str, ...]]
+        Module-config paths whose omitted firmware-true defaults are exported as
+        explicit ``False`` values.
+
+    Returns
+    -------
+    str
+        YAML text prefixed with the historical configure-file header.
+    """
+    config_obj: dict[str, Any] = {}
+
+    owner = interface.getLongName()
+    owner_short = interface.getShortName()
+    channel_url = interface.localNode.getURL()
+    my_info = interface.getMyNodeInfo()
+    canned_messages = interface.getCannedMessage()
+    ringtone = interface.getRingtone()
+    position = my_info.get("position") if my_info else None
+    latitude = position.get("latitude") if position else None
+    longitude = position.get("longitude") if position else None
+    altitude = position.get("altitude") if position else None
+
+    if owner:
+        config_obj["owner"] = owner
+    if owner_short:
+        config_obj["owner_short"] = owner_short
+    if channel_url:
+        config_obj["channelUrl" if camel_case else "channel_url"] = channel_url
+    if canned_messages:
+        config_obj["canned_messages"] = canned_messages
+    if ringtone:
+        config_obj["ringtone"] = ringtone
+    if latitude is not None or longitude is not None:
+        config_obj["location"] = {
+            "lat": latitude if latitude is not None else 0.0,
+            "lon": longitude if longitude is not None else 0.0,
+        }
+        if altitude is not None:
+            config_obj["location"]["alt"] = altitude
+
+    config = message_to_dict(interface.localNode.localConfig)
+    if config:
+        prefix_base64_bytes_fields_fn(interface.localNode.localConfig, config)
+        set_missing_flags_false_fn(config, config_true_defaults)
+        config_obj["config"] = _converted_section_keys(config, camel_case=camel_case)
+
+    module_config = message_to_dict(interface.localNode.moduleConfig)
+    if module_config:
+        prefix_base64_bytes_fields_fn(interface.localNode.moduleConfig, module_config)
+        set_missing_flags_false_fn(module_config, module_true_defaults)
+        config_obj["module_config"] = _converted_section_keys(
+            module_config, camel_case=camel_case
+        )
+
+    return "# start of Meshtastic configure yaml\n" + yaml.dump(config_obj)

--- a/meshtastic/tests/test_cli_config_io_compat.py
+++ b/meshtastic/tests/test_cli_config_io_compat.py
@@ -1,0 +1,71 @@
+"""Compatibility seams for the extracted CLI configuration I/O runtime."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import meshtastic.__main__ as main_module
+
+
+@pytest.mark.unit
+def test_export_config_facade_injects_current_main_module_shims(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy monkeypatches on ``meshtastic.__main__`` must still affect export."""
+    prefix = MagicMock()
+    materialize = MagicMock()
+    message_to_dict = MagicMock()
+    config_defaults = {("device", "serial_enabled")}
+    module_defaults = {("mqtt", "enabled")}
+    monkeypatch.setattr(main_module, "_prefix_base64_bytes_fields", prefix)
+    monkeypatch.setattr(main_module, "_set_missing_flags_false", materialize)
+    monkeypatch.setattr(main_module, "MessageToDict", message_to_dict)
+    monkeypatch.setattr(main_module, "CONFIG_TRUE_DEFAULTS", config_defaults)
+    monkeypatch.setattr(main_module, "MODULE_TRUE_DEFAULTS", module_defaults)
+
+    iface = MagicMock()
+    with patch.object(
+        main_module.cli_config_io,
+        "export_config",
+        return_value="exported",
+    ) as runtime_export:
+        result = main_module.exportConfig(iface)
+
+    assert result == "exported"
+    runtime_export.assert_called_once_with(
+        iface,
+        camel_case=main_module.mt_config.camel_case,
+        message_to_dict=message_to_dict,
+        prefix_base64_bytes_fields_fn=prefix,
+        set_missing_flags_false_fn=materialize,
+        config_true_defaults=config_defaults,
+        module_true_defaults=module_defaults,
+    )
+
+
+@pytest.mark.unit
+def test_print_available_fields_facade_uses_current_localonly_factories(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replacing the legacy localonly module must still affect field discovery."""
+    local_factory = MagicMock()
+    module_factory = MagicMock()
+    monkeypatch.setattr(
+        main_module,
+        "localonly_pb2",
+        SimpleNamespace(
+            LocalConfig=local_factory,
+            LocalModuleConfig=module_factory,
+        ),
+    )
+
+    with patch.object(
+        main_module.cli_config_io,
+        "print_available_config_fields",
+    ) as runtime_print:
+        main_module.printAvailableConfigFields()
+
+    kwargs = runtime_print.call_args.kwargs
+    assert kwargs["local_config_factory"] is local_factory
+    assert kwargs["module_config_factory"] is module_factory

--- a/meshtastic/tests/test_cli_config_io_compat.py
+++ b/meshtastic/tests/test_cli_config_io_compat.py
@@ -93,6 +93,10 @@ def test_is_repeated_field_supports_legacy_descriptor_labels() -> None:
     singular = SimpleNamespace(label=1, LABEL_REPEATED=3)
     missing_label = SimpleNamespace(LABEL_REPEATED=3)
 
-    assert main_module.cli_config_io.is_repeated_field(repeated) is True
-    assert main_module.cli_config_io.is_repeated_field(singular) is False
-    assert main_module.cli_config_io.is_repeated_field(missing_label) is False
+    for descriptor, expected in (
+        (repeated, True),
+        (singular, False),
+        (missing_label, False),
+    ):
+        assert main_module.cli_config_io.is_repeated_field(descriptor) is expected
+        assert main_module._is_repeated_field(descriptor) is expected

--- a/meshtastic/tests/test_cli_config_io_compat.py
+++ b/meshtastic/tests/test_cli_config_io_compat.py
@@ -69,3 +69,18 @@ def test_print_available_fields_facade_uses_current_localonly_factories(
     kwargs = runtime_print.call_args.kwargs
     assert kwargs["local_config_factory"] is local_factory
     assert kwargs["module_config_factory"] is module_factory
+
+
+@pytest.mark.unit
+def test_print_config_facade_uses_current_camel_case_setting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy ``printConfig`` should delegate with the current CLI casing mode."""
+    config = MagicMock()
+    runtime_print = MagicMock()
+    monkeypatch.setattr(main_module.cli_config_io, "print_config", runtime_print)
+    monkeypatch.setattr(main_module.mt_config, "camel_case", True)
+
+    main_module.printConfig(config)
+
+    runtime_print.assert_called_once_with(config, camel_case=True)

--- a/meshtastic/tests/test_cli_config_io_compat.py
+++ b/meshtastic/tests/test_cli_config_io_compat.py
@@ -84,3 +84,15 @@ def test_print_config_facade_uses_current_camel_case_setting(
     main_module.printConfig(config)
 
     runtime_print.assert_called_once_with(config, camel_case=True)
+
+
+@pytest.mark.unit
+def test_is_repeated_field_supports_legacy_descriptor_labels() -> None:
+    """Legacy protobuf descriptors should fall back to label comparison."""
+    repeated = SimpleNamespace(label=3, LABEL_REPEATED=3)
+    singular = SimpleNamespace(label=1, LABEL_REPEATED=3)
+    missing_label = SimpleNamespace(LABEL_REPEATED=3)
+
+    assert main_module.cli_config_io.is_repeated_field(repeated) is True
+    assert main_module.cli_config_io.is_repeated_field(singular) is False
+    assert main_module.cli_config_io.is_repeated_field(missing_label) is False

--- a/meshtastic/tests/test_cli_config_io_export.py
+++ b/meshtastic/tests/test_cli_config_io_export.py
@@ -1,0 +1,32 @@
+"""Regression tests for CLI configuration export normalization."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+from meshtastic.cli.config_io import export_config
+from meshtastic.protobuf import localonly_pb2
+
+
+@pytest.mark.unit
+def test_empty_config_mappings_export_firmware_true_defaults_as_false() -> None:
+    """Empty protobuf mappings must still preserve firmware-true settings."""
+    interface = MagicMock()
+    interface.getLongName.return_value = None
+    interface.getShortName.return_value = None
+    interface.getMyNodeInfo.return_value = None
+    interface.getCannedMessage.return_value = None
+    interface.getRingtone.return_value = None
+    interface.localNode = SimpleNamespace(
+        localConfig=localonly_pb2.LocalConfig(),
+        moduleConfig=localonly_pb2.LocalModuleConfig(),
+        getURL=lambda: None,
+    )
+
+    exported = yaml.safe_load(export_config(interface, camel_case=False))
+
+    assert exported["config"]["bluetooth"]["enabled"] is False
+    assert exported["config"]["lora"]["txEnabled"] is False
+    assert exported["module_config"]["mqtt"]["encryptionEnabled"] is False


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR extracts CLI configuration presentation and export logic into `meshtastic.cli.config_io`. `meshtastic.__main__` now delegates these operations while preserving historical helper names and monkeypatch behavior. Tests cover compatibility seams and legacy protobuf descriptors.

## Key changes

### Features
- Added `print_config` for configuration display.
- Added `print_available_config_fields` for writable field discovery.
- Added `export_config` for local and module configuration YAML export.
- Added helpers for:
  - Repeated protobuf field detection.
  - Missing boolean defaults.
  - Base64 encoding of protobuf byte fields.
  - Legacy security-key handling.
- Added injectable factories and conversion functions for testing and compatibility.

### Fixes
- Preserved legacy protobuf repeated-field detection using descriptor labels.
- Preserved `localonly` configuration factory behavior.
- Preserved legacy monkeypatches applied through `meshtastic.__main__`.
- Preserved the current camel-case setting during configuration printing.

### Refactors
- Moved configuration I/O implementations from `meshtastic.__main__` to `meshtastic.cli.config_io`.
- Kept compatibility aliases for historical private helpers and constants.
- Removed the local protobuf `Message` import and duplicate implementations from `__main__.py`.
- Added tests in `meshtastic/tests/test_cli_config_io_compat.py`.

## Breaking changes and migration

No breaking changes are intended. Existing callers can continue to use the compatibility names in `meshtastic.__main__`. New code should use `meshtastic.cli.config_io`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->