### PR TITLE
Extract core runtime primitives

### DIFF
--- a/meshtastic/__init__.py
+++ b/meshtastic/__init__.py
@@ -85,6 +85,18 @@ from meshtastic.util import (
 )
 
 from . import util
+from ._core_constants import (
+    BROADCAST_ADDR as _BROADCAST_ADDR,
+    BROADCAST_NUM as _BROADCAST_NUM,
+    DECODE_ERROR_KEY as _DECODE_ERROR_KEY,
+    LOCAL_ADDR as _LOCAL_ADDR,
+    NODELESS_WANT_CONFIG_ID as _NODELESS_WANT_CONFIG_ID,
+    OUR_APP_VERSION as _OUR_APP_VERSION,
+)
+from ._response_types import (
+    ResponseCallback as _ResponseCallback,
+    ResponseHandler as _ResponseHandler,
+)
 from .protobuf import (
     admin_pb2,
     apponly_pb2,
@@ -144,23 +156,23 @@ def __getattr__(name: str) -> _Any:
 
 # Note: To follow PEP224, comments should be after the module variable.
 
-LOCAL_ADDR = "^local"
+LOCAL_ADDR = _LOCAL_ADDR
 """A special ID that means the local node"""
 
-BROADCAST_NUM: int = 0xFFFFFFFF
+BROADCAST_NUM: int = _BROADCAST_NUM
 """if using 8 bit nodenums this will be shortened on the target"""
 
-BROADCAST_ADDR = "^all"
+BROADCAST_ADDR = _BROADCAST_ADDR
 """A special ID that means broadcast"""
 
-OUR_APP_VERSION: int = 20300
+OUR_APP_VERSION: int = _OUR_APP_VERSION
 """The numeric buildnumber (shared with android apps) specifying the
    level of device code we are guaranteed to understand
 
    format is Mmmss (where M is 1+the numeric major number. i.e. 20120 means 1.1.20
 """
 
-NODELESS_WANT_CONFIG_ID = 69420
+NODELESS_WANT_CONFIG_ID = _NODELESS_WANT_CONFIG_ID
 """A special thing to pass for want_config_id that instructs nodes to skip sending nodeinfos other than its own."""
 
 publishingThread = DeferredExecution("publishing")
@@ -174,24 +186,13 @@ logger = logging.getLogger(__name__)
 
 REDACTED_TEXT = "<redacted>"
 REDACTED_BYTES = b"<redacted>"
-DECODE_ERROR_KEY = "error"
+DECODE_ERROR_KEY = _DECODE_ERROR_KEY
 
 
-ResponseCallback = _Callable[[dict[str, _Any]], _Any]
+ResponseCallback = _ResponseCallback
+ResponseHandler = _ResponseHandler
 ProtobufFactory = _Callable[[], _Any]
 OnReceive = _Callable[[_Any, dict[str, _Any]], None]
-
-
-class ResponseHandler(_NamedTuple):
-    """A pending response callback, waiting for a response to one of our messages."""
-
-    # requestId: int - used only as a key
-    #: a callable to call when a response is received
-    callback: ResponseCallback
-    #: Whether ACKs and NAKs should be passed to this handler
-    ackPermitted: bool = False
-    # Registration timestamps are intentionally tracked out-of-band by the
-    # request runtime so this historical two-field tuple remains compatible.
 
 
 class KnownProtocol(_NamedTuple):

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -33,7 +33,8 @@ import meshtastic.ota
 import meshtastic.serial_interface
 import meshtastic.tcp_interface
 import meshtastic.util
-from meshtastic import BROADCAST_ADDR, LOCAL_ADDR, mt_config, remote_hardware
+from meshtastic import mt_config, remote_hardware
+from meshtastic._core_constants import BROADCAST_ADDR, LOCAL_ADDR
 
 # COMPAT_STABLE_SHIM: Preserve legacy imports from meshtastic.cli.parser.
 # pylint: disable=unused-import

--- a/meshtastic/_core_constants.py
+++ b/meshtastic/_core_constants.py
@@ -1,0 +1,23 @@
+"""Internal leaf constants shared by Meshtastic runtime components.
+
+This module intentionally contains no imports from other ``meshtastic`` modules.
+Public compatibility is provided by re-exports from :mod:`meshtastic`.
+"""
+
+LOCAL_ADDR = "^local"
+"""Special destination identifier for the local node."""
+
+BROADCAST_NUM: int = 0xFFFFFFFF
+"""Numeric broadcast node identifier."""
+
+BROADCAST_ADDR = "^all"
+"""Special destination identifier for broadcast traffic."""
+
+OUR_APP_VERSION: int = 20300
+"""Numeric client capability version shared with Meshtastic applications."""
+
+NODELESS_WANT_CONFIG_ID = 69420
+"""Configuration request id that suppresses non-local node-info streaming."""
+
+DECODE_ERROR_KEY = "error"
+"""Dictionary key used to retain protobuf decode failures in packet data."""

--- a/meshtastic/_core_constants.py
+++ b/meshtastic/_core_constants.py
@@ -4,6 +4,16 @@ This module intentionally contains no imports from other ``meshtastic`` modules.
 Public compatibility is provided by re-exports from :mod:`meshtastic`.
 """
 
+__all__ = (
+    "BROADCAST_ADDR",
+    "BROADCAST_NUM",
+    "DECODE_ERROR_KEY",
+    "LOCAL_ADDR",
+    "NODELESS_WANT_CONFIG_ID",
+    "OUR_APP_VERSION",
+)
+
+
 LOCAL_ADDR = "^local"
 """Special destination identifier for the local node."""
 

--- a/meshtastic/_response_types.py
+++ b/meshtastic/_response_types.py
@@ -1,0 +1,21 @@
+"""Internal response-bookkeeping types shared by runtime components.
+
+The public aliases remain available from :mod:`meshtastic`; this leaf module
+exists so internal request runtimes do not depend on package-root implementation.
+"""
+
+from typing import Any, Callable, NamedTuple
+
+ResponseCallback = Callable[[dict[str, Any]], Any]
+
+
+class ResponseHandler(NamedTuple):
+    """A pending response callback, waiting for a response to one of our messages."""
+
+    callback: ResponseCallback
+    ackPermitted: bool = False
+
+
+# Registration timestamps remain out-of-band so the historical two-field tuple
+# shape stays compatible. Preserve its original public module metadata too.
+ResponseHandler.__module__ = "meshtastic"

--- a/meshtastic/_response_types.py
+++ b/meshtastic/_response_types.py
@@ -6,6 +6,8 @@ exists so internal request runtimes do not depend on package-root implementation
 
 from typing import Any, Callable, NamedTuple
 
+__all__ = ("ResponseCallback", "ResponseHandler")
+
 ResponseCallback = Callable[[dict[str, Any]], Any]
 
 
@@ -17,5 +19,7 @@ class ResponseHandler(NamedTuple):
 
 
 # Registration timestamps remain out-of-band so the historical two-field tuple
-# shape stays compatible. Preserve its original public module metadata too.
+# shape stays compatible. NamedTuple records its defining module in pickle and
+# introspection metadata, so preserve the historical public lookup path after
+# moving the implementation into this private leaf module.
 ResponseHandler.__module__ = "meshtastic"

--- a/meshtastic/cli/values.py
+++ b/meshtastic/cli/values.py
@@ -6,7 +6,7 @@ import argparse
 from typing import Any, Protocol
 
 import meshtastic.util
-from meshtastic import BROADCAST_ADDR, LOCAL_ADDR
+from meshtastic._core_constants import BROADCAST_ADDR, LOCAL_ADDR
 from meshtastic.protobuf import config_pb2
 
 

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -21,12 +21,9 @@ except ImportError:
 from pubsub import pub
 
 import meshtastic.node
-from meshtastic import (
-    BROADCAST_ADDR,
-    NODELESS_WANT_CONFIG_ID,
-    ResponseHandler,
-    publishingThread,
-)
+from meshtastic import publishingThread
+from meshtastic._core_constants import BROADCAST_ADDR, NODELESS_WANT_CONFIG_ID
+from meshtastic._response_types import ResponseHandler
 from meshtastic.mesh_interface_runtime.flows import (
     DEFAULT_TELEMETRY_TYPE,
     TelemetryType,

--- a/meshtastic/mesh_interface_runtime/flows.py
+++ b/meshtastic/mesh_interface_runtime/flows.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 import google.protobuf.json_format
 from google.protobuf import message as protobuf_message
 
-from meshtastic import BROADCAST_ADDR
+from meshtastic._core_constants import BROADCAST_ADDR
 from meshtastic.mesh_interface_runtime.request_wait import (
     RESPONSE_WAIT_REQID_ERROR,
     WAIT_ATTR_POSITION,

--- a/meshtastic/mesh_interface_runtime/node_view.py
+++ b/meshtastic/mesh_interface_runtime/node_view.py
@@ -17,11 +17,7 @@ from pubsub import pub
 from tabulate import tabulate
 
 import meshtastic.node
-from meshtastic import (
-    BROADCAST_ADDR,
-    BROADCAST_NUM,
-    LOCAL_ADDR,
-)
+from meshtastic._core_constants import BROADCAST_ADDR, BROADCAST_NUM, LOCAL_ADDR
 from meshtastic.protobuf import mesh_pb2
 from meshtastic.util import (
     convert_mac_addr,

--- a/meshtastic/mesh_interface_runtime/receive_pipeline.py
+++ b/meshtastic/mesh_interface_runtime/receive_pipeline.py
@@ -12,13 +12,8 @@ import google.protobuf.json_format
 from google.protobuf import message as protobuf_message
 from pubsub import pub
 
-from meshtastic import (
-    BROADCAST_ADDR,
-    BROADCAST_NUM,
-    DECODE_ERROR_KEY,
-    protocols,
-    publishingThread,
-)
+from meshtastic import protocols, publishingThread
+from meshtastic._core_constants import BROADCAST_ADDR, BROADCAST_NUM, DECODE_ERROR_KEY
 from meshtastic._topics import LOCKDOWN_STATUS_TOPIC
 from meshtastic.protobuf import (
     channel_pb2,

--- a/meshtastic/mesh_interface_runtime/request_wait.py
+++ b/meshtastic/mesh_interface_runtime/request_wait.py
@@ -8,7 +8,8 @@ import time
 from collections.abc import Callable
 from typing import Any
 
-from meshtastic import ResponseHandler
+from meshtastic._core_constants import DECODE_ERROR_KEY
+from meshtastic._response_types import ResponseHandler
 from meshtastic.protobuf import portnums_pb2
 from meshtastic.util import Acknowledgment, Timeout
 
@@ -35,7 +36,6 @@ RESPONSE_WAIT_REQID_ERROR: str = (
     "Internal error: response wait requires a positive packet id."
 )
 
-DECODE_ERROR_KEY: str = "error"
 DECODE_FAILED_PREFIX: str = "decode-failed: "
 # Placeholder for legacy unscoped wait attribute mapping (currently unused)
 RETIRED_WAIT_REQUEST_ID_TTL_SECONDS: float = 60.0

--- a/meshtastic/mesh_interface_runtime/send_pipeline.py
+++ b/meshtastic/mesh_interface_runtime/send_pipeline.py
@@ -8,7 +8,7 @@ import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, cast
 
-from meshtastic import BROADCAST_ADDR, BROADCAST_NUM, LOCAL_ADDR
+from meshtastic._core_constants import BROADCAST_ADDR, BROADCAST_NUM, LOCAL_ADDR
 from meshtastic.mesh_interface_runtime.flows import (
     DEFAULT_TELEMETRY_TYPE,
     TelemetryType,

--- a/meshtastic/test.py
+++ b/meshtastic/test.py
@@ -11,7 +11,7 @@ from typing import Any, NoReturn
 from pubsub import pub
 
 import meshtastic.util
-from meshtastic import BROADCAST_NUM
+from meshtastic._core_constants import BROADCAST_NUM
 from meshtastic.protobuf import portnums_pb2
 from meshtastic.serial_interface import SerialInterface
 from meshtastic.tcp_interface import TCPInterface

--- a/meshtastic/tests/test_core_runtime_primitives.py
+++ b/meshtastic/tests/test_core_runtime_primitives.py
@@ -1,0 +1,81 @@
+"""Compatibility and dependency-boundary tests for core runtime primitives."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pickle
+from pathlib import Path
+
+import meshtastic
+from meshtastic import _core_constants, _response_types
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _imports_from_meshtastic_root(path: Path) -> set[str]:
+    """Return names imported directly from the package root by one module."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.level == 0 and node.module == "meshtastic":
+            imported.update(alias.name for alias in node.names)
+    return imported
+
+
+def test_public_core_constants_are_leaf_module_identities() -> None:
+    """Package-root constants should remain exact re-exports of leaf primitives."""
+    assert meshtastic.LOCAL_ADDR is _core_constants.LOCAL_ADDR
+    assert meshtastic.BROADCAST_ADDR is _core_constants.BROADCAST_ADDR
+    assert meshtastic.BROADCAST_NUM is _core_constants.BROADCAST_NUM
+    assert meshtastic.OUR_APP_VERSION is _core_constants.OUR_APP_VERSION
+    assert meshtastic.NODELESS_WANT_CONFIG_ID is _core_constants.NODELESS_WANT_CONFIG_ID
+    assert meshtastic.DECODE_ERROR_KEY is _core_constants.DECODE_ERROR_KEY
+
+
+def test_public_response_types_are_leaf_module_identities() -> None:
+    """Historical response types should retain identity through the package facade."""
+    assert meshtastic.ResponseCallback is _response_types.ResponseCallback
+    assert meshtastic.ResponseHandler is _response_types.ResponseHandler
+
+
+def test_core_runtime_consumers_do_not_import_moved_primitives_from_package_root() -> None:
+    """Internal runtimes should depend on leaf primitives rather than package implementation."""
+    moved_names = {
+        "BROADCAST_ADDR",
+        "BROADCAST_NUM",
+        "DECODE_ERROR_KEY",
+        "LOCAL_ADDR",
+        "NODELESS_WANT_CONFIG_ID",
+        "ResponseHandler",
+    }
+    paths = (
+        ROOT / "meshtastic/mesh_interface.py",
+        ROOT / "meshtastic/mesh_interface_runtime/flows.py",
+        ROOT / "meshtastic/mesh_interface_runtime/node_view.py",
+        ROOT / "meshtastic/mesh_interface_runtime/receive_pipeline.py",
+        ROOT / "meshtastic/mesh_interface_runtime/request_wait.py",
+        ROOT / "meshtastic/mesh_interface_runtime/send_pipeline.py",
+    )
+    for path in paths:
+        assert _imports_from_meshtastic_root(path).isdisjoint(moved_names), path
+
+
+def test_public_response_handler_metadata_and_pickle_contract_are_preserved() -> None:
+    """Moving ResponseHandler must not change its historical public metadata."""
+    assert meshtastic.ResponseHandler.__module__ == "meshtastic"
+    response_handler = meshtastic.ResponseHandler(callback=str, ackPermitted=True)
+    assert pickle.loads(pickle.dumps(response_handler)) == response_handler
+    assert str(inspect.signature(meshtastic.ResponseHandler)) == (
+        "(callback: Callable[[dict[str, Any]], Any], ackPermitted: bool = False)"
+    )
+
+
+def test_core_owner_modules_do_not_import_package_root() -> None:
+    """Core leaf modules should stay below the package facade."""
+    for path in (
+        ROOT / "meshtastic/_core_constants.py",
+        ROOT / "meshtastic/_response_types.py",
+    ):
+        assert _imports_from_meshtastic_root(path) == set(), path

--- a/meshtastic/tests/test_core_runtime_primitives.py
+++ b/meshtastic/tests/test_core_runtime_primitives.py
@@ -14,68 +14,100 @@ from meshtastic import _core_constants, _response_types
 ROOT = Path(__file__).resolve().parents[2]
 
 
-def _imports_from_meshtastic_root(path: Path) -> set[str]:
-    """Return names imported directly from the package root by one module."""
+def _meshtastic_root_references(path: Path) -> set[str]:
+    """Return package-root names referenced by one Python module.
+
+    Both ``from meshtastic import name`` and ``import meshtastic;
+    meshtastic.name`` forms are included so the dependency-boundary test does
+    not depend on a particular import style.
+    """
     tree = ast.parse(path.read_text(encoding="utf-8"))
-    imported: set[str] = set()
+    referenced: set[str] = set()
+    root_aliases: set[str] = set()
     for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom) and node.level == 0 and node.module == "meshtastic":
-            imported.update(alias.name for alias in node.names)
-    return imported
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "meshtastic":
+                    root_aliases.add(alias.asname or alias.name)
+        elif (
+            isinstance(node, ast.ImportFrom)
+            and node.level == 0
+            and node.module == "meshtastic"
+        ):
+            referenced.update(alias.name for alias in node.names)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id in root_aliases
+        ):
+            referenced.add(node.attr)
+    return referenced
+
+
+def _production_python_modules() -> tuple[Path, ...]:
+    """Return production modules that must consume core primitives directly."""
+    package_root = ROOT / "meshtastic"
+    return tuple(
+        path
+        for path in sorted(package_root.rglob("*.py"))
+        if path != package_root / "__init__.py"
+        and "tests" not in path.parts
+        and "protobuf" not in path.parts
+    )
 
 
 def test_public_core_constants_are_leaf_module_identities() -> None:
     """Package-root constants should remain exact re-exports of leaf primitives."""
-    assert meshtastic.LOCAL_ADDR is _core_constants.LOCAL_ADDR
-    assert meshtastic.BROADCAST_ADDR is _core_constants.BROADCAST_ADDR
-    assert meshtastic.BROADCAST_NUM is _core_constants.BROADCAST_NUM
-    assert meshtastic.OUR_APP_VERSION is _core_constants.OUR_APP_VERSION
-    assert meshtastic.NODELESS_WANT_CONFIG_ID is _core_constants.NODELESS_WANT_CONFIG_ID
-    assert meshtastic.DECODE_ERROR_KEY is _core_constants.DECODE_ERROR_KEY
+    for name in _core_constants.__all__:
+        assert getattr(meshtastic, name) is getattr(_core_constants, name), name
 
 
 def test_public_response_types_are_leaf_module_identities() -> None:
     """Historical response types should retain identity through the package facade."""
-    assert meshtastic.ResponseCallback is _response_types.ResponseCallback
-    assert meshtastic.ResponseHandler is _response_types.ResponseHandler
+    for name in _response_types.__all__:
+        assert getattr(meshtastic, name) is getattr(_response_types, name), name
 
 
-def test_core_runtime_consumers_do_not_import_moved_primitives_from_package_root() -> None:
-    """Internal runtimes should depend on leaf primitives rather than package implementation."""
-    moved_names = {
-        "BROADCAST_ADDR",
-        "BROADCAST_NUM",
-        "DECODE_ERROR_KEY",
-        "LOCAL_ADDR",
-        "NODELESS_WANT_CONFIG_ID",
-        "ResponseHandler",
-    }
-    paths = (
-        ROOT / "meshtastic/mesh_interface.py",
-        ROOT / "meshtastic/mesh_interface_runtime/flows.py",
-        ROOT / "meshtastic/mesh_interface_runtime/node_view.py",
-        ROOT / "meshtastic/mesh_interface_runtime/receive_pipeline.py",
-        ROOT / "meshtastic/mesh_interface_runtime/request_wait.py",
-        ROOT / "meshtastic/mesh_interface_runtime/send_pipeline.py",
-    )
-    for path in paths:
-        assert _imports_from_meshtastic_root(path).isdisjoint(moved_names), path
+def test_production_consumers_do_not_reference_moved_primitives_from_package_root() -> None:
+    """Production internals should consume leaf-owned primitives directly."""
+    moved_names = set(_core_constants.__all__) | set(_response_types.__all__)
+    for path in _production_python_modules():
+        assert _meshtastic_root_references(path).isdisjoint(moved_names), path
 
 
 def test_public_response_handler_metadata_and_pickle_contract_are_preserved() -> None:
     """Moving ResponseHandler must not change its historical public metadata."""
     assert meshtastic.ResponseHandler.__module__ == "meshtastic"
+    assert meshtastic.ResponseHandler.__qualname__ == "ResponseHandler"
+    assert meshtastic.ResponseHandler._fields == ("callback", "ackPermitted")
+    assert meshtastic.ResponseHandler._field_defaults == {"ackPermitted": False}
+
     response_handler = meshtastic.ResponseHandler(callback=str, ackPermitted=True)
     assert pickle.loads(pickle.dumps(response_handler)) == response_handler
-    assert str(inspect.signature(meshtastic.ResponseHandler)) == (
-        "(callback: Callable[[dict[str, Any]], Any], ackPermitted: bool = False)"
-    )
+
+    signature = inspect.signature(meshtastic.ResponseHandler)
+    assert tuple(signature.parameters) == ("callback", "ackPermitted")
+    callback_parameter = signature.parameters["callback"]
+    assert callback_parameter.default is inspect.Signature.empty
+    assert callback_parameter.annotation == _response_types.ResponseCallback
+    ack_parameter = signature.parameters["ackPermitted"]
+    assert ack_parameter.default is False
+    assert ack_parameter.annotation is bool
+    assert signature.return_annotation is inspect.Signature.empty
+
+
+def test_request_wait_uses_shared_decode_error_key_primitive() -> None:
+    """Request waits must share the single leaf-owned decode error key."""
+    from meshtastic.mesh_interface_runtime import request_wait
+
+    assert request_wait.DECODE_ERROR_KEY is _core_constants.DECODE_ERROR_KEY
+    assert request_wait.DECODE_ERROR_KEY is meshtastic.DECODE_ERROR_KEY
 
 
 def test_core_owner_modules_do_not_import_package_root() -> None:
     """Core leaf modules should stay below the package facade."""
-    for path in (
-        ROOT / "meshtastic/_core_constants.py",
-        ROOT / "meshtastic/_response_types.py",
-    ):
-        assert _imports_from_meshtastic_root(path) == set(), path
+    for module in (_core_constants, _response_types):
+        assert module.__file__ is not None
+        path = Path(module.__file__).resolve()
+        assert _meshtastic_root_references(path) == set(), path


### PR DESCRIPTION
## Summary by Sourcery

Extract core runtime primitives into dedicated leaf modules and re-export them from the package root while preserving public contracts and compatibility.

New Features:
- Introduce internal leaf modules for core constants and response types shared by runtime components.

Enhancements:
- Update runtime and CLI modules to consume core constants and response types from dedicated leaf modules instead of the package root.
- Maintain public aliases and metadata for response-related types to preserve historical behavior and serialization contracts.

Tests:
- Add tests that validate re-export identity of core primitives, enforce dependency boundaries between leaf modules and the package root, and ensure ResponseHandler metadata and pickle compatibility remain unchanged.