### PR TITLE
Define runtime compatibility import manifest

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -2,7 +2,7 @@
 
 This document is the canonical human-readable policy for compatibility aliases,
 deprecations, and legacy compatibility behaviors in this repository. Runtime
-decomposition import guarantees are additionally defined by the machine-readable
+import guarantees are additionally defined by the machine-readable
 ``meshtastic/_runtime_compatibility.json`` manifest consumed by API-baseline tooling.
 
 If a compatibility symbol is not listed here, or a runtime import guarantee is

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,9 +1,12 @@
 # Compatibility Inventory and Deprecation Matrix
 
-This document is the canonical source of truth for compatibility aliases,
-deprecations, and legacy compatibility behaviors in this repository.
+This document is the canonical human-readable policy for compatibility aliases,
+deprecations, and legacy compatibility behaviors in this repository. Runtime
+decomposition import guarantees are additionally defined by the machine-readable
+``meshtastic/_runtime_compatibility.json`` manifest consumed by API-baseline tooling.
 
-If a compatibility symbol is not listed here, do not add or keep it by default.
+If a compatibility symbol is not listed here, or a runtime import guarantee is
+not present in that manifest, do not add or keep it by default.
 
 ## Scope and Policy
 
@@ -56,13 +59,17 @@ implementation details that are NOT part of the public stable API.
 
 ### Documented Runtime Compatibility Exports
 
-The following specific exports from runtime modules are retained for
-test ecosystem compatibility. These are the ONLY runtime imports with
-stability guarantees:
+The machine-readable manifest ``meshtastic/_runtime_compatibility.json`` is the
+source of truth consumed by API-baseline tooling for runtime import guarantees.
+It currently guarantees only:
 
 | Module Path                                | Export      | Purpose                    | Status               |
 | ------------------------------------------ | ----------- | -------------------------- | -------------------- |
 | `meshtastic.node_runtime.settings_runtime` | `toNodeNum` | Test mocking compatibility | `COMPAT_STABLE_SHIM` |
+
+Adding a runtime compatibility guarantee requires updating the manifest and this
+policy together. Internal test imports do not become compatibility commitments
+merely because they exist in the repository.
 
 ### Policy for External Test Authors
 

--- a/bin/extract_api_surface.py
+++ b/bin/extract_api_surface.py
@@ -14,18 +14,67 @@ import sys
 from pathlib import Path
 from typing import Any
 
-LEGACY_IMPORT_PATHS = [
-    "meshtastic.node_runtime.settings_runtime",
-    "meshtastic.node_runtime.channel_request_runtime",
-    "meshtastic.node_runtime.channel_lookup_runtime",
-    "meshtastic.node_runtime.channel_export_runtime",
-    "meshtastic.node_runtime.channel_presentation_runtime",
-    "meshtastic.node_runtime.channel_normalization_runtime",
-    "meshtastic.node_runtime.seturl_runtime",
-    "meshtastic.node_runtime.transport_runtime",
-    "meshtastic.node_runtime.content_runtime",
-    "meshtastic.node_runtime.shared",
-]
+RUNTIME_COMPATIBILITY_MANIFEST = "_runtime_compatibility.json"
+_RUNTIME_MODULE_STATUSES = {"INTERNAL_COMPAT"}
+_RUNTIME_EXPORT_STATUSES = {"COMPAT_STABLE_SHIM", "COMPAT_DEPRECATE", "INTERNAL_COMPAT"}
+
+
+def _load_runtime_compatibility_import_paths(pkg_dir: Path) -> list[str]:
+    """Return documented runtime compatibility module paths for one source tree.
+
+    Older source trees may predate the manifest; in that case they have no
+    manifest-backed runtime import guarantees.
+    """
+    manifest_path = pkg_dir / RUNTIME_COMPATIBILITY_MANIFEST
+    if not manifest_path.exists():
+        return []
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if manifest.get("schema_version") != 1:
+        raise ValueError(
+            f"Unsupported runtime compatibility manifest schema: {manifest_path}"
+        )
+    modules = manifest.get("modules")
+    if not isinstance(modules, list):
+        raise ValueError(
+            f"Runtime compatibility manifest modules must be a list: {manifest_path}"
+        )
+    paths: list[str] = []
+    seen_paths: set[str] = set()
+    for entry in modules:
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"Runtime compatibility manifest has an invalid module entry: {entry!r}"
+            )
+        path = entry.get("path")
+        status = entry.get("status")
+        purpose = entry.get("purpose")
+        exports = entry.get("exports")
+        if not isinstance(path, str) or not path:
+            raise ValueError(f"Runtime compatibility module path is invalid: {entry!r}")
+        if path in seen_paths:
+            raise ValueError(f"Duplicate runtime compatibility module path: {path}")
+        if status not in _RUNTIME_MODULE_STATUSES:
+            raise ValueError(
+                f"Unsupported runtime compatibility module status for {path}: {status!r}"
+            )
+        if not isinstance(purpose, str) or not purpose.strip():
+            raise ValueError(f"Runtime compatibility purpose is required for {path}")
+        if not isinstance(exports, dict) or not exports:
+            raise ValueError(f"Runtime compatibility exports are required for {path}")
+        for export_name, export_status in exports.items():
+            if not isinstance(export_name, str) or not export_name:
+                raise ValueError(
+                    f"Runtime compatibility export name is invalid for {path}: {export_name!r}"
+                )
+            if export_status not in _RUNTIME_EXPORT_STATUSES:
+                raise ValueError(
+                    "Unsupported runtime compatibility export status for "
+                    f"{path}.{export_name}: {export_status!r}"
+                )
+        seen_paths.add(path)
+        paths.append(path)
+    return sorted(paths)
+
 
 
 def _annotation_to_str(node: ast.AST | None) -> str:
@@ -290,10 +339,9 @@ def _module_path_exists(pkg_dir: Path, dotted_path: str) -> bool:
 
 
 def _capture_legacy_import_paths(pkg_dir: Path) -> list[str]:
-    """Capture compatibility import paths that exist in the provided tree."""
-    return sorted(
-        [path for path in LEGACY_IMPORT_PATHS if _module_path_exists(pkg_dir, path)]
-    )
+    """Capture manifest-backed runtime compatibility paths present in the tree."""
+    documented_paths = _load_runtime_compatibility_import_paths(pkg_dir)
+    return [path for path in documented_paths if _module_path_exists(pkg_dir, path)]
 
 
 def extract_api_surface(

--- a/bin/extract_api_surface.py
+++ b/bin/extract_api_surface.py
@@ -54,8 +54,10 @@ def _load_runtime_compatibility_import_paths(pkg_dir: Path) -> list[str]:
         if path in seen_paths:
             raise ValueError(f"Duplicate runtime compatibility module path: {path}")
         if status not in _RUNTIME_MODULE_STATUSES:
+            allowed_statuses = ", ".join(sorted(_RUNTIME_MODULE_STATUSES))
             raise ValueError(
-                f"Unsupported runtime compatibility module status for {path}: {status!r}"
+                "Unsupported runtime compatibility module status for "
+                f"{path}: {status!r}; expected one of: {allowed_statuses}"
             )
         if not isinstance(purpose, str) or not purpose.strip():
             raise ValueError(f"Runtime compatibility purpose is required for {path}")
@@ -67,9 +69,11 @@ def _load_runtime_compatibility_import_paths(pkg_dir: Path) -> list[str]:
                     f"Runtime compatibility export name is invalid for {path}: {export_name!r}"
                 )
             if export_status not in _RUNTIME_EXPORT_STATUSES:
+                allowed_statuses = ", ".join(sorted(_RUNTIME_EXPORT_STATUSES))
                 raise ValueError(
                     "Unsupported runtime compatibility export status for "
-                    f"{path}.{export_name}: {export_status!r}"
+                    f"{path}.{export_name}: {export_status!r}; "
+                    f"expected one of: {allowed_statuses}"
                 )
         seen_paths.add(path)
         paths.append(path)

--- a/meshtastic/_runtime_compatibility.json
+++ b/meshtastic/_runtime_compatibility.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "modules": [
+    {
+      "path": "meshtastic.node_runtime.settings_runtime",
+      "status": "INTERNAL_COMPAT",
+      "purpose": "Test mocking compatibility",
+      "exports": {
+        "toNodeNum": "COMPAT_STABLE_SHIM"
+      }
+    }
+  ]
+}

--- a/meshtastic/node_runtime/__init__.py
+++ b/meshtastic/node_runtime/__init__.py
@@ -1,8 +1,9 @@
-"""Public API for node runtime constants and helpers.
+"""Internal convenience exports for Node runtime implementations.
 
-This module exports constants and utility functions intended for use across
-Meshtastic Node implementations. Symbols listed in __all__ are part of the
-stable public interface.
+The ``node_runtime`` package is an implementation detail and its ``__all__``
+list is not public API. Runtime compatibility guarantees are limited to entries
+in ``meshtastic/_runtime_compatibility.json`` and documented in
+``COMPATIBILITY.md``.
 """
 
 from .shared import (

--- a/meshtastic/tests/api_baselines/api_baseline.json
+++ b/meshtastic/tests/api_baselines/api_baseline.json
@@ -1,15 +1,6 @@
 {
   "legacy_import_paths": [
-    "meshtastic.node_runtime.channel_export_runtime",
-    "meshtastic.node_runtime.channel_lookup_runtime",
-    "meshtastic.node_runtime.channel_normalization_runtime",
-    "meshtastic.node_runtime.channel_presentation_runtime",
-    "meshtastic.node_runtime.channel_request_runtime",
-    "meshtastic.node_runtime.content_runtime",
-    "meshtastic.node_runtime.settings_runtime",
-    "meshtastic.node_runtime.seturl_runtime",
-    "meshtastic.node_runtime.shared",
-    "meshtastic.node_runtime.transport_runtime"
+    "meshtastic.node_runtime.settings_runtime"
   ],
   "mesh_interface_methods": {
     "close": "(self)",

--- a/meshtastic/tests/test_api_baseline_comparison.py
+++ b/meshtastic/tests/test_api_baseline_comparison.py
@@ -463,15 +463,15 @@ class TestTopLevelExportsAgainstBaseline:
 
 
 class TestLegacyImportPathsAgainstBaseline:
-    """Tests to verify internal import paths still work."""
+    """Tests to verify documented runtime compatibility import paths."""
 
     def test_legacy_import_paths_against_baseline(
         self, current_baseline, stored_baseline, pytestconfig
     ):
-        """Verify legacy internal import paths still work.
+        """Verify manifest-backed runtime compatibility import paths remain stable.
 
-        This test ensures that code using internal imports doesn't break
-        when the package structure changes.
+        Internal runtime modules that are absent from the manifest are free to move
+        without creating an API-baseline failure.
         """
         if stored_baseline is None:
             if _should_update_baselines(pytestconfig):

--- a/meshtastic/tests/test_import_compatibility.py
+++ b/meshtastic/tests/test_import_compatibility.py
@@ -11,6 +11,8 @@ Reference: COMPATIBILITY.md for documented compatibility aliases.
 from __future__ import annotations
 
 import importlib
+import json
+from pathlib import Path
 from types import ModuleType
 
 import pytest
@@ -410,3 +412,19 @@ class TestModuleReimport:
         assert meshtastic is not None
         assert hasattr(meshtastic, "Node")
         assert hasattr(meshtastic, "BROADCAST_ADDR")
+
+
+def test_runtime_compatibility_manifest_exports_are_importable() -> None:
+    """Every manifest-backed runtime compatibility export should remain importable."""
+    project_root = Path(__file__).resolve().parents[2]
+    manifest = json.loads(
+        (project_root / "meshtastic" / "_runtime_compatibility.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert manifest["schema_version"] == 1
+    for entry in manifest["modules"]:
+        module = importlib.import_module(entry["path"])
+        for export_name in entry["exports"]:
+            assert hasattr(module, export_name), (entry["path"], export_name)


### PR DESCRIPTION
## Summary by Sourcery

Define a machine-readable runtime compatibility manifest and integrate it into API surface extraction and tests.

New Features:
- Introduce a JSON-based runtime compatibility manifest that defines supported internal runtime import paths and exports.

Enhancements:
- Update compatibility documentation and node_runtime package docs to reference the new manifest-driven runtime import guarantees.
- Adjust API baseline and compatibility tests to validate manifest-backed runtime compatibility imports and exports instead of hardcoded legacy paths.

Tests:
- Add tests ensuring all manifest-declared runtime compatibility exports remain importable.