### PR TITLE
Align local and CI quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,10 +109,14 @@ jobs:
     steps:
       - *checkout_step
       - *setup_python_step
+      - name: Load quality tool versions
+        run: cat tools/quality_versions.env >> "$GITHUB_ENV"
+      - name: Verify quality tool version pins
+        run: python bin/check_quality_tool_versions.py
       - name: Install ruff
-        run: python -m pip install --upgrade "ruff==0.15.10"
+        run: python -m pip install --upgrade "ruff==${RUFF_VERSION}"
       - name: Run ruff on tests
-        run: ruff check meshtastic/tests
+        run: ruff check meshtastic/tests tests
   mypy:
     name: Mypy (py3.13)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,10 +109,8 @@ jobs:
     steps:
       - *checkout_step
       - *setup_python_step
-      - name: Load quality tool versions
-        run: cat tools/quality_versions.env >> "$GITHUB_ENV"
-      - name: Verify quality tool version pins
-        run: python bin/check_quality_tool_versions.py
+      - name: Load and verify quality tool versions
+        run: python bin/check_quality_tool_versions.py --github-env "$GITHUB_ENV"
       - name: Install ruff
         run: python -m pip install --upgrade "ruff==${RUFF_VERSION}"
       - name: Run ruff on tests

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -47,7 +47,6 @@ lint:
         # Keep Trunk's mypy scope aligned with CI (meshtastic/ only).
         - examples/**
         - tests/**
-        - meshtastic/tests/**
     - linters: [pylint-poetry]
       paths:
         # Keep Trunk's pylint scope aligned with CI (meshtastic/ + examples/).
@@ -65,11 +64,11 @@ lint:
       commands:
         - name: lint
           output: mypy
-          run: poetry -C ${workspace} run mypy meshtastic/ --strict --exclude '^meshtastic/tests/'
+          run: poetry -C ${workspace} run mypy meshtastic/
           target: meshtastic
           run_from: ${root_or_parent_with_any_config}
           disable_upstream: true
-          success_codes: [0, 1]
+          success_codes: [0]
           batch: true
           stdin: false
     - name: pylint-poetry
@@ -83,7 +82,7 @@ lint:
       commands:
         - name: lint
           output: pylint
-          run: poetry -C ${workspace} run pylint meshtastic examples/ --exit-zero --ignore-patterns='.*_pb2.py,.*_pb2.pyi' --ignore-paths='^meshtastic/tests/|^meshtastic/protobuf/.*_pb2\\.pyi?$' --output ${tmpfile} --output-format json
+          run: poetry -C ${workspace} run pylint meshtastic examples/ --ignore-patterns='.*_pb2.py,.*_pb2.pyi' --ignore-paths='^meshtastic/tests/|^meshtastic/protobuf/.*_pb2\\.pyi?$' --output ${tmpfile} --output-format json
           target: meshtastic
           read_output_from: tmp_file
           run_from: ${root_or_parent_with_any_config}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,7 +224,7 @@ Current `COMPAT_DEPRECATE` methods:
 
 - CI `pylint` intentionally targets production/library paths (`meshtastic`,
   `examples`) and excludes `meshtastic/tests/**`.
-- Test linting is enforced by `ruff check meshtastic/tests` (CI `Ruff Tests`
+- Test linting is enforced by `ruff check meshtastic/tests tests` (CI `Ruff Tests`
   job and local `make lint-tests` / `make ci`).
 
 ## Baseline Generation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,7 +145,7 @@ Alternatively, run each check individually:
 ```bash
 poetry run pytest --cov=meshtastic --cov-report=xml
 poetry run pylint meshtastic examples/ --ignore-patterns ".*_pb2\.pyi?$"
-ruff check meshtastic/tests
+ruff check meshtastic/tests tests
 poetry run mypy meshtastic/
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -81,9 +81,17 @@ docs:
 lint:
 	PYLINTHOME=$${TMPDIR:-/tmp}/pylint-cache $(POETRY_RUN) pylint meshtastic examples/ --ignore-patterns ".*_pb2\\.pyi?$$"
 
-# lint tests with ruff (same command as CI)
+# lint tests with the canonical Ruff version (same scope as CI)
 lint-tests:
-	ruff check meshtastic/tests
+	@set -a; . ./tools/quality_versions.env; set +a; \
+		python bin/check_quality_tool_versions.py; \
+		actual=$$(ruff --version | awk '{print $$2}'); \
+		if [ "$$actual" != "$$RUFF_VERSION" ]; then \
+			echo "error: ruff $$actual installed; expected $$RUFF_VERSION" >&2; \
+			echo "install with: python -m pip install ruff==$$RUFF_VERSION" >&2; \
+			exit 2; \
+		fi; \
+		ruff check meshtastic/tests tests
 
 # show the slowest unit tests
 slow:

--- a/Makefile
+++ b/Makefile
@@ -83,12 +83,12 @@ lint:
 
 # lint tests with the canonical Ruff version (same scope as CI)
 lint-tests:
-	@set -a; . ./tools/quality_versions.env; set +a; \
-		python bin/check_quality_tool_versions.py; \
+	@set -eu; \
+		expected=$$(python bin/check_quality_tool_versions.py --print-ruff-version); \
 		actual=$$(ruff --version | awk '{print $$2}'); \
-		if [ "$$actual" != "$$RUFF_VERSION" ]; then \
-			echo "error: ruff $$actual installed; expected $$RUFF_VERSION" >&2; \
-			echo "install with: python -m pip install ruff==$$RUFF_VERSION" >&2; \
+		if [ "$$actual" != "$$expected" ]; then \
+			echo "error: ruff $$actual installed; expected $$expected" >&2; \
+			echo "install with: python -m pip install ruff==$$expected" >&2; \
 			exit 2; \
 		fi; \
 		ruff check meshtastic/tests tests

--- a/bin/check_quality_tool_versions.py
+++ b/bin/check_quality_tool_versions.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Verify standalone quality-tool pins agree with repository configuration."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VERSIONS_FILE = REPO_ROOT / "tools" / "quality_versions.env"
+TRUNK_CONFIG = REPO_ROOT / ".trunk" / "trunk.yaml"
+
+
+def _load_env_version(name: str) -> str:
+    """Return one ``NAME=value`` entry from the canonical versions file."""
+    prefix = f"{name}="
+    for raw_line in VERSIONS_FILE.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line.startswith(prefix):
+            return line[len(prefix) :]
+    raise RuntimeError(f"Missing {name} in {VERSIONS_FILE}")
+
+
+def main() -> int:
+    """Validate configured standalone tool versions and return a process status."""
+    ruff_version = _load_env_version("RUFF_VERSION")
+    trunk_text = TRUNK_CONFIG.read_text(encoding="utf-8")
+    match = re.search(r"^\s*- ruff@([^\s]+)\s*$", trunk_text, flags=re.MULTILINE)
+    if match is None:
+        raise RuntimeError(f"Missing Ruff pin in {TRUNK_CONFIG}")
+    trunk_version = match.group(1)
+    if trunk_version != ruff_version:
+        raise RuntimeError(
+            "Ruff version mismatch: "
+            f"tools/quality_versions.env={ruff_version}, trunk={trunk_version}"
+        )
+    print(f"Quality tool versions are coherent (ruff {ruff_version}).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/check_quality_tool_versions.py
+++ b/bin/check_quality_tool_versions.py
@@ -3,26 +3,54 @@
 
 from __future__ import annotations
 
+import argparse
 import re
+from collections.abc import Sequence
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 VERSIONS_FILE = REPO_ROOT / "tools" / "quality_versions.env"
 TRUNK_CONFIG = REPO_ROOT / ".trunk" / "trunk.yaml"
+_ENV_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _load_env_values() -> dict[str, str]:
+    """Parse the canonical versions file without executing it as shell code."""
+    values: dict[str, str] = {}
+    for line_number, raw_line in enumerate(
+        VERSIONS_FILE.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line.removeprefix("export ").lstrip()
+        name, separator, value = line.partition("=")
+        name = name.strip()
+        value = value.strip()
+        if not separator or not _ENV_NAME_PATTERN.fullmatch(name) or not value:
+            raise RuntimeError(
+                f"Invalid NAME=value entry in {VERSIONS_FILE}:{line_number}: {raw_line!r}"
+            )
+        if name in values:
+            raise RuntimeError(
+                f"Duplicate {name} entry in {VERSIONS_FILE}:{line_number}"
+            )
+        values[name] = value
+    return values
 
 
 def _load_env_version(name: str) -> str:
-    """Return one ``NAME=value`` entry from the canonical versions file."""
-    prefix = f"{name}="
-    for raw_line in VERSIONS_FILE.read_text(encoding="utf-8").splitlines():
-        line = raw_line.strip()
-        if line.startswith(prefix):
-            return line[len(prefix) :]
-    raise RuntimeError(f"Missing {name} in {VERSIONS_FILE}")
+    """Return one required version from the canonical versions file."""
+    values = _load_env_values()
+    try:
+        return values[name]
+    except KeyError as exc:
+        raise RuntimeError(f"Missing {name} in {VERSIONS_FILE}") from exc
 
 
-def main() -> int:
-    """Validate configured standalone tool versions and return a process status."""
+def _validated_ruff_version() -> str:
+    """Return the canonical Ruff version after validating the Trunk pin."""
     ruff_version = _load_env_version("RUFF_VERSION")
     trunk_text = TRUNK_CONFIG.read_text(encoding="utf-8")
     match = re.search(r"^\s*- ruff@([^\s]+)\s*$", trunk_text, flags=re.MULTILINE)
@@ -34,7 +62,38 @@ def main() -> int:
             "Ruff version mismatch: "
             f"tools/quality_versions.env={ruff_version}, trunk={trunk_version}"
         )
-    print(f"Quality tool versions are coherent (ruff {ruff_version}).")
+    return ruff_version
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    """Parse command-line options for CI/local version consumers."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    output = parser.add_mutually_exclusive_group()
+    output.add_argument(
+        "--github-env",
+        type=Path,
+        metavar="PATH",
+        help="append validated quality-tool variables to a GitHub Actions env file",
+    )
+    output.add_argument(
+        "--print-ruff-version",
+        action="store_true",
+        help="print only the validated Ruff version",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Validate configured standalone tool versions and return a process status."""
+    args = _parse_args(argv)
+    ruff_version = _validated_ruff_version()
+    if args.github_env is not None:
+        with args.github_env.open("a", encoding="utf-8") as env_file:
+            env_file.write(f"RUFF_VERSION={ruff_version}\n")
+    if args.print_ruff_version:
+        print(ruff_version)
+    else:
+        print(f"Quality tool versions are coherent (ruff {ruff_version}).")
     return 0
 
 

--- a/meshtastic/tests/test_quality_tool_versions.py
+++ b/meshtastic/tests/test_quality_tool_versions.py
@@ -1,0 +1,79 @@
+"""Tests for the standalone quality-tool version contract."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_checker_module() -> ModuleType:
+    """Load the repository quality-version checker as an isolated script module."""
+    project_root = Path(__file__).resolve().parents[2]
+    script_path = project_root / "bin" / "check_quality_tool_versions.py"
+    spec = importlib.util.spec_from_file_location("check_quality_tool_versions", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.unit
+def test_quality_version_parser_accepts_comments_and_export_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The canonical version parser should accept normal dotenv-style formatting."""
+    module = _load_checker_module()
+    versions_file = tmp_path / "quality_versions.env"
+    versions_file.write_text(
+        "# standalone tools\n\nexport RUFF_VERSION = 0.16.1\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(module, "VERSIONS_FILE", versions_file)
+
+    assert module._load_env_version("RUFF_VERSION") == "0.16.1"  # type: ignore[attr-defined]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "contents",
+    [
+        "not-an-assignment\n",
+        "RUFF_VERSION=\n",
+        "RUFF_VERSION=0.16.1\nRUFF_VERSION=0.16.2\n",
+    ],
+)
+def test_quality_version_parser_rejects_malformed_entries(
+    contents: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Malformed or duplicate version declarations should fail loudly."""
+    module = _load_checker_module()
+    versions_file = tmp_path / "quality_versions.env"
+    versions_file.write_text(contents, encoding="utf-8")
+    monkeypatch.setattr(module, "VERSIONS_FILE", versions_file)
+
+    with pytest.raises(RuntimeError):
+        module._load_env_values()  # type: ignore[attr-defined]
+
+
+@pytest.mark.unit
+def test_quality_version_checker_writes_sanitized_github_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GitHub Actions should receive only validated NAME=value entries."""
+    module = _load_checker_module()
+    versions_file = tmp_path / "quality_versions.env"
+    versions_file.write_text(
+        "# comment must never be copied to GITHUB_ENV\nRUFF_VERSION=0.16.1\n",
+        encoding="utf-8",
+    )
+    trunk_file = tmp_path / "trunk.yaml"
+    trunk_file.write_text("lint:\n  enabled:\n    - ruff@0.16.1\n", encoding="utf-8")
+    github_env = tmp_path / "github-env"
+    monkeypatch.setattr(module, "VERSIONS_FILE", versions_file)
+    monkeypatch.setattr(module, "TRUNK_CONFIG", trunk_file)
+
+    assert module.main(["--github-env", str(github_env)]) == 0  # type: ignore[attr-defined]
+    assert github_env.read_text(encoding="utf-8") == "RUFF_VERSION=0.16.1\n"

--- a/tools/quality_versions.env
+++ b/tools/quality_versions.env
@@ -1,0 +1,2 @@
+# Canonical versions for standalone quality tools that are not Poetry dependencies.
+RUFF_VERSION=0.16.1


### PR DESCRIPTION
## Summary by Sourcery

Align local, CI, and Trunk quality checks and version pins for Ruff and type/lint scopes.

New Features:
- Add a script to validate pinned quality-tool versions against repository configuration.

Enhancements:
- Introduce a shared environment file for quality tool version pins and use it in CI and local lint commands.
- Expand Ruff test linting scope to include the top-level tests directory and keep documentation in sync.
- Align Trunk mypy and pylint integration with CI by matching scopes and enforcing strict success codes.

Documentation:
- Update contributor and agent documentation to reflect the expanded Ruff test linting command.