### PR TITLE
Refactor publishing worker ownership from package facade

### DIFF
--- a/meshtastic/__init__.py
+++ b/meshtastic/__init__.py
@@ -174,6 +174,8 @@ OUR_APP_VERSION: int = _OUR_APP_VERSION
 NODELESS_WANT_CONFIG_ID = _NODELESS_WANT_CONFIG_ID
 """A special thing to pass for want_config_id that instructs nodes to skip sending nodeinfos other than its own."""
 
+# COMPAT_STABLE_SHIM: preserve the historical package-root publishingThread
+# singleton while internal publishers depend on its private owner directly.
 publishingThread = _publishing.publishing_thread
 """Process-wide deferred publisher worker.
 

--- a/meshtastic/__init__.py
+++ b/meshtastic/__init__.py
@@ -95,6 +95,7 @@ from ._response_types import (
     ResponseHandler as _ResponseHandler,
 )
 from . import _protocol_runtime
+from . import _publishing
 from .protobuf import (
     admin_pb2,
     apponly_pb2,
@@ -173,7 +174,7 @@ OUR_APP_VERSION: int = _OUR_APP_VERSION
 NODELESS_WANT_CONFIG_ID = _NODELESS_WANT_CONFIG_ID
 """A special thing to pass for want_config_id that instructs nodes to skip sending nodeinfos other than its own."""
 
-publishingThread = DeferredExecution("publishing")
+publishingThread = _publishing.publishing_thread
 """Process-wide deferred publisher worker.
 
 `DeferredExecution.queueWork()` is thread-safe (backed by Queue) and all

--- a/meshtastic/_publishing.py
+++ b/meshtastic/_publishing.py
@@ -1,0 +1,12 @@
+"""Internal owner of the process-wide deferred publication executor.
+
+The historical :data:`meshtastic.publishingThread` name remains a direct alias
+to :data:`publishing_thread`. Keeping construction here removes publisher
+ownership from the package facade while preserving import-time behavior and
+object identity for compatibility.
+"""
+
+from meshtastic.util import DeferredExecution
+
+publishing_thread = DeferredExecution("publishing")
+"""Process-wide worker that serializes deferred publication callbacks."""

--- a/meshtastic/_publishing.py
+++ b/meshtastic/_publishing.py
@@ -2,8 +2,8 @@
 
 The historical :data:`meshtastic.publishingThread` name remains a direct alias
 to :data:`publishing_thread`. Keeping construction here removes publisher
-ownership from the package facade while preserving import-time behavior and
-object identity for compatibility.
+ownership from the package facade while ensuring package-root and internal
+consumers share one process-wide worker.
 """
 
 from meshtastic.util import DeferredExecution

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -43,7 +43,7 @@ from bleak import BleakClient as BleakRootClient
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakDBusError, BleakError
 
-from meshtastic import publishingThread
+from meshtastic._publishing import publishing_thread as publishingThread
 from meshtastic.interfaces.ble import constants as _ble_constants
 from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.compatibility_service import (

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -21,7 +21,7 @@ except ImportError:
 from pubsub import pub
 
 import meshtastic.node
-from meshtastic import publishingThread
+from meshtastic._publishing import publishing_thread as publishingThread
 from meshtastic._core_constants import BROADCAST_ADDR, NODELESS_WANT_CONFIG_ID
 from meshtastic._response_types import ResponseHandler
 from meshtastic.mesh_interface_runtime.flows import (

--- a/meshtastic/mesh_interface_runtime/receive_pipeline.py
+++ b/meshtastic/mesh_interface_runtime/receive_pipeline.py
@@ -12,7 +12,7 @@ import google.protobuf.json_format
 from google.protobuf import message as protobuf_message
 from pubsub import pub
 
-from meshtastic import publishingThread
+from meshtastic._publishing import publishing_thread as publishingThread
 from meshtastic._core_constants import BROADCAST_ADDR, BROADCAST_NUM, DECODE_ERROR_KEY
 from meshtastic._protocol_runtime import protocols
 from meshtastic._topics import LOCKDOWN_STATUS_TOPIC

--- a/meshtastic/tests/test_core_runtime_primitives.py
+++ b/meshtastic/tests/test_core_runtime_primitives.py
@@ -171,3 +171,28 @@ def test_protocol_owner_module_does_not_import_package_root() -> None:
     assert _protocol_runtime.__file__ is not None
     path = Path(_protocol_runtime.__file__).resolve()
     assert _meshtastic_root_references(path) == set()
+
+
+def test_public_publishing_thread_is_internal_owner_identity() -> None:
+    """Historical publishingThread should alias the internal singleton exactly."""
+    from meshtastic import _publishing
+
+    assert meshtastic.publishingThread is _publishing.publishing_thread
+
+
+def test_publishing_consumers_do_not_import_worker_from_package_root() -> None:
+    """Internal publishers should depend on the internal worker owner directly."""
+    paths = (
+        ROOT / "meshtastic/mesh_interface.py",
+        ROOT / "meshtastic/mesh_interface_runtime/receive_pipeline.py",
+        ROOT / "meshtastic/interfaces/ble/interface.py",
+    )
+    for path in paths:
+        assert "publishingThread" not in _imports_from_meshtastic_root(path), path
+
+
+def test_publishing_owner_module_does_not_import_package_root() -> None:
+    """Publishing ownership should remain below the package facade."""
+    path = ROOT / "meshtastic/_publishing.py"
+    assert _imports_from_meshtastic_root(path) == set()
+>>>>>>> fc83821e (Move publishing worker ownership out of package facade)

--- a/meshtastic/tests/test_core_runtime_primitives.py
+++ b/meshtastic/tests/test_core_runtime_primitives.py
@@ -11,7 +11,7 @@ import typing
 import pytest
 
 import meshtastic
-from meshtastic import _core_constants, _protocol_runtime, _response_types
+from meshtastic import _core_constants, _protocol_runtime, _publishing, _response_types
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -175,24 +175,17 @@ def test_protocol_owner_module_does_not_import_package_root() -> None:
 
 def test_public_publishing_thread_is_internal_owner_identity() -> None:
     """Historical publishingThread should alias the internal singleton exactly."""
-    from meshtastic import _publishing
-
     assert meshtastic.publishingThread is _publishing.publishing_thread
 
 
-def test_publishing_consumers_do_not_import_worker_from_package_root() -> None:
-    """Internal publishers should depend on the internal worker owner directly."""
-    paths = (
-        ROOT / "meshtastic/mesh_interface.py",
-        ROOT / "meshtastic/mesh_interface_runtime/receive_pipeline.py",
-        ROOT / "meshtastic/interfaces/ble/interface.py",
-    )
-    for path in paths:
-        assert "publishingThread" not in _imports_from_meshtastic_root(path), path
+def test_production_consumers_do_not_import_publishing_worker_from_package_root() -> None:
+    """Production modules should depend on the internal publishing owner directly."""
+    for path in _production_python_modules():
+        assert "publishingThread" not in _meshtastic_root_references(path), path
 
 
 def test_publishing_owner_module_does_not_import_package_root() -> None:
     """Publishing ownership should remain below the package facade."""
-    path = ROOT / "meshtastic/_publishing.py"
-    assert _imports_from_meshtastic_root(path) == set()
->>>>>>> fc83821e (Move publishing worker ownership out of package facade)
+    assert _publishing.__file__ is not None
+    path = Path(_publishing.__file__).resolve()
+    assert _meshtastic_root_references(path) == set()


### PR DESCRIPTION
## Summary by Sourcery

Move ownership of the process-wide deferred publishing worker into an internal module while preserving the public publishingThread alias and updating consumers and tests to reflect the new ownership boundary.

New Features:
- Introduce internal publishing owner module providing a singleton publishing_thread worker.

Enhancements:
- Decouple publishing worker ownership from the package facade by making meshtastic.publishingThread an alias of the internal singleton.
- Update BLE, mesh interface, and receive pipeline consumers to import the internal publishing worker directly instead of through the package root.

Tests:
- Add tests to verify the publishingThread alias points to the internal singleton and that publishing ownership and consumers no longer depend on the package root for the worker.