### PR TITLE
Drain deferred execution tasks on shutdown

### DIFF
--- a/meshtastic/tests/test_util.py
+++ b/meshtastic/tests/test_util.py
@@ -1620,6 +1620,62 @@ def test_deferred_execution_runs_closure() -> None:
 
 
 @pytest.mark.unit
+def test_deferred_execution_stop_drains_previously_queued_work() -> None:
+    """stop() should drain work accepted before the shutdown sentinel."""
+    first_started = threading.Event()
+    release_first = threading.Event()
+    second_completed = threading.Event()
+    first_wait_timed_out = threading.Event()
+    execution_order: list[str] = []
+    de = DeferredExecution(name="test_drain_thread")
+
+    def first() -> None:
+        execution_order.append("first")
+        first_started.set()
+        if not release_first.wait(timeout=1.0):
+            first_wait_timed_out.set()
+
+    def second() -> None:
+        execution_order.append("second")
+        second_completed.set()
+
+    de.queueWork(first)
+    assert first_started.wait(timeout=1.0)
+    de.queueWork(second)
+    de.stop()
+    release_first.set()
+
+    assert de.join(timeout=1.0)
+    assert second_completed.is_set()
+    assert not first_wait_timed_out.is_set()
+    assert execution_order == ["first", "second"]
+
+
+@pytest.mark.unit
+def test_deferred_execution_ignores_work_submitted_after_stop() -> None:
+    """queueWork() should preserve non-raising behavior after shutdown starts."""
+    called = threading.Event()
+    de = DeferredExecution(name="test_post_stop_thread")
+
+    de.stop()
+    de.queueWork(called.set)
+
+    assert de.join(timeout=1.0)
+    assert not called.is_set()
+
+
+@pytest.mark.unit
+def test_deferred_execution_stop_is_idempotent() -> None:
+    """Repeated stop() calls should enqueue only one effective shutdown boundary."""
+    de = DeferredExecution(name="test_repeated_stop_thread")
+
+    de.stop()
+    de.stop()
+
+    assert de.join(timeout=1.0)
+
+
+@pytest.mark.unit
 def test_deferred_execution_handles_exceptions(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/meshtastic/util.py
+++ b/meshtastic/util.py
@@ -680,19 +680,28 @@ class DeferredExecution:
     def queueWork(self, runnable: Callable[[], Any]) -> None:
         """Enqueue a callable to be executed by the background worker thread.
 
+        Work accepted before :meth:`stop` is guaranteed to run before the worker
+        exits. Work submitted after shutdown begins is ignored, preserving the
+        historical non-raising behavior while making the shutdown boundary
+        deterministic.
+
         Parameters
         ----------
         runnable : Callable[[], Any]
             A zero-argument callable to be executed later.
         """
-        self.queue.put(runnable)
+        with self._stop_lock:
+            if self._shutdown:
+                return
+            self.queue.put(runnable)
 
     def stop(self) -> None:
         """Signal the worker thread to shut down gracefully.
 
-        Enqueues a sentinel value that causes the worker loop to exit. After calling
-        stop(), the worker will finish processing pending items and exits. This method
-        is safe to call multiple times and is a no-op if already stopped.
+        Enqueues a sentinel value after all work accepted before this call. The
+        worker drains those pending items in FIFO order and exits when it reaches
+        the sentinel. This method is safe to call multiple times and is a no-op if
+        shutdown has already started.
         """
         with self._stop_lock:
             if not self._shutdown:
@@ -723,11 +732,12 @@ class DeferredExecution:
     def _run(self) -> None:
         """Continuously executes callables retrieved from the internal work queue.
 
-        Runs an infinite loop that takes callables from self.queue and invokes them; any
-        exception raised by a callable is logged and processing continues. The loop exits
-        when the _SHUTDOWN sentinel is received or when stop() is called.
+        Runs an infinite loop that takes callables from ``self.queue`` and invokes
+        them. Exceptions raised by queued work are logged and processing continues.
+        The loop exits only when it consumes the shutdown sentinel, ensuring work
+        accepted before :meth:`stop` is drained first.
         """
-        while not self._shutdown:
+        while True:
             try:
                 o = self.queue.get(timeout=_DEFERRED_QUEUE_POLL_TIMEOUT_SECONDS)
                 if o is self._SHUTDOWN:


### PR DESCRIPTION
## Summary by Sourcery

Ensure DeferredExecution drains previously accepted tasks deterministically on shutdown while ignoring work submitted after shutdown begins.

Enhancements:
- Guard DeferredExecution.queueWork with a shutdown flag and lock so only work accepted before stop() is enqueued and drained before exit.
- Change the worker loop to terminate only upon consuming a shutdown sentinel, making shutdown ordering deterministic.

Tests:
- Add unit tests verifying that DeferredExecution drains queued work before shutdown, ignores work submitted after stop(), and treats repeated stop() calls as idempotent.