### PR TITLE
Isolate warn-once compatibility test state

### DIFF
--- a/meshtastic/tests/conftest.py
+++ b/meshtastic/tests/conftest.py
@@ -22,6 +22,7 @@ import pytest
 
 from meshtastic import mt_config, publishingThread
 from meshtastic.powermon import power_supply as power_supply_module
+import meshtastic.util as util_module
 from meshtastic.util import DeferredExecution
 
 from ..mesh_interface import MeshInterface
@@ -45,6 +46,20 @@ if TYPE_CHECKING:
 
 SINGLE_NODE_PORT_OFFSET = 100
 _SINGLE_NODE_PORT_SEQUENCE = itertools.count()
+
+
+@pytest.fixture(name="isolated_dotdict_deprecation_state")
+def _isolated_dotdict_deprecation_state() -> Generator[None, None, None]:
+    """Isolate the process-wide warn-once state used by the deprecated dotdict alias."""
+    with util_module._warned_deprecations_lock:  # noqa: SLF001 - test isolation seam
+        previous = set(util_module._warned_deprecations)  # noqa: SLF001
+        util_module._warned_deprecations.discard("dotdict")  # noqa: SLF001
+    try:
+        yield
+    finally:
+        with util_module._warned_deprecations_lock:  # noqa: SLF001
+            util_module._warned_deprecations.clear()  # noqa: SLF001
+            util_module._warned_deprecations.update(previous)  # noqa: SLF001
 
 
 def _skip_simradio_if_unavailable() -> None:

--- a/meshtastic/tests/test_import_compatibility.py
+++ b/meshtastic/tests/test_import_compatibility.py
@@ -15,7 +15,6 @@ from types import ModuleType
 
 import pytest
 
-import meshtastic.util as util_module
 
 
 @pytest.mark.unit
@@ -238,19 +237,14 @@ class TestTopLevelModuleImports:
 class TestBackwardCompatAliases:
     """Test backward compatibility aliases that are maintained but may warn."""
 
-    def test_util_dotdict_deprecated_import(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    @pytest.mark.usefixtures("isolated_dotdict_deprecation_state")
+    def test_util_dotdict_deprecated_import(self) -> None:
         """Test that dotdict can still be imported from meshtastic.util.
 
         This is a COMPAT_DEPRECATE alias that emits a warn-once DeprecationWarning.
         The canonical name is DotDict.
         """
         import warnings  # pylint: disable=import-outside-toplevel
-
-        # Warn-once state is process-wide. Isolate this test from whichever
-        # compatibility test happened to instantiate the alias first.
-        monkeypatch.setattr(util_module, "_warned_deprecations", set())
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")

--- a/meshtastic/tests/test_import_compatibility.py
+++ b/meshtastic/tests/test_import_compatibility.py
@@ -15,6 +15,8 @@ from types import ModuleType
 
 import pytest
 
+import meshtastic.util as util_module
+
 
 @pytest.mark.unit
 class TestCoreModuleImports:
@@ -236,13 +238,19 @@ class TestTopLevelModuleImports:
 class TestBackwardCompatAliases:
     """Test backward compatibility aliases that are maintained but may warn."""
 
-    def test_util_dotdict_deprecated_import(self) -> None:
+    def test_util_dotdict_deprecated_import(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test that dotdict can still be imported from meshtastic.util.
 
         This is a COMPAT_DEPRECATE alias that emits a warn-once DeprecationWarning.
         The canonical name is DotDict.
         """
         import warnings  # pylint: disable=import-outside-toplevel
+
+        # Warn-once state is process-wide. Isolate this test from whichever
+        # compatibility test happened to instantiate the alias first.
+        monkeypatch.setattr(util_module, "_warned_deprecations", set())
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")

--- a/meshtastic/tests/test_util.py
+++ b/meshtastic/tests/test_util.py
@@ -1822,17 +1822,9 @@ def test_dotdict_missing_attr_returns_none() -> None:
 
 
 @pytest.mark.unit
+@pytest.mark.usefixtures("isolated_dotdict_deprecation_state")
 def test_dotdict_deprecated_warns() -> None:
-    """Test dotdict deprecated alias warns once per process."""
-    # Clear warn-once state to ensure we get a warning
-    from meshtastic.util import (  # pylint: disable=import-outside-toplevel
-        _warned_deprecations,
-        _warned_deprecations_lock,
-    )
-
-    with _warned_deprecations_lock:
-        _warned_deprecations.discard("dotdict")
-
+    """Test dotdict deprecated alias warns once per isolated process state."""
     with warnings.catch_warnings(record=True) as captured:
         warnings.simplefilter("always", DeprecationWarning)
         dd = dotdict()  # pyright: ignore[reportDeprecated]


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Reset process-wide warn-once deprecation tracking in the dotdict compatibility test using monkeypatch to ensure test isolation.