### PR TITLE
Bound response handler lifecycle

### DIFF
--- a/meshtastic/__init__.py
+++ b/meshtastic/__init__.py
@@ -190,7 +190,8 @@ class ResponseHandler(_NamedTuple):
     callback: ResponseCallback
     #: Whether ACKs and NAKs should be passed to this handler
     ackPermitted: bool = False
-    # FIXME, add timestamp and age out old requests
+    # Registration timestamps are intentionally tracked out-of-band by the
+    # request runtime so this historical two-field tuple remains compatible.
 
 
 class KnownProtocol(_NamedTuple):

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -573,6 +573,10 @@ class MeshInterface:  # pylint: disable=R0902
                         "Failed to send disconnect during interpreter finalization; continuing shutdown.",
                         exc_info=True,
                     )
+        request_wait_runtime = getattr(self, "_request_wait_runtime", None)
+        if request_wait_runtime is not None:
+            request_wait_runtime.clear_response_handlers()
+
         # debugOut is caller-owned (often shared via outer context managers);
         # do not close it here. Only clear our reference on shutdown.
         if hasattr(self, "debugOut"):

--- a/meshtastic/mesh_interface_runtime/request_wait.py
+++ b/meshtastic/mesh_interface_runtime/request_wait.py
@@ -104,6 +104,7 @@ class _RequestWaitRuntime:
         self._ack_nak_handlers: dict[int, bool] = {}
         self._response_matchers: dict[int, Callable[[dict[str, Any]], bool]] = {}
         self._response_handler_registered_at: dict[int, float] = {}
+        self._managed_response_handlers: dict[int, ResponseHandler] = {}
 
     def mark_ack_nak_handler(self, request_id: int, *, flag: bool = True) -> None:
         """Mark or unmark a request_id as an ACK/NAK handler."""
@@ -126,10 +127,12 @@ class _RequestWaitRuntime:
         now = time.monotonic()
         with self._lock:
             self._prune_stale_response_handlers_locked(now=now)
-            self._get_response_handlers()[request_id] = ResponseHandler(
+            response_handler = ResponseHandler(
                 callback=callback,
                 ackPermitted=ack_permitted,
             )
+            self._get_response_handlers()[request_id] = response_handler
+            self._managed_response_handlers[request_id] = response_handler
             self._response_handler_registered_at[request_id] = now
             if is_ack_nak_handler:
                 self._ack_nak_handlers[request_id] = True
@@ -148,11 +151,11 @@ class _RequestWaitRuntime:
     def clear_response_handlers(self) -> None:
         """Remove all response callbacks and associated managed metadata."""
         with self._lock:
-            for request_id in list(self._get_response_handlers()):
-                self._remove_response_handler_locked(request_id)
+            self._get_response_handlers().clear()
             self._ack_nak_handlers.clear()
             self._response_matchers.clear()
             self._response_handler_registered_at.clear()
+            self._managed_response_handlers.clear()
 
     def prune_stale_response_handlers(self, *, now: float | None = None) -> list[int]:
         """Remove expired managed callbacks that are not part of an active wait."""
@@ -162,6 +165,11 @@ class _RequestWaitRuntime:
 
     def _prune_stale_response_handlers_locked(self, *, now: float) -> list[int]:
         """Prune expired managed callbacks while the response-state lock is held."""
+        response_handlers = self._get_response_handlers()
+        for request_id, managed_handler in list(self._managed_response_handlers.items()):
+            if response_handlers.get(request_id) is not managed_handler:
+                self._clear_managed_response_metadata_locked(request_id)
+
         cutoff = now - self._response_handler_ttl_seconds
         active_request_ids = {
             request_id
@@ -183,14 +191,29 @@ class _RequestWaitRuntime:
             )
         return stale_request_ids
 
+    def _response_handler_is_stale_locked(self, request_id: int, *, now: float) -> bool:
+        """Return whether one managed callback is expired and not actively awaited."""
+        registered_at = self._response_handler_registered_at.get(request_id)
+        if registered_at is None:
+            return False
+        active_request_ids = self._get_active_wait_request_ids()
+        if any(request_id in ids for ids in active_request_ids.values()):
+            return False
+        return now - registered_at > self._response_handler_ttl_seconds
+
+    def _clear_managed_response_metadata_locked(self, request_id: int) -> None:
+        """Forget runtime-owned metadata without touching a legacy replacement."""
+        self._ack_nak_handlers.pop(request_id, None)
+        self._response_matchers.pop(request_id, None)
+        self._response_handler_registered_at.pop(request_id, None)
+        self._managed_response_handlers.pop(request_id, None)
+
     def _remove_response_handler_locked(
         self, request_id: int
     ) -> ResponseHandler | None:
         """Remove one response registration while the response-state lock is held."""
         response_handler = self._get_response_handlers().pop(request_id, None)
-        self._ack_nak_handlers.pop(request_id, None)
-        self._response_matchers.pop(request_id, None)
-        self._response_handler_registered_at.pop(request_id, None)
+        self._clear_managed_response_metadata_locked(request_id)
         return response_handler
 
     def clear_wait_error(
@@ -512,7 +535,6 @@ class _RequestWaitRuntime:
         extract_request_id: Callable[[dict[str, Any]], int | None],
     ) -> None:
         """Correlate inbound response packets with callbacks and wait-state updates."""
-        self.prune_stale_response_handlers()
         request_id = extract_request_id(packet_dict)
         if request_id is None:
             return
@@ -559,6 +581,14 @@ class _RequestWaitRuntime:
             response_handlers = self._get_response_handlers()
             candidate = response_handlers.get(request_id, None)
             if candidate is not None:
+                managed_handler = self._managed_response_handlers.get(request_id)
+                if managed_handler is not None and candidate is not managed_handler:
+                    self._clear_managed_response_metadata_locked(request_id)
+                elif managed_handler is candidate and self._response_handler_is_stale_locked(
+                    request_id, now=time.monotonic()
+                ):
+                    self._remove_response_handler_locked(request_id)
+                    return None, False
                 matcher = self._response_matchers.get(request_id)
                 if not is_ack and matcher is not None:
                     try:

--- a/meshtastic/mesh_interface_runtime/request_wait.py
+++ b/meshtastic/mesh_interface_runtime/request_wait.py
@@ -39,6 +39,9 @@ DECODE_ERROR_KEY: str = "error"
 DECODE_FAILED_PREFIX: str = "decode-failed: "
 # Placeholder for legacy unscoped wait attribute mapping (currently unused)
 RETIRED_WAIT_REQUEST_ID_TTL_SECONDS: float = 60.0
+# Generic asynchronous callbacks are bounded independently of short ACK waits.
+# Active scoped waits are exempt from this TTL until their normal retirement path.
+RESPONSE_HANDLER_TTL_SECONDS: float = 3600.0
 
 
 class _RequestWaitRuntime:
@@ -70,6 +73,8 @@ class _RequestWaitRuntime:
         Factory that returns the shared timeout configuration object.
     retired_wait_ttl_seconds : float
         Time-to-live in seconds for retired request IDs before pruning.
+    response_handler_ttl_seconds : float
+        Time-to-live in seconds for managed response callbacks before pruning.
     """
 
     def __init__(
@@ -84,6 +89,7 @@ class _RequestWaitRuntime:
         get_acknowledgment: Callable[[], Acknowledgment],
         get_timeout: Callable[[], Timeout],
         retired_wait_ttl_seconds: float,
+        response_handler_ttl_seconds: float = RESPONSE_HANDLER_TTL_SECONDS,
     ) -> None:
         self._lock = lock
         self._get_response_handlers = get_response_handlers
@@ -94,8 +100,10 @@ class _RequestWaitRuntime:
         self._get_acknowledgment = get_acknowledgment
         self._get_timeout = get_timeout
         self._retired_wait_ttl_seconds = retired_wait_ttl_seconds
+        self._response_handler_ttl_seconds = response_handler_ttl_seconds
         self._ack_nak_handlers: dict[int, bool] = {}
         self._response_matchers: dict[int, Callable[[dict[str, Any]], bool]] = {}
+        self._response_handler_registered_at: dict[int, float] = {}
 
     def mark_ack_nak_handler(self, request_id: int, *, flag: bool = True) -> None:
         """Mark or unmark a request_id as an ACK/NAK handler."""
@@ -114,23 +122,76 @@ class _RequestWaitRuntime:
         is_ack_nak_handler: bool = False,
         matcher: Callable[[dict[str, Any]], bool] | None = None,
     ) -> None:
-        """Register a response callback for a request id."""
+        """Register a managed response callback for a request id."""
+        now = time.monotonic()
         with self._lock:
+            self._prune_stale_response_handlers_locked(now=now)
             self._get_response_handlers()[request_id] = ResponseHandler(
                 callback=callback,
                 ackPermitted=ack_permitted,
             )
+            self._response_handler_registered_at[request_id] = now
             if is_ack_nak_handler:
                 self._ack_nak_handlers[request_id] = True
+            else:
+                self._ack_nak_handlers.pop(request_id, None)
             if matcher is not None:
                 self._response_matchers[request_id] = matcher
+            else:
+                self._response_matchers.pop(request_id, None)
 
     def drop_response_handler(self, request_id: int) -> None:
         """Remove a response callback registration if present."""
         with self._lock:
-            self._get_response_handlers().pop(request_id, None)
-            self._ack_nak_handlers.pop(request_id, None)
-            self._response_matchers.pop(request_id, None)
+            self._remove_response_handler_locked(request_id)
+
+    def clear_response_handlers(self) -> None:
+        """Remove all response callbacks and associated managed metadata."""
+        with self._lock:
+            for request_id in list(self._get_response_handlers()):
+                self._remove_response_handler_locked(request_id)
+            self._ack_nak_handlers.clear()
+            self._response_matchers.clear()
+            self._response_handler_registered_at.clear()
+
+    def prune_stale_response_handlers(self, *, now: float | None = None) -> list[int]:
+        """Remove expired managed callbacks that are not part of an active wait."""
+        prune_time = time.monotonic() if now is None else now
+        with self._lock:
+            return self._prune_stale_response_handlers_locked(now=prune_time)
+
+    def _prune_stale_response_handlers_locked(self, *, now: float) -> list[int]:
+        """Prune expired managed callbacks while the response-state lock is held."""
+        cutoff = now - self._response_handler_ttl_seconds
+        active_request_ids = {
+            request_id
+            for request_ids in self._get_active_wait_request_ids().values()
+            for request_id in request_ids
+        }
+        stale_request_ids = [
+            request_id
+            for request_id, registered_at in self._response_handler_registered_at.items()
+            if registered_at <= cutoff and request_id not in active_request_ids
+        ]
+        for request_id in stale_request_ids:
+            self._remove_response_handler_locked(request_id)
+        if stale_request_ids:
+            logger.debug(
+                "Pruned %d stale response handler(s): %s",
+                len(stale_request_ids),
+                stale_request_ids,
+            )
+        return stale_request_ids
+
+    def _remove_response_handler_locked(
+        self, request_id: int
+    ) -> ResponseHandler | None:
+        """Remove one response registration while the response-state lock is held."""
+        response_handler = self._get_response_handlers().pop(request_id, None)
+        self._ack_nak_handlers.pop(request_id, None)
+        self._response_matchers.pop(request_id, None)
+        self._response_handler_registered_at.pop(request_id, None)
+        return response_handler
 
     def clear_wait_error(
         self,
@@ -345,7 +406,6 @@ class _RequestWaitRuntime:
     ) -> None:
         """Retire response handlers and scoped wait state after completion/timeout."""
         with self._lock:
-            response_handlers = self._get_response_handlers()
             wait_errors = self._get_wait_errors()
             wait_acks = self._get_wait_acks()
             active_wait_request_ids = self._get_active_wait_request_ids()
@@ -371,17 +431,13 @@ class _RequestWaitRuntime:
                         active_wait_request_ids[acknowledgment_attr] = (
                             active_request_ids
                         )
-                response_handlers.pop(request_id, None)
-                self._ack_nak_handlers.pop(request_id, None)
-                self._response_matchers.pop(request_id, None)
+                self._remove_response_handler_locked(request_id)
                 wait_errors.pop((acknowledgment_attr, request_id), None)
                 wait_acks.discard((acknowledgment_attr, request_id))
             else:
                 if acknowledgment_attr in active_wait_request_ids:
                     for active_request_id in active_request_ids:
-                        response_handlers.pop(active_request_id, None)
-                        self._ack_nak_handlers.pop(active_request_id, None)
-                        self._response_matchers.pop(active_request_id, None)
+                        self._remove_response_handler_locked(active_request_id)
                         wait_errors.pop((acknowledgment_attr, active_request_id), None)
                         wait_acks.discard((acknowledgment_attr, active_request_id))
                     active_wait_request_ids.pop(acknowledgment_attr, None)
@@ -456,6 +512,7 @@ class _RequestWaitRuntime:
         extract_request_id: Callable[[dict[str, Any]], int | None],
     ) -> None:
         """Correlate inbound response packets with callbacks and wait-state updates."""
+        self.prune_stale_response_handlers()
         request_id = extract_request_id(packet_dict)
         if request_id is None:
             return
@@ -523,14 +580,10 @@ class _RequestWaitRuntime:
                     or not candidate.ackPermitted
                 )
                 if skip_response_callback_for_decode_failure and not is_ack_nak_handler:
-                    response_handlers.pop(request_id, None)
-                    self._ack_nak_handlers.pop(request_id, None)
-                    self._response_matchers.pop(request_id, None)
+                    self._remove_response_handler_locked(request_id)
                     dropped_due_to_decode_failure = True
                 elif (not is_ack) or is_ack_nak_handler or candidate.ackPermitted:
-                    response_handler = response_handlers.pop(request_id, None)
-                    self._ack_nak_handlers.pop(request_id, None)
-                    self._response_matchers.pop(request_id, None)
+                    response_handler = self._remove_response_handler_locked(request_id)
         return response_handler, dropped_due_to_decode_failure
 
     def _apply_admin_decode_failure_wait_state(

--- a/meshtastic/tests/test_mesh_interface_wait_receive.py
+++ b/meshtastic/tests/test_mesh_interface_wait_receive.py
@@ -2006,6 +2006,8 @@ def test_response_handler_pruning_expires_managed_callbacks_only() -> None:
         assert 501 not in iface.responseHandlers
         assert 501 not in iface._request_wait_runtime._response_matchers
         assert 501 not in iface._request_wait_runtime._ack_nak_handlers
+        assert 501 not in iface._request_wait_runtime._response_handler_registered_at
+        assert 501 not in iface._request_wait_runtime._managed_response_handlers
 
 
 @pytest.mark.unit
@@ -2057,6 +2059,8 @@ def test_response_handler_pruning_preserves_legacy_unmanaged_entry() -> None:
             now=time.monotonic() + 10_000.0
         ) == []
         assert 504 in iface.responseHandlers
+        assert 504 not in iface._request_wait_runtime._response_handler_registered_at
+        assert 504 not in iface._request_wait_runtime._managed_response_handlers
 
 
 @pytest.mark.unit
@@ -2076,4 +2080,57 @@ def test_response_handler_registration_prunes_previous_stale_callback() -> None:
         )
 
         assert 505 not in iface.responseHandlers
+        assert 505 not in iface._request_wait_runtime._response_handler_registered_at
+        assert 505 not in iface._request_wait_runtime._response_matchers
+        assert 505 not in iface._request_wait_runtime._ack_nak_handlers
+        assert 505 not in iface._request_wait_runtime._managed_response_handlers
         assert 506 in iface.responseHandlers
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_inbound_response_expires_only_its_correlated_stale_handler() -> None:
+    """Inbound traffic should enforce TTL without scanning unrelated handlers."""
+    with MeshInterface(noProto=True) as iface:
+        runtime = iface._request_wait_runtime
+        stale_callback = MagicMock()
+        other_callback = MagicMock()
+        runtime.add_response_handler(507, stale_callback, ack_permitted=True)
+        runtime.add_response_handler(509, other_callback, ack_permitted=True)
+        runtime._response_handler_registered_at[507] = (
+            time.monotonic() - RESPONSE_HANDLER_TTL_SECONDS - 1.0
+        )
+        runtime._response_handler_registered_at[509] = (
+            time.monotonic() - RESPONSE_HANDLER_TTL_SECONDS - 1.0
+        )
+
+        iface._request_wait_runtime.correlate_inbound_response(
+            packet_dict={"decoded": {"requestId": 507}},
+            skip_response_callback_for_decode_failure=False,
+            extract_request_id=lambda packet: packet["decoded"]["requestId"],
+        )
+
+        stale_callback.assert_not_called()
+        assert 507 not in iface.responseHandlers
+        assert 509 in iface.responseHandlers
+        assert 509 in runtime._response_handler_registered_at
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_response_handler_pruning_preserves_legacy_replacement() -> None:
+    """A direct legacy replacement should shed stale managed metadata only."""
+    with MeshInterface(noProto=True) as iface:
+        runtime = iface._request_wait_runtime
+        runtime.add_response_handler(508, MagicMock(), ack_permitted=True)
+        registered_at = runtime._response_handler_registered_at[508]
+        legacy_handler = ResponseHandler(callback=MagicMock(), ackPermitted=True)
+        iface.responseHandlers[508] = legacy_handler
+
+        assert runtime.prune_stale_response_handlers(
+            now=registered_at + RESPONSE_HANDLER_TTL_SECONDS + 1.0
+        ) == []
+        assert iface.responseHandlers[508] is legacy_handler
+        assert 508 not in runtime._response_handler_registered_at
+        assert 508 not in runtime._response_matchers
+        assert 508 not in runtime._ack_nak_handlers
+        assert 508 not in runtime._managed_response_handlers

--- a/meshtastic/tests/test_mesh_interface_wait_receive.py
+++ b/meshtastic/tests/test_mesh_interface_wait_receive.py
@@ -19,6 +19,7 @@ from meshtastic.mesh_interface_runtime import (
     receive_pipeline as receive_pipeline_module,
 )
 from meshtastic.mesh_interface_runtime.request_wait import (
+    RESPONSE_HANDLER_TTL_SECONDS,
     UNSCOPED_WAIT_REQUEST_ID,
     WAIT_ATTR_NAK,
     WAIT_ATTR_POSITION,
@@ -1982,3 +1983,97 @@ def test_connect_failure_log_level_respects_quiet_probe_mode() -> None:
         assert iface._connect_failure_log_level() == logging.ERROR
         iface._suppress_connect_failure_logging = True
         assert iface._connect_failure_log_level() == logging.DEBUG
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_response_handler_pruning_expires_managed_callbacks_only() -> None:
+    """Expired managed callbacks should be pruned with matcher/ACK metadata."""
+    with MeshInterface(noProto=True) as iface:
+        callback = MagicMock()
+        matcher = MagicMock(return_value=True)
+        iface._request_wait_runtime.add_response_handler(
+            501,
+            callback,
+            ack_permitted=True,
+            is_ack_nak_handler=True,
+            matcher=matcher,
+        )
+        registered_at = iface._request_wait_runtime._response_handler_registered_at[501]
+        assert iface._request_wait_runtime.prune_stale_response_handlers(
+            now=registered_at + RESPONSE_HANDLER_TTL_SECONDS + 1.0
+        ) == [501]
+        assert 501 not in iface.responseHandlers
+        assert 501 not in iface._request_wait_runtime._response_matchers
+        assert 501 not in iface._request_wait_runtime._ack_nak_handlers
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_response_handler_pruning_preserves_active_scoped_wait() -> None:
+    """TTL pruning must not retire callbacks that still back an active wait."""
+    with MeshInterface(noProto=True) as iface:
+        iface._request_wait_runtime.add_response_handler(
+            502, MagicMock(), ack_permitted=True
+        )
+        iface._clear_wait_error(WAIT_ATTR_NAK, request_id=502)
+        registered_at = iface._request_wait_runtime._response_handler_registered_at[502]
+        assert iface._request_wait_runtime.prune_stale_response_handlers(
+            now=registered_at + RESPONSE_HANDLER_TTL_SECONDS + 1.0
+        ) == []
+        assert 502 in iface.responseHandlers
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_close_clears_pending_response_callbacks() -> None:
+    """Closing an interface should release pending managed callback references."""
+    iface = MeshInterface(noProto=True)
+    iface._request_wait_runtime.add_response_handler(
+        503,
+        MagicMock(),
+        ack_permitted=True,
+        matcher=MagicMock(return_value=True),
+    )
+
+    iface.close()
+
+    assert iface.responseHandlers == {}
+    assert iface._request_wait_runtime._response_matchers == {}
+    assert iface._request_wait_runtime._ack_nak_handlers == {}
+    assert iface._request_wait_runtime._response_handler_registered_at == {}
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_response_handler_pruning_preserves_legacy_unmanaged_entry() -> None:
+    """TTL pruning should not assign a lifetime to direct legacy dict entries."""
+    with MeshInterface(noProto=True) as iface:
+        iface.responseHandlers[504] = ResponseHandler(
+            callback=MagicMock(), ackPermitted=True
+        )
+
+        assert iface._request_wait_runtime.prune_stale_response_handlers(
+            now=time.monotonic() + 10_000.0
+        ) == []
+        assert 504 in iface.responseHandlers
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_response_handler_registration_prunes_previous_stale_callback() -> None:
+    """A later managed registration should bound stale callback accumulation."""
+    with MeshInterface(noProto=True) as iface:
+        iface._request_wait_runtime.add_response_handler(
+            505, MagicMock(), ack_permitted=True
+        )
+        iface._request_wait_runtime._response_handler_registered_at[505] = (
+            time.monotonic() - RESPONSE_HANDLER_TTL_SECONDS - 1.0
+        )
+
+        iface._request_wait_runtime.add_response_handler(
+            506, MagicMock(), ack_permitted=True
+        )
+
+        assert 505 not in iface.responseHandlers
+        assert 506 in iface.responseHandlers


### PR DESCRIPTION
## Summary by Sourcery

Introduce bounded lifecycle management for response handlers and ensure they are cleaned up with wait runtime and interface shutdown.

Enhancements:
- Track registration timestamps for managed response handlers and prune stale callbacks based on a configurable TTL while preserving active scoped waits and legacy unmanaged handlers.
- Centralize response handler removal logic and invoke pruning during response registration, inbound correlation, and wait retirement to limit accumulation of orphaned callbacks.
- Ensure MeshInterface.close() clears all pending managed response handlers and associated matcher/ACK metadata while keeping the ResponseHandler tuple backward compatible.

Tests:
- Add unit tests covering response handler TTL pruning behavior, preservation of active waits and legacy handlers, and cleanup on interface close.