### PR TITLE
Scope remote admin ACK waits by request

### DIFF
--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -1360,6 +1360,10 @@ class MeshInterface:  # pylint: disable=R0902
         """
         self._send_pipeline.waitForConfig()
 
+    def _wait_for_ack_nak(self, request_id: int) -> None:
+        """Wait for the ACK/NAK correlated to one internal request id."""
+        self._send_pipeline._wait_for_ack_nak(request_id)
+
     def waitForAckNak(self) -> None:
         """Wait until an acknowledgement (ACK) or negative acknowledgement (NAK) is received or the wait times out.
 

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -1064,6 +1064,14 @@ class MeshInterface:  # pylint: disable=R0902
             request_id=request_id,
         )
 
+    def _has_active_wait_request(
+        self, acknowledgment_attr: str, request_id: int
+    ) -> bool:
+        """Return whether one request is active in the given wait scope."""
+        return self._send_pipeline._has_active_wait_request(
+            acknowledgment_attr, request_id
+        )
+
     def _wait_for_request_ack(
         self,
         acknowledgment_attr: str,

--- a/meshtastic/mesh_interface_runtime/request_wait.py
+++ b/meshtastic/mesh_interface_runtime/request_wait.py
@@ -394,6 +394,16 @@ class _RequestWaitRuntime:
         if request_id is None:
             setattr(self._get_acknowledgment(), acknowledgment_attr, False)
 
+    def has_active_wait_request(
+        self, acknowledgment_attr: str, request_id: int
+    ) -> bool:
+        """Return whether one request id is active for an acknowledgment scope."""
+        with self._lock:
+            active_request_ids = self._get_active_wait_request_ids().get(
+                acknowledgment_attr
+            )
+            return active_request_ids is not None and request_id in active_request_ids
+
     def wait_for_request_ack(
         self,
         acknowledgment_attr: str,

--- a/meshtastic/mesh_interface_runtime/send_pipeline.py
+++ b/meshtastic/mesh_interface_runtime/send_pipeline.py
@@ -778,6 +778,22 @@ class SendPipeline:
                 "Timed out waiting for interface config"
             )
 
+    def _wait_for_ack_nak(self, request_id: int) -> None:
+        """Wait for one request-scoped admin ACK/NAK response."""
+        try:
+            success = self._wait_for_request_ack(
+                WAIT_ATTR_NAK,
+                request_id,
+                timeout_seconds=self._timeout.expireTimeout,
+            )
+            self._raise_wait_error_if_present(WAIT_ATTR_NAK, request_id=request_id)
+            if not success:
+                raise self._interface.MeshInterfaceError(
+                    "Timed out waiting for an acknowledgment"
+                )
+        finally:
+            self._retire_wait_request(WAIT_ATTR_NAK, request_id=request_id)
+
     def waitForAckNak(self) -> None:
         """Wait until an acknowledgement (ACK) or negative acknowledgement (NAK) is received or the wait times out."""
         success = self._timeout.waitForAckNak(self._acknowledgment)

--- a/meshtastic/mesh_interface_runtime/send_pipeline.py
+++ b/meshtastic/mesh_interface_runtime/send_pipeline.py
@@ -469,6 +469,14 @@ class SendPipeline:
             request_id=request_id,
         )
 
+    def _has_active_wait_request(
+        self, acknowledgment_attr: str, request_id: int
+    ) -> bool:
+        """Return whether one request is active in the given wait scope."""
+        return self._request_wait_runtime.has_active_wait_request(
+            acknowledgment_attr, request_id
+        )
+
     def _wait_for_request_ack(
         self,
         acknowledgment_attr: str,

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -20,6 +20,10 @@ from meshtastic.node_runtime.channel_presentation_runtime import (
     _NodeChannelPresentationRuntime,
 )
 from meshtastic.node_runtime.channel_request_runtime import _NodeChannelRequestRuntime
+from meshtastic.node_runtime.admin_wait import (
+    _send_admin_with_ack_scope,
+    _wait_for_admin_ack,
+)
 from meshtastic.node_runtime import contact_runtime
 from meshtastic.node_runtime.settings_runtime import (
     _NodeAdminCommandRuntime,
@@ -1333,8 +1337,14 @@ class Node:  # pylint: disable=too-many-instance-attributes
         with self._metadata_stdout_event_lock:
             self._metadata_stdout_event = metadata_stdout_event
         try:
-            self._send_admin(p, wantResponse=True, onResponse=self.onRequestGetMetadata)
-            self.iface.waitForAckNak()
+            request = _send_admin_with_ack_scope(
+                self,
+                p,
+                scope_ack=True,
+                wantResponse=True,
+                onResponse=self.onRequestGetMetadata,
+            )
+            _wait_for_admin_ack(self, request)
             if sys.stdout is not sys.__stdout__:
                 callback_completed = metadata_stdout_event.wait(
                     METADATA_STDOUT_COMPAT_WAIT_SECONDS

--- a/meshtastic/node_runtime/admin_wait.py
+++ b/meshtastic/node_runtime/admin_wait.py
@@ -1,0 +1,145 @@
+"""Request-scoped wait helpers for remote admin operations."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from meshtastic.protobuf import admin_pb2, mesh_pb2
+
+WAIT_ATTR_NAK = "receivedNak"
+
+if TYPE_CHECKING:
+    from meshtastic.node import Node
+
+
+def _extract_request_id_from_sent_packet(
+    node: "Node", request: mesh_pb2.MeshPacket | None
+) -> int | None:
+    """Return a positive request id from a sent packet when available."""
+    if request is None:
+        return None
+    extract_request_id = getattr(
+        node.iface,
+        "_extract_request_id_from_sent_packet",
+        None,
+    )
+    if callable(extract_request_id):
+        request_id = extract_request_id(request)
+        if isinstance(request_id, int) and not isinstance(request_id, bool):
+            return request_id if request_id > 0 else None
+        return None
+
+    raw_request_id = getattr(request, "id", None)
+    if isinstance(raw_request_id, int) and not isinstance(raw_request_id, bool):
+        return raw_request_id if raw_request_id > 0 else None
+    return None
+
+
+def _extract_request_id_from_response(
+    node: "Node", packet: dict[str, Any]
+) -> int | None:
+    """Return the request id carried by a decoded response packet when available."""
+    extract_request_id = getattr(node.iface, "_extract_request_id_from_packet", None)
+    if not callable(extract_request_id):
+        return None
+    request_id = extract_request_id(packet)
+    if isinstance(request_id, int) and not isinstance(request_id, bool):
+        return request_id if request_id > 0 else None
+    return None
+
+
+def _mark_admin_wait_acknowledged(node: "Node", request_id: int | None) -> None:
+    """Mark a request-scoped admin wait complete while preserving legacy flags."""
+    mark_wait_acknowledged = getattr(node.iface, "_mark_wait_acknowledged", None)
+    if callable(mark_wait_acknowledged):
+        mark_wait_acknowledged(WAIT_ATTR_NAK, request_id=request_id)
+
+
+def _set_admin_wait_error(
+    node: "Node",
+    message: str,
+    *,
+    request_id: int | None,
+) -> None:
+    """Record an admin wait error for both scoped and legacy wait paths."""
+    set_wait_error = getattr(node.iface, "_set_wait_error", None)
+    if not callable(set_wait_error):
+        return
+    set_wait_error(WAIT_ATTR_NAK, message)
+    if request_id is not None:
+        set_wait_error(WAIT_ATTR_NAK, message, request_id=request_id)
+
+
+def _accepts_response_wait_attr(send_admin: Callable[..., Any]) -> bool:
+    """Return whether a bound admin sender accepts the private wait keyword."""
+    try:
+        parameters = inspect.signature(send_admin).parameters.values()
+    except (TypeError, ValueError):
+        return False
+    return any(
+        parameter.name == "responseWaitAttr"
+        or parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters
+    )
+
+
+def _send_admin_with_ack_scope(
+    node: "Node",
+    message: admin_pb2.AdminMessage,
+    *,
+    scope_ack: bool,
+    **kwargs: Any,
+) -> mesh_pb2.MeshPacket | None:
+    """Send through the real Node transport with pre-registered ACK scope.
+
+    Instance-level test doubles and compatibility monkeypatches historically
+    replace ``Node._send_admin`` with simpler callables that do not accept the
+    private ``responseWaitAttr`` keyword. Preserve that seam while enabling
+    request-scoped bookkeeping for the real bound method.
+    """
+    send_admin = node._send_admin  # noqa: SLF001
+    scoped_send = _get_bound_interface_helper(node, "_send_data_with_wait")
+    if (
+        scope_ack
+        and getattr(send_admin, "__self__", None) is node
+        and scoped_send is not None
+        and _accepts_response_wait_attr(send_admin)
+    ):
+        kwargs["responseWaitAttr"] = WAIT_ATTR_NAK
+    return send_admin(message, **kwargs)
+
+
+def _get_bound_interface_helper(
+    node: "Node", name: str
+) -> Callable[..., Any] | None:
+    """Return a real bound interface helper, excluding loose mock attributes."""
+    helper = getattr(node.iface, name, None)
+    if callable(helper) and getattr(helper, "__self__", None) is node.iface:
+        return helper
+    return None
+
+
+def _wait_for_admin_ack(
+    node: "Node", request: mesh_pb2.MeshPacket | None
+) -> None:
+    """Wait for the ACK/NAK that belongs to one remote admin request.
+
+    The modern MeshInterface exposes a private request-scoped wait helper. The
+    public ``waitForAckNak()`` entrypoint remains unchanged for compatibility,
+    and minimal interface doubles without the scoped helper retain that legacy
+    fallback.
+    """
+    request_id = _extract_request_id_from_sent_packet(node, request)
+    scoped_wait = _get_bound_interface_helper(node, "_wait_for_ack_nak")
+    active_waits = getattr(node.iface, "_active_wait_request_ids", None)
+    request_is_scoped = (
+        request_id is not None
+        and isinstance(active_waits, dict)
+        and request_id in active_waits.get(WAIT_ATTR_NAK, set())
+    )
+    if request_is_scoped and scoped_wait is not None:
+        scoped_wait(request_id)
+        return
+    node.iface.waitForAckNak()

--- a/meshtastic/node_runtime/admin_wait.py
+++ b/meshtastic/node_runtime/admin_wait.py
@@ -72,6 +72,27 @@ def _set_admin_wait_error(
         set_wait_error(WAIT_ATTR_NAK, message, request_id=request_id)
 
 
+def _record_admin_wait_error_for_packet(
+    node: "Node", packet: dict[str, Any], message: str
+) -> None:
+    """Record one request-scoped admin failure from a response packet."""
+    _set_admin_wait_error(
+        node,
+        message,
+        request_id=_extract_request_id_from_response(node, packet),
+    )
+
+
+def _mark_admin_wait_acknowledged_for_packet(
+    node: "Node", packet: dict[str, Any]
+) -> None:
+    """Mark one request-scoped admin wait complete from a response packet."""
+    _mark_admin_wait_acknowledged(
+        node,
+        _extract_request_id_from_response(node, packet),
+    )
+
+
 def _accepts_response_wait_attr(send_admin: Callable[..., Any]) -> bool:
     """Return whether a bound admin sender accepts the private wait keyword."""
     try:
@@ -133,11 +154,11 @@ def _wait_for_admin_ack(
     """
     request_id = _extract_request_id_from_sent_packet(node, request)
     scoped_wait = _get_bound_interface_helper(node, "_wait_for_ack_nak")
-    active_waits = getattr(node.iface, "_active_wait_request_ids", None)
+    has_active_wait = _get_bound_interface_helper(node, "_has_active_wait_request")
     request_is_scoped = (
         request_id is not None
-        and isinstance(active_waits, dict)
-        and request_id in active_waits.get(WAIT_ATTR_NAK, set())
+        and has_active_wait is not None
+        and bool(has_active_wait(WAIT_ATTR_NAK, request_id))
     )
     if request_is_scoped and scoped_wait is not None:
         scoped_wait(request_id)

--- a/meshtastic/node_runtime/contact_runtime.py
+++ b/meshtastic/node_runtime/contact_runtime.py
@@ -10,6 +10,10 @@ from urllib.parse import urlparse
 
 import google.protobuf.message
 
+from meshtastic.node_runtime.admin_wait import (
+    _send_admin_with_ack_scope,
+    _wait_for_admin_ack,
+)
 from meshtastic.protobuf import admin_pb2, config_pb2, mesh_pb2
 from meshtastic.util import toNodeNum
 
@@ -212,10 +216,12 @@ class _NodeContactRuntime:
         on_response = (
             self._node.onAckNak if self._node != self._node.iface.localNode else None
         )
-        request = self._node._send_admin(  # noqa: SLF001
+        request = _send_admin_with_ack_scope(
+            self._node,
             message,
+            scope_ack=on_response is not None,
             onResponse=on_response,
         )
         if on_response is not None and request is not None:
-            self._node.iface.waitForAckNak()
+            _wait_for_admin_ack(self._node, request)
         return request

--- a/meshtastic/node_runtime/response_runtime.py
+++ b/meshtastic/node_runtime/response_runtime.py
@@ -3,6 +3,11 @@
 import logging
 from typing import TYPE_CHECKING, Any
 
+from meshtastic.node_runtime.admin_wait import (
+    _extract_request_id_from_response,
+    _mark_admin_wait_acknowledged,
+    _set_admin_wait_error,
+)
 from meshtastic.node_runtime.shared import ERROR_REASON_NONE, MAX_CHANNELS
 from meshtastic.protobuf import channel_pb2, config_pb2, mesh_pb2, portnums_pb2
 from meshtastic.util import stripnl
@@ -31,7 +36,24 @@ class _NodeMetadataResponseRuntime:
     def __init__(self, node: "Node") -> None:
         self._node = node
 
-    def _handle_routing_portnum(self, decoded: dict[str, Any]) -> bool:
+    def _record_wait_error(self, packet: dict[str, Any], message: str) -> None:
+        """Record one request-scoped metadata-response failure."""
+        _set_admin_wait_error(
+            self._node,
+            message,
+            request_id=_extract_request_id_from_response(self._node, packet),
+        )
+
+    def _mark_wait_acknowledged(self, packet: dict[str, Any]) -> None:
+        """Mark one request-scoped metadata response complete."""
+        _mark_admin_wait_acknowledged(
+            self._node,
+            _extract_request_id_from_response(self._node, packet),
+        )
+
+    def _handle_routing_portnum(
+        self, decoded: dict[str, Any], packet: dict[str, Any] | None = None
+    ) -> bool:
         """Handle ROUTING_APP metadata responses and indicate whether processing is complete."""
         if decoded.get("portnum") != portnums_pb2.PortNum.Name(
             portnums_pb2.PortNum.ROUTING_APP
@@ -59,6 +81,10 @@ class _NodeMetadataResponseRuntime:
                 error_reason,
             )
             self._node.iface._acknowledgment.receivedNak = True
+            if packet is not None:
+                self._record_wait_error(
+                    packet, f"Routing error on response: {error_reason}"
+                )
             self._node._signal_metadata_stdout_event()
             return True
         logger.debug(
@@ -66,7 +92,9 @@ class _NodeMetadataResponseRuntime:
         )
         return True
 
-    def _handle_generic_routing_error(self, decoded: dict[str, Any]) -> bool:
+    def _handle_generic_routing_error(
+        self, decoded: dict[str, Any], packet: dict[str, Any] | None = None
+    ) -> bool:
         """Handle non-routing-port metadata errors and indicate completion."""
         routing = decoded.get("routing")
         if not isinstance(routing, dict):
@@ -82,6 +110,10 @@ class _NodeMetadataResponseRuntime:
         if error_reason != ERROR_REASON_NONE:
             logger.error("Error on response: %s", error_reason)
             self._node.iface._acknowledgment.receivedNak = True
+            if packet is not None:
+                self._record_wait_error(
+                    packet, f"Routing error on response: {error_reason}"
+                )
             self._node._signal_metadata_stdout_event()
             return True
         return False
@@ -135,9 +167,9 @@ class _NodeMetadataResponseRuntime:
             )
             self._node._signal_metadata_stdout_event()
             return
-        if self._handle_routing_portnum(decoded):
+        if self._handle_routing_portnum(decoded, packet):
             return
-        if self._handle_generic_routing_error(decoded):
+        if self._handle_generic_routing_error(decoded, packet):
             return
 
         admin_message = decoded.get("admin")
@@ -162,6 +194,7 @@ class _NodeMetadataResponseRuntime:
         metadata_snapshot = mesh_pb2.DeviceMetadata()
         metadata_snapshot.CopyFrom(metadata_response)
         self._node.iface._acknowledgment.receivedAck = True
+        self._mark_wait_acknowledged(packet)
         self._node._set_metadata_snapshot(metadata_snapshot)
         self._node._timeout.reset()  # We made forward progress
         logger.debug("Received metadata %s", stripnl(metadata_response))

--- a/meshtastic/node_runtime/response_runtime.py
+++ b/meshtastic/node_runtime/response_runtime.py
@@ -4,9 +4,8 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from meshtastic.node_runtime.admin_wait import (
-    _extract_request_id_from_response,
-    _mark_admin_wait_acknowledged,
-    _set_admin_wait_error,
+    _mark_admin_wait_acknowledged_for_packet,
+    _record_admin_wait_error_for_packet,
 )
 from meshtastic.node_runtime.shared import ERROR_REASON_NONE, MAX_CHANNELS
 from meshtastic.protobuf import channel_pb2, config_pb2, mesh_pb2, portnums_pb2
@@ -36,21 +35,6 @@ class _NodeMetadataResponseRuntime:
     def __init__(self, node: "Node") -> None:
         self._node = node
 
-    def _record_wait_error(self, packet: dict[str, Any], message: str) -> None:
-        """Record one request-scoped metadata-response failure."""
-        _set_admin_wait_error(
-            self._node,
-            message,
-            request_id=_extract_request_id_from_response(self._node, packet),
-        )
-
-    def _mark_wait_acknowledged(self, packet: dict[str, Any]) -> None:
-        """Mark one request-scoped metadata response complete."""
-        _mark_admin_wait_acknowledged(
-            self._node,
-            _extract_request_id_from_response(self._node, packet),
-        )
-
     def _handle_routing_portnum(
         self, decoded: dict[str, Any], packet: dict[str, Any] | None = None
     ) -> bool:
@@ -65,6 +49,11 @@ class _NodeMetadataResponseRuntime:
                 "Received malformed metadata response (missing routing): %s",
                 decoded,
             )
+            self._node.iface._acknowledgment.receivedNak = True
+            if packet is not None:
+                _record_admin_wait_error_for_packet(
+                    self._node, packet, "Received malformed metadata response (missing routing)."
+                )
             self._node._signal_metadata_stdout_event()
             return True
         error_reason = routing.get("errorReason")
@@ -73,6 +62,13 @@ class _NodeMetadataResponseRuntime:
                 "Received malformed metadata response (invalid routing.errorReason): %s",
                 decoded,
             )
+            self._node.iface._acknowledgment.receivedNak = True
+            if packet is not None:
+                _record_admin_wait_error_for_packet(
+                    self._node,
+                    packet,
+                    "Received malformed metadata response (invalid routing.errorReason).",
+                )
             self._node._signal_metadata_stdout_event()
             return True
         if error_reason != ERROR_REASON_NONE:
@@ -82,8 +78,8 @@ class _NodeMetadataResponseRuntime:
             )
             self._node.iface._acknowledgment.receivedNak = True
             if packet is not None:
-                self._record_wait_error(
-                    packet, f"Routing error on response: {error_reason}"
+                _record_admin_wait_error_for_packet(
+                    self._node, packet, f"Routing error on response: {error_reason}"
                 )
             self._node._signal_metadata_stdout_event()
             return True
@@ -105,14 +101,21 @@ class _NodeMetadataResponseRuntime:
                 "Received malformed metadata response (invalid routing.errorReason): %s",
                 decoded,
             )
+            self._node.iface._acknowledgment.receivedNak = True
+            if packet is not None:
+                _record_admin_wait_error_for_packet(
+                    self._node,
+                    packet,
+                    "Received malformed metadata response (invalid routing.errorReason).",
+                )
             self._node._signal_metadata_stdout_event()
             return True
         if error_reason != ERROR_REASON_NONE:
             logger.error("Error on response: %s", error_reason)
             self._node.iface._acknowledgment.receivedNak = True
             if packet is not None:
-                self._record_wait_error(
-                    packet, f"Routing error on response: {error_reason}"
+                _record_admin_wait_error_for_packet(
+                    self._node, packet, f"Routing error on response: {error_reason}"
                 )
             self._node._signal_metadata_stdout_event()
             return True
@@ -165,6 +168,10 @@ class _NodeMetadataResponseRuntime:
                 "Received malformed metadata response (missing decoded): %s",
                 packet,
             )
+            self._node.iface._acknowledgment.receivedNak = True
+            _record_admin_wait_error_for_packet(
+                self._node, packet, "Received malformed metadata response (missing decoded)."
+            )
             self._node._signal_metadata_stdout_event()
             return
         if self._handle_routing_portnum(decoded, packet):
@@ -178,6 +185,10 @@ class _NodeMetadataResponseRuntime:
                 "Received malformed metadata response (missing admin): %s",
                 packet,
             )
+            self._node.iface._acknowledgment.receivedNak = True
+            _record_admin_wait_error_for_packet(
+                self._node, packet, "Received malformed metadata response (missing admin)."
+            )
             self._node._signal_metadata_stdout_event()
             return
         raw_admin = admin_message.get("raw")
@@ -188,13 +199,17 @@ class _NodeMetadataResponseRuntime:
                 "Received malformed metadata response (missing admin.raw): %s",
                 packet,
             )
+            self._node.iface._acknowledgment.receivedNak = True
+            _record_admin_wait_error_for_packet(
+                self._node, packet, "Received malformed metadata response (missing admin.raw)."
+            )
             self._node._signal_metadata_stdout_event()
             return
         metadata_response = raw_admin.get_device_metadata_response
         metadata_snapshot = mesh_pb2.DeviceMetadata()
         metadata_snapshot.CopyFrom(metadata_response)
         self._node.iface._acknowledgment.receivedAck = True
-        self._mark_wait_acknowledged(packet)
+        _mark_admin_wait_acknowledged_for_packet(self._node, packet)
         self._node._set_metadata_snapshot(metadata_snapshot)
         self._node._timeout.reset()  # We made forward progress
         logger.debug("Received metadata %s", stripnl(metadata_response))

--- a/meshtastic/node_runtime/settings_runtime/admin.py
+++ b/meshtastic/node_runtime/settings_runtime/admin.py
@@ -4,6 +4,11 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from meshtastic.node_runtime.admin_wait import (
+    WAIT_ATTR_NAK,
+    _send_admin_with_ack_scope,
+    _wait_for_admin_ack,
+)
 from meshtastic.protobuf import admin_pb2, mesh_pb2
 from meshtastic.util import toNodeNum
 
@@ -11,8 +16,6 @@ if TYPE_CHECKING:
     from meshtastic.node import Node
 
 logger = logging.getLogger(__name__)
-
-WAIT_ATTR_NAK = "receivedNak"
 
 
 class _NodeAdminCommandRuntime:
@@ -40,11 +43,14 @@ class _NodeAdminCommandRuntime:
         on_response = (
             self._select_remote_ack_callback() if use_remote_ack_callback else None
         )
-        request = self._node._send_admin(message, onResponse=on_response)
+        request = _send_admin_with_ack_scope(
+            self._node,
+            message,
+            scope_ack=on_response is not None,
+            onResponse=on_response,
+        )
         if on_response is not None and request is not None:
-            # Remote admin command callbacks still signal ACK/NAK via legacy
-            # shared acknowledgment flags.
-            self._node.iface.waitForAckNak()
+            _wait_for_admin_ack(self._node, request)
         return request
 
     def sendOwnerMessage(

--- a/meshtastic/node_runtime/settings_runtime/config_runtime.py
+++ b/meshtastic/node_runtime/settings_runtime/config_runtime.py
@@ -6,6 +6,10 @@ from typing import TYPE_CHECKING, Any
 
 from google.protobuf.descriptor import FieldDescriptor
 
+from meshtastic.node_runtime.admin_wait import (
+    _send_admin_with_ack_scope,
+    _wait_for_admin_ack,
+)
 from meshtastic.node_runtime.settings_runtime.message import (  # pylint: disable=no-name-in-module
     _NodeSettingsMessageBuilder,
 )
@@ -44,8 +48,10 @@ class _NodeSettingsRuntime:
             )
 
         message = self._message_builder.build_request_message(config_type)
-        request = self._node._send_admin(  # noqa: SLF001
+        request = _send_admin_with_ack_scope(
+            self._node,
             message,
+            scope_ack=on_response is not None,
             wantResponse=True,
             onResponse=on_response,
             adminIndex=admin_index,
@@ -56,7 +62,7 @@ class _NodeSettingsRuntime:
                 f"requestConfig failed: admin message not started (admin_index={admin_index})"
             )
         if on_response is not None and request is not None:
-            self._node.iface.waitForAckNak()
+            _wait_for_admin_ack(self._node, request)
 
     def _validate_write_configs_loaded(self, config_name: str) -> None:
         """Preserve historical writeConfig loaded-state behavior.
@@ -98,8 +104,11 @@ class _NodeSettingsRuntime:
         on_response = (
             None if self._node is self._node.iface.localNode else self._node.onAckNak
         )
-        request = self._node._send_admin(  # noqa: SLF001
-            message, onResponse=on_response
+        request = _send_admin_with_ack_scope(
+            self._node,
+            message,
+            scope_ack=on_response is not None,
+            onResponse=on_response,
         )
         # In noProto mode, _send_admin legitimately returns None (no actual sending)
         if request is None and not getattr(self._node, "noProto", False):
@@ -107,5 +116,5 @@ class _NodeSettingsRuntime:
                 f"writeConfig failed: admin message not started (config_name={config_name})"
             )
         if on_response is not None and request is not None:
-            self._node.iface.waitForAckNak()
+            _wait_for_admin_ack(self._node, request)
         logger.debug("Config write completed: %s", config_name)

--- a/meshtastic/node_runtime/settings_runtime/response.py
+++ b/meshtastic/node_runtime/settings_runtime/response.py
@@ -4,9 +4,8 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from meshtastic.node_runtime.admin_wait import (
-    _extract_request_id_from_response,
-    _mark_admin_wait_acknowledged,
-    _set_admin_wait_error,
+    _mark_admin_wait_acknowledged_for_packet,
+    _record_admin_wait_error_for_packet,
 )
 from meshtastic.node_runtime.shared import ERROR_REASON_NONE
 from meshtastic.protobuf import admin_pb2
@@ -23,21 +22,6 @@ class _NodeSettingsResponseRuntime:
 
     def __init__(self, node: "Node") -> None:
         self._node = node
-
-    def _record_wait_error(self, packet: dict[str, Any], message: str) -> None:
-        """Record one request-scoped settings-response failure."""
-        _set_admin_wait_error(
-            self._node,
-            message,
-            request_id=_extract_request_id_from_response(self._node, packet),
-        )
-
-    def _mark_wait_acknowledged(self, packet: dict[str, Any]) -> None:
-        """Mark one request-scoped settings response complete."""
-        _mark_admin_wait_acknowledged(
-            self._node,
-            _extract_request_id_from_response(self._node, packet),
-        )
 
     # pylint: disable=too-many-positional-arguments
     def _resolve_config_response(
@@ -119,7 +103,7 @@ class _NodeSettingsResponseRuntime:
             message = "Received malformed settings response (missing decoded)."
             logger.warning(message)
             self._node.iface._acknowledgment.receivedNak = True
-            self._record_wait_error(packet, message)
+            _record_admin_wait_error_for_packet(self._node, packet, message)
             return
         routing = decoded.get("routing")
         if isinstance(routing, dict):
@@ -130,8 +114,8 @@ class _NodeSettingsResponseRuntime:
                     error_reason,
                 )
                 self._node.iface._acknowledgment.receivedNak = True
-                self._record_wait_error(
-                    packet, f"Routing error on response: {error_reason}"
+                _record_admin_wait_error_for_packet(
+                    self._node, packet, f"Routing error on response: {error_reason}"
                 )
                 return
 
@@ -140,13 +124,15 @@ class _NodeSettingsResponseRuntime:
             message = "Received malformed settings response (missing admin)."
             logger.warning(message)
             self._node.iface._acknowledgment.receivedNak = True
-            self._record_wait_error(packet, message)
+            _record_admin_wait_error_for_packet(self._node, packet, message)
             return
         target = self._resolve_config_target(admin_message)
         if target is None:
             self._node.iface._acknowledgment.receivedNak = True
-            self._record_wait_error(
-                packet, "Received settings response without a recognized config field."
+            _record_admin_wait_error_for_packet(
+                self._node,
+                packet,
+                "Received settings response without a recognized config field.",
             )
             return
 
@@ -156,7 +142,7 @@ class _NodeSettingsResponseRuntime:
             message = "Received malformed settings response (invalid admin.raw)."
             logger.warning(message)
             self._node.iface._acknowledgment.receivedNak = True
-            self._record_wait_error(packet, message)
+            _record_admin_wait_error_for_packet(self._node, packet, message)
             return
         parent_config = getattr(raw_admin, oneof)
         if not parent_config.HasField(field_name):
@@ -165,7 +151,8 @@ class _NodeSettingsResponseRuntime:
                 field_name,
             )
             self._node.iface._acknowledgment.receivedNak = True
-            self._record_wait_error(
+            _record_admin_wait_error_for_packet(
+                self._node,
                 packet,
                 f"Received settings response without expected field '{field_name}'.",
             )
@@ -173,5 +160,5 @@ class _NodeSettingsResponseRuntime:
         raw_config = getattr(parent_config, field_name)
         config_values.CopyFrom(raw_config)
         self._node.iface._acknowledgment.receivedAck = True
-        self._mark_wait_acknowledged(packet)
+        _mark_admin_wait_acknowledged_for_packet(self._node, packet)
         logger.info("Received settings block: %s", field_name)

--- a/meshtastic/node_runtime/settings_runtime/response.py
+++ b/meshtastic/node_runtime/settings_runtime/response.py
@@ -3,6 +3,11 @@
 import logging
 from typing import TYPE_CHECKING, Any
 
+from meshtastic.node_runtime.admin_wait import (
+    _extract_request_id_from_response,
+    _mark_admin_wait_acknowledged,
+    _set_admin_wait_error,
+)
 from meshtastic.node_runtime.shared import ERROR_REASON_NONE
 from meshtastic.protobuf import admin_pb2
 from meshtastic.util import camel_to_snake
@@ -18,6 +23,21 @@ class _NodeSettingsResponseRuntime:
 
     def __init__(self, node: "Node") -> None:
         self._node = node
+
+    def _record_wait_error(self, packet: dict[str, Any], message: str) -> None:
+        """Record one request-scoped settings-response failure."""
+        _set_admin_wait_error(
+            self._node,
+            message,
+            request_id=_extract_request_id_from_response(self._node, packet),
+        )
+
+    def _mark_wait_acknowledged(self, packet: dict[str, Any]) -> None:
+        """Mark one request-scoped settings response complete."""
+        _mark_admin_wait_acknowledged(
+            self._node,
+            _extract_request_id_from_response(self._node, packet),
+        )
 
     # pylint: disable=too-many-positional-arguments
     def _resolve_config_response(
@@ -96,8 +116,10 @@ class _NodeSettingsResponseRuntime:
         logger.debug("handleSettingsResponse() response received")
         decoded = packet.get("decoded")
         if not isinstance(decoded, dict):
-            logger.warning("Received malformed settings response (missing decoded).")
+            message = "Received malformed settings response (missing decoded)."
+            logger.warning(message)
             self._node.iface._acknowledgment.receivedNak = True
+            self._record_wait_error(packet, message)
             return
         routing = decoded.get("routing")
         if isinstance(routing, dict):
@@ -108,23 +130,33 @@ class _NodeSettingsResponseRuntime:
                     error_reason,
                 )
                 self._node.iface._acknowledgment.receivedNak = True
+                self._record_wait_error(
+                    packet, f"Routing error on response: {error_reason}"
+                )
                 return
 
         admin_message = decoded.get("admin")
         if not isinstance(admin_message, dict):
-            logger.warning("Received malformed settings response (missing admin).")
+            message = "Received malformed settings response (missing admin)."
+            logger.warning(message)
             self._node.iface._acknowledgment.receivedNak = True
+            self._record_wait_error(packet, message)
             return
         target = self._resolve_config_target(admin_message)
         if target is None:
             self._node.iface._acknowledgment.receivedNak = True
+            self._record_wait_error(
+                packet, "Received settings response without a recognized config field."
+            )
             return
 
         oneof, field_name, config_values = target
         raw_admin = admin_message.get("raw")
         if not isinstance(raw_admin, admin_pb2.AdminMessage):
-            logger.warning("Received malformed settings response (invalid admin.raw).")
+            message = "Received malformed settings response (invalid admin.raw)."
+            logger.warning(message)
             self._node.iface._acknowledgment.receivedNak = True
+            self._record_wait_error(packet, message)
             return
         parent_config = getattr(raw_admin, oneof)
         if not parent_config.HasField(field_name):
@@ -133,8 +165,13 @@ class _NodeSettingsResponseRuntime:
                 field_name,
             )
             self._node.iface._acknowledgment.receivedNak = True
+            self._record_wait_error(
+                packet,
+                f"Received settings response without expected field '{field_name}'.",
+            )
             return
         raw_config = getattr(parent_config, field_name)
         config_values.CopyFrom(raw_config)
         self._node.iface._acknowledgment.receivedAck = True
+        self._mark_wait_acknowledged(packet)
         logger.info("Received settings block: %s", field_name)

--- a/meshtastic/node_runtime/transport_runtime/ack.py
+++ b/meshtastic/node_runtime/transport_runtime/ack.py
@@ -1,16 +1,19 @@
 """ACK/NAK payload classification and acknowledgment flag mutation."""
 
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
+from meshtastic.node_runtime.admin_wait import (
+    _extract_request_id_from_response,
+    _mark_admin_wait_acknowledged,
+    _set_admin_wait_error,
+)
 from meshtastic.node_runtime.shared import ERROR_REASON_NONE
 
 if TYPE_CHECKING:
     from meshtastic.node import Node
 
 logger = logging.getLogger(__name__)
-
-WAIT_ATTR_NAK = "receivedNak"
 
 
 class _NodeAckNakRuntime:
@@ -20,15 +23,8 @@ class _NodeAckNakRuntime:
         self._node = node
 
     def _extract_request_id(self, packet: dict[str, Any]) -> int | None:
-        """Extract request id from packet when interface helper is available."""
-        extract_request_id = getattr(
-            self._node.iface,
-            "_extract_request_id_from_packet",
-            None,
-        )
-        if not callable(extract_request_id):
-            return None
-        return cast(int | None, extract_request_id(packet))
+        """Extract the request id used for ACK/NAK correlation."""
+        return _extract_request_id_from_response(self._node, packet)
 
     def _set_wait_nak_error(
         self,
@@ -37,22 +33,15 @@ class _NodeAckNakRuntime:
         request_id: int | None,
     ) -> None:
         """Record scoped/unscoped wait errors for ACK/NAK waits when supported."""
-        set_wait_error = getattr(self._node.iface, "_set_wait_error", None)
-        if not callable(set_wait_error):
-            return
-        set_wait_error(WAIT_ATTR_NAK, message)
-        if request_id is not None:
-            set_wait_error(WAIT_ATTR_NAK, message, request_id=request_id)
+        _set_admin_wait_error(
+            self._node,
+            message,
+            request_id=request_id,
+        )
 
     def _mark_wait_acknowledged(self, request_id: int | None) -> None:
         """Mark ACK wait completion for request-scoped waiters when supported."""
-        mark_wait_acknowledged = getattr(
-            self._node.iface,
-            "_mark_wait_acknowledged",
-            None,
-        )
-        if callable(mark_wait_acknowledged):
-            mark_wait_acknowledged(WAIT_ATTR_NAK, request_id=request_id)
+        _mark_admin_wait_acknowledged(self._node, request_id)
 
     # pylint: disable=too-many-return-statements
     def _handle_ack_nak(self, packet: dict[str, Any]) -> None:

--- a/meshtastic/node_runtime/transport_runtime/channel.py
+++ b/meshtastic/node_runtime/transport_runtime/channel.py
@@ -4,6 +4,10 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from meshtastic.node_runtime.admin_wait import (
+    _send_admin_with_ack_scope,
+    _wait_for_admin_ack,
+)
 from meshtastic.node_runtime.shared import (
     MAX_CHANNELS,
 )
@@ -60,8 +64,10 @@ class _NodeChannelWriteRuntime:
             if self._node is not self._node.iface.localNode
             else None
         )
-        request = self._node._send_admin(
+        request = _send_admin_with_ack_scope(
+            self._node,
             request_message,
+            scope_ack=on_response is not None,
             adminIndex=admin_index,
             onResponse=on_response,
         )
@@ -76,7 +82,7 @@ class _NodeChannelWriteRuntime:
         # Wait for ACK/NAK response for remote nodes
         if on_response is not None and request is not None:
             try:
-                self._node.iface.waitForAckNak()
+                _wait_for_admin_ack(self._node, request)
             except Exception as exc:
                 self._node._raise_interface_error(
                     f"Channel write for index {channel_to_write.index} failed: {exc}"

--- a/meshtastic/node_runtime/transport_runtime/position_time.py
+++ b/meshtastic/node_runtime/transport_runtime/position_time.py
@@ -5,6 +5,10 @@ import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from meshtastic.node_runtime.admin_wait import (
+    _send_admin_with_ack_scope,
+    _wait_for_admin_ack,
+)
 from meshtastic.protobuf import admin_pb2, mesh_pb2
 
 if TYPE_CHECKING:
@@ -34,13 +38,15 @@ class _NodePositionTimeCommandRuntime:
     ) -> mesh_pb2.MeshPacket | None:
         """Send position/time admin command and wait for remote ACK/NAK when needed."""
         on_response = self._select_remote_ack_callback()
-        request = self._node._send_admin(
+        request = _send_admin_with_ack_scope(
+            self._node,
             admin_message,
+            scope_ack=on_response is not None,
             onResponse=on_response,
             wantResponse=True,
         )
         if on_response is not None and request is not None:
-            self._node.iface.waitForAckNak()
+            _wait_for_admin_ack(self._node, request)
         return request
 
     def _set_fixed_position(

--- a/meshtastic/tests/test_admin_ack_wait_scoping.py
+++ b/meshtastic/tests/test_admin_ack_wait_scoping.py
@@ -1,0 +1,543 @@
+"""Request-scoped ACK/NAK behavior for remote admin operations."""
+
+from __future__ import annotations
+
+import threading
+import time
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from meshtastic.mesh_interface import MeshInterface
+from meshtastic.node_runtime.admin_wait import (
+    WAIT_ATTR_NAK,
+    _wait_for_admin_ack,
+)
+from meshtastic.node_runtime.settings_runtime.admin import _NodeAdminCommandRuntime
+from meshtastic.node_runtime.settings_runtime.response import (
+    _NodeSettingsResponseRuntime,
+)
+from meshtastic.protobuf import admin_pb2, config_pb2, localonly_pb2, mesh_pb2
+from meshtastic.util import Acknowledgment
+
+
+class _ScopedIfaceDouble:
+    """Minimal interface double exposing a real bound scoped-wait helper."""
+
+    def __init__(self) -> None:
+        self.localNode = object()
+        self.scoped_waits: list[int] = []
+        self.legacy_waits = 0
+        self._active_wait_request_ids: dict[str, set[int]] = {}
+
+    @staticmethod
+    def _extract_request_id_from_sent_packet(packet: object) -> int | None:
+        request_id = getattr(packet, "id", None)
+        return request_id if isinstance(request_id, int) and request_id > 0 else None
+
+    def _wait_for_ack_nak(self, request_id: int) -> None:
+        self.scoped_waits.append(request_id)
+        active = self._active_wait_request_ids.get(WAIT_ATTR_NAK)
+        if active is not None:
+            active.discard(request_id)
+            if not active:
+                self._active_wait_request_ids.pop(WAIT_ATTR_NAK, None)
+
+    def _send_data_with_wait(self, *_args: object, **_kwargs: object) -> None:
+        """Marker for the real-interface pre-registration capability."""
+
+    def waitForAckNak(self) -> None:  # noqa: N802 - compatibility surface
+        self.legacy_waits += 1
+
+
+class _RemoteAdminNodeDouble:
+    """Minimal node double with a real bound ``_send_admin`` method."""
+
+    def __init__(self) -> None:
+        self.iface = _ScopedIfaceDouble()
+        self.sent_response_wait_attrs: list[str | None] = []
+        self.session_key_checks = 0
+
+    def ensureSessionKey(self) -> None:  # noqa: N802 - compatibility surface
+        self.session_key_checks += 1
+
+    def onAckNak(self, _packet: dict[str, Any]) -> None:  # noqa: N802
+        """ACK callback placeholder used only to select remote wait policy."""
+
+    def _send_admin(
+        self,
+        _message: admin_pb2.AdminMessage,
+        *,
+        onResponse: Any = None,  # noqa: N803 - compatibility surface
+        responseWaitAttr: str | None = None,  # noqa: N803 - compatibility surface
+    ) -> mesh_pb2.MeshPacket:
+        _ = onResponse
+        self.sent_response_wait_attrs.append(responseWaitAttr)
+        if responseWaitAttr is not None:
+            self.iface._active_wait_request_ids.setdefault(responseWaitAttr, set()).add(731)
+        return mesh_pb2.MeshPacket(id=731)
+
+
+def _wait_until(predicate: Any, *, timeout: float = 1.0) -> None:
+    """Wait until a test predicate becomes true or fail deterministically."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.001)
+    pytest.fail("timed out waiting for test condition")
+
+
+@pytest.mark.unit
+def test_remote_admin_command_registers_and_uses_request_scoped_ack_wait() -> None:
+    """Remote admin commands should bind their wait to the packet they sent."""
+    node = _RemoteAdminNodeDouble()
+    runtime = _NodeAdminCommandRuntime(node)  # type: ignore[arg-type]
+
+    request = runtime._send_command(  # noqa: SLF001 - runtime contract under test
+        admin_pb2.AdminMessage(reboot_seconds=1),
+        ensure_session_key=True,
+        use_remote_ack_callback=True,
+    )
+
+    assert request is not None
+    assert request.id == 731
+    assert node.session_key_checks == 1
+    assert node.sent_response_wait_attrs == [WAIT_ATTR_NAK]
+    assert node.iface.scoped_waits == [731]
+    assert node.iface.legacy_waits == 0
+
+
+class _LegacyBoundAdminNodeDouble(_RemoteAdminNodeDouble):
+    """Bound admin sender that preserves the pre-scope private signature."""
+
+    def _send_admin(
+        self,
+        _message: admin_pb2.AdminMessage,
+        *,
+        onResponse: Any = None,  # noqa: N803 - compatibility surface
+    ) -> mesh_pb2.MeshPacket:
+        _ = onResponse
+        self.sent_response_wait_attrs.append(None)
+        return mesh_pb2.MeshPacket(id=732)
+
+
+@pytest.mark.unit
+def test_bound_legacy_admin_sender_falls_back_without_private_scope_keyword() -> None:
+    """Bound compatibility overrides need not accept the new private keyword."""
+    node = _LegacyBoundAdminNodeDouble()
+    runtime = _NodeAdminCommandRuntime(node)  # type: ignore[arg-type]
+
+    request = runtime._send_command(  # noqa: SLF001 - runtime contract under test
+        admin_pb2.AdminMessage(reboot_seconds=1),
+        ensure_session_key=False,
+        use_remote_ack_callback=True,
+    )
+
+    assert request is not None
+    assert request.id == 732
+    assert node.sent_response_wait_attrs == [None]
+    assert node.iface.scoped_waits == []
+    assert node.iface.legacy_waits == 1
+    assert node.iface._active_wait_request_ids == {}
+
+
+@pytest.mark.unit
+def test_admin_wait_falls_back_to_legacy_interface_contract() -> None:
+    """Minimal interfaces without a real scoped helper should retain legacy waits."""
+    iface = SimpleNamespace(waitForAckNak=MagicMock())
+    node = SimpleNamespace(iface=iface)
+
+    _wait_for_admin_ack(  # type: ignore[arg-type]
+        node,
+        mesh_pb2.MeshPacket(id=99),
+    )
+
+    iface.waitForAckNak.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_request_scoped_admin_waits_do_not_crosstalk() -> None:
+    """An ACK for one request must not release a different admin waiter."""
+    with MeshInterface(noProto=True) as iface:
+        iface._timeout.expireTimeout = 1.0  # noqa: SLF001
+        iface._timeout.sleepInterval = 0.001  # noqa: SLF001
+        request_a = 101
+        request_b = 202
+        iface._clear_wait_error(WAIT_ATTR_NAK, request_id=request_a)  # noqa: SLF001
+        iface._clear_wait_error(WAIT_ATTR_NAK, request_id=request_b)  # noqa: SLF001
+
+        completed: list[int] = []
+        errors: list[BaseException] = []
+        lock = threading.Lock()
+
+        def _wait(request_id: int) -> None:
+            try:
+                iface._wait_for_ack_nak(request_id)  # noqa: SLF001
+                with lock:
+                    completed.append(request_id)
+            except BaseException as exc:  # noqa: BLE001 - captured for test assertion
+                with lock:
+                    errors.append(exc)
+
+        thread_a = threading.Thread(target=_wait, args=(request_a,), daemon=True)
+        thread_b = threading.Thread(target=_wait, args=(request_b,), daemon=True)
+        thread_a.start()
+        thread_b.start()
+
+        iface._mark_wait_acknowledged(WAIT_ATTR_NAK, request_id=request_a)  # noqa: SLF001
+        _wait_until(lambda: request_a in completed)
+        assert request_b not in completed
+        assert thread_b.is_alive()
+
+        iface._mark_wait_acknowledged(WAIT_ATTR_NAK, request_id=request_b)  # noqa: SLF001
+        thread_a.join(timeout=1.0)
+        thread_b.join(timeout=1.0)
+
+        assert not thread_a.is_alive()
+        assert not thread_b.is_alive()
+        assert errors == []
+        assert sorted(completed) == [request_a, request_b]
+        assert WAIT_ATTR_NAK not in iface._active_wait_request_ids  # noqa: SLF001
+
+
+@pytest.mark.unit
+def test_scoped_admin_nak_only_fails_matching_request() -> None:
+    """A request-scoped NAK should fail its owner without poisoning another wait."""
+    with MeshInterface(noProto=True) as iface:
+        iface._timeout.expireTimeout = 1.0  # noqa: SLF001
+        iface._timeout.sleepInterval = 0.001  # noqa: SLF001
+        request_ok = 303
+        request_nak = 404
+        iface._clear_wait_error(WAIT_ATTR_NAK, request_id=request_ok)  # noqa: SLF001
+        iface._clear_wait_error(WAIT_ATTR_NAK, request_id=request_nak)  # noqa: SLF001
+
+        ok_complete = threading.Event()
+        nak_error: list[BaseException] = []
+
+        def _wait_ok() -> None:
+            iface._wait_for_ack_nak(request_ok)  # noqa: SLF001
+            ok_complete.set()
+
+        def _wait_nak() -> None:
+            try:
+                iface._wait_for_ack_nak(request_nak)  # noqa: SLF001
+            except BaseException as exc:  # noqa: BLE001 - captured for assertion
+                nak_error.append(exc)
+
+        ok_thread = threading.Thread(target=_wait_ok, daemon=True)
+        nak_thread = threading.Thread(target=_wait_nak, daemon=True)
+        ok_thread.start()
+        nak_thread.start()
+
+        iface._set_wait_error(  # noqa: SLF001
+            WAIT_ATTR_NAK,
+            "Routing error on response: NO_RESPONSE",
+            request_id=request_nak,
+        )
+        nak_thread.join(timeout=1.0)
+        assert not nak_thread.is_alive()
+        assert len(nak_error) == 1
+        assert "NO_RESPONSE" in str(nak_error[0])
+        assert not ok_complete.is_set()
+        assert ok_thread.is_alive()
+
+        iface._mark_wait_acknowledged(WAIT_ATTR_NAK, request_id=request_ok)  # noqa: SLF001
+        ok_thread.join(timeout=1.0)
+        assert not ok_thread.is_alive()
+        assert ok_complete.is_set()
+
+
+@pytest.mark.unit
+def test_settings_response_marks_scoped_request_completion() -> None:
+    """Successful settings callbacks should release only their request-scoped waiter."""
+    iface = SimpleNamespace(
+        _acknowledgment=Acknowledgment(),
+        _extract_request_id_from_packet=lambda _packet: 515,
+        _mark_wait_acknowledged=MagicMock(),
+        _set_wait_error=MagicMock(),
+    )
+    node = SimpleNamespace(
+        iface=iface,
+        localConfig=localonly_pb2.LocalConfig(),
+        moduleConfig=localonly_pb2.LocalModuleConfig(),
+    )
+    raw = admin_pb2.AdminMessage()
+    raw.get_config_response.device.role = config_pb2.Config.DeviceConfig.Role.CLIENT
+    packet: dict[str, Any] = {
+        "decoded": {
+            "admin": {
+                "getConfigResponse": {"device": {}},
+                "raw": raw,
+            }
+        }
+    }
+
+    _NodeSettingsResponseRuntime(node).handleSettingsResponse(packet)  # type: ignore[arg-type]
+
+    assert iface._acknowledgment.receivedAck is True
+    iface._mark_wait_acknowledged.assert_called_once_with(
+        WAIT_ATTR_NAK,
+        request_id=515,
+    )
+    iface._set_wait_error.assert_not_called()
+
+
+@pytest.mark.unit
+def test_settings_routing_error_records_scoped_request_failure() -> None:
+    """Settings routing errors should be attached to the response request id."""
+    iface = SimpleNamespace(
+        _acknowledgment=Acknowledgment(),
+        _extract_request_id_from_packet=lambda _packet: 616,
+        _mark_wait_acknowledged=MagicMock(),
+        _set_wait_error=MagicMock(),
+    )
+    node = SimpleNamespace(
+        iface=iface,
+        localConfig=localonly_pb2.LocalConfig(),
+        moduleConfig=localonly_pb2.LocalModuleConfig(),
+    )
+    packet = {"decoded": {"routing": {"errorReason": "NO_RESPONSE"}}}
+
+    _NodeSettingsResponseRuntime(node).handleSettingsResponse(packet)  # type: ignore[arg-type]
+
+    assert iface._acknowledgment.receivedNak is True
+    assert iface._set_wait_error.call_args_list == [
+        ((WAIT_ATTR_NAK, "Routing error on response: NO_RESPONSE"), {}),
+        (
+            (WAIT_ATTR_NAK, "Routing error on response: NO_RESPONSE"),
+            {"request_id": 616},
+        ),
+    ]
+    iface._mark_wait_acknowledged.assert_not_called()
+
+
+@pytest.mark.unit
+def test_admin_send_helper_preserves_instance_level_transport_monkeypatch() -> None:
+    """Legacy instance-level ``_send_admin`` doubles must not receive private kwargs."""
+    calls: list[dict[str, Any]] = []
+
+    def _send_admin(
+        _message: admin_pb2.AdminMessage,
+        *,
+        onResponse: Any = None,  # noqa: N803 - compatibility surface under test
+    ) -> mesh_pb2.MeshPacket:
+        calls.append({"onResponse": onResponse})
+        return mesh_pb2.MeshPacket(id=700)
+
+    iface = SimpleNamespace(waitForAckNak=MagicMock())
+    node = SimpleNamespace(iface=iface, _send_admin=_send_admin)
+
+    from meshtastic.node_runtime.admin_wait import _send_admin_with_ack_scope
+
+    request = _send_admin_with_ack_scope(
+        node,  # type: ignore[arg-type]
+        admin_pb2.AdminMessage(reboot_seconds=1),
+        scope_ack=True,
+        onResponse=object(),
+    )
+
+    assert request is not None
+    assert request.id == 700
+    assert len(calls) == 1
+    assert set(calls[0]) == {"onResponse"}
+
+
+@pytest.mark.unit
+def test_fast_admin_ack_is_not_lost_between_send_and_wait() -> None:
+    """A synchronous ACK during transport send must satisfy the later scoped wait."""
+    from types import MethodType
+
+    from meshtastic.node import Node
+
+    with MeshInterface(noProto=True) as iface:
+        iface.myInfo = SimpleNamespace(my_node_num=1)
+        iface.localNode.nodeNum = 1
+        iface._get_or_create_by_num = MethodType(  # type: ignore[method-assign]  # noqa: SLF001
+            lambda _self, _node_num: {},
+            iface,
+        )
+        remote = Node(iface, 2, noProto=False, timeout=0.2)
+        observed_active_scope: list[bool] = []
+
+        def _send_packet(
+            packet: mesh_pb2.MeshPacket,
+            *_args: object,
+            **_kwargs: object,
+        ) -> mesh_pb2.MeshPacket:
+            observed_active_scope.append(
+                packet.id
+                in iface._active_wait_request_ids.get(WAIT_ATTR_NAK, set())  # noqa: SLF001
+            )
+            remote.onAckNak(
+                {
+                    "decoded": {
+                        "requestId": packet.id,
+                        "routing": {"errorReason": "NONE"},
+                    },
+                    "from": remote.nodeNum,
+                }
+            )
+            return packet
+
+        iface._send_packet = _send_packet  # type: ignore[method-assign]  # noqa: SLF001
+
+        request = remote._admin_command_runtime._send_command(  # noqa: SLF001
+            admin_pb2.AdminMessage(reboot_seconds=1),
+            ensure_session_key=False,
+            use_remote_ack_callback=True,
+        )
+
+        assert request is not None
+        assert observed_active_scope == [True]
+        assert iface._active_wait_request_ids.get(WAIT_ATTR_NAK) is None  # noqa: SLF001
+        assert request.id in iface._retired_wait_request_ids[WAIT_ATTR_NAK]  # noqa: SLF001
+
+
+@pytest.mark.unit
+def test_metadata_response_marks_scoped_request_completion() -> None:
+    """Successful metadata payloads should complete their own request-scoped wait."""
+    from meshtastic.node_runtime.response_runtime import _NodeMetadataResponseRuntime
+
+    iface = SimpleNamespace(
+        _acknowledgment=Acknowledgment(),
+        _extract_request_id_from_packet=lambda _packet: 717,
+        _mark_wait_acknowledged=MagicMock(),
+        _set_wait_error=MagicMock(),
+    )
+    node = SimpleNamespace(
+        iface=iface,
+        _set_metadata_snapshot=MagicMock(),
+        _emit_metadata_line=MagicMock(),
+        position_flags_list=MagicMock(return_value=[]),
+        excluded_modules_list=MagicMock(return_value=[]),
+        _timeout=SimpleNamespace(reset=MagicMock()),
+        _signal_metadata_stdout_event=MagicMock(),
+    )
+    raw = admin_pb2.AdminMessage()
+    metadata = raw.get_device_metadata_response
+    metadata.firmware_version = "2.8.0"
+    metadata.device_state_version = 1
+    metadata.role = config_pb2.Config.DeviceConfig.Role.CLIENT
+    metadata.hw_model = mesh_pb2.HardwareModel.PORTDUINO
+    packet: dict[str, Any] = {
+        "decoded": {
+            "portnum": "ADMIN_APP",
+            "admin": {"raw": raw},
+        }
+    }
+
+    _NodeMetadataResponseRuntime(node).handleMetadataResponse(packet)  # type: ignore[arg-type]
+
+    assert iface._acknowledgment.receivedAck is True
+    iface._mark_wait_acknowledged.assert_called_once_with(
+        WAIT_ATTR_NAK,
+        request_id=717,
+    )
+    iface._set_wait_error.assert_not_called()
+    node._set_metadata_snapshot.assert_called_once()
+    node._signal_metadata_stdout_event.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_overlapping_remote_admin_commands_correlate_ack_and_nak_by_request() -> None:
+    """Overlapping remote admin calls must resolve only from their own responses."""
+    from types import MethodType
+
+    from meshtastic.node import Node
+
+    with MeshInterface(noProto=True) as iface:
+        iface.myInfo = SimpleNamespace(my_node_num=1)
+        iface.localNode.nodeNum = 1
+        iface._get_or_create_by_num = MethodType(  # type: ignore[method-assign]  # noqa: SLF001
+            lambda _self, _node_num: {},
+            iface,
+        )
+        remote = Node(iface, 2, noProto=False, timeout=1.0)
+        sent_packets: list[mesh_pb2.MeshPacket] = []
+        sent_lock = threading.Lock()
+
+        def _send_packet(
+            packet: mesh_pb2.MeshPacket,
+            *_args: object,
+            **_kwargs: object,
+        ) -> mesh_pb2.MeshPacket:
+            snapshot = mesh_pb2.MeshPacket()
+            snapshot.CopyFrom(packet)
+            with sent_lock:
+                sent_packets.append(snapshot)
+            return packet
+
+        iface._send_packet = _send_packet  # type: ignore[method-assign]  # noqa: SLF001
+
+        results: dict[int, str] = {}
+        errors: dict[int, BaseException] = {}
+
+        def _run(label: int) -> None:
+            try:
+                remote._admin_command_runtime._send_command(  # noqa: SLF001
+                    admin_pb2.AdminMessage(reboot_seconds=label),
+                    ensure_session_key=False,
+                    use_remote_ack_callback=True,
+                )
+                results[label] = "ack"
+            except BaseException as exc:  # noqa: BLE001 - captured for assertion
+                errors[label] = exc
+
+        thread_a = threading.Thread(target=_run, args=(1,), daemon=True)
+        thread_b = threading.Thread(target=_run, args=(2,), daemon=True)
+        thread_a.start()
+        thread_b.start()
+        _wait_until(lambda: len(sent_packets) == 2)
+
+        with sent_lock:
+            request_ids_by_seconds: dict[int, int] = {}
+            for packet in sent_packets:
+                admin_message = admin_pb2.AdminMessage()
+                admin_message.ParseFromString(packet.decoded.payload)
+                request_ids_by_seconds[admin_message.reboot_seconds] = packet.id
+        assert set(request_ids_by_seconds) == {1, 2}
+        assert len(set(request_ids_by_seconds.values())) == 2
+        assert set(request_ids_by_seconds.values()).issubset(
+            iface._active_wait_request_ids[WAIT_ATTR_NAK]  # noqa: SLF001
+        )
+
+        request_a = request_ids_by_seconds[1]
+        request_b = request_ids_by_seconds[2]
+        iface._request_wait_runtime.correlate_inbound_response(  # noqa: SLF001
+            packet_dict={
+                "decoded": {
+                    "requestId": request_b,
+                    "routing": {"errorReason": "NO_RESPONSE"},
+                },
+                "from": remote.nodeNum,
+            },
+            skip_response_callback_for_decode_failure=False,
+            extract_request_id=iface._extract_request_id_from_packet,  # noqa: SLF001
+        )
+        _wait_until(lambda: len(errors) == 1)
+        assert len(results) == 0
+        assert thread_a.is_alive() or thread_b.is_alive()
+
+        iface._request_wait_runtime.correlate_inbound_response(  # noqa: SLF001
+            packet_dict={
+                "decoded": {
+                    "requestId": request_a,
+                    "routing": {"errorReason": "NONE"},
+                },
+                "from": remote.nodeNum,
+            },
+            skip_response_callback_for_decode_failure=False,
+            extract_request_id=iface._extract_request_id_from_packet,  # noqa: SLF001
+        )
+
+        thread_a.join(timeout=1.0)
+        thread_b.join(timeout=1.0)
+        assert not thread_a.is_alive()
+        assert not thread_b.is_alive()
+        assert results == {1: "ack"}
+        assert set(errors) == {2}
+        assert "NO_RESPONSE" in str(errors[2])
+        assert iface._active_wait_request_ids.get(WAIT_ATTR_NAK) is None  # noqa: SLF001

--- a/meshtastic/tests/test_admin_ack_wait_scoping.py
+++ b/meshtastic/tests/test_admin_ack_wait_scoping.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import threading
 import time
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -13,6 +13,10 @@ import pytest
 from meshtastic.mesh_interface import MeshInterface
 from meshtastic.node_runtime.admin_wait import (
     WAIT_ATTR_NAK,
+    _accepts_response_wait_attr,
+    _extract_request_id_from_response,
+    _extract_request_id_from_sent_packet,
+    _set_admin_wait_error,
     _wait_for_admin_ack,
 )
 from meshtastic.node_runtime.settings_runtime.admin import _NodeAdminCommandRuntime
@@ -52,8 +56,8 @@ class _ScopedIfaceDouble:
         self.legacy_waits += 1
 
 
-class _RemoteAdminNodeDouble:
-    """Minimal node double with a real bound ``_send_admin`` method."""
+class _AdminNodeDoubleBase:
+    """Shared state for modern and legacy bound admin sender doubles."""
 
     def __init__(self) -> None:
         self.iface = _ScopedIfaceDouble()
@@ -65,6 +69,10 @@ class _RemoteAdminNodeDouble:
 
     def onAckNak(self, _packet: dict[str, Any]) -> None:  # noqa: N802
         """ACK callback placeholder used only to select remote wait policy."""
+
+
+class _RemoteAdminNodeDouble(_AdminNodeDoubleBase):
+    """Minimal node double with the current bound ``_send_admin`` signature."""
 
     def _send_admin(
         self,
@@ -110,7 +118,7 @@ def test_remote_admin_command_registers_and_uses_request_scoped_ack_wait() -> No
     assert node.iface.legacy_waits == 0
 
 
-class _LegacyBoundAdminNodeDouble(_RemoteAdminNodeDouble):
+class _LegacyBoundAdminNodeDouble(_AdminNodeDoubleBase):
     """Bound admin sender that preserves the pre-scope private signature."""
 
     def _send_admin(
@@ -150,8 +158,8 @@ def test_admin_wait_falls_back_to_legacy_interface_contract() -> None:
     iface = SimpleNamespace(waitForAckNak=MagicMock())
     node = SimpleNamespace(iface=iface)
 
-    _wait_for_admin_ack(  # type: ignore[arg-type]
-        node,
+    _wait_for_admin_ack(
+        cast(Any, node),
         mesh_pb2.MeshPacket(id=99),
     )
 
@@ -346,14 +354,16 @@ def test_admin_send_helper_preserves_instance_level_transport_monkeypatch() -> N
 
 
 @pytest.mark.unit
-def test_fast_admin_ack_is_not_lost_between_send_and_wait() -> None:
+def test_fast_admin_ack_is_not_lost_between_send_and_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """A synchronous ACK during transport send must satisfy the later scoped wait."""
     from types import MethodType
 
     from meshtastic.node import Node
 
     with MeshInterface(noProto=True) as iface:
-        iface.myInfo = SimpleNamespace(my_node_num=1)
+        iface.myInfo = mesh_pb2.MyNodeInfo(my_node_num=1)
         iface.localNode.nodeNum = 1
         iface._get_or_create_by_num = MethodType(  # type: ignore[method-assign]  # noqa: SLF001
             lambda _self, _node_num: {},
@@ -382,7 +392,7 @@ def test_fast_admin_ack_is_not_lost_between_send_and_wait() -> None:
             )
             return packet
 
-        iface._send_packet = _send_packet  # type: ignore[method-assign]  # noqa: SLF001
+        monkeypatch.setattr(iface, "_send_packet", _send_packet)
 
         request = remote._admin_command_runtime._send_command(  # noqa: SLF001
             admin_pb2.AdminMessage(reboot_seconds=1),
@@ -442,14 +452,16 @@ def test_metadata_response_marks_scoped_request_completion() -> None:
 
 
 @pytest.mark.unit
-def test_overlapping_remote_admin_commands_correlate_ack_and_nak_by_request() -> None:
+def test_overlapping_remote_admin_commands_correlate_ack_and_nak_by_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Overlapping remote admin calls must resolve only from their own responses."""
     from types import MethodType
 
     from meshtastic.node import Node
 
     with MeshInterface(noProto=True) as iface:
-        iface.myInfo = SimpleNamespace(my_node_num=1)
+        iface.myInfo = mesh_pb2.MyNodeInfo(my_node_num=1)
         iface.localNode.nodeNum = 1
         iface._get_or_create_by_num = MethodType(  # type: ignore[method-assign]  # noqa: SLF001
             lambda _self, _node_num: {},
@@ -470,7 +482,7 @@ def test_overlapping_remote_admin_commands_correlate_ack_and_nak_by_request() ->
                 sent_packets.append(snapshot)
             return packet
 
-        iface._send_packet = _send_packet  # type: ignore[method-assign]  # noqa: SLF001
+        monkeypatch.setattr(iface, "_send_packet", _send_packet)
 
         results: dict[int, str] = {}
         errors: dict[int, BaseException] = {}
@@ -541,3 +553,106 @@ def test_overlapping_remote_admin_commands_correlate_ack_and_nak_by_request() ->
         assert set(errors) == {2}
         assert "NO_RESPONSE" in str(errors[2])
         assert iface._active_wait_request_ids.get(WAIT_ATTR_NAK) is None  # noqa: SLF001
+
+
+@pytest.mark.unit
+def test_admin_wait_request_id_helpers_handle_missing_legacy_hooks() -> None:
+    """Request-id extraction should degrade safely on minimal compatibility doubles."""
+    node = SimpleNamespace(iface=SimpleNamespace())
+
+    assert _extract_request_id_from_sent_packet(node, None) is None  # type: ignore[arg-type]
+    assert (
+        _extract_request_id_from_sent_packet(  # type: ignore[arg-type]
+            node,
+            mesh_pb2.MeshPacket(id=0),
+        )
+        is None
+    )
+    assert _extract_request_id_from_response(node, {}) is None  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_admin_wait_error_noops_without_wait_error_hook() -> None:
+    """Minimal interface doubles without scoped error storage should remain supported."""
+    node = SimpleNamespace(iface=SimpleNamespace())
+
+    _set_admin_wait_error(  # type: ignore[arg-type]
+        node,
+        "ignored",
+        request_id=123,
+    )
+
+
+@pytest.mark.unit
+def test_admin_sender_signature_probe_handles_uninspectable_callable() -> None:
+    """Compatibility send callables with invalid signatures should disable private scoping."""
+    class _UninspectableCallable:
+        @property
+        def __signature__(self) -> object:
+            raise ValueError("no signature")
+
+        def __call__(self, *_args: object, **_kwargs: object) -> None:
+            return None
+
+    assert _accepts_response_wait_attr(_UninspectableCallable()) is False
+
+
+@pytest.mark.unit
+def test_request_scoped_admin_wait_timeout_retires_request() -> None:
+    """A timed-out scoped ACK wait should retire its request bookkeeping."""
+    request_id = 909
+    with MeshInterface(noProto=True) as iface:
+        iface._timeout.expireTimeout = 0.01  # noqa: SLF001
+        iface._timeout.sleepInterval = 0.001  # noqa: SLF001
+        iface._clear_wait_error(WAIT_ATTR_NAK, request_id=request_id)  # noqa: SLF001
+
+        with pytest.raises(
+            MeshInterface.MeshInterfaceError,
+            match="Timed out waiting for an acknowledgment",
+        ):
+            iface._wait_for_ack_nak(request_id)  # noqa: SLF001
+
+        assert request_id not in iface._active_wait_request_ids.get(  # noqa: SLF001
+            WAIT_ATTR_NAK, set()
+        )
+        assert request_id in iface._retired_wait_request_ids[WAIT_ATTR_NAK]  # noqa: SLF001
+
+
+@pytest.mark.unit
+def test_settings_response_missing_expected_field_records_scoped_failure() -> None:
+    """A structurally valid settings envelope missing its field should NAK its request."""
+    iface = SimpleNamespace(
+        _acknowledgment=Acknowledgment(),
+        _extract_request_id_from_packet=lambda _packet: 818,
+        _mark_wait_acknowledged=MagicMock(),
+        _set_wait_error=MagicMock(),
+    )
+    node = SimpleNamespace(
+        iface=iface,
+        localConfig=localonly_pb2.LocalConfig(),
+        moduleConfig=localonly_pb2.LocalModuleConfig(),
+    )
+    raw = admin_pb2.AdminMessage()
+    packet: dict[str, Any] = {
+        "decoded": {
+            "admin": {
+                "getConfigResponse": {"device": {}},
+                "raw": raw,
+            }
+        }
+    }
+
+    _NodeSettingsResponseRuntime(node).handleSettingsResponse(packet)  # type: ignore[arg-type]
+
+    assert iface._acknowledgment.receivedNak is True
+    assert iface._set_wait_error.call_args_list == [
+        (
+            (WAIT_ATTR_NAK, "Received settings response without expected field 'device'."),
+            {},
+        ),
+        (
+            (WAIT_ATTR_NAK, "Received settings response without expected field 'device'."),
+            {"request_id": 818},
+        ),
+    ]
+    iface._mark_wait_acknowledged.assert_not_called()

--- a/meshtastic/tests/test_admin_ack_wait_scoping.py
+++ b/meshtastic/tests/test_admin_ack_wait_scoping.py
@@ -41,6 +41,12 @@ class _ScopedIfaceDouble:
         request_id = getattr(packet, "id", None)
         return request_id if isinstance(request_id, int) and request_id > 0 else None
 
+    def _has_active_wait_request(
+        self, acknowledgment_attr: str, request_id: int
+    ) -> bool:
+        active = self._active_wait_request_ids.get(acknowledgment_attr)
+        return active is not None and request_id in active
+
     def _wait_for_ack_nak(self, request_id: int) -> None:
         self.scoped_waits.append(request_id)
         active = self._active_wait_request_ids.get(WAIT_ATTR_NAK)
@@ -167,10 +173,23 @@ def test_admin_wait_falls_back_to_legacy_interface_contract() -> None:
 
 
 @pytest.mark.unit
+def test_active_wait_scope_query_tracks_registration_and_retirement() -> None:
+    """Active-wait membership should be queried through the lock-owning runtime."""
+    with MeshInterface(noProto=True) as iface:
+        request_id = 100
+        iface._clear_wait_error(WAIT_ATTR_NAK, request_id=request_id)  # noqa: SLF001
+
+        assert iface._has_active_wait_request(WAIT_ATTR_NAK, request_id)  # noqa: SLF001
+
+        iface._retire_wait_request(WAIT_ATTR_NAK, request_id=request_id)  # noqa: SLF001
+        assert not iface._has_active_wait_request(WAIT_ATTR_NAK, request_id)  # noqa: SLF001
+
+
+@pytest.mark.unit
 def test_request_scoped_admin_waits_do_not_crosstalk() -> None:
     """An ACK for one request must not release a different admin waiter."""
     with MeshInterface(noProto=True) as iface:
-        iface._timeout.expireTimeout = 1.0  # noqa: SLF001
+        iface._timeout.expireTimeout = 30.0  # noqa: SLF001
         iface._timeout.sleepInterval = 0.001  # noqa: SLF001
         request_a = 101
         request_b = 202
@@ -215,7 +234,7 @@ def test_request_scoped_admin_waits_do_not_crosstalk() -> None:
 def test_scoped_admin_nak_only_fails_matching_request() -> None:
     """A request-scoped NAK should fail its owner without poisoning another wait."""
     with MeshInterface(noProto=True) as iface:
-        iface._timeout.expireTimeout = 1.0  # noqa: SLF001
+        iface._timeout.expireTimeout = 30.0  # noqa: SLF001
         iface._timeout.sleepInterval = 0.001  # noqa: SLF001
         request_ok = 303
         request_nak = 404
@@ -452,6 +471,80 @@ def test_metadata_response_marks_scoped_request_completion() -> None:
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    ("packet", "error_fragment"),
+    [
+        ({"decoded": None}, "missing decoded"),
+        (
+            {
+                "decoded": {
+                    "portnum": "ROUTING_APP",
+                    "routing": None,
+                }
+            },
+            "missing routing",
+        ),
+        (
+            {
+                "decoded": {
+                    "portnum": "ROUTING_APP",
+                    "routing": {"errorReason": 1},
+                }
+            },
+            "invalid routing.errorReason",
+        ),
+        ({"decoded": {"portnum": "ADMIN_APP"}}, "missing admin"),
+        (
+            {"decoded": {"portnum": "ADMIN_APP", "admin": {}}},
+            "missing admin.raw",
+        ),
+        (
+            {
+                "decoded": {
+                    "portnum": "ADMIN_APP",
+                    "routing": {"errorReason": 1},
+                }
+            },
+            "invalid routing.errorReason",
+        ),
+    ],
+)
+def test_malformed_metadata_response_records_request_scoped_failure(
+    packet: dict[str, Any], error_fragment: str
+) -> None:
+    """Every terminal malformed metadata response should fail its scoped waiter."""
+    from meshtastic.node_runtime.response_runtime import _NodeMetadataResponseRuntime
+
+    request_id = 818
+    packet.setdefault("decoded", {})
+    if isinstance(packet.get("decoded"), dict):
+        packet["decoded"]["requestId"] = request_id
+    iface = SimpleNamespace(
+        _acknowledgment=Acknowledgment(),
+        _extract_request_id_from_packet=lambda _packet: request_id,
+        _mark_wait_acknowledged=MagicMock(),
+        _set_wait_error=MagicMock(),
+    )
+    node = SimpleNamespace(
+        iface=iface,
+        _signal_metadata_stdout_event=MagicMock(),
+    )
+
+    _NodeMetadataResponseRuntime(cast(Any, node)).handleMetadataResponse(packet)
+
+    assert iface._acknowledgment.receivedNak is True
+    assert iface._set_wait_error.call_args_list == [
+        ((WAIT_ATTR_NAK, f"Received malformed metadata response ({error_fragment})."), {}),
+        (
+            (WAIT_ATTR_NAK, f"Received malformed metadata response ({error_fragment})."),
+            {"request_id": request_id},
+        ),
+    ]
+    iface._mark_wait_acknowledged.assert_not_called()
+    node._signal_metadata_stdout_event.assert_called_once_with()
+
+
+@pytest.mark.unit
 def test_overlapping_remote_admin_commands_correlate_ack_and_nak_by_request(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -531,7 +624,8 @@ def test_overlapping_remote_admin_commands_correlate_ack_and_nak_by_request(
         )
         _wait_until(lambda: len(errors) == 1)
         assert len(results) == 0
-        assert thread_a.is_alive() or thread_b.is_alive()
+        assert set(errors) == {2}
+        assert thread_a.is_alive()
 
         iface._request_wait_runtime.correlate_inbound_response(  # noqa: SLF001
             packet_dict={
@@ -560,15 +654,15 @@ def test_admin_wait_request_id_helpers_handle_missing_legacy_hooks() -> None:
     """Request-id extraction should degrade safely on minimal compatibility doubles."""
     node = SimpleNamespace(iface=SimpleNamespace())
 
-    assert _extract_request_id_from_sent_packet(node, None) is None  # type: ignore[arg-type]
+    assert _extract_request_id_from_sent_packet(cast(Any, node), None) is None
     assert (
-        _extract_request_id_from_sent_packet(  # type: ignore[arg-type]
-            node,
+        _extract_request_id_from_sent_packet(
+            cast(Any, node),
             mesh_pb2.MeshPacket(id=0),
         )
         is None
     )
-    assert _extract_request_id_from_response(node, {}) is None  # type: ignore[arg-type]
+    assert _extract_request_id_from_response(cast(Any, node), {}) is None
 
 
 @pytest.mark.unit
@@ -576,8 +670,8 @@ def test_admin_wait_error_noops_without_wait_error_hook() -> None:
     """Minimal interface doubles without scoped error storage should remain supported."""
     node = SimpleNamespace(iface=SimpleNamespace())
 
-    _set_admin_wait_error(  # type: ignore[arg-type]
-        node,
+    _set_admin_wait_error(
+        cast(Any, node),
         "ignored",
         request_id=123,
     )

--- a/meshtastic/tests/test_admin_ack_wait_scoping.py
+++ b/meshtastic/tests/test_admin_ack_wait_scoping.py
@@ -4,21 +4,26 @@ from __future__ import annotations
 
 import threading
 import time
-from types import SimpleNamespace
+from collections.abc import Callable
+from types import MethodType, SimpleNamespace
 from typing import Any, cast
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 
 from meshtastic.mesh_interface import MeshInterface
+from meshtastic.node import Node
 from meshtastic.node_runtime.admin_wait import (
     WAIT_ATTR_NAK,
     _accepts_response_wait_attr,
     _extract_request_id_from_response,
     _extract_request_id_from_sent_packet,
+    _send_admin_with_ack_scope,
     _set_admin_wait_error,
     _wait_for_admin_ack,
 )
+from meshtastic.node_runtime.contact_runtime import _NodeContactRuntime
+from meshtastic.node_runtime.response_runtime import _NodeMetadataResponseRuntime
 from meshtastic.node_runtime.settings_runtime.admin import _NodeAdminCommandRuntime
 from meshtastic.node_runtime.settings_runtime.response import (
     _NodeSettingsResponseRuntime,
@@ -77,6 +82,9 @@ class _AdminNodeDoubleBase:
         """ACK callback placeholder used only to select remote wait policy."""
 
 
+_REMOTE_REQUEST_ID = 731
+
+
 class _RemoteAdminNodeDouble(_AdminNodeDoubleBase):
     """Minimal node double with the current bound ``_send_admin`` signature."""
 
@@ -90,11 +98,13 @@ class _RemoteAdminNodeDouble(_AdminNodeDoubleBase):
         _ = onResponse
         self.sent_response_wait_attrs.append(responseWaitAttr)
         if responseWaitAttr is not None:
-            self.iface._active_wait_request_ids.setdefault(responseWaitAttr, set()).add(731)
-        return mesh_pb2.MeshPacket(id=731)
+            self.iface._active_wait_request_ids.setdefault(responseWaitAttr, set()).add(
+                _REMOTE_REQUEST_ID
+            )
+        return mesh_pb2.MeshPacket(id=_REMOTE_REQUEST_ID)
 
 
-def _wait_until(predicate: Any, *, timeout: float = 1.0) -> None:
+def _wait_until(predicate: Callable[[], bool], *, timeout: float = 1.0) -> None:
     """Wait until a test predicate becomes true or fail deterministically."""
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -102,6 +112,22 @@ def _wait_until(predicate: Any, *, timeout: float = 1.0) -> None:
             return
         time.sleep(0.001)
     pytest.fail("timed out waiting for test condition")
+
+
+def _settings_doubles(request_id: int) -> tuple[SimpleNamespace, SimpleNamespace]:
+    """Build matching interface and node doubles for settings response tests."""
+    iface = SimpleNamespace(
+        _acknowledgment=Acknowledgment(),
+        _extract_request_id_from_packet=lambda _packet: request_id,
+        _mark_wait_acknowledged=MagicMock(),
+        _set_wait_error=MagicMock(),
+    )
+    node = SimpleNamespace(
+        iface=iface,
+        localConfig=localonly_pb2.LocalConfig(),
+        moduleConfig=localonly_pb2.LocalModuleConfig(),
+    )
+    return iface, node
 
 
 @pytest.mark.unit
@@ -117,11 +143,34 @@ def test_remote_admin_command_registers_and_uses_request_scoped_ack_wait() -> No
     )
 
     assert request is not None
-    assert request.id == 731
+    assert request.id == _REMOTE_REQUEST_ID
     assert node.session_key_checks == 1
     assert node.sent_response_wait_attrs == [WAIT_ATTR_NAK]
-    assert node.iface.scoped_waits == [731]
+    assert node.iface.scoped_waits == [_REMOTE_REQUEST_ID]
     assert node.iface.legacy_waits == 0
+
+
+@pytest.mark.unit
+def test_contact_import_registers_and_uses_request_scoped_ack_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Remote contact imports should use the same request-scoped ACK wait."""
+    node = _RemoteAdminNodeDouble()
+    runtime = _NodeContactRuntime(node)  # type: ignore[arg-type]
+    contact = admin_pb2.SharedContact(node_num=123)
+    contact.user.id = "!0000007b"
+    decode_contact = MagicMock(return_value=contact)
+    monkeypatch.setattr(runtime, "_decode_contact", decode_contact)
+
+    request = runtime.add_contact_url("https://meshtastic.org/v/#ignored")
+
+    assert request is not None
+    assert request.id == _REMOTE_REQUEST_ID
+    assert node.session_key_checks == 1
+    assert node.sent_response_wait_attrs == [WAIT_ATTR_NAK]
+    assert node.iface.scoped_waits == [_REMOTE_REQUEST_ID]
+    assert node.iface.legacy_waits == 0
+    decode_contact.assert_called_once()
 
 
 class _LegacyBoundAdminNodeDouble(_AdminNodeDoubleBase):
@@ -214,6 +263,18 @@ def test_request_scoped_admin_waits_do_not_crosstalk() -> None:
         thread_a.start()
         thread_b.start()
 
+        # Responses for an id that was never registered must not affect either waiter.
+        iface._set_wait_error(  # noqa: SLF001
+            WAIT_ATTR_NAK,
+            "Routing error on response: NO_RESPONSE",
+            request_id=999,
+        )
+        iface._mark_wait_acknowledged(WAIT_ATTR_NAK, request_id=999)  # noqa: SLF001
+        assert completed == []
+        assert errors == []
+        assert thread_a.is_alive()
+        assert thread_b.is_alive()
+
         iface._mark_wait_acknowledged(WAIT_ATTR_NAK, request_id=request_a)  # noqa: SLF001
         _wait_until(lambda: request_a in completed)
         assert request_b not in completed
@@ -242,11 +303,15 @@ def test_scoped_admin_nak_only_fails_matching_request() -> None:
         iface._clear_wait_error(WAIT_ATTR_NAK, request_id=request_nak)  # noqa: SLF001
 
         ok_complete = threading.Event()
+        ok_error: list[BaseException] = []
         nak_error: list[BaseException] = []
 
         def _wait_ok() -> None:
-            iface._wait_for_ack_nak(request_ok)  # noqa: SLF001
-            ok_complete.set()
+            try:
+                iface._wait_for_ack_nak(request_ok)  # noqa: SLF001
+                ok_complete.set()
+            except BaseException as exc:  # noqa: BLE001 - captured for assertion
+                ok_error.append(exc)
 
         def _wait_nak() -> None:
             try:
@@ -268,6 +333,7 @@ def test_scoped_admin_nak_only_fails_matching_request() -> None:
         assert not nak_thread.is_alive()
         assert len(nak_error) == 1
         assert "NO_RESPONSE" in str(nak_error[0])
+        assert ok_error == []
         assert not ok_complete.is_set()
         assert ok_thread.is_alive()
 
@@ -280,17 +346,7 @@ def test_scoped_admin_nak_only_fails_matching_request() -> None:
 @pytest.mark.unit
 def test_settings_response_marks_scoped_request_completion() -> None:
     """Successful settings callbacks should release only their request-scoped waiter."""
-    iface = SimpleNamespace(
-        _acknowledgment=Acknowledgment(),
-        _extract_request_id_from_packet=lambda _packet: 515,
-        _mark_wait_acknowledged=MagicMock(),
-        _set_wait_error=MagicMock(),
-    )
-    node = SimpleNamespace(
-        iface=iface,
-        localConfig=localonly_pb2.LocalConfig(),
-        moduleConfig=localonly_pb2.LocalModuleConfig(),
-    )
+    iface, node = _settings_doubles(515)
     raw = admin_pb2.AdminMessage()
     raw.get_config_response.device.role = config_pb2.Config.DeviceConfig.Role.CLIENT
     packet: dict[str, Any] = {
@@ -315,28 +371,15 @@ def test_settings_response_marks_scoped_request_completion() -> None:
 @pytest.mark.unit
 def test_settings_routing_error_records_scoped_request_failure() -> None:
     """Settings routing errors should be attached to the response request id."""
-    iface = SimpleNamespace(
-        _acknowledgment=Acknowledgment(),
-        _extract_request_id_from_packet=lambda _packet: 616,
-        _mark_wait_acknowledged=MagicMock(),
-        _set_wait_error=MagicMock(),
-    )
-    node = SimpleNamespace(
-        iface=iface,
-        localConfig=localonly_pb2.LocalConfig(),
-        moduleConfig=localonly_pb2.LocalModuleConfig(),
-    )
+    iface, node = _settings_doubles(616)
     packet = {"decoded": {"routing": {"errorReason": "NO_RESPONSE"}}}
 
     _NodeSettingsResponseRuntime(node).handleSettingsResponse(packet)  # type: ignore[arg-type]
 
     assert iface._acknowledgment.receivedNak is True
     assert iface._set_wait_error.call_args_list == [
-        ((WAIT_ATTR_NAK, "Routing error on response: NO_RESPONSE"), {}),
-        (
-            (WAIT_ATTR_NAK, "Routing error on response: NO_RESPONSE"),
-            {"request_id": 616},
-        ),
+        call(WAIT_ATTR_NAK, "Routing error on response: NO_RESPONSE"),
+        call(WAIT_ATTR_NAK, "Routing error on response: NO_RESPONSE", request_id=616),
     ]
     iface._mark_wait_acknowledged.assert_not_called()
 
@@ -357,8 +400,6 @@ def test_admin_send_helper_preserves_instance_level_transport_monkeypatch() -> N
     iface = SimpleNamespace(waitForAckNak=MagicMock())
     node = SimpleNamespace(iface=iface, _send_admin=_send_admin)
 
-    from meshtastic.node_runtime.admin_wait import _send_admin_with_ack_scope
-
     request = _send_admin_with_ack_scope(
         node,  # type: ignore[arg-type]
         admin_pb2.AdminMessage(reboot_seconds=1),
@@ -377,10 +418,6 @@ def test_fast_admin_ack_is_not_lost_between_send_and_wait(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A synchronous ACK during transport send must satisfy the later scoped wait."""
-    from types import MethodType
-
-    from meshtastic.node import Node
-
     with MeshInterface(noProto=True) as iface:
         iface.myInfo = mesh_pb2.MyNodeInfo(my_node_num=1)
         iface.localNode.nodeNum = 1
@@ -428,8 +465,6 @@ def test_fast_admin_ack_is_not_lost_between_send_and_wait(
 @pytest.mark.unit
 def test_metadata_response_marks_scoped_request_completion() -> None:
     """Successful metadata payloads should complete their own request-scoped wait."""
-    from meshtastic.node_runtime.response_runtime import _NodeMetadataResponseRuntime
-
     iface = SimpleNamespace(
         _acknowledgment=Acknowledgment(),
         _extract_request_id_from_packet=lambda _packet: 717,
@@ -513,12 +548,7 @@ def test_malformed_metadata_response_records_request_scoped_failure(
     packet: dict[str, Any], error_fragment: str
 ) -> None:
     """Every terminal malformed metadata response should fail its scoped waiter."""
-    from meshtastic.node_runtime.response_runtime import _NodeMetadataResponseRuntime
-
     request_id = 818
-    packet.setdefault("decoded", {})
-    if isinstance(packet.get("decoded"), dict):
-        packet["decoded"]["requestId"] = request_id
     iface = SimpleNamespace(
         _acknowledgment=Acknowledgment(),
         _extract_request_id_from_packet=lambda _packet: request_id,
@@ -534,10 +564,11 @@ def test_malformed_metadata_response_records_request_scoped_failure(
 
     assert iface._acknowledgment.receivedNak is True
     assert iface._set_wait_error.call_args_list == [
-        ((WAIT_ATTR_NAK, f"Received malformed metadata response ({error_fragment})."), {}),
-        (
-            (WAIT_ATTR_NAK, f"Received malformed metadata response ({error_fragment})."),
-            {"request_id": request_id},
+        call(WAIT_ATTR_NAK, f"Received malformed metadata response ({error_fragment})."),
+        call(
+            WAIT_ATTR_NAK,
+            f"Received malformed metadata response ({error_fragment}).",
+            request_id=request_id,
         ),
     ]
     iface._mark_wait_acknowledged.assert_not_called()
@@ -549,10 +580,6 @@ def test_overlapping_remote_admin_commands_correlate_ack_and_nak_by_request(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Overlapping remote admin calls must resolve only from their own responses."""
-    from types import MethodType
-
-    from meshtastic.node import Node
-
     with MeshInterface(noProto=True) as iface:
         iface.myInfo = mesh_pb2.MyNodeInfo(my_node_num=1)
         iface.localNode.nodeNum = 1
@@ -560,7 +587,7 @@ def test_overlapping_remote_admin_commands_correlate_ack_and_nak_by_request(
             lambda _self, _node_num: {},
             iface,
         )
-        remote = Node(iface, 2, noProto=False, timeout=1.0)
+        remote = Node(iface, 2, noProto=False, timeout=30.0)
         sent_packets: list[mesh_pb2.MeshPacket] = []
         sent_lock = threading.Lock()
 
@@ -715,17 +742,7 @@ def test_request_scoped_admin_wait_timeout_retires_request() -> None:
 @pytest.mark.unit
 def test_settings_response_missing_expected_field_records_scoped_failure() -> None:
     """A structurally valid settings envelope missing its field should NAK its request."""
-    iface = SimpleNamespace(
-        _acknowledgment=Acknowledgment(),
-        _extract_request_id_from_packet=lambda _packet: 818,
-        _mark_wait_acknowledged=MagicMock(),
-        _set_wait_error=MagicMock(),
-    )
-    node = SimpleNamespace(
-        iface=iface,
-        localConfig=localonly_pb2.LocalConfig(),
-        moduleConfig=localonly_pb2.LocalModuleConfig(),
-    )
+    iface, node = _settings_doubles(818)
     raw = admin_pb2.AdminMessage()
     packet: dict[str, Any] = {
         "decoded": {
@@ -740,13 +757,11 @@ def test_settings_response_missing_expected_field_records_scoped_failure() -> No
 
     assert iface._acknowledgment.receivedNak is True
     assert iface._set_wait_error.call_args_list == [
-        (
-            (WAIT_ATTR_NAK, "Received settings response without expected field 'device'."),
-            {},
-        ),
-        (
-            (WAIT_ATTR_NAK, "Received settings response without expected field 'device'."),
-            {"request_id": 818},
+        call(WAIT_ATTR_NAK, "Received settings response without expected field 'device'."),
+        call(
+            WAIT_ATTR_NAK,
+            "Received settings response without expected field 'device'.",
+            request_id=818,
         ),
     ]
     iface._mark_wait_acknowledged.assert_not_called()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This change scopes remote administrator ACK/NAK waits to individual request IDs. It prevents concurrent admin requests from consuming each other’s acknowledgments. It preserves legacy wait behavior when scoped helpers are unavailable.

## Key changes

### Features
- Added request-scoped ACK/NAK wait handling in `SendPipeline`.
- Added shared helpers to register, update, and wait for remote admin ACK scopes.
- Correlated ACKs, NAKs, errors, metadata responses, and settings responses with request IDs.
- Updated admin, configuration, channel, position/time, contact import, and metadata operations to use scoped waits.
- Added fallback support for legacy transports and senders.

### Fixes
- Isolated ACK and NAK results for concurrent requests.
- Handled acknowledgments that arrive during a send operation.
- Retired scoped wait state after completion, errors, or timeouts.
- Preserved remote-only ACK callbacks for contact imports.
- Added request-scoped handling for malformed, incomplete, invalid, and routing-error responses.

### Refactors
- Centralized admin ACK-scope and wait logic in `admin_wait.py`.
- Reused shared request-ID extraction and wait-state update helpers.
- Removed duplicated `WAIT_ATTR_NAK` definitions and direct legacy wait calls.
- Added comprehensive tests for concurrency, fallback behavior, timeout handling, sender compatibility, and response correlation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->