### PR TITLE
Refactor BLE Boundary Access, Centralize Session State, and Harden Lifecycle Concurrency

### DIFF
--- a/meshtastic/_core_constants.py
+++ b/meshtastic/_core_constants.py
@@ -8,6 +8,7 @@ __all__ = (
     "BROADCAST_ADDR",
     "BROADCAST_NUM",
     "DECODE_ERROR_KEY",
+    "LAST_DISCONNECT_SOURCE_TYPE_ERROR",
     "LOCAL_ADDR",
     "NODELESS_WANT_CONFIG_ID",
     "OUR_APP_VERSION",
@@ -31,3 +32,8 @@ NODELESS_WANT_CONFIG_ID = 69420
 
 DECODE_ERROR_KEY = "error"
 """Dictionary key used to retain protobuf decode failures in packet data."""
+
+LAST_DISCONNECT_SOURCE_TYPE_ERROR = (
+    "_last_disconnect_source must be a str or None, got {type_name}"
+)
+"""Stable validation message for disconnect-source compatibility views."""

--- a/meshtastic/_core_constants.py
+++ b/meshtastic/_core_constants.py
@@ -1,14 +1,14 @@
 """Internal leaf constants shared by Meshtastic runtime components.
 
 This module intentionally contains no imports from other ``meshtastic`` modules.
-Public compatibility is provided by re-exports from :mod:`meshtastic`.
+Names listed in ``__all__`` are re-exported from :mod:`meshtastic`;
+other constants in this leaf module remain internal implementation details.
 """
 
 __all__ = (
     "BROADCAST_ADDR",
     "BROADCAST_NUM",
     "DECODE_ERROR_KEY",
-    "LAST_DISCONNECT_SOURCE_TYPE_ERROR",
     "LOCAL_ADDR",
     "NODELESS_WANT_CONFIG_ID",
     "OUR_APP_VERSION",

--- a/meshtastic/interfaces/ble/client.py
+++ b/meshtastic/interfaces/ble/client.py
@@ -19,6 +19,7 @@ from bleak import BleakScanner
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakError
 
+from meshtastic.interfaces.ble.compat_adapter import (_get_declared_callable, _get_declared_member)
 from meshtastic.interfaces.ble.constants import (
     BLECLIENT_ERROR_ASYNC_OPERATION_FAILED,
     BLECLIENT_ERROR_ASYNC_TIMEOUT,
@@ -49,8 +50,6 @@ from meshtastic.interfaces.ble.constants import (
 from meshtastic.interfaces.ble.errors import BLEErrorHandler
 from meshtastic.interfaces.ble.runner import BLECoroutineRunner
 from meshtastic.interfaces.ble.utils import (
-    _get_declared_callable,
-    _get_declared_member,
     _is_unexpected_keyword_error,
     _safe_execute_through_adapter,
     with_timeout,

--- a/meshtastic/interfaces/ble/client.py
+++ b/meshtastic/interfaces/ble/client.py
@@ -611,7 +611,7 @@ class BLEClient:
 
         def operation() -> Coroutine[Any, Any, object]:
             bleak_client = self._require_bleak_client(not_initialized_error)
-            method = getattr(bleak_client, method_name, None)
+            method = _get_declared_member(bleak_client, method_name)
             if not callable(method):
                 raise self.BLEError(unsupported_error)
             return cast(Coroutine[Any, Any, object], method(**(call_kwargs or {})))

--- a/meshtastic/interfaces/ble/client.py
+++ b/meshtastic/interfaces/ble/client.py
@@ -19,7 +19,10 @@ from bleak import BleakScanner
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakError
 
-from meshtastic.interfaces.ble.compat_adapter import (_get_declared_callable, _get_declared_member)
+from meshtastic.interfaces.ble.compat_adapter import (
+    _get_declared_member,
+    _resolve_declared_callable,
+)
 from meshtastic.interfaces.ble.constants import (
     BLECLIENT_ERROR_ASYNC_OPERATION_FAILED,
     BLECLIENT_ERROR_ASYNC_TIMEOUT,
@@ -290,13 +293,7 @@ class BLEClient:
         if error_handler is None:
             return None
 
-        hook = _get_declared_callable(error_handler, public_name)
-        if callable(hook):
-            return cast(Callable[..., Any], hook)
-        legacy_hook = _get_declared_callable(error_handler, legacy_name)
-        if callable(legacy_hook):
-            return cast(Callable[..., Any], legacy_hook)
-        return None
+        return _resolve_declared_callable(error_handler, public_name, legacy_name)
 
     def _error_handler_safe_execute(
         self,

--- a/meshtastic/interfaces/ble/client.py
+++ b/meshtastic/interfaces/ble/client.py
@@ -49,8 +49,8 @@ from meshtastic.interfaces.ble.constants import (
 from meshtastic.interfaces.ble.errors import BLEErrorHandler
 from meshtastic.interfaces.ble.runner import BLECoroutineRunner
 from meshtastic.interfaces.ble.utils import (
-    _is_unconfigured_mock_callable,
-    _is_unconfigured_mock_member,
+    _get_declared_callable,
+    _get_declared_member,
     _is_unexpected_keyword_error,
     _safe_execute_through_adapter,
     with_timeout,
@@ -291,11 +291,11 @@ class BLEClient:
         if error_handler is None:
             return None
 
-        hook = getattr(error_handler, public_name, None)
-        if callable(hook) and not _is_unconfigured_mock_callable(hook):
+        hook = _get_declared_callable(error_handler, public_name)
+        if callable(hook):
             return cast(Callable[..., Any], hook)
-        legacy_hook = getattr(error_handler, legacy_name, None)
-        if callable(legacy_hook) and not _is_unconfigured_mock_callable(legacy_hook):
+        legacy_hook = _get_declared_callable(error_handler, legacy_name)
+        if callable(legacy_hook):
             return cast(Callable[..., Any], legacy_hook)
         return None
 
@@ -613,7 +613,7 @@ class BLEClient:
         def operation() -> Coroutine[Any, Any, object]:
             bleak_client = self._require_bleak_client(not_initialized_error)
             method = getattr(bleak_client, method_name, None)
-            if not callable(method) or _is_unconfigured_mock_callable(method):
+            if not callable(method):
                 raise self.BLEError(unsupported_error)
             return cast(Coroutine[Any, Any, object], method(**(call_kwargs or {})))
 
@@ -742,13 +742,9 @@ class BLEClient:
             bool
                 `True` if the client reports an active connection, `False` otherwise.
             """
-            connected = getattr(bleak_client, "is_connected", False)
+            connected = _get_declared_member(bleak_client, "is_connected", False)
             if callable(connected):
-                if _is_unconfigured_mock_callable(connected):
-                    return False
                 connected = connected()  # pylint: disable=E1102
-            if _is_unconfigured_mock_member(connected):
-                return False
             return connected if isinstance(connected, bool) else False
 
         result = self._error_handler_safe_execute(

--- a/meshtastic/interfaces/ble/compat_adapter.py
+++ b/meshtastic/interfaces/ble/compat_adapter.py
@@ -135,9 +135,10 @@ def _get_declared_lock(
     candidate = _get_declared_member(target, name)
     if candidate is None:
         return None
+    candidate_type = type(candidate)
     if (
-        _get_declared_callable(candidate, "__enter__") is None
-        or _get_declared_callable(candidate, "__exit__") is None
+        _get_declared_callable(candidate_type, "__enter__") is None
+        or _get_declared_callable(candidate_type, "__exit__") is None
     ):
         return None
     return cast(_LockPort, candidate)

--- a/meshtastic/interfaces/ble/compat_adapter.py
+++ b/meshtastic/interfaces/ble/compat_adapter.py
@@ -12,6 +12,8 @@ import inspect
 from collections.abc import Callable, Iterator
 from typing import Any, TypeVar, cast
 
+from meshtastic.interfaces.ble.ports import _LockPort
+
 T = TypeVar("T")
 _MISSING = object()
 
@@ -68,7 +70,6 @@ def _get_declared_callable(
     return cast(Callable[..., Any], candidate) if callable(candidate) else None
 
 
-
 def _iter_declared_members(
     target: object | None,
     *names: str,
@@ -88,6 +89,7 @@ def _iter_declared_callables(
     for name, candidate in _iter_declared_members(target, *names):
         if callable(candidate):
             yield name, cast(Callable[..., Any], candidate)
+
 
 def _resolve_declared_member(
     target: object | None,
@@ -110,10 +112,8 @@ def _resolve_declared_member(
     object | T | None
         First declared non-``None`` member or ``default``.
     """
-    for name in names:
-        candidate = _get_declared_member(target, name, _MISSING)
-        if candidate is not _MISSING and candidate is not None:
-            return candidate
+    for _name, candidate in _iter_declared_members(target, *names):
+        return candidate
     return default
 
 
@@ -122,8 +122,22 @@ def _resolve_declared_callable(
     *names: str,
 ) -> Callable[..., Any] | None:
     """Resolve the first explicitly declared callable in precedence order."""
-    for name in names:
-        candidate = _get_declared_callable(target, name)
-        if candidate is not None:
-            return candidate
+    for _name, candidate in _iter_declared_callables(target, *names):
+        return candidate
     return None
+
+
+def _get_declared_lock(
+    target: object | None,
+    name: str,
+) -> _LockPort | None:
+    """Return a declared context-manager lock member when available."""
+    candidate = _get_declared_member(target, name)
+    if candidate is None:
+        return None
+    if (
+        _get_declared_callable(candidate, "__enter__") is None
+        or _get_declared_callable(candidate, "__exit__") is None
+    ):
+        return None
+    return cast(_LockPort, candidate)

--- a/meshtastic/interfaces/ble/compat_adapter.py
+++ b/meshtastic/interfaces/ble/compat_adapter.py
@@ -1,0 +1,129 @@
+"""Structural compatibility dispatch for BLE collaborators.
+
+The BLE implementation preserves a number of historical public/underscore
+member pairs.  Resolution belongs in one place so production code does not
+need to know how dynamic proxies, partial collaborators, or legacy spellings
+are represented.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable, Iterator
+from typing import Any, TypeVar, cast
+
+T = TypeVar("T")
+_MISSING = object()
+
+
+def _get_declared_member(
+    target: object | None,
+    name: str,
+    default: T | None = None,
+) -> object | T | None:
+    """Return an explicitly declared member without dynamic fallback.
+
+    Parameters
+    ----------
+    target : object | None
+        Object to inspect.
+    name : str
+        Attribute name to resolve.
+    default : T | None
+        Value returned when the member is not explicitly declared.
+
+    Returns
+    -------
+    object | T | None
+        The resolved member or ``default``.
+
+    Notes
+    -----
+    ``inspect.getattr_static`` is used only to establish declaration.  The
+    subsequent direct ``__getattribute__`` call preserves the target type's
+    declared access semantics while deliberately bypassing dynamic ``__getattr__``
+    synthesis, including when a declared descriptor itself raises
+    ``AttributeError``.
+    """
+    if target is None:
+        return default
+    try:
+        inspect.getattr_static(target, name)
+    except AttributeError:
+        return default
+    try:
+        return type(target).__getattribute__(  # pylint: disable=unnecessary-dunder-call
+            target, name
+        )
+    except AttributeError:
+        return default
+
+
+def _get_declared_callable(
+    target: object | None,
+    name: str,
+) -> Callable[..., Any] | None:
+    """Return an explicitly declared callable member when available."""
+    candidate = _get_declared_member(target, name)
+    return cast(Callable[..., Any], candidate) if callable(candidate) else None
+
+
+
+def _iter_declared_members(
+    target: object | None,
+    *names: str,
+) -> Iterator[tuple[str, object]]:
+    """Yield explicitly declared non-``None`` members in precedence order."""
+    for name in names:
+        candidate = _get_declared_member(target, name, _MISSING)
+        if candidate is not _MISSING and candidate is not None:
+            yield name, candidate
+
+
+def _iter_declared_callables(
+    target: object | None,
+    *names: str,
+) -> Iterator[tuple[str, Callable[..., Any]]]:
+    """Yield explicitly declared callable members in precedence order."""
+    for name, candidate in _iter_declared_members(target, *names):
+        if callable(candidate):
+            yield name, cast(Callable[..., Any], candidate)
+
+def _resolve_declared_member(
+    target: object | None,
+    *names: str,
+    default: T | None = None,
+) -> object | T | None:
+    """Resolve the first non-``None`` explicitly declared compatibility member.
+
+    Parameters
+    ----------
+    target : object | None
+        Collaborator exposing current and/or legacy members.
+    *names : str
+        Member names in precedence order.
+    default : T | None
+        Fallback returned when no usable member exists.
+
+    Returns
+    -------
+    object | T | None
+        First declared non-``None`` member or ``default``.
+    """
+    for name in names:
+        candidate = _get_declared_member(target, name, _MISSING)
+        if candidate is not _MISSING and candidate is not None:
+            return candidate
+    return default
+
+
+def _resolve_declared_callable(
+    target: object | None,
+    *names: str,
+) -> Callable[..., Any] | None:
+    """Resolve the first explicitly declared callable in precedence order."""
+    for name in names:
+        candidate = _get_declared_callable(target, name)
+        if candidate is not None:
+            return candidate
+    return None

--- a/meshtastic/interfaces/ble/compatibility_service.py
+++ b/meshtastic/interfaces/ble/compatibility_service.py
@@ -4,6 +4,11 @@ from queue import Empty, Full
 from threading import Event, Thread
 from typing import TYPE_CHECKING, Any, Callable, cast
 
+from meshtastic.interfaces.ble.compat_adapter import (
+    _get_declared_callable,
+    _get_declared_member,
+)
+from meshtastic.interfaces.ble.lifecycle_primitives import _LifecycleStateAccess
 from meshtastic.interfaces.ble.constants import (
     DISCONNECT_TIMEOUT_SECONDS,
     MAX_DRAIN_ITERATIONS,
@@ -522,31 +527,13 @@ class BLECompatibilityEventService:
                 )
 
         def _is_iface_closing() -> bool:
-            is_closing = bool(getattr(iface, "_closed", False))
-            state_manager = getattr(iface, "_state_manager", None)
-            raw_is_closing = getattr(state_manager, "is_closing", None)
-            if callable(raw_is_closing):
-                try:
-                    state_probe = raw_is_closing()
-                except Exception:  # noqa: BLE001 - shutdown probe remains best effort
-                    state_probe = None
-                if isinstance(state_probe, bool):
-                    is_closing = is_closing or state_probe
-            elif isinstance(raw_is_closing, bool):
-                is_closing = is_closing or raw_is_closing
-            if is_closing:
+            closed = _get_declared_member(iface, "_closed", False)
+            if closed is True:
                 return True
-            legacy_is_closing = getattr(state_manager, "_is_closing", None)
-            if callable(legacy_is_closing):
-                try:
-                    legacy_probe = legacy_is_closing()
-                except Exception:  # noqa: BLE001 - shutdown probe remains best effort
-                    legacy_probe = None
-                if isinstance(legacy_probe, bool):
-                    is_closing = is_closing or legacy_probe
-            elif isinstance(legacy_is_closing, bool):
-                is_closing = is_closing or legacy_is_closing
-            return is_closing
+            state_manager = _get_declared_member(iface, "_state_manager")
+            if state_manager is None:
+                return False
+            return _LifecycleStateAccess(state_manager).is_closing()
 
         def _publish_status_async(reason: str) -> bool:
             if _is_iface_closing():
@@ -641,8 +628,10 @@ class BLECompatibilityEventService:
         """
         resolved_publishing_thread = publishing_thread
         if resolved_publishing_thread is None:
-            get_publishing_thread = getattr(iface, "_get_publishing_thread", None)
-            if callable(get_publishing_thread):
+            get_publishing_thread = _get_declared_callable(
+                iface, "_get_publishing_thread"
+            )
+            if get_publishing_thread is not None:
                 try:
                     resolved_publishing_thread = get_publishing_thread()
                 except Exception:  # noqa: BLE001 - compatibility shim is best effort

--- a/meshtastic/interfaces/ble/compatibility_service.py
+++ b/meshtastic/interfaces/ble/compatibility_service.py
@@ -9,6 +9,10 @@ from meshtastic.interfaces.ble.compat_adapter import (
     _get_declared_member,
 )
 from meshtastic.interfaces.ble.lifecycle_primitives import _LifecycleStateAccess
+from meshtastic.interfaces.ble.failure_policy import (
+    _BLEFailureDisposition,
+    _log_ble_failure,
+)
 from meshtastic.interfaces.ble.constants import (
     DISCONNECT_TIMEOUT_SECONDS,
     MAX_DRAIN_ITERATIONS,
@@ -527,13 +531,20 @@ class BLECompatibilityEventService:
                 )
 
         def _is_iface_closing() -> bool:
-            closed = _get_declared_member(iface, "_closed", False)
-            if closed is True:
-                return True
-            state_manager = _get_declared_member(iface, "_state_manager")
-            if state_manager is None:
+            try:
+                closed = _get_declared_member(iface, "_closed", False)
+                if closed is True:
+                    return True
+                state_manager = _get_declared_member(iface, "_state_manager")
+                if state_manager is None:
+                    return False
+                return _LifecycleStateAccess(state_manager).is_closing()
+            except Exception:  # noqa: BLE001 - status publication is best effort
+                _log_ble_failure(
+                    _BLEFailureDisposition.COMPATIBILITY_FALLBACK,
+                    "Error probing interface closing state during status publication",
+                )
                 return False
-            return _LifecycleStateAccess(state_manager).is_closing()
 
         def _publish_status_async(reason: str) -> bool:
             if _is_iface_closing():

--- a/meshtastic/interfaces/ble/compatibility_service.py
+++ b/meshtastic/interfaces/ble/compatibility_service.py
@@ -10,10 +10,6 @@ from meshtastic.interfaces.ble.constants import (
     logger,
 )
 from meshtastic.interfaces.ble.utils import (
-    _is_unconfigured_mock_callable,
-    _is_unconfigured_mock_member,
-)
-from meshtastic.interfaces.ble.utils import (
     _resolve_safe_execute as _resolve_safe_execute_hook,
 )
 from meshtastic.interfaces.ble.utils import (
@@ -55,13 +51,13 @@ class BLECompatibilityEventPublisher:
     @staticmethod
     def _is_live_publishing_thread(publishing_thread: object | None) -> bool:
         """Return whether a publishing-thread facade appears alive/usable."""
-        if publishing_thread is None or _is_unconfigured_mock_member(publishing_thread):
+        if publishing_thread is None:
             return False
         thread = getattr(publishing_thread, "thread", None)
-        if thread is None or _is_unconfigured_mock_member(thread):
+        if thread is None:
             return True
         is_alive = getattr(thread, "is_alive", None)
-        if not callable(is_alive) or _is_unconfigured_mock_callable(is_alive):
+        if not callable(is_alive):
             return True
         try:
             alive_result = is_alive()
@@ -294,12 +290,8 @@ class BLECompatibilityEventService:
         queue_work = getattr(publishing_thread, "queueWork", None)
         queue = getattr(publishing_thread, "queue", None)
         put_nowait = getattr(queue, "put_nowait", None)
-        can_queue_work = callable(queue_work) and not _is_unconfigured_mock_callable(
-            queue_work
-        )
-        can_put_nowait = callable(put_nowait) and not _is_unconfigured_mock_callable(
-            put_nowait
-        )
+        can_queue_work = callable(queue_work)
+        can_put_nowait = callable(put_nowait)
         queue_work_callback: Callable[[Any], object] | None = (
             cast(Callable[[Any], object], queue_work) if can_queue_work else None
         )
@@ -309,7 +301,7 @@ class BLECompatibilityEventService:
         thread = getattr(publishing_thread, "thread", None)
         is_alive = getattr(thread, "is_alive", None)
         thread_is_alive: bool | None = None
-        if callable(is_alive) and not _is_unconfigured_mock_callable(is_alive):
+        if callable(is_alive):
             try:
                 alive_result = is_alive()
             except Exception:  # noqa: BLE001 - enqueue path is best effort
@@ -393,7 +385,7 @@ class BLECompatibilityEventService:
             thread = getattr(publishing_thread, "thread", None)
             is_alive = getattr(thread, "is_alive", None)
             alive_result = False
-            if callable(is_alive) and not _is_unconfigured_mock_callable(is_alive):
+            if callable(is_alive):
                 try:
                     alive_result = is_alive()
                 except Exception:  # noqa: BLE001 - disconnect fallback must continue
@@ -435,7 +427,7 @@ class BLECompatibilityEventService:
             return
         thread = getattr(publishing_thread, "thread", None)
         thread_drain = getattr(thread, "_drain_publish_queue", None)
-        if callable(thread_drain) and not _is_unconfigured_mock_callable(thread_drain):
+        if callable(thread_drain):
             try:
                 BLECompatibilityEventService._safe_execute(
                     iface,
@@ -459,7 +451,6 @@ class BLECompatibilityEventService:
         if (
             queue is None
             or not callable(get_nowait)
-            or _is_unconfigured_mock_callable(get_nowait)
         ):
             return
         iterations = 0
@@ -534,9 +525,7 @@ class BLECompatibilityEventService:
             is_closing = bool(getattr(iface, "_closed", False))
             state_manager = getattr(iface, "_state_manager", None)
             raw_is_closing = getattr(state_manager, "is_closing", None)
-            if callable(raw_is_closing) and not _is_unconfigured_mock_callable(
-                raw_is_closing
-            ):
+            if callable(raw_is_closing):
                 try:
                     state_probe = raw_is_closing()
                 except Exception:  # noqa: BLE001 - shutdown probe remains best effort
@@ -548,9 +537,7 @@ class BLECompatibilityEventService:
             if is_closing:
                 return True
             legacy_is_closing = getattr(state_manager, "_is_closing", None)
-            if callable(legacy_is_closing) and not _is_unconfigured_mock_callable(
-                legacy_is_closing
-            ):
+            if callable(legacy_is_closing):
                 try:
                     legacy_probe = legacy_is_closing()
                 except Exception:  # noqa: BLE001 - shutdown probe remains best effort
@@ -655,9 +642,7 @@ class BLECompatibilityEventService:
         resolved_publishing_thread = publishing_thread
         if resolved_publishing_thread is None:
             get_publishing_thread = getattr(iface, "_get_publishing_thread", None)
-            if callable(get_publishing_thread) and not _is_unconfigured_mock_callable(
-                get_publishing_thread
-            ):
+            if callable(get_publishing_thread):
                 try:
                     resolved_publishing_thread = get_publishing_thread()
                 except Exception:  # noqa: BLE001 - compatibility shim is best effort

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -12,12 +12,12 @@ from typing import TYPE_CHECKING, cast
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakDBusError, BleakDeviceNotFoundError, BleakError
 
+from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.compat_adapter import (
     _get_declared_callable,
     _get_declared_member,
     _resolve_declared_callable,
 )
-from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.constants import (
     AWAIT_TIMEOUT_BUFFER_SECONDS,
     BLECLIENT_ERROR_ALREADY_CONNECTED,
@@ -44,6 +44,7 @@ from meshtastic.interfaces.ble.errors import (
 from meshtastic.interfaces.ble.errors import (
     BLEErrorHandler,
 )
+from meshtastic.interfaces.ble.lifecycle_primitives import _client_is_connected_compat
 from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
 from meshtastic.interfaces.ble.utils import (
     _is_unexpected_keyword_error,
@@ -122,7 +123,6 @@ def _is_device_not_found_error(err: Exception) -> bool:
         return True
     message = str(err).casefold()
     return bool(message) and _DEVICE_NOT_FOUND_MESSAGE_RE.search(message) is not None
-
 
 
 def _run_safe_cleanup(
@@ -270,18 +270,10 @@ class ConnectionValidator:
     @staticmethod
     def _client_is_connected(client: BLEClient | None) -> bool:
         """Resolve connected state from public/legacy BLEClient compatibility members."""
-        if client is None:
+        try:
+            return _client_is_connected_compat(client)
+        except AttributeError:
             return False
-        for candidate_name in ("isConnected", "is_connected", "_is_connected"):
-            candidate = _get_declared_member(client, candidate_name)
-            if callable(candidate):
-                connected = candidate()
-                if isinstance(connected, bool):
-                    return connected
-                continue
-            if isinstance(candidate, bool):
-                return candidate
-        return False
 
     def _check_existing_client(
         self,
@@ -706,9 +698,7 @@ class ClientManager:
                 is_connected = False
                 for probe_name in ("is_connected", "isConnected", "_is_connected"):
                     is_connected_probe = _get_declared_member(client, probe_name)
-                    if callable(
-                        is_connected_probe
-                    ):
+                    if callable(is_connected_probe):
                         try:
                             is_connected = bool(is_connected_probe())
                         except (
@@ -721,9 +711,7 @@ class ClientManager:
                             )
                         if is_connected:
                             break
-                    elif isinstance(
-                        is_connected_probe, bool
-                    ):
+                    elif isinstance(is_connected_probe, bool):
                         is_connected = is_connected_probe
                         if is_connected:
                             break
@@ -936,11 +924,12 @@ class ConnectionOrchestrator:
         )
         kwargs = {} if kwargs is None else kwargs
         public_member = _get_declared_member(target, public_name, missing_sentinel)
-        underscore_member = _get_declared_member(target, underscore_name, missing_sentinel)
+        underscore_member = _get_declared_member(
+            target, underscore_name, missing_sentinel
+        )
 
-        if (
-            prefer_instance_type is not None
-            and issubclass(type(target), prefer_instance_type)
+        if prefer_instance_type is not None and issubclass(
+            type(target), prefer_instance_type
         ):
             if public_member is missing_sentinel:
                 raise AttributeError(
@@ -1908,7 +1897,9 @@ class ConnectionOrchestrator:
             self.interface, "findDevice", "find_device", "_find_device"
         )
         if find_device is None:
-            raise AttributeError("Interface is missing findDevice/find_device/_find_device")
+            raise AttributeError(
+                "Interface is missing findDevice/find_device/_find_device"
+            )
         return cast(BLEDevice, find_device(target_address))
 
     def _finalize_connection(
@@ -1989,7 +1980,9 @@ class ConnectionOrchestrator:
                 )
 
         if emit_connected_side_effects:
-            raw_ever_connected = _get_declared_member(self.interface, "_ever_connected", False)
+            raw_ever_connected = _get_declared_member(
+                self.interface, "_ever_connected", False
+            )
             prior_ever_connected = (
                 raw_ever_connected if isinstance(raw_ever_connected, bool) else False
             )

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -12,7 +12,11 @@ from typing import TYPE_CHECKING, cast
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakDBusError, BleakDeviceNotFoundError, BleakError
 
-from meshtastic.interfaces.ble.compat_adapter import (_get_declared_callable, _get_declared_member)
+from meshtastic.interfaces.ble.compat_adapter import (
+    _get_declared_callable,
+    _get_declared_member,
+    _resolve_declared_callable,
+)
 from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.constants import (
     AWAIT_TIMEOUT_BUFFER_SECONDS,
@@ -400,17 +404,11 @@ class ClientManager:
         daemon: bool,
     ) -> ThreadLike:
         """Create thread via public API with underscore fallback for test doubles."""
-        create_thread = _get_declared_callable(self.thread_coordinator, "create_thread")
-        legacy_create_thread = _get_declared_callable(self.thread_coordinator, "_create_thread")
-        valid_create_thread = (
-            create_thread
-            if callable(create_thread)
-            else None
+        valid_create_thread = _get_declared_callable(
+            self.thread_coordinator, "create_thread"
         )
-        valid_legacy_create_thread = (
-            legacy_create_thread
-            if callable(legacy_create_thread)
-            else None
+        valid_legacy_create_thread = _get_declared_callable(
+            self.thread_coordinator, "_create_thread"
         )
         if valid_create_thread is not None:
             return cast(
@@ -438,17 +436,11 @@ class ClientManager:
 
     def _thread_start_thread(self, thread: ThreadLike) -> None:
         """Start thread via public API with underscore fallback for test doubles."""
-        start_thread = _get_declared_callable(self.thread_coordinator, "start_thread")
-        legacy_start_thread = _get_declared_callable(self.thread_coordinator, "_start_thread")
-        valid_start_thread = (
-            start_thread
-            if callable(start_thread)
-            else None
+        valid_start_thread = _get_declared_callable(
+            self.thread_coordinator, "start_thread"
         )
-        valid_legacy_start_thread = (
-            legacy_start_thread
-            if callable(legacy_start_thread)
-            else None
+        valid_legacy_start_thread = _get_declared_callable(
+            self.thread_coordinator, "_start_thread"
         )
         if valid_start_thread is not None:
             valid_start_thread(thread)
@@ -701,11 +693,9 @@ class ClientManager:
         """
         is_finalizing = getattr(sys, "is_finalizing", None)
         skip_disconnect = bool(is_finalizing()) if callable(is_finalizing) else False
-        safe_cleanup_hook = _get_declared_callable(self.error_handler, "safe_cleanup")
-        if not callable(safe_cleanup_hook):
-            safe_cleanup_hook = _get_declared_callable(self.error_handler, "_safe_cleanup")
-        if not callable(safe_cleanup_hook):
-            safe_cleanup_hook = None
+        safe_cleanup_hook = _resolve_declared_callable(
+            self.error_handler, "safe_cleanup", "_safe_cleanup"
+        )
 
         try:
             if (
@@ -1914,18 +1904,12 @@ class ConnectionOrchestrator:
         AttributeError
             If no supported find-device compatibility helper exists.
         """
-        find_device = getattr(self.interface, "findDevice", None)
-        if callable(find_device):
-            return cast(BLEDevice, find_device(target_address))
-
-        legacy_find_device = getattr(self.interface, "find_device", None)
-        if callable(legacy_find_device):
-            return cast(BLEDevice, legacy_find_device(target_address))
-
-        underscore_find_device = getattr(self.interface, "_find_device", None)
-        if callable(underscore_find_device):
-            return cast(BLEDevice, underscore_find_device(target_address))
-        raise AttributeError("Interface is missing findDevice/find_device/_find_device")
+        find_device = _resolve_declared_callable(
+            self.interface, "findDevice", "find_device", "_find_device"
+        )
+        if find_device is None:
+            raise AttributeError("Interface is missing findDevice/find_device/_find_device")
+        return cast(BLEDevice, find_device(target_address))
 
     def _finalize_connection(
         self,

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -41,8 +41,8 @@ from meshtastic.interfaces.ble.errors import (
 )
 from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
 from meshtastic.interfaces.ble.utils import (
-    _is_unconfigured_mock_callable,
-    _is_unconfigured_mock_member,
+    _get_declared_callable,
+    _get_declared_member,
     _is_unexpected_keyword_error,
     _thread_start_probe,
     sanitize_address,
@@ -120,25 +120,6 @@ def _is_device_not_found_error(err: Exception) -> bool:
     message = str(err).casefold()
     return bool(message) and _DEVICE_NOT_FOUND_MESSAGE_RE.search(message) is not None
 
-
-def _is_mock_instance(target: object) -> bool:
-    """Return whether ``target`` is a unittest mock instance.
-
-    Parameters
-    ----------
-    target : object
-        Candidate object inspected for mock-instance type.
-
-    Returns
-    -------
-    bool
-        ``True`` when ``target`` is a ``Mock`` or ``NonCallableMock``.
-    """
-    try:
-        from unittest.mock import Mock, NonCallableMock
-    except ImportError:  # pragma: no cover - stdlib import should always exist
-        return False
-    return isinstance(target, (Mock, NonCallableMock))
 
 
 def _run_safe_cleanup(
@@ -289,17 +270,13 @@ class ConnectionValidator:
         if client is None:
             return False
         for candidate_name in ("isConnected", "is_connected", "_is_connected"):
-            candidate = getattr(client, candidate_name, None)
+            candidate = _get_declared_member(client, candidate_name)
             if callable(candidate):
-                if _is_unconfigured_mock_callable(candidate):
-                    continue
                 connected = candidate()
                 if isinstance(connected, bool):
                     return connected
                 continue
-            if isinstance(candidate, bool) and not _is_unconfigured_mock_member(
-                candidate
-            ):
+            if isinstance(candidate, bool):
                 return candidate
         return False
 
@@ -335,7 +312,7 @@ class ConnectionValidator:
             return False
         normalized_request_key = sanitize_address(normalized_request)
         client_address = sanitize_address(getattr(client, "address", None))
-        bleak_client = getattr(client, "bleak_client", None)
+        bleak_client = _get_declared_member(client, "bleak_client")
         bleak_address = getattr(bleak_client, "address", None)
         normalized_known_targets = {
             t
@@ -424,18 +401,16 @@ class ClientManager:
         daemon: bool,
     ) -> ThreadLike:
         """Create thread via public API with underscore fallback for test doubles."""
-        create_thread = getattr(self.thread_coordinator, "create_thread", None)
-        legacy_create_thread = getattr(self.thread_coordinator, "_create_thread", None)
+        create_thread = _get_declared_callable(self.thread_coordinator, "create_thread")
+        legacy_create_thread = _get_declared_callable(self.thread_coordinator, "_create_thread")
         valid_create_thread = (
             create_thread
             if callable(create_thread)
-            and not _is_unconfigured_mock_callable(create_thread)
             else None
         )
         valid_legacy_create_thread = (
             legacy_create_thread
             if callable(legacy_create_thread)
-            and not _is_unconfigured_mock_callable(legacy_create_thread)
             else None
         )
         if valid_create_thread is not None:
@@ -464,18 +439,16 @@ class ClientManager:
 
     def _thread_start_thread(self, thread: ThreadLike) -> None:
         """Start thread via public API with underscore fallback for test doubles."""
-        start_thread = getattr(self.thread_coordinator, "start_thread", None)
-        legacy_start_thread = getattr(self.thread_coordinator, "_start_thread", None)
+        start_thread = _get_declared_callable(self.thread_coordinator, "start_thread")
+        legacy_start_thread = _get_declared_callable(self.thread_coordinator, "_start_thread")
         valid_start_thread = (
             start_thread
             if callable(start_thread)
-            and not _is_unconfigured_mock_callable(start_thread)
             else None
         )
         valid_legacy_start_thread = (
             legacy_start_thread
             if callable(legacy_start_thread)
-            and not _is_unconfigured_mock_callable(legacy_start_thread)
             else None
         )
         if valid_start_thread is not None:
@@ -729,28 +702,24 @@ class ClientManager:
         """
         is_finalizing = getattr(sys, "is_finalizing", None)
         skip_disconnect = bool(is_finalizing()) if callable(is_finalizing) else False
-        safe_cleanup_hook = getattr(self.error_handler, "safe_cleanup", None)
-        if not callable(safe_cleanup_hook) or _is_unconfigured_mock_callable(
-            safe_cleanup_hook
-        ):
-            safe_cleanup_hook = getattr(self.error_handler, "_safe_cleanup", None)
-        if not callable(safe_cleanup_hook) or _is_unconfigured_mock_callable(
-            safe_cleanup_hook
-        ):
+        safe_cleanup_hook = _get_declared_callable(self.error_handler, "safe_cleanup")
+        if not callable(safe_cleanup_hook):
+            safe_cleanup_hook = _get_declared_callable(self.error_handler, "_safe_cleanup")
+        if not callable(safe_cleanup_hook):
             safe_cleanup_hook = None
 
         try:
             if (
                 not skip_disconnect
-                and not getattr(client, "_closed", False)
-                and getattr(client, "bleak_client", None)
+                and not _get_declared_member(client, "_closed", False)
+                and _get_declared_member(client, "bleak_client")
             ):
                 is_connected = False
                 for probe_name in ("is_connected", "isConnected", "_is_connected"):
-                    is_connected_probe = getattr(client, probe_name, None)
+                    is_connected_probe = _get_declared_member(client, probe_name)
                     if callable(
                         is_connected_probe
-                    ) and not _is_unconfigured_mock_callable(is_connected_probe):
+                    ):
                         try:
                             is_connected = bool(is_connected_probe())
                         except (
@@ -765,7 +734,7 @@ class ClientManager:
                             break
                     elif isinstance(
                         is_connected_probe, bool
-                    ) and not _is_unconfigured_mock_member(is_connected_probe):
+                    ):
                         is_connected = is_connected_probe
                         if is_connected:
                             break
@@ -977,24 +946,12 @@ class ConnectionOrchestrator:
             dispatch_kwdefaults.get("default_if_missing", _DISPATCH_MISSING),
         )
         kwargs = {} if kwargs is None else kwargs
-        public_member = getattr(target, public_name, missing_sentinel)
-        underscore_member = getattr(target, underscore_name, missing_sentinel)
-
-        if not call_member:
-            if _is_unconfigured_mock_member(public_member):
-                public_member = missing_sentinel
-            if _is_unconfigured_mock_member(underscore_member):
-                underscore_member = missing_sentinel
-        else:
-            if _is_unconfigured_mock_callable(public_member):
-                public_member = missing_sentinel
-            if _is_unconfigured_mock_callable(underscore_member):
-                underscore_member = missing_sentinel
+        public_member = _get_declared_member(target, public_name, missing_sentinel)
+        underscore_member = _get_declared_member(target, underscore_name, missing_sentinel)
 
         if (
             prefer_instance_type is not None
-            and isinstance(target, prefer_instance_type)
-            and not _is_mock_instance(target)
+            and issubclass(type(target), prefer_instance_type)
         ):
             if public_member is missing_sentinel:
                 raise AttributeError(
@@ -1390,7 +1347,7 @@ class ConnectionOrchestrator:
     @staticmethod
     def _extract_client_address(client: BLEClient) -> str | None:
         """Return the best-known connected address from a BLE client."""
-        bleak_client = getattr(client, "bleak_client", None)
+        bleak_client = _get_declared_member(client, "bleak_client")
         bleak_address = getattr(bleak_client, "address", None)
         if isinstance(bleak_address, str) and bleak_address:
             return bleak_address
@@ -1959,19 +1916,15 @@ class ConnectionOrchestrator:
             If no supported find-device compatibility helper exists.
         """
         find_device = getattr(self.interface, "findDevice", None)
-        if callable(find_device) and not _is_unconfigured_mock_callable(find_device):
+        if callable(find_device):
             return cast(BLEDevice, find_device(target_address))
 
         legacy_find_device = getattr(self.interface, "find_device", None)
-        if callable(legacy_find_device) and not _is_unconfigured_mock_callable(
-            legacy_find_device
-        ):
+        if callable(legacy_find_device):
             return cast(BLEDevice, legacy_find_device(target_address))
 
         underscore_find_device = getattr(self.interface, "_find_device", None)
-        if callable(underscore_find_device) and not _is_unconfigured_mock_callable(
-            underscore_find_device
-        ):
+        if callable(underscore_find_device):
             return cast(BLEDevice, underscore_find_device(target_address))
         raise AttributeError("Interface is missing findDevice/find_device/_find_device")
 
@@ -2053,15 +2006,9 @@ class ConnectionOrchestrator:
                 )
 
         if emit_connected_side_effects:
-            raw_ever_connected = getattr(self.interface, "_ever_connected", False)
+            raw_ever_connected = _get_declared_member(self.interface, "_ever_connected", False)
             prior_ever_connected = (
-                False
-                if _is_unconfigured_mock_member(raw_ever_connected)
-                else (
-                    raw_ever_connected
-                    if isinstance(raw_ever_connected, bool)
-                    else False
-                )
+                raw_ever_connected if isinstance(raw_ever_connected, bool) else False
             )
             on_connected_func()
             if prior_ever_connected:

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, cast
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakDBusError, BleakDeviceNotFoundError, BleakError
 
+from meshtastic.interfaces.ble.compat_adapter import (_get_declared_callable, _get_declared_member)
 from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.constants import (
     AWAIT_TIMEOUT_BUFFER_SECONDS,
@@ -41,8 +42,6 @@ from meshtastic.interfaces.ble.errors import (
 )
 from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
 from meshtastic.interfaces.ble.utils import (
-    _get_declared_callable,
-    _get_declared_member,
     _is_unexpected_keyword_error,
     _thread_start_probe,
     sanitize_address,

--- a/meshtastic/interfaces/ble/discovery.py
+++ b/meshtastic/interfaces/ble/discovery.py
@@ -15,6 +15,7 @@ from bleak.exc import BleakDBusError, BleakError
 
 from meshtastic.interfaces.ble.compat_adapter import (
     _get_declared_callable,
+    _get_declared_member,
     _resolve_declared_callable,
 )
 from meshtastic.interfaces.ble.client import BLEClient
@@ -509,7 +510,7 @@ class DiscoveryManager:
 
         def _probe_connected_state(candidate: object) -> bool | None:
             for method_name in ("isConnected", "is_connected"):
-                probe = getattr(candidate, method_name, None)
+                probe = _get_declared_member(candidate, method_name)
                 if callable(probe):
                     try:
                         result = probe()
@@ -522,7 +523,7 @@ class DiscoveryManager:
                         return None
                     if isinstance(result, bool):
                         return result
-            member_probe = getattr(candidate, "is_connected", None)
+            member_probe = _get_declared_member(candidate, "is_connected")
             if isinstance(member_probe, bool):
                 return member_probe
             return None

--- a/meshtastic/interfaces/ble/discovery.py
+++ b/meshtastic/interfaces/ble/discovery.py
@@ -13,7 +13,10 @@ from typing import Any, Callable, Protocol, cast, runtime_checkable
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakDBusError, BleakError
 
-from meshtastic.interfaces.ble.compat_adapter import (_get_declared_callable)
+from meshtastic.interfaces.ble.compat_adapter import (
+    _get_declared_callable,
+    _resolve_declared_callable,
+)
 from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.constants import (
     SERVICE_UUID,
@@ -652,12 +655,8 @@ class DiscoveryManager:
             if not target_identifier:
                 discover_kwargs["service_uuids"] = [SERVICE_UUID]
 
-            discover = _get_declared_callable(client, "discover")
-            if not callable(discover):
-                # Compatibility for minimal test doubles that still expose
-                # underscore-prefixed discover helpers.
-                discover = getattr(client, "_discover", None)
-            if not callable(discover):
+            discover = _resolve_declared_callable(client, "discover", "_discover")
+            if discover is None:
                 self._invalidate_cached_client_if_same(client)
                 raise DiscoveryClientError.invalid_client(
                     resolved_factory,
@@ -694,10 +693,10 @@ class DiscoveryManager:
                     ["discover", "_discover"],
                 ) from exc
             if inspect.isawaitable(response):
-                await_bridge = getattr(client, "async_await", None)
-                if not callable(await_bridge):
-                    await_bridge = getattr(client, "_async_await", None)
-                if callable(await_bridge):
+                await_bridge = _resolve_declared_callable(
+                    client, "async_await", "_async_await"
+                )
+                if await_bridge is not None:
                     response = await_bridge(response)
                 if inspect.isawaitable(response):
                     if inspect.iscoroutine(response):

--- a/meshtastic/interfaces/ble/discovery.py
+++ b/meshtastic/interfaces/ble/discovery.py
@@ -13,6 +13,7 @@ from typing import Any, Callable, Protocol, cast, runtime_checkable
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakDBusError, BleakError
 
+from meshtastic.interfaces.ble.compat_adapter import (_get_declared_callable)
 from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.constants import (
     SERVICE_UUID,
@@ -20,7 +21,6 @@ from meshtastic.interfaces.ble.constants import (
     logger,
 )
 from meshtastic.interfaces.ble.utils import (
-    _get_declared_callable,
     _call_factory_with_optional_kwarg,
     _is_unexpected_keyword_error,
     resolve_ble_module,

--- a/meshtastic/interfaces/ble/discovery.py
+++ b/meshtastic/interfaces/ble/discovery.py
@@ -14,7 +14,6 @@ from bleak.backends.device import BLEDevice
 from bleak.exc import BleakDBusError, BleakError
 
 from meshtastic.interfaces.ble.compat_adapter import (
-    _get_declared_callable,
     _get_declared_member,
     _resolve_declared_callable,
 )
@@ -100,11 +99,7 @@ def _is_discovery_client_like(client: object) -> bool:
         ``True`` when the client exposes a callable supported discovery method
         otherwise ``False``.
     """
-    discover = _get_declared_callable(client, "discover")
-    if callable(discover):
-        return True
-    underscore_discover = _get_declared_callable(client, "_discover")
-    return callable(underscore_discover)
+    return _resolve_declared_callable(client, "discover", "_discover") is not None
 
 
 def _looks_like_ble_address(identifier: str) -> bool:

--- a/meshtastic/interfaces/ble/discovery.py
+++ b/meshtastic/interfaces/ble/discovery.py
@@ -20,9 +20,8 @@ from meshtastic.interfaces.ble.constants import (
     logger,
 )
 from meshtastic.interfaces.ble.utils import (
+    _get_declared_callable,
     _call_factory_with_optional_kwarg,
-    _is_unconfigured_mock_callable,
-    _is_unconfigured_mock_member,
     _is_unexpected_keyword_error,
     resolve_ble_module,
     sanitize_address,
@@ -95,15 +94,13 @@ def _is_discovery_client_like(client: object) -> bool:
     -------
     bool
         ``True`` when the client exposes a callable supported discovery method
-        that is not an unconfigured mock callable, otherwise ``False``.
+        otherwise ``False``.
     """
-    discover = getattr(client, "discover", None)
-    if callable(discover) and not _is_unconfigured_mock_callable(discover):
+    discover = _get_declared_callable(client, "discover")
+    if callable(discover):
         return True
-    underscore_discover = getattr(client, "_discover", None)
-    return callable(underscore_discover) and not _is_unconfigured_mock_callable(
-        underscore_discover
-    )
+    underscore_discover = _get_declared_callable(client, "_discover")
+    return callable(underscore_discover)
 
 
 def _looks_like_ble_address(identifier: str) -> bool:
@@ -510,7 +507,7 @@ class DiscoveryManager:
         def _probe_connected_state(candidate: object) -> bool | None:
             for method_name in ("isConnected", "is_connected"):
                 probe = getattr(candidate, method_name, None)
-                if callable(probe) and not _is_unconfigured_mock_callable(probe):
+                if callable(probe):
                     try:
                         result = probe()
                     except Exception:  # noqa: BLE001 - defensive probe path
@@ -523,9 +520,7 @@ class DiscoveryManager:
                     if isinstance(result, bool):
                         return result
             member_probe = getattr(candidate, "is_connected", None)
-            if isinstance(member_probe, bool) and not _is_unconfigured_mock_member(
-                member_probe
-            ):
+            if isinstance(member_probe, bool):
                 return member_probe
             return None
 
@@ -657,12 +652,12 @@ class DiscoveryManager:
             if not target_identifier:
                 discover_kwargs["service_uuids"] = [SERVICE_UUID]
 
-            discover = getattr(client, "discover", None)
-            if not callable(discover) or _is_unconfigured_mock_callable(discover):
+            discover = _get_declared_callable(client, "discover")
+            if not callable(discover):
                 # Compatibility for minimal test doubles that still expose
                 # underscore-prefixed discover helpers.
                 discover = getattr(client, "_discover", None)
-            if not callable(discover) or _is_unconfigured_mock_callable(discover):
+            if not callable(discover):
                 self._invalidate_cached_client_if_same(client)
                 raise DiscoveryClientError.invalid_client(
                     resolved_factory,
@@ -700,13 +695,9 @@ class DiscoveryManager:
                 ) from exc
             if inspect.isawaitable(response):
                 await_bridge = getattr(client, "async_await", None)
-                if not callable(await_bridge) or _is_unconfigured_mock_callable(
-                    await_bridge
-                ):
+                if not callable(await_bridge):
                     await_bridge = getattr(client, "_async_await", None)
-                if callable(await_bridge) and not _is_unconfigured_mock_callable(
-                    await_bridge
-                ):
+                if callable(await_bridge):
                     response = await_bridge(response)
                 if inspect.isawaitable(response):
                     if inspect.iscoroutine(response):

--- a/meshtastic/interfaces/ble/failure_policy.py
+++ b/meshtastic/interfaces/ble/failure_policy.py
@@ -1,0 +1,54 @@
+"""Explicit failure dispositions for BLE runtime error handling."""
+
+from __future__ import annotations
+
+import logging
+from enum import Enum
+
+from meshtastic.interfaces.ble.constants import logger
+
+
+class _BLEFailureDisposition(str, Enum):
+    """How a caught BLE failure affects the current operation."""
+
+    COMPATIBILITY_FALLBACK = "compatibility_fallback"
+    BEST_EFFORT = "best_effort"
+    RETRYABLE = "retryable"
+    TERMINAL = "terminal"
+
+
+def _log_ble_failure(
+    disposition: _BLEFailureDisposition,
+    message: str,
+    *args: object,
+    level: int = logging.DEBUG,
+    exc_info: bool = True,
+) -> None:
+    """Log a caught BLE failure without changing its user-visible message.
+
+    Parameters
+    ----------
+    disposition : _BLEFailureDisposition
+        Semantic outcome of the caught failure.
+    message : str
+        Existing log message format.
+    *args : object
+        Values interpolated by the logger.
+    level : int
+        Logging level preserving the caller's historical severity.
+    exc_info : bool
+        Whether to attach the active exception traceback.
+
+    Notes
+    -----
+    The disposition is attached as structured ``LogRecord`` metadata so tests,
+    diagnostics, and future telemetry can reason about policy without changing
+    historical log text.
+    """
+    logger.log(
+        level,
+        message,
+        *args,
+        exc_info=exc_info,
+        extra={"ble_failure_disposition": disposition.value},
+    )

--- a/meshtastic/interfaces/ble/gating.py
+++ b/meshtastic/interfaces/ble/gating.py
@@ -38,19 +38,60 @@ from meshtastic.interfaces.ble.utils import sanitize_address
 
 logger = logging.getLogger("meshtastic.ble")
 
-_REGISTRY_LOCK = RLock()
-_ADDR_LOCKS: dict[str, RLock] = {}
-_CONNECTED_ADDRS: set[str] = set()
-_CONNECTING_ADDRS: set[str] = set()
-# Optional owner references for active connected-address claims.
-_CONNECTED_OWNERS: dict[str, weakref.ReferenceType[Any] | None] = {}
-_CONNECTED_OWNER_IDS: dict[str, int | None] = {}
-_CONNECTED_MARKED_AT: dict[str, float] = {}
-_CONNECTING_OWNERS: dict[str, weakref.ReferenceType[Any] | None] = {}
-_CONNECTING_OWNER_IDS: dict[str, int | None] = {}
-_CONNECTING_MARKED_AT: dict[str, float] = {}
-# Track locks that are currently held to prevent premature cleanup
-_LOCK_HOLDERS: dict[str, int] = {}  # key -> count of holders
+class _BLEAddressRegistry:
+    """Own process-wide BLE address claims and per-address lock bookkeeping.
+
+    The registry object owns all mutable gating state.  Module-level aliases are
+    retained below because a small amount of historical test/support code imports
+    the collections directly.  Runtime code should treat this object as the
+    ownership boundary and use the existing module-level operations rather than
+    mutating the collections itself.
+    """
+
+    def __init__(self) -> None:
+        """Initialize empty ownership, claim, and lock registries."""
+        self.lock = RLock()
+        self.addr_locks: dict[str, RLock] = {}
+        self.connected_addrs: set[str] = set()
+        self.connecting_addrs: set[str] = set()
+        self.connected_owners: dict[str, weakref.ReferenceType[Any] | None] = {}
+        self.connected_owner_ids: dict[str, int | None] = {}
+        self.connected_marked_at: dict[str, float] = {}
+        self.connecting_owners: dict[str, weakref.ReferenceType[Any] | None] = {}
+        self.connecting_owner_ids: dict[str, int | None] = {}
+        self.connecting_marked_at: dict[str, float] = {}
+        self.lock_holders: dict[str, int] = {}
+
+    def clear(self) -> None:
+        """Clear every registry collection while holding the owner lock."""
+        with self.lock:
+            self.addr_locks.clear()
+            self.connected_addrs.clear()
+            self.connecting_addrs.clear()
+            self.connected_marked_at.clear()
+            self.connecting_marked_at.clear()
+            self.connected_owner_ids.clear()
+            self.connecting_owner_ids.clear()
+            self.connected_owners.clear()
+            self.connecting_owners.clear()
+            self.lock_holders.clear()
+
+
+_DEFAULT_REGISTRY = _BLEAddressRegistry()
+
+# Internal compatibility aliases: keep existing imported collection identities
+# stable while making `_DEFAULT_REGISTRY` the single owner of mutable state.
+_REGISTRY_LOCK = _DEFAULT_REGISTRY.lock
+_ADDR_LOCKS = _DEFAULT_REGISTRY.addr_locks
+_CONNECTED_ADDRS = _DEFAULT_REGISTRY.connected_addrs
+_CONNECTING_ADDRS = _DEFAULT_REGISTRY.connecting_addrs
+_CONNECTED_OWNERS = _DEFAULT_REGISTRY.connected_owners
+_CONNECTED_OWNER_IDS = _DEFAULT_REGISTRY.connected_owner_ids
+_CONNECTED_MARKED_AT = _DEFAULT_REGISTRY.connected_marked_at
+_CONNECTING_OWNERS = _DEFAULT_REGISTRY.connecting_owners
+_CONNECTING_OWNER_IDS = _DEFAULT_REGISTRY.connecting_owner_ids
+_CONNECTING_MARKED_AT = _DEFAULT_REGISTRY.connecting_marked_at
+_LOCK_HOLDERS = _DEFAULT_REGISTRY.lock_holders
 
 
 def _clear_all_registries() -> None:
@@ -66,17 +107,7 @@ def _clear_all_registries() -> None:
     helper, because it force-clears global ownership and lock state.
     Intended for tests and full process-level reset paths.
     """
-    with _REGISTRY_LOCK:
-        _ADDR_LOCKS.clear()
-        _CONNECTED_ADDRS.clear()
-        _CONNECTING_ADDRS.clear()
-        _CONNECTED_MARKED_AT.clear()
-        _CONNECTING_MARKED_AT.clear()
-        _CONNECTED_OWNER_IDS.clear()
-        _CONNECTING_OWNER_IDS.clear()
-        _CONNECTED_OWNERS.clear()
-        _CONNECTING_OWNERS.clear()
-        _LOCK_HOLDERS.clear()
+    _DEFAULT_REGISTRY.clear()
 
 
 def _addr_key(addr: str | None) -> str | None:

--- a/meshtastic/interfaces/ble/gating.py
+++ b/meshtastic/interfaces/ble/gating.py
@@ -50,6 +50,9 @@ class _BLEAddressRegistry:
 
     def __init__(self) -> None:
         """Initialize empty ownership, claim, and lock registries."""
+        # Invariant: never rebind these collections after construction. The
+        # module-level compatibility aliases below capture object identity, so
+        # registry reset must mutate in place (for example via ``.clear()``).
         self.lock = RLock()
         self.addr_locks: dict[str, RLock] = {}
         self.connected_addrs: set[str] = set()

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -79,7 +79,7 @@ from meshtastic.interfaces.ble.constants import (
     BLEConfig,
     logger,
 )
-from meshtastic.interfaces.ble.coordination import ThreadCoordinator, ThreadLike
+from meshtastic.interfaces.ble.coordination import ThreadCoordinator
 from meshtastic.interfaces.ble.discovery import (
     DiscoveryManager,
     _looks_like_ble_address,
@@ -118,6 +118,10 @@ from meshtastic.interfaces.ble.policies import RetryPolicy
 from meshtastic.interfaces.ble.receive_service import BLEReceiveRecoveryController
 from meshtastic.interfaces.ble.reconnection import ReconnectScheduler
 from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
+from meshtastic.interfaces.ble.session_state import (
+    BLESessionState,
+    _BLESessionStateCompatMixin,
+)
 from meshtastic.interfaces.ble.utils import (
     _is_unconfigured_mock_callable,
     _is_unconfigured_mock_member,
@@ -187,7 +191,7 @@ ERROR_CLIENT_MANAGER_MISSING_UPDATE_CLIENT_REFERENCE: str = (
 )
 
 
-class BLEInterface(MeshInterface):
+class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
     """MeshInterface using BLE to connect to Meshtastic devices.
 
     This class provides a complete BLE interface for Meshtastic communication,
@@ -287,10 +291,8 @@ class BLEInterface(MeshInterface):
         #     only one connection attempt can be in the critical section at a time.
         #     This prevents race conditions when checking existing_client and
         #     managing the connection state machine.
-        self._state_manager = BLEStateManager()  # Centralized state tracking
-        self._state_lock = (
-            self._state_manager.lock
-        )  # `lock` returns the shared RLock instance
+        self._state_manager = BLEStateManager()  # Centralized connection state
+        self._session_state = BLESessionState(lock=self._state_manager.lock)
         self._connect_lock = threading.RLock()  # Serializes connection attempts
         self._management_lock = (
             threading.RLock()
@@ -298,9 +300,6 @@ class BLEInterface(MeshInterface):
         self._management_idle_condition = threading.Condition(self._management_lock)
         self._management_inflight = 0  # Tracks end-to-end management operations.
         self._disconnect_lock = threading.Lock()  # Serializes disconnect handling
-        self._closed: bool = (
-            False  # Tracks completion of shutdown for idempotent close()
-        )
         self._exit_handler: Any | None = None
         self.address = address
         self._last_connection_request: str | None = sanitize_address(address)
@@ -308,18 +307,6 @@ class BLEInterface(MeshInterface):
         if not isinstance(pair_on_connect, bool):
             raise self.BLEError(ERROR_PAIR_ON_CONNECT_BOOL)
         self.pair_on_connect = pair_on_connect
-        self._disconnect_notified = False  # Prevents duplicate disconnect events
-        self._client_publish_pending: bool = False  # Hide provisional clients.
-        self._connected_publish_inflight_client: BLEClient | None = None
-        self._client_replacement_pending = False
-        self._last_disconnect_source: str = (
-            ""  # Set by _handle_disconnect on each disconnect
-        )
-        self._connection_alias_key: str | None = None  # Track alias for cleanup
-        self._prior_publish_was_reconnect = False
-        self._last_connect_pair_override: bool | None = None
-        self._last_connect_timeout_override: float | None = None
-        self._publishing_thread_override: object | None = None
 
         # Error handling infrastructure
         self.error_handler = BLEErrorHandler()
@@ -377,16 +364,8 @@ class BLEInterface(MeshInterface):
         # Whether FROMNUM notifications were successfully registered for the
         # active connection. When false, receive loop falls back to periodic
         # FROMRADIO polling.
-        self._fromnum_notify_enabled = False
-        self._malformed_notification_count = 0  # Tracks corrupted packets for threshold
-        self._ever_connected = (
-            False  # Track first successful connection to tune logging
-        )
         # Monotonic session counter used to suppress stale disconnect side effects.
-        self._connection_session_epoch = 0
         # Recovery throttling to prevent tight crash→spawn loops
-        self._receive_recovery_attempts = 0
-        self._last_recovery_time = 0.0  # monotonic clock
 
         # Initialize parent interface
         super().__init__(
@@ -397,19 +376,11 @@ class BLEInterface(MeshInterface):
         # Policies are immutable presets; cache instances to avoid churn in hot loops.
         self._empty_read_policy = RetryPolicy._empty_read()
         self._transient_read_policy = RetryPolicy._transient_error()
-        self._read_retry_count = 0
-        self._last_empty_read_warning = 0.0
-        self._suppressed_empty_read_warnings = 0
 
         self.client: BLEClient | None = None
 
         # Start background receive thread for inbound packet processing
         logger.debug("Threads starting")
-        with self._state_lock:
-            self._want_receive = True
-            self._receive_start_pending = False
-            self._receive_start_pending_since: float | None = None
-        self._receiveThread: ThreadLike | None = None
         self._start_receive_thread(name="BLEReceive")
         logger.debug("Threads running")
         try:

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -44,7 +44,9 @@ from bleak.exc import BleakDBusError, BleakError
 
 from meshtastic.interfaces.ble.compat_adapter import (
     _get_declared_callable,
-    _get_declared_member,
+    _get_declared_lock,
+    _iter_declared_members,
+    _resolve_declared_callable,
 )
 from meshtastic._publishing import publishing_thread as publishingThread
 from meshtastic.interfaces.ble import constants as _ble_constants
@@ -87,6 +89,10 @@ from meshtastic.interfaces.ble.discovery import (
     DiscoveryManager,
     _looks_like_ble_address,
     _parse_scan_response,
+)
+from meshtastic.interfaces.ble.failure_policy import (
+    _BLEFailureDisposition,
+    _log_ble_failure,
 )
 from meshtastic.interfaces.ble.errors import (
     BLEConnectionSuppressedError,
@@ -450,15 +456,9 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
             True to request the receive loop to run, False to stop it.
         """
         lifecycle_controller = self._get_lifecycle_controller()
-        set_receive_wanted = _get_declared_callable(
-            lifecycle_controller, "_set_receive_wanted"
+        set_receive_wanted = _resolve_declared_callable(
+            lifecycle_controller, "_set_receive_wanted", "set_receive_wanted"
         )
-        if set_receive_wanted is None:
-            legacy_set_receive_wanted = getattr(
-                lifecycle_controller, "set_receive_wanted", None
-            )
-            if callable(legacy_set_receive_wanted):
-                set_receive_wanted = legacy_set_receive_wanted
         if set_receive_wanted is not None:
             set_receive_wanted(want_receive=want_receive)
 
@@ -471,14 +471,12 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
             `True` if the receive loop is desired and the interface is not closed, `False` otherwise.
         """
         lifecycle_controller = self._get_lifecycle_controller()
-        should_run_receive_loop = getattr(
-            lifecycle_controller, "_should_run_receive_loop", None
+        should_run_receive_loop = _resolve_declared_callable(
+            lifecycle_controller,
+            "_should_run_receive_loop",
+            "should_run_receive_loop",
         )
-        if should_run_receive_loop is None:
-            should_run_receive_loop = getattr(
-                lifecycle_controller, "should_run_receive_loop", None
-            )
-        if callable(should_run_receive_loop):
+        if should_run_receive_loop is not None:
             result = should_run_receive_loop()
             return result if isinstance(result, bool) else False
         return False
@@ -496,14 +494,10 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
             backoff tracking. Defaults to True.
         """
         lifecycle_controller = self._get_lifecycle_controller()
-        start_receive_thread = getattr(
-            lifecycle_controller, "_start_receive_thread", None
+        start_receive_thread = _resolve_declared_callable(
+            lifecycle_controller, "_start_receive_thread", "start_receive_thread"
         )
-        if start_receive_thread is None:
-            start_receive_thread = getattr(
-                lifecycle_controller, "start_receive_thread", None
-            )
-        if callable(start_receive_thread):
+        if start_receive_thread is not None:
             start_receive_thread(
                 name=name,
                 reset_recovery=reset_recovery,
@@ -1087,7 +1081,7 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
     ) -> BLEClient | None:
         """Return available management client via management collaborator."""
         handler = self._get_management_command_handler()
-        state_lock = _get_declared_member(self, "_state_lock")
+        state_lock = _get_declared_lock(self, "_state_lock")
         if state_lock is None:
             return handler.get_management_client_if_available(address)
         lock_is_owned = _get_declared_callable(state_lock, "_is_owned")
@@ -1119,7 +1113,7 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
     ) -> BLEClient | None:
         """Return reusable target-matching management client via collaborator."""
         handler = self._get_management_command_handler()
-        state_lock = _get_declared_member(self, "_state_lock")
+        state_lock = _get_declared_lock(self, "_state_lock")
         if state_lock is None:
             return handler.get_management_client_for_target(
                 target_address,
@@ -1205,7 +1199,7 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
         collaborator = getattr(self, attr_name, None)
         if collaborator is not None:
             return cast(T, collaborator)
-        state_lock = _get_declared_member(self, "_state_lock")
+        state_lock = _get_declared_lock(self, "_state_lock")
         if state_lock is None:
             collaborator = getattr(self, attr_name, None)
             if collaborator is None:
@@ -1579,18 +1573,15 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
     ) -> object:
         """Dispatch a callable through public/legacy/fallback compatibility names."""
         kwargs = {} if kwargs is None else kwargs
-        public_member = getattr(target, public_name, None)
-        if callable(public_member):
-            return public_member(*args, **kwargs)
-        legacy_member = getattr(target, legacy_name, None)
-        if callable(legacy_member):
-            return legacy_member(*args, **kwargs)
-        if fallback_attr_name is None:
+        names = (
+            (public_name, legacy_name)
+            if fallback_attr_name is None
+            else (public_name, legacy_name, fallback_attr_name)
+        )
+        member = _resolve_declared_callable(target, *names)
+        if member is None:
             raise AttributeError(error_message)
-        fallback_member = getattr(target, fallback_attr_name, None)
-        if not callable(fallback_member):
-            raise AttributeError(error_message)
-        return fallback_member(*args, **kwargs)
+        return member(*args, **kwargs)
 
     @staticmethod
     def _compat_get_bool_member(
@@ -1602,38 +1593,26 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
         error_message: str,
     ) -> bool:
         """Resolve bool members via public/legacy/fallback compatibility names."""
-        public_member = getattr(target, public_name, None)
-        if callable(public_member):
-            try:
-                resolved_public = public_member()
-            except Exception:  # noqa: BLE001 - probe dispatch must stay best effort
-                resolved_public = None
-            if isinstance(resolved_public, bool):
-                return resolved_public
-        if isinstance(public_member, bool):
-            return public_member
-        legacy_member = getattr(target, legacy_name, None)
-        if callable(legacy_member):
-            try:
-                resolved_legacy = legacy_member()
-            except Exception:  # noqa: BLE001 - probe dispatch must stay best effort
-                resolved_legacy = None
-            if isinstance(resolved_legacy, bool):
-                return resolved_legacy
-        if isinstance(legacy_member, bool):
-            return legacy_member
-        if fallback_attr_name is None:
-            raise AttributeError(error_message)
-        fallback_member = getattr(target, fallback_attr_name, None)
-        if callable(fallback_member):
-            try:
-                resolved_fallback = fallback_member()
-            except Exception:  # noqa: BLE001 - probe dispatch must stay best effort
-                resolved_fallback = None
-            if isinstance(resolved_fallback, bool):
-                return resolved_fallback
-        if isinstance(fallback_member, bool):
-            return fallback_member
+        names = (
+            (public_name, legacy_name)
+            if fallback_attr_name is None
+            else (public_name, legacy_name, fallback_attr_name)
+        )
+        for member_name, member in _iter_declared_members(target, *names):
+            if callable(member):
+                try:
+                    resolved = member()
+                except Exception:  # noqa: BLE001 - probe dispatch stays best effort
+                    _log_ble_failure(
+                        _BLEFailureDisposition.COMPATIBILITY_FALLBACK,
+                        "Error probing BLE compatibility member %s()",
+                        member_name,
+                    )
+                    continue
+            else:
+                resolved = member
+            if isinstance(resolved, bool):
+                return resolved
         raise AttributeError(error_message)
 
     def _discover_devices(self, address: str | None) -> list[BLEDevice]:

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -1221,6 +1221,7 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
             notification_manager=notification_manager,
             error_handler_provider=self._get_or_create_error_handler,
             trigger_read_event=lambda: self._set_thread_event(READ_TRIGGER_EVENT),
+            registration_current_provider=self._is_notification_registration_current,
         )
 
     @staticmethod
@@ -1235,6 +1236,42 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
         return self._get_or_create_collaborator(
             "_notification_dispatcher", self._create_notification_dispatcher
         )
+
+    def _is_notification_registration_current(
+        self,
+        client: BLEClient,
+        expected_session_epoch: int,
+    ) -> bool:
+        """Return whether notification setup still belongs to the active BLE session.
+
+        Notification registration occurs during connection finalization before the
+        newly connected client is published through ``self.client``. Treat that
+        provisional CONNECTING phase as current when the session epoch still
+        matches and publication is pending. Once the client is published, identity
+        with ``self.client`` becomes the ownership check.
+
+        Parameters
+        ----------
+        client : BLEClient
+            Client whose notification subscriptions are being registered.
+        expected_session_epoch : int
+            Connection-attempt epoch captured before notification I/O begins.
+
+        Returns
+        -------
+        bool
+            ``True`` only while the registration belongs to the same live session.
+        """
+        with self._state_lock:
+            if self._closed or self._connection_session_epoch != expected_session_epoch:
+                return False
+            lifecycle_owner_is_current = self.client is client or (
+                self._client_publish_pending
+                and self._state_manager_current_state() == ConnectionState.CONNECTING
+            )
+        if not lifecycle_owner_is_current:
+            return False
+        return ConnectionValidator._client_is_connected(client)
 
     # COMPAT_STABLE_SHIM: internal bridge for historical FROMNUM notify state probes.
     @property

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -42,15 +42,15 @@ from bleak import BleakClient as BleakRootClient
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakDBusError, BleakError
 
+from meshtastic._publishing import publishing_thread as publishingThread
+from meshtastic.interfaces.ble import constants as _ble_constants
+from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.compat_adapter import (
     _get_declared_callable,
     _get_declared_lock,
     _iter_declared_members,
     _resolve_declared_callable,
 )
-from meshtastic._publishing import publishing_thread as publishingThread
-from meshtastic.interfaces.ble import constants as _ble_constants
-from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.compatibility_service import (
     BLECompatibilityEventPublisher,
 )
@@ -90,16 +90,16 @@ from meshtastic.interfaces.ble.discovery import (
     _looks_like_ble_address,
     _parse_scan_response,
 )
-from meshtastic.interfaces.ble.failure_policy import (
-    _BLEFailureDisposition,
-    _log_ble_failure,
-)
 from meshtastic.interfaces.ble.errors import (
     BLEConnectionSuppressedError,
     BLEDeviceNotFoundError,
     BLEDiscoveryError,
     BLEErrorHandler,
     MeshtasticBLEError,
+)
+from meshtastic.interfaces.ble.failure_policy import (
+    _BLEFailureDisposition,
+    _log_ble_failure,
 )
 from meshtastic.interfaces.ble.gating import (
     _addr_key,
@@ -126,11 +126,11 @@ from meshtastic.interfaces.ble.notifications import (
 from meshtastic.interfaces.ble.policies import RetryPolicy
 from meshtastic.interfaces.ble.receive_service import BLEReceiveRecoveryController
 from meshtastic.interfaces.ble.reconnection import ReconnectScheduler
-from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
 from meshtastic.interfaces.ble.session_state import (
     BLESessionState,
     _BLESessionStateCompatMixin,
 )
+from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
 from meshtastic.interfaces.ble.utils import (
     _is_unexpected_keyword_error,
     _sleep,
@@ -299,7 +299,8 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
         #     This prevents race conditions when checking existing_client and
         #     managing the connection state machine.
         self._state_manager = BLEStateManager()  # Centralized connection state
-        self._session_state = BLESessionState(lock=self._state_manager.lock)
+        state_lock = self._state_manager.lock
+        self._session_state = BLESessionState(lock=state_lock)
         self._connect_lock = threading.RLock()  # Serializes connection attempts
         self._management_lock = (
             threading.RLock()
@@ -324,11 +325,11 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
         self._notification_dispatcher = self._create_notification_dispatcher()
         self._discovery_manager: DiscoveryManager | None = DiscoveryManager()
         self._connection_validator = ConnectionValidator(
-            self._state_manager, self._state_lock, self.BLEError
+            self._state_manager, state_lock, self.BLEError
         )
         self._client_manager = ClientManager(
             self._state_manager,
-            self._state_lock,
+            state_lock,
             self.thread_coordinator,
             self.error_handler,
         )
@@ -338,12 +339,12 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
             self._client_manager,
             self._discovery_manager,
             self._state_manager,
-            self._state_lock,
+            state_lock,
             self.thread_coordinator,
         )
         self._reconnect_scheduler = ReconnectScheduler(
             self._state_manager,
-            self._state_lock,
+            state_lock,
             self.thread_coordinator,
             self,
         )
@@ -1076,27 +1077,57 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
             target_address
         )
 
+    def _dispatch_management_lookup_by_lock(
+        self,
+        *,
+        unlocked: Callable[[], T],
+        locked: Callable[[], T],
+        operation_name: str,
+    ) -> T:
+        """Dispatch a management lookup for the current state-lock context.
+
+        Parameters
+        ----------
+        unlocked : Callable[[], T]
+            Lookup to invoke when the state lock is not owned by this thread.
+        locked : Callable[[], T]
+            Lock-aware lookup to invoke when ownership is confirmed.
+        operation_name : str
+            Diagnostic name used when the best-effort ownership probe fails.
+
+        Returns
+        -------
+        T
+            Result from the selected lookup.
+        """
+        state_lock = _get_declared_lock(self, "_state_lock")
+        lock_is_owned = (
+            _get_declared_callable(state_lock, "_is_owned")
+            if state_lock is not None
+            else None
+        )
+        if lock_is_owned is not None:
+            try:
+                if lock_is_owned() is True:
+                    return locked()
+            except Exception:  # noqa: BLE001 - lock probe remains best effort
+                logger.debug(
+                    "Failed to probe _state_lock ownership before %s",
+                    operation_name,
+                    exc_info=True,
+                )
+        return unlocked()
+
     def _get_management_client_if_available(
         self, address: str | None
     ) -> BLEClient | None:
         """Return available management client via management collaborator."""
         handler = self._get_management_command_handler()
-        state_lock = _get_declared_lock(self, "_state_lock")
-        if state_lock is None:
-            return handler.get_management_client_if_available(address)
-        lock_is_owned = _get_declared_callable(state_lock, "_is_owned")
-        if lock_is_owned is not None:
-            owns_lock = False
-            try:
-                owns_lock = lock_is_owned() is True
-            except Exception:  # noqa: BLE001 - lock probe remains best effort
-                logger.debug(
-                    "Failed to probe _state_lock ownership before management lookup",
-                    exc_info=True,
-                )
-            if owns_lock:
-                return handler.get_management_client_if_available_locked(address)
-        return handler.get_management_client_if_available(address)
+        return self._dispatch_management_lookup_by_lock(
+            unlocked=lambda: handler.get_management_client_if_available(address),
+            locked=lambda: handler.get_management_client_if_available_locked(address),
+            operation_name="management lookup",
+        )
 
     def _get_management_client_if_available_locked(
         self, address: str | None
@@ -1113,30 +1144,15 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
     ) -> BLEClient | None:
         """Return reusable target-matching management client via collaborator."""
         handler = self._get_management_command_handler()
-        state_lock = _get_declared_lock(self, "_state_lock")
-        if state_lock is None:
-            return handler.get_management_client_for_target(
+        return self._dispatch_management_lookup_by_lock(
+            unlocked=lambda: handler.get_management_client_for_target(
                 target_address,
                 prefer_current_client=prefer_current_client,
-            )
-        lock_is_owned = _get_declared_callable(state_lock, "_is_owned")
-        if lock_is_owned is not None:
-            owns_lock = False
-            try:
-                owns_lock = lock_is_owned() is True
-            except Exception:  # noqa: BLE001 - lock probe remains best effort
-                logger.debug(
-                    "Failed to probe _state_lock ownership before target lookup",
-                    exc_info=True,
-                )
-            if owns_lock:
-                return handler.get_management_client_for_target_locked(
-                    target_address,
-                    prefer_current_client=prefer_current_client,
-                )
-        return handler.get_management_client_for_target(
-            target_address,
-            prefer_current_client=prefer_current_client,
+            ),
+            locked=lambda: handler.get_management_client_for_target_locked(
+                target_address, prefer_current_client=prefer_current_client
+            ),
+            operation_name="target lookup",
         )
 
     def _get_management_client_for_target_locked(
@@ -2378,10 +2394,7 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
 
         def _restore_notification_session_after_rollback() -> None:
             """Best-effort rollback for notification session bookkeeping."""
-            if (
-                notification_dispatcher is None
-                or notification_session_snapshot is None
-            ):
+            if notification_dispatcher is None or notification_session_snapshot is None:
                 return
             with contextlib.suppress(
                 Exception

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -1235,6 +1235,7 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
             ``True`` only while the registration belongs to the same live session.
         """
         state_manager = self._state_manager
+        lifecycle_owner_is_current: bool | None
         canonical_locked_probe = (
             type(state_manager) is BLEStateManager  # pylint: disable=unidiomatic-typecheck
             and state_manager.lock is self._state_lock

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -634,12 +634,10 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
             are unavailable on compatibility doubles.
         """
         lifecycle_controller = self._get_lifecycle_controller()
-        handle_disconnect = getattr(
-            lifecycle_controller,
-            "_handle_disconnect",
-            getattr(lifecycle_controller, "handle_disconnect", None),
+        handle_disconnect = _resolve_declared_callable(
+            lifecycle_controller, "_handle_disconnect", "handle_disconnect"
         )
-        if callable(handle_disconnect):
+        if handle_disconnect is not None:
             result = handle_disconnect(
                 source,
                 client=client,
@@ -657,12 +655,10 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
             The Bleak client instance that disconnected.
         """
         lifecycle_controller = self._get_lifecycle_controller()
-        on_ble_disconnect = getattr(
-            lifecycle_controller,
-            "_on_ble_disconnect",
-            getattr(lifecycle_controller, "on_ble_disconnect", None),
+        on_ble_disconnect = _resolve_declared_callable(
+            lifecycle_controller, "_on_ble_disconnect", "on_ble_disconnect"
         )
-        if callable(on_ble_disconnect):
+        if on_ble_disconnect is not None:
             on_ble_disconnect(client)
 
     def _schedule_auto_reconnect(self) -> None:
@@ -671,33 +667,19 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
         Does nothing if automatic reconnection is disabled or the interface is closing or already closed.
         """
         lifecycle_controller = self._get_lifecycle_controller()
-        schedule_auto_reconnect = getattr(
-            lifecycle_controller,
-            "_schedule_auto_reconnect",
-            getattr(lifecycle_controller, "schedule_auto_reconnect", None),
+        schedule_auto_reconnect = _resolve_declared_callable(
+            lifecycle_controller, "_schedule_auto_reconnect", "schedule_auto_reconnect"
         )
-        if callable(schedule_auto_reconnect):
+        if schedule_auto_reconnect is not None:
             schedule_auto_reconnect()
 
     @staticmethod
     def _resolve_thread_event_dispatcher(
         coordinator: object,
     ) -> Callable[[str], None] | None:
-        """Resolve set-event hook with instance-override compatibility behavior."""
-        instance_set_event = getattr(coordinator, "__dict__", {}).get("set_event")
-        if callable(instance_set_event):
-            return cast(Callable[[str], None], instance_set_event)
-        class_set_event = getattr(type(coordinator), "set_event", None)
-        if callable(class_set_event):
-
-            def _dispatch_class_event(event_name: str) -> None:
-                class_set_event(coordinator, event_name)
-
-            return _dispatch_class_event
-        legacy_set_event = getattr(coordinator, "_set_event", None)
-        if callable(legacy_set_event):
-            return cast(Callable[[str], None], legacy_set_event)
-        return None
+        """Resolve a declared current/legacy set-event hook in precedence order."""
+        set_event = _resolve_declared_callable(coordinator, "set_event", "_set_event")
+        return cast(Callable[[str], None], set_event) if set_event is not None else None
 
     def _set_thread_event(self, event_name: str) -> None:
         """Set thread-coordinator event via public-first compatibility dispatch."""
@@ -2673,12 +2655,12 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
     ) -> None:
         """Publish `_connected()` only if ownership is still valid at publish time."""
         lifecycle_controller = self._get_lifecycle_controller()
-        verify_and_publish_connected = getattr(
+        verify_and_publish_connected = _resolve_declared_callable(
             lifecycle_controller,
             "_verify_and_publish_connected",
-            getattr(lifecycle_controller, "verify_and_publish_connected", None),
+            "verify_and_publish_connected",
         )
-        if callable(verify_and_publish_connected):
+        if verify_and_publish_connected is not None:
             verify_and_publish_connected(
                 connected_client,
                 connected_device_key,
@@ -2692,16 +2674,12 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
     ) -> None:
         """Emit reconnect signaling/logging only after verified connect publish."""
         lifecycle_controller = self._get_lifecycle_controller()
-        emit_verified_connection_side_effects = getattr(
+        emit_verified_connection_side_effects = _resolve_declared_callable(
             lifecycle_controller,
             "_emit_verified_connection_side_effects",
-            getattr(
-                lifecycle_controller,
-                "emit_verified_connection_side_effects",
-                None,
-            ),
+            "emit_verified_connection_side_effects",
         )
-        if callable(emit_verified_connection_side_effects):
+        if emit_verified_connection_side_effects is not None:
             emit_verified_connection_side_effects(connected_client)
 
     def _discard_invalidated_connected_client(
@@ -2726,16 +2704,12 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
             is discarded before ownership is finalized.
         """
         lifecycle_controller = self._get_lifecycle_controller()
-        discard_invalidated_connected_client = getattr(
+        discard_invalidated_connected_client = _resolve_declared_callable(
             lifecycle_controller,
             "_discard_invalidated_connected_client",
-            getattr(
-                lifecycle_controller,
-                "discard_invalidated_connected_client",
-                None,
-            ),
+            "discard_invalidated_connected_client",
         )
-        if callable(discard_invalidated_connected_client):
+        if discard_invalidated_connected_client is not None:
             discard_invalidated_connected_client(
                 client,
                 restore_address=restore_address,
@@ -2762,12 +2736,10 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
             Optional alias key used when claiming connection gates, or `None` if not used.
         """
         lifecycle_controller = self._get_lifecycle_controller()
-        finalize_connection_gates = getattr(
-            lifecycle_controller,
-            "_finalize_connection_gates",
-            getattr(lifecycle_controller, "finalize_connection_gates", None),
+        finalize_connection_gates = _resolve_declared_callable(
+            lifecycle_controller, "_finalize_connection_gates", "finalize_connection_gates"
         )
-        if callable(finalize_connection_gates):
+        if finalize_connection_gates is not None:
             finalize_connection_gates(
                 connected_client,
                 connected_device_key,
@@ -2789,12 +2761,10 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
             and the state machine reports CONNECTED.
         """
         lifecycle_controller = self._get_lifecycle_controller()
-        is_owned_connected_client = getattr(
-            lifecycle_controller,
-            "_is_owned_connected_client",
-            getattr(lifecycle_controller, "is_owned_connected_client", None),
+        is_owned_connected_client = _resolve_declared_callable(
+            lifecycle_controller, "_is_owned_connected_client", "is_owned_connected_client"
         )
-        if callable(is_owned_connected_client):
+        if is_owned_connected_client is not None:
             result = is_owned_connected_client(client)
             return result if isinstance(result, bool) else False
         return False
@@ -3219,10 +3189,8 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
                     exc_info=True,
                 )
         lifecycle_controller = self._get_lifecycle_controller()
-        close = getattr(
-            lifecycle_controller, "_close", getattr(lifecycle_controller, "close", None)
-        )
-        if callable(close):
+        close = _resolve_declared_callable(lifecycle_controller, "_close", "close")
+        if close is not None:
             close_kwargs: dict[str, float | None] = {
                 "management_shutdown_wait_timeout": _MANAGEMENT_SHUTDOWN_WAIT_TIMEOUT_SECONDS,
                 "management_wait_poll_seconds": _MANAGEMENT_CONNECT_WAIT_POLL_SECONDS,
@@ -3272,12 +3240,12 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
             BLE client to disconnect and close; operation is idempotent and safe to call on already-closed clients.
         """
         lifecycle_controller = self._get_lifecycle_controller()
-        disconnect_and_close_client = getattr(
+        disconnect_and_close_client = _resolve_declared_callable(
             lifecycle_controller,
             "_disconnect_and_close_client",
-            getattr(lifecycle_controller, "disconnect_and_close_client", None),
+            "disconnect_and_close_client",
         )
-        if callable(disconnect_and_close_client):
+        if disconnect_and_close_client is not None:
             try:
                 disconnect_and_close_client(client, timeout=timeout)
             except TypeError as exc:

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -1234,13 +1234,43 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
         bool
             ``True`` only while the registration belongs to the same live session.
         """
+        state_manager = self._state_manager
+        canonical_locked_probe = (
+            type(state_manager) is BLEStateManager  # pylint: disable=unidiomatic-typecheck
+            and state_manager.lock is self._state_lock
+        )
         with self._state_lock:
             if self._closed or self._connection_session_epoch != expected_session_epoch:
                 return False
-            lifecycle_owner_is_current = self.client is client or (
-                self._client_publish_pending
-                and self._state_manager_current_state() == ConnectionState.CONNECTING
-            )
+            if self.client is client:
+                lifecycle_owner_is_current = True
+            elif not self._client_publish_pending:
+                lifecycle_owner_is_current = False
+            elif canonical_locked_probe:
+                lifecycle_owner_is_current = (
+                    BLEStateManager._current_state_unlocked(state_manager)
+                    == ConnectionState.CONNECTING
+                )
+            else:
+                lifecycle_owner_is_current = None
+
+        if lifecycle_owner_is_current is None:
+            # Compatibility state probes can execute arbitrary collaborator code.
+            # Run them outside the shared lock, then revalidate the complete
+            # registration ownership snapshot before accepting the result.
+            current_state = self._state_manager_current_state()
+            with self._state_lock:
+                lifecycle_owner_is_current = (
+                    not self._closed
+                    and self._connection_session_epoch == expected_session_epoch
+                    and (
+                        self.client is client
+                        or (
+                            self._client_publish_pending
+                            and current_state == ConnectionState.CONNECTING
+                        )
+                    )
+                )
         if not lifecycle_owner_is_current:
             return False
         return ConnectionValidator._client_is_connected(client)

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -341,7 +341,9 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
             self,
         )
         self._lifecycle_controller = BLELifecycleController(self)
-        self._receive_recovery_controller = BLEReceiveRecoveryController(self)
+        self._receive_recovery_controller = BLEReceiveRecoveryController(
+            self, session_state=self._session_state
+        )
         self._compatibility_publisher = BLECompatibilityEventPublisher(
             self,
             publishing_thread_provider=self._get_publishing_thread,
@@ -1749,11 +1751,11 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
 
     def _state_manager_current_state(self) -> ConnectionState:
         """Read current state through lifecycle state-access compatibility dispatch."""
-        return _LifecycleStateAccess(self).current_state()
+        return _LifecycleStateAccess(self._state_manager).current_state()
 
     def _state_manager_is_closing(self) -> bool:
         """Read closing-state flag through lifecycle state-access compatibility dispatch."""
-        return _LifecycleStateAccess(self).is_closing()
+        return _LifecycleStateAccess(self._state_manager).is_closing()
 
     def _validator_check_existing_client(
         self,

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -37,7 +37,6 @@ import time
 from collections.abc import Awaitable, Callable
 from threading import Event
 from typing import IO, Any, NoReturn, TypedDict, TypeVar, cast
-from unittest.mock import Mock
 
 from bleak import BleakClient as BleakRootClient
 from bleak.backends.device import BLEDevice
@@ -123,8 +122,8 @@ from meshtastic.interfaces.ble.session_state import (
     _BLESessionStateCompatMixin,
 )
 from meshtastic.interfaces.ble.utils import (
-    _is_unconfigured_mock_callable,
-    _is_unconfigured_mock_member,
+    _get_declared_callable,
+    _get_declared_member,
     _is_unexpected_keyword_error,
     _sleep,
     sanitize_address,
@@ -449,19 +448,11 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
             True to request the receive loop to run, False to stop it.
         """
         lifecycle_controller = self._get_lifecycle_controller()
-        set_receive_wanted = getattr(lifecycle_controller, "_set_receive_wanted", None)
-        if callable(set_receive_wanted) and _is_unconfigured_mock_callable(
-            set_receive_wanted
-        ):
-            set_receive_wanted = None
+        set_receive_wanted = _get_declared_callable(lifecycle_controller, "_set_receive_wanted")
         if set_receive_wanted is None:
             set_receive_wanted = getattr(
                 lifecycle_controller, "set_receive_wanted", None
             )
-            if callable(set_receive_wanted) and _is_unconfigured_mock_callable(
-                set_receive_wanted
-            ):
-                set_receive_wanted = None
         if callable(set_receive_wanted):
             set_receive_wanted(want_receive=want_receive)
 
@@ -477,18 +468,10 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
         should_run_receive_loop = getattr(
             lifecycle_controller, "_should_run_receive_loop", None
         )
-        if callable(should_run_receive_loop) and _is_unconfigured_mock_callable(
-            should_run_receive_loop
-        ):
-            should_run_receive_loop = None
         if should_run_receive_loop is None:
             should_run_receive_loop = getattr(
                 lifecycle_controller, "should_run_receive_loop", None
             )
-            if callable(should_run_receive_loop) and _is_unconfigured_mock_callable(
-                should_run_receive_loop
-            ):
-                should_run_receive_loop = None
         if callable(should_run_receive_loop):
             result = should_run_receive_loop()
             return result if isinstance(result, bool) else False
@@ -510,18 +493,10 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
         start_receive_thread = getattr(
             lifecycle_controller, "_start_receive_thread", None
         )
-        if callable(start_receive_thread) and _is_unconfigured_mock_callable(
-            start_receive_thread
-        ):
-            start_receive_thread = None
         if start_receive_thread is None:
             start_receive_thread = getattr(
                 lifecycle_controller, "start_receive_thread", None
             )
-            if callable(start_receive_thread) and _is_unconfigured_mock_callable(
-                start_receive_thread
-            ):
-                start_receive_thread = None
         if callable(start_receive_thread):
             start_receive_thread(
                 name=name,
@@ -709,30 +684,24 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
     ) -> Callable[[str], None] | None:
         """Resolve set-event hook with instance-override compatibility behavior."""
         instance_set_event = getattr(coordinator, "__dict__", {}).get("set_event")
-        if callable(instance_set_event) and not _is_unconfigured_mock_callable(
-            instance_set_event
-        ):
+        if callable(instance_set_event):
             return cast(Callable[[str], None], instance_set_event)
         class_set_event = getattr(type(coordinator), "set_event", None)
-        if callable(class_set_event) and not _is_unconfigured_mock_callable(
-            class_set_event
-        ):
+        if callable(class_set_event):
 
             def _dispatch_class_event(event_name: str) -> None:
                 class_set_event(coordinator, event_name)
 
             return _dispatch_class_event
         legacy_set_event = getattr(coordinator, "_set_event", None)
-        if callable(legacy_set_event) and not _is_unconfigured_mock_callable(
-            legacy_set_event
-        ):
+        if callable(legacy_set_event):
             return cast(Callable[[str], None], legacy_set_event)
         return None
 
     def _set_thread_event(self, event_name: str) -> None:
         """Set thread-coordinator event via public-first compatibility dispatch."""
         coordinator = getattr(self, "thread_coordinator", None)
-        if coordinator is None or _is_unconfigured_mock_member(coordinator):
+        if coordinator is None:
             logger.debug(
                 "Thread coordinator is missing set_event/_set_event for event %s",
                 event_name,
@@ -1112,18 +1081,14 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
     ) -> BLEClient | None:
         """Return available management client via management collaborator."""
         handler = self._get_management_command_handler()
-        state_lock = getattr(self, "_state_lock", None)
-        if state_lock is None or _is_unconfigured_mock_member(state_lock):
+        state_lock = _get_declared_member(self, "_state_lock")
+        if state_lock is None:
             return handler.get_management_client_if_available(address)
-        lock_is_owned = getattr(state_lock, "_is_owned", None)
-        if isinstance(lock_is_owned, Mock):
-            return handler.get_management_client_if_available(address)
-        if callable(lock_is_owned) and not _is_unconfigured_mock_callable(
-            lock_is_owned
-        ):
+        lock_is_owned = _get_declared_callable(state_lock, "_is_owned")
+        if lock_is_owned is not None:
             owns_lock = False
             try:
-                owns_lock = bool(lock_is_owned())
+                owns_lock = lock_is_owned() is True
             except Exception:  # noqa: BLE001 - lock probe remains best effort
                 logger.debug(
                     "Failed to probe _state_lock ownership before management lookup",
@@ -1148,24 +1113,17 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
     ) -> BLEClient | None:
         """Return reusable target-matching management client via collaborator."""
         handler = self._get_management_command_handler()
-        state_lock = getattr(self, "_state_lock", None)
-        if state_lock is None or _is_unconfigured_mock_member(state_lock):
+        state_lock = _get_declared_member(self, "_state_lock")
+        if state_lock is None:
             return handler.get_management_client_for_target(
                 target_address,
                 prefer_current_client=prefer_current_client,
             )
-        lock_is_owned = getattr(state_lock, "_is_owned", None)
-        if isinstance(lock_is_owned, Mock):
-            return handler.get_management_client_for_target(
-                target_address,
-                prefer_current_client=prefer_current_client,
-            )
-        if callable(lock_is_owned) and not _is_unconfigured_mock_callable(
-            lock_is_owned
-        ):
+        lock_is_owned = _get_declared_callable(state_lock, "_is_owned")
+        if lock_is_owned is not None:
             owns_lock = False
             try:
-                owns_lock = bool(lock_is_owned())
+                owns_lock = lock_is_owned() is True
             except Exception:  # noqa: BLE001 - lock probe remains best effort
                 logger.debug(
                     "Failed to probe _state_lock ownership before target lookup",
@@ -1225,7 +1183,7 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
     def _get_or_create_error_handler(self) -> BLEErrorHandler:
         """Return bound error handler, creating one lazily for partial test doubles."""
         handler = getattr(self, "error_handler", None)
-        if handler is None or _is_unconfigured_mock_member(handler):
+        if handler is None:
             handler = BLEErrorHandler()
             self.error_handler = handler
         return cast(BLEErrorHandler, handler)
@@ -1239,18 +1197,18 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
         to lockless initialization for partial test doubles that bypass `__init__`.
         """
         collaborator = getattr(self, attr_name, None)
-        if collaborator is not None and not _is_unconfigured_mock_member(collaborator):
+        if collaborator is not None:
             return cast(T, collaborator)
-        state_lock = getattr(self, "_state_lock", None)
-        if state_lock is None or _is_unconfigured_mock_member(state_lock):
+        state_lock = _get_declared_member(self, "_state_lock")
+        if state_lock is None:
             collaborator = getattr(self, attr_name, None)
-            if collaborator is None or _is_unconfigured_mock_member(collaborator):
+            if collaborator is None:
                 collaborator = factory()
                 setattr(self, attr_name, collaborator)
             return cast(T, collaborator)
         with state_lock:
             collaborator = getattr(self, attr_name, None)
-            if collaborator is None or _is_unconfigured_mock_member(collaborator):
+            if collaborator is None:
                 collaborator = factory()
                 setattr(self, attr_name, collaborator)
         return cast(T, collaborator)
@@ -1258,9 +1216,7 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
     def _create_notification_dispatcher(self) -> BLENotificationDispatcher:
         """Build notification dispatcher with canonical collaborator wiring."""
         notification_manager = getattr(self, "_notification_manager", None)
-        if notification_manager is None or _is_unconfigured_mock_member(
-            notification_manager
-        ):
+        if notification_manager is None:
             notification_manager = NotificationManager()
             self._notification_manager = notification_manager
         return BLENotificationDispatcher(
@@ -1618,21 +1574,15 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
         """Dispatch a callable through public/legacy/fallback compatibility names."""
         kwargs = {} if kwargs is None else kwargs
         public_member = getattr(target, public_name, None)
-        if callable(public_member) and not _is_unconfigured_mock_callable(
-            public_member
-        ):
+        if callable(public_member):
             return public_member(*args, **kwargs)
         legacy_member = getattr(target, legacy_name, None)
-        if callable(legacy_member) and not _is_unconfigured_mock_callable(
-            legacy_member
-        ):
+        if callable(legacy_member):
             return legacy_member(*args, **kwargs)
         if fallback_attr_name is None:
             raise AttributeError(error_message)
         fallback_member = getattr(target, fallback_attr_name, None)
-        if not callable(fallback_member) or _is_unconfigured_mock_callable(
-            fallback_member
-        ):
+        if not callable(fallback_member):
             raise AttributeError(error_message)
         return fallback_member(*args, **kwargs)
 
@@ -1647,48 +1597,36 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
     ) -> bool:
         """Resolve bool members via public/legacy/fallback compatibility names."""
         public_member = getattr(target, public_name, None)
-        if callable(public_member) and not _is_unconfigured_mock_callable(
-            public_member
-        ):
+        if callable(public_member):
             try:
                 resolved_public = public_member()
             except Exception:  # noqa: BLE001 - probe dispatch must stay best effort
                 resolved_public = None
             if isinstance(resolved_public, bool):
                 return resolved_public
-        if isinstance(public_member, bool) and not _is_unconfigured_mock_member(
-            public_member
-        ):
+        if isinstance(public_member, bool):
             return public_member
         legacy_member = getattr(target, legacy_name, None)
-        if callable(legacy_member) and not _is_unconfigured_mock_callable(
-            legacy_member
-        ):
+        if callable(legacy_member):
             try:
                 resolved_legacy = legacy_member()
             except Exception:  # noqa: BLE001 - probe dispatch must stay best effort
                 resolved_legacy = None
             if isinstance(resolved_legacy, bool):
                 return resolved_legacy
-        if isinstance(legacy_member, bool) and not _is_unconfigured_mock_member(
-            legacy_member
-        ):
+        if isinstance(legacy_member, bool):
             return legacy_member
         if fallback_attr_name is None:
             raise AttributeError(error_message)
         fallback_member = getattr(target, fallback_attr_name, None)
-        if callable(fallback_member) and not _is_unconfigured_mock_callable(
-            fallback_member
-        ):
+        if callable(fallback_member):
             try:
                 resolved_fallback = fallback_member()
             except Exception:  # noqa: BLE001 - probe dispatch must stay best effort
                 resolved_fallback = None
             if isinstance(resolved_fallback, bool):
                 return resolved_fallback
-        if isinstance(fallback_member, bool) and not _is_unconfigured_mock_member(
-            fallback_member
-        ):
+        if isinstance(fallback_member, bool):
             return fallback_member
         raise AttributeError(error_message)
 
@@ -2276,9 +2214,7 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
             resolved_dispatcher = self._get_notification_dispatcher()
         except Exception:  # noqa: BLE001 - rollback snapshot is best effort
             resolved_dispatcher = None
-        if resolved_dispatcher is not None and not _is_unconfigured_mock_member(
-            resolved_dispatcher
-        ):
+        if resolved_dispatcher is not None:
             notification_dispatcher = resolved_dispatcher
             try:
                 registered_epoch = (
@@ -2460,7 +2396,6 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
             if (
                 notification_dispatcher is None
                 or notification_session_snapshot is None
-                or _is_unconfigured_mock_member(notification_dispatcher)
             ):
                 return
             with contextlib.suppress(

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -1060,57 +1060,12 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
             target_address
         )
 
-    def _dispatch_management_lookup_by_lock(
-        self,
-        *,
-        unlocked: Callable[[], T],
-        locked: Callable[[], T],
-        operation_name: str,
-    ) -> T:
-        """Dispatch a management lookup for the current state-lock context.
-
-        Parameters
-        ----------
-        unlocked : Callable[[], T]
-            Lookup to invoke when the state lock is not owned by this thread.
-        locked : Callable[[], T]
-            Lock-aware lookup to invoke when ownership is confirmed.
-        operation_name : str
-            Diagnostic name used when the best-effort ownership probe fails.
-
-        Returns
-        -------
-        T
-            Result from the selected lookup.
-        """
-        state_lock = _get_declared_lock(self, "_state_lock")
-        lock_is_owned = (
-            _get_declared_callable(state_lock, "_is_owned")
-            if state_lock is not None
-            else None
-        )
-        if lock_is_owned is not None:
-            try:
-                if lock_is_owned() is True:
-                    return locked()
-            except Exception:  # noqa: BLE001 - lock probe remains best effort
-                logger.debug(
-                    "Failed to probe _state_lock ownership before %s",
-                    operation_name,
-                    exc_info=True,
-                )
-        return unlocked()
-
     def _get_management_client_if_available(
         self, address: str | None
     ) -> BLEClient | None:
         """Return available management client via management collaborator."""
         handler = self._get_management_command_handler()
-        return self._dispatch_management_lookup_by_lock(
-            unlocked=lambda: handler.get_management_client_if_available(address),
-            locked=lambda: handler.get_management_client_if_available_locked(address),
-            operation_name="management lookup",
-        )
+        return handler.get_management_client_if_available(address)
 
     def _get_management_client_if_available_locked(
         self, address: str | None
@@ -1127,15 +1082,9 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
     ) -> BLEClient | None:
         """Return reusable target-matching management client via collaborator."""
         handler = self._get_management_command_handler()
-        return self._dispatch_management_lookup_by_lock(
-            unlocked=lambda: handler.get_management_client_for_target(
-                target_address,
-                prefer_current_client=prefer_current_client,
-            ),
-            locked=lambda: handler.get_management_client_for_target_locked(
-                target_address, prefer_current_client=prefer_current_client
-            ),
-            operation_name="target lookup",
+        return handler.get_management_client_for_target(
+            target_address,
+            prefer_current_client=prefer_current_client,
         )
 
     def _get_management_client_for_target_locked(

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -48,6 +48,7 @@ from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.compat_adapter import (
     _get_declared_callable,
     _get_declared_lock,
+    _get_declared_member,
     _iter_declared_members,
     _resolve_declared_callable,
 )
@@ -1199,6 +1200,28 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
             return cast(T, collaborator)
         state_lock = _get_declared_lock(self, "_state_lock")
         if state_lock is None:
+            instance_dict = _get_declared_member(self, "__dict__")
+            if isinstance(instance_dict, dict):
+                # Partial test doubles can lack the canonical state lock. A
+                # lazily shared per-instance lock preserves single construction
+                # without imposing a process-wide fallback lock.
+                fallback_lock = instance_dict.setdefault(
+                    "_ble_collaborator_init_lock", threading.RLock()
+                )
+                fallback_lock_type = type(fallback_lock)
+                if (
+                    _get_declared_callable(fallback_lock_type, "__enter__") is None
+                    or _get_declared_callable(fallback_lock_type, "__exit__") is None
+                ):
+                    raise TypeError(
+                        "_ble_collaborator_init_lock must be a context-manager lock"
+                    )
+                with cast(Any, fallback_lock):
+                    collaborator = instance_dict.get(attr_name)
+                    if collaborator is None:
+                        collaborator = factory()
+                        instance_dict[attr_name] = collaborator
+                return cast(T, collaborator)
             collaborator = getattr(self, attr_name, None)
             if collaborator is None:
                 collaborator = factory()
@@ -1703,7 +1726,7 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
             self._state_manager,
             public_name="is_connected",
             legacy_name="_is_connected",
-            fallback_attr_name="_is_connected",
+            fallback_attr_name=None,
             error_message=ERROR_STATE_MANAGER_MISSING_BOOL_IS_CONNECTED,
         )
 
@@ -1749,7 +1772,7 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
                 self._connection_validator,
                 public_name="check_existing_client",
                 legacy_name="_check_existing_client",
-                fallback_attr_name="check_existing_client",
+                fallback_attr_name=None,
                 error_message=ERROR_CONNECTION_VALIDATOR_MISSING_CHECK_EXISTING_CLIENT,
                 args=(
                     client,
@@ -1809,7 +1832,7 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
                 self._connection_orchestrator,
                 public_name="establish_connection",
                 legacy_name="_establish_connection",
-                fallback_attr_name="establish_connection",
+                fallback_attr_name=None,
                 error_message=ERROR_CONNECTION_ORCHESTRATOR_MISSING_ESTABLISH_CONNECTION,
                 args=args,
                 kwargs=kwargs,
@@ -1825,7 +1848,7 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
                 self._connection_orchestrator,
                 public_name="establish_connection",
                 legacy_name="_establish_connection",
-                fallback_attr_name="establish_connection",
+                fallback_attr_name=None,
                 error_message=ERROR_CONNECTION_ORCHESTRATOR_MISSING_ESTABLISH_CONNECTION,
                 args=args,
                 kwargs=legacy_kwargs,
@@ -1861,7 +1884,7 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
                 self._client_manager,
                 public_name="safe_close_client",
                 legacy_name="_safe_close_client",
-                fallback_attr_name="safe_close_client",
+                fallback_attr_name=None,
                 error_message=ERROR_CLIENT_MANAGER_MISSING_SAFE_CLOSE_CLIENT,
                 args=(client,),
                 kwargs={"disconnect_timeout": disconnect_timeout},
@@ -1873,7 +1896,7 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
                 self._client_manager,
                 public_name="safe_close_client",
                 legacy_name="_safe_close_client",
-                fallback_attr_name="safe_close_client",
+                fallback_attr_name=None,
                 error_message=ERROR_CLIENT_MANAGER_MISSING_SAFE_CLOSE_CLIENT,
                 args=(client,),
             )
@@ -1905,7 +1928,7 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
             self._client_manager,
             public_name="update_client_reference",
             legacy_name="_update_client_reference",
-            fallback_attr_name="update_client_reference",
+            fallback_attr_name=None,
             error_message=ERROR_CLIENT_MANAGER_MISSING_UPDATE_CLIENT_REFERENCE,
             args=(client, previous_client),
         )

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -42,6 +42,10 @@ from bleak import BleakClient as BleakRootClient
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakDBusError, BleakError
 
+from meshtastic.interfaces.ble.compat_adapter import (
+    _get_declared_callable,
+    _get_declared_member,
+)
 from meshtastic._publishing import publishing_thread as publishingThread
 from meshtastic.interfaces.ble import constants as _ble_constants
 from meshtastic.interfaces.ble.client import BLEClient
@@ -122,8 +126,6 @@ from meshtastic.interfaces.ble.session_state import (
     _BLESessionStateCompatMixin,
 )
 from meshtastic.interfaces.ble.utils import (
-    _get_declared_callable,
-    _get_declared_member,
     _is_unexpected_keyword_error,
     _sleep,
     sanitize_address,
@@ -448,12 +450,16 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
             True to request the receive loop to run, False to stop it.
         """
         lifecycle_controller = self._get_lifecycle_controller()
-        set_receive_wanted = _get_declared_callable(lifecycle_controller, "_set_receive_wanted")
+        set_receive_wanted = _get_declared_callable(
+            lifecycle_controller, "_set_receive_wanted"
+        )
         if set_receive_wanted is None:
-            set_receive_wanted = getattr(
+            legacy_set_receive_wanted = getattr(
                 lifecycle_controller, "set_receive_wanted", None
             )
-        if callable(set_receive_wanted):
+            if callable(legacy_set_receive_wanted):
+                set_receive_wanted = legacy_set_receive_wanted
+        if set_receive_wanted is not None:
             set_receive_wanted(want_receive=want_receive)
 
     def _should_run_receive_loop(self) -> bool:

--- a/meshtastic/interfaces/ble/lifecycle_compat_service.py
+++ b/meshtastic/interfaces/ble/lifecycle_compat_service.py
@@ -1063,7 +1063,7 @@ class BLELifecycleService:
     def _get_connected_client_status_locked(
         iface: "BLEInterface", client: "BLEClient"
     ) -> tuple[bool, bool]:
-        """Return ownership and closing flags for ``client`` under state lock.
+        """Return ownership and closing flags through the historical ``_locked`` shim.
 
         Parameters
         ----------

--- a/meshtastic/interfaces/ble/lifecycle_compat_service.py
+++ b/meshtastic/interfaces/ble/lifecycle_compat_service.py
@@ -934,7 +934,7 @@ class BLELifecycleService:
         -----
         Dispatches through ``_LifecycleStateAccess``.
         """
-        return _LifecycleStateAccess(iface).is_connected()
+        return _LifecycleStateAccess(getattr(iface, "_state_manager", iface)).is_connected()
 
     @staticmethod
     def _state_manager_current_state(iface: "BLEInterface") -> ConnectionState:
@@ -959,7 +959,7 @@ class BLELifecycleService:
         -----
         Dispatches through ``_LifecycleStateAccess``.
         """
-        return _LifecycleStateAccess(iface).current_state()
+        return _LifecycleStateAccess(getattr(iface, "_state_manager", iface)).current_state()
 
     @staticmethod
     def _state_manager_transition_to(
@@ -988,7 +988,7 @@ class BLELifecycleService:
         -----
         Dispatches through ``_LifecycleStateAccess``.
         """
-        return _LifecycleStateAccess(iface).transition_to(new_state)
+        return _LifecycleStateAccess(getattr(iface, "_state_manager", iface)).transition_to(new_state)
 
     @staticmethod
     def _state_manager_reset_to_disconnected(iface: "BLEInterface") -> bool:
@@ -1013,7 +1013,7 @@ class BLELifecycleService:
         -----
         Dispatches through ``_LifecycleStateAccess``.
         """
-        return _LifecycleStateAccess(iface).reset_to_disconnected()
+        return _LifecycleStateAccess(getattr(iface, "_state_manager", iface)).reset_to_disconnected()
 
     @staticmethod
     def _state_manager_is_closing(iface: "BLEInterface") -> bool:
@@ -1034,7 +1034,7 @@ class BLELifecycleService:
         -----
         Dispatches through ``_LifecycleStateAccess``.
         """
-        return _LifecycleStateAccess(iface).is_closing()
+        return _LifecycleStateAccess(getattr(iface, "_state_manager", iface)).is_closing()
 
     @staticmethod
     def _client_is_connected(client: "BLEClient") -> bool:

--- a/meshtastic/interfaces/ble/lifecycle_compat_service.py
+++ b/meshtastic/interfaces/ble/lifecycle_compat_service.py
@@ -30,10 +30,8 @@ from meshtastic.interfaces.ble.lifecycle_shutdown_runtime import (
     BLEShutdownLifecycleCoordinator,
 )
 from meshtastic.interfaces.ble.state import ConnectionState
-from meshtastic.interfaces.ble.utils import (
-    _is_unconfigured_mock_callable,
-    _is_unconfigured_mock_member,
-)
+
+from meshtastic.interfaces.ble.utils import _get_declared_callable
 
 if TYPE_CHECKING:
     from meshtastic.interfaces.ble.client import BLEClient
@@ -83,7 +81,7 @@ class BLELifecycleService:
         )
         for method_name in required_methods:
             method = getattr(candidate, method_name, None)
-            if not callable(method) or _is_unconfigured_mock_callable(method):
+            if not callable(method):
                 return False
         return True
 
@@ -94,7 +92,7 @@ class BLELifecycleService:
     ) -> bool:
         """Return whether candidate exposes a specific receive-lifecycle method."""
         method = getattr(candidate, expected_method, None)
-        return callable(method) and not _is_unconfigured_mock_callable(method)
+        return callable(method)
 
     @staticmethod
     def _receive_lifecycle_coordinator(
@@ -135,13 +133,9 @@ class BLELifecycleService:
             )
 
         get_lifecycle_controller = getattr(iface, "_get_lifecycle_controller", None)
-        if callable(get_lifecycle_controller) and not _is_unconfigured_mock_callable(
-            get_lifecycle_controller
-        ):
+        if callable(get_lifecycle_controller):
             lifecycle_controller = get_lifecycle_controller()
-            if lifecycle_controller is not None and not _is_unconfigured_mock_member(
-                lifecycle_controller
-            ):
+            if lifecycle_controller is not None:
                 for attr_name in (
                     "_receive",
                     "receive_lifecycle_coordinator",
@@ -150,17 +144,14 @@ class BLELifecycleService:
                     receive_coordinator = getattr(lifecycle_controller, attr_name, None)
                     if (
                         receive_coordinator is not None
-                        and not _is_unconfigured_mock_member(receive_coordinator)
                         and _matches_receive_candidate(receive_coordinator)
                     ):
                         return cast(BLEReceiveLifecycleCoordinator, receive_coordinator)
                 if _matches_receive_candidate(lifecycle_controller):
                     return cast(BLEReceiveLifecycleCoordinator, lifecycle_controller)
 
-        get_or_create = getattr(iface, "_get_or_create_collaborator", None)
-        if callable(get_or_create) and not _is_unconfigured_mock_callable(
-            get_or_create
-        ):
+        get_or_create = _get_declared_callable(iface, "_get_or_create_collaborator")
+        if callable(get_or_create):
             try:
                 signature(get_or_create).bind(
                     "_ble_receive_lifecycle_coordinator",
@@ -176,7 +167,6 @@ class BLELifecycleService:
                 )
                 if (
                     coordinator is not None
-                    and not _is_unconfigured_mock_member(coordinator)
                     and _matches_receive_candidate(coordinator)
                 ):
                     return cast(BLEReceiveLifecycleCoordinator, coordinator)
@@ -209,10 +199,8 @@ class BLELifecycleService:
         iface: "BLEInterface",
     ) -> BLEShutdownLifecycleCoordinator:
         """Return the shared shutdown lifecycle coordinator when available."""
-        get_or_create = getattr(iface, "_get_or_create_collaborator", None)
-        if callable(get_or_create) and not _is_unconfigured_mock_callable(
-            get_or_create
-        ):
+        get_or_create = _get_declared_callable(iface, "_get_or_create_collaborator")
+        if callable(get_or_create):
             try:
                 signature(get_or_create).bind(
                     "_ble_shutdown_lifecycle_coordinator",
@@ -225,9 +213,7 @@ class BLELifecycleService:
                     "_ble_shutdown_lifecycle_coordinator",
                     lambda: BLEShutdownLifecycleCoordinator(iface),
                 )
-                if coordinator is not None and not _is_unconfigured_mock_member(
-                    coordinator
-                ):
+                if coordinator is not None:
                     return cast(BLEShutdownLifecycleCoordinator, coordinator)
         return BLEShutdownLifecycleCoordinator(iface)
 
@@ -1149,9 +1135,7 @@ class BLELifecycleService:
             "_is_currently_connected_elsewhere",
             _is_currently_connected_elsewhere,
         )
-        if not callable(connected_elsewhere) or _is_unconfigured_mock_callable(
-            connected_elsewhere
-        ):
+        if not callable(connected_elsewhere):
             connected_elsewhere = _is_currently_connected_elsewhere
         connected_elsewhere_fn = cast(Callable[..., bool], connected_elsewhere)
 
@@ -1248,7 +1232,7 @@ class BLELifecycleService:
 
     @staticmethod
     def _ever_connected_flag(iface: "BLEInterface") -> bool:
-        """Return a mock-safe boolean view of ``iface._ever_connected``.
+        """Return a strict boolean view of ``iface._ever_connected``.
 
         Parameters
         ----------

--- a/meshtastic/interfaces/ble/lifecycle_compat_service.py
+++ b/meshtastic/interfaces/ble/lifecycle_compat_service.py
@@ -7,6 +7,11 @@ from typing import TYPE_CHECKING, NoReturn, cast
 
 from bleak import BleakClient as BleakRootClient
 
+from meshtastic.interfaces.ble.compat_adapter import (
+    _get_declared_callable,
+    _get_declared_member,
+    _resolve_declared_member,
+)
 from meshtastic.interfaces.ble.coordination import ThreadLike
 from meshtastic.interfaces.ble.gating import _is_currently_connected_elsewhere
 from meshtastic.interfaces.ble.lifecycle_disconnect_runtime import (
@@ -31,7 +36,6 @@ from meshtastic.interfaces.ble.lifecycle_shutdown_runtime import (
 )
 from meshtastic.interfaces.ble.state import ConnectionState
 
-from meshtastic.interfaces.ble.utils import _get_declared_callable
 
 if TYPE_CHECKING:
     from meshtastic.interfaces.ble.client import BLEClient
@@ -80,8 +84,7 @@ class BLELifecycleService:
             "start_receive_thread",
         )
         for method_name in required_methods:
-            method = getattr(candidate, method_name, None)
-            if not callable(method):
+            if _get_declared_callable(candidate, method_name) is None:
                 return False
         return True
 
@@ -91,8 +94,7 @@ class BLELifecycleService:
         expected_method: str,
     ) -> bool:
         """Return whether candidate exposes a specific receive-lifecycle method."""
-        method = getattr(candidate, expected_method, None)
-        return callable(method)
+        return _get_declared_callable(candidate, expected_method) is not None
 
     @staticmethod
     def _receive_lifecycle_coordinator(
@@ -132,26 +134,26 @@ class BLELifecycleService:
                 )
             )
 
-        get_lifecycle_controller = getattr(iface, "_get_lifecycle_controller", None)
-        if callable(get_lifecycle_controller):
+        get_lifecycle_controller = _get_declared_callable(iface, "_get_lifecycle_controller")
+        if get_lifecycle_controller is not None:
             lifecycle_controller = get_lifecycle_controller()
             if lifecycle_controller is not None:
-                for attr_name in (
+                receive_coordinator = _resolve_declared_member(
+                    lifecycle_controller,
                     "_receive",
                     "receive_lifecycle_coordinator",
                     "_receive_lifecycle_coordinator",
+                )
+                if (
+                    receive_coordinator is not None
+                    and _matches_receive_candidate(receive_coordinator)
                 ):
-                    receive_coordinator = getattr(lifecycle_controller, attr_name, None)
-                    if (
-                        receive_coordinator is not None
-                        and _matches_receive_candidate(receive_coordinator)
-                    ):
-                        return cast(BLEReceiveLifecycleCoordinator, receive_coordinator)
+                    return cast(BLEReceiveLifecycleCoordinator, receive_coordinator)
                 if _matches_receive_candidate(lifecycle_controller):
                     return cast(BLEReceiveLifecycleCoordinator, lifecycle_controller)
 
         get_or_create = _get_declared_callable(iface, "_get_or_create_collaborator")
-        if callable(get_or_create):
+        if get_or_create is not None:
             try:
                 signature(get_or_create).bind(
                     "_ble_receive_lifecycle_coordinator",
@@ -200,7 +202,7 @@ class BLELifecycleService:
     ) -> BLEShutdownLifecycleCoordinator:
         """Return the shared shutdown lifecycle coordinator when available."""
         get_or_create = _get_declared_callable(iface, "_get_or_create_collaborator")
-        if callable(get_or_create):
+        if get_or_create is not None:
             try:
                 signature(get_or_create).bind(
                     "_ble_shutdown_lifecycle_coordinator",
@@ -920,7 +922,7 @@ class BLELifecycleService:
         -----
         Dispatches through ``_LifecycleStateAccess``.
         """
-        return _LifecycleStateAccess(getattr(iface, "_state_manager", iface)).is_connected()
+        return _LifecycleStateAccess(_get_declared_member(iface, "_state_manager", iface)).is_connected()
 
     @staticmethod
     def _state_manager_current_state(iface: "BLEInterface") -> ConnectionState:
@@ -945,7 +947,7 @@ class BLELifecycleService:
         -----
         Dispatches through ``_LifecycleStateAccess``.
         """
-        return _LifecycleStateAccess(getattr(iface, "_state_manager", iface)).current_state()
+        return _LifecycleStateAccess(_get_declared_member(iface, "_state_manager", iface)).current_state()
 
     @staticmethod
     def _state_manager_transition_to(
@@ -974,7 +976,7 @@ class BLELifecycleService:
         -----
         Dispatches through ``_LifecycleStateAccess``.
         """
-        return _LifecycleStateAccess(getattr(iface, "_state_manager", iface)).transition_to(new_state)
+        return _LifecycleStateAccess(_get_declared_member(iface, "_state_manager", iface)).transition_to(new_state)
 
     @staticmethod
     def _state_manager_reset_to_disconnected(iface: "BLEInterface") -> bool:
@@ -999,7 +1001,7 @@ class BLELifecycleService:
         -----
         Dispatches through ``_LifecycleStateAccess``.
         """
-        return _LifecycleStateAccess(getattr(iface, "_state_manager", iface)).reset_to_disconnected()
+        return _LifecycleStateAccess(_get_declared_member(iface, "_state_manager", iface)).reset_to_disconnected()
 
     @staticmethod
     def _state_manager_is_closing(iface: "BLEInterface") -> bool:
@@ -1020,7 +1022,7 @@ class BLELifecycleService:
         -----
         Dispatches through ``_LifecycleStateAccess``.
         """
-        return _LifecycleStateAccess(getattr(iface, "_state_manager", iface)).is_closing()
+        return _LifecycleStateAccess(_get_declared_member(iface, "_state_manager", iface)).is_closing()
 
     @staticmethod
     def _client_is_connected(client: "BLEClient") -> bool:

--- a/meshtastic/interfaces/ble/lifecycle_compat_service.py
+++ b/meshtastic/interfaces/ble/lifecycle_compat_service.py
@@ -9,7 +9,6 @@ from bleak import BleakClient as BleakRootClient
 
 from meshtastic.interfaces.ble.compat_adapter import (
     _get_declared_callable,
-    _get_declared_member,
     _resolve_declared_member,
 )
 from meshtastic.interfaces.ble.coordination import ThreadLike
@@ -922,7 +921,7 @@ class BLELifecycleService:
         -----
         Dispatches through ``_LifecycleStateAccess``.
         """
-        return _LifecycleStateAccess(_get_declared_member(iface, "_state_manager", iface)).is_connected()
+        return _LifecycleStateAccess(iface).is_connected()
 
     @staticmethod
     def _state_manager_current_state(iface: "BLEInterface") -> ConnectionState:
@@ -947,7 +946,7 @@ class BLELifecycleService:
         -----
         Dispatches through ``_LifecycleStateAccess``.
         """
-        return _LifecycleStateAccess(_get_declared_member(iface, "_state_manager", iface)).current_state()
+        return _LifecycleStateAccess(iface).current_state()
 
     @staticmethod
     def _state_manager_transition_to(
@@ -976,7 +975,7 @@ class BLELifecycleService:
         -----
         Dispatches through ``_LifecycleStateAccess``.
         """
-        return _LifecycleStateAccess(_get_declared_member(iface, "_state_manager", iface)).transition_to(new_state)
+        return _LifecycleStateAccess(iface).transition_to(new_state)
 
     @staticmethod
     def _state_manager_reset_to_disconnected(iface: "BLEInterface") -> bool:
@@ -1001,7 +1000,7 @@ class BLELifecycleService:
         -----
         Dispatches through ``_LifecycleStateAccess``.
         """
-        return _LifecycleStateAccess(_get_declared_member(iface, "_state_manager", iface)).reset_to_disconnected()
+        return _LifecycleStateAccess(iface).reset_to_disconnected()
 
     @staticmethod
     def _state_manager_is_closing(iface: "BLEInterface") -> bool:
@@ -1022,7 +1021,7 @@ class BLELifecycleService:
         -----
         Dispatches through ``_LifecycleStateAccess``.
         """
-        return _LifecycleStateAccess(_get_declared_member(iface, "_state_manager", iface)).is_closing()
+        return _LifecycleStateAccess(iface).is_closing()
 
     @staticmethod
     def _client_is_connected(client: "BLEClient") -> bool:

--- a/meshtastic/interfaces/ble/lifecycle_compat_service.py
+++ b/meshtastic/interfaces/ble/lifecycle_compat_service.py
@@ -1244,17 +1244,23 @@ class BLELifecycleService:
 
     @staticmethod
     def _ever_connected_flag(iface: "BLEInterface") -> bool:
-        """Return a strict boolean view of ``iface._ever_connected``.
+        """Return a strict boolean view of the shared session's ``ever_connected``.
+
+        The result reflects the shared session owner's ``ever_connected`` field
+        as returned by
+        ``BLEConnectionOwnershipLifecycleCoordinator(iface)._has_ever_connected_session()``,
+        rather than ``iface._ever_connected``.
 
         Parameters
         ----------
         iface : BLEInterface
-            Interface containing connection publication state.
+            Interface bound to the shared session owner.
 
         Returns
         -------
         bool
-            ``True`` only when ``_ever_connected`` is explicitly boolean true.
+            ``True`` only when the shared session owner's ``ever_connected``
+            field is explicitly boolean true.
         """
         return BLEConnectionOwnershipLifecycleCoordinator(
             iface

--- a/meshtastic/interfaces/ble/lifecycle_compat_service.py
+++ b/meshtastic/interfaces/ble/lifecycle_compat_service.py
@@ -12,6 +12,10 @@ from meshtastic.interfaces.ble.compat_adapter import (
     _resolve_declared_member,
 )
 from meshtastic.interfaces.ble.coordination import ThreadLike
+from meshtastic.interfaces.ble.failure_policy import (
+    _BLEFailureDisposition,
+    _log_ble_failure,
+)
 from meshtastic.interfaces.ble.gating import _is_currently_connected_elsewhere
 from meshtastic.interfaces.ble.lifecycle_disconnect_runtime import (
     BLEDisconnectLifecycleCoordinator,
@@ -135,7 +139,14 @@ class BLELifecycleService:
 
         get_lifecycle_controller = _get_declared_callable(iface, "_get_lifecycle_controller")
         if get_lifecycle_controller is not None:
-            lifecycle_controller = get_lifecycle_controller()
+            try:
+                lifecycle_controller = get_lifecycle_controller()
+            except Exception:  # noqa: BLE001 - compatibility probe falls back
+                _log_ble_failure(
+                    _BLEFailureDisposition.COMPATIBILITY_FALLBACK,
+                    "BLE lifecycle controller probe failed",
+                )
+                lifecycle_controller = None
             if lifecycle_controller is not None:
                 receive_coordinator = _resolve_declared_member(
                     lifecycle_controller,

--- a/meshtastic/interfaces/ble/lifecycle_controller_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_controller_runtime.py
@@ -26,6 +26,7 @@ from meshtastic.interfaces.ble.lifecycle_receive_runtime import (
 from meshtastic.interfaces.ble.lifecycle_shutdown_runtime import (
     BLEShutdownLifecycleCoordinator,
 )
+from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.state import ConnectionState
 from meshtastic.interfaces.ble.utils import (
     _is_unconfigured_mock_callable,
@@ -74,10 +75,13 @@ class BLELifecycleController:
             Initializes bound controller collaborators.
         """
         self._iface = iface
-        self._receive = BLEReceiveLifecycleCoordinator(iface)
-        self._disconnect = BLEDisconnectLifecycleCoordinator(iface)
-        self._connection_ownership = BLEConnectionOwnershipLifecycleCoordinator(iface)
-        self._shutdown = BLEShutdownLifecycleCoordinator(iface)
+        session = _session_state_for(iface)
+        self._receive = BLEReceiveLifecycleCoordinator(iface, session_state=session)
+        self._disconnect = BLEDisconnectLifecycleCoordinator(iface, session_state=session)
+        self._connection_ownership = BLEConnectionOwnershipLifecycleCoordinator(
+            iface, session_state=session
+        )
+        self._shutdown = BLEShutdownLifecycleCoordinator(iface, session_state=session)
 
     def _set_receive_wanted(self, *, want_receive: bool) -> None:
         """Request or clear the receive loop on the bound interface."""

--- a/meshtastic/interfaces/ble/lifecycle_controller_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_controller_runtime.py
@@ -28,9 +28,7 @@ from meshtastic.interfaces.ble.lifecycle_shutdown_runtime import (
 )
 from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.state import ConnectionState
-from meshtastic.interfaces.ble.utils import (
-    _is_unconfigured_mock_callable,
-)
+from meshtastic.interfaces.ble.utils import _get_declared_callable
 
 if TYPE_CHECKING:
     from meshtastic.interfaces.ble.client import BLEClient
@@ -206,10 +204,8 @@ class BLELifecycleController:
             attr_name: str,
             fallback_factory: Callable[[], _HookT],
         ) -> _HookT:
-            raw_hook = getattr(iface, attr_name, None)
-            if not callable(raw_hook) or _is_unconfigured_mock_callable(raw_hook):
-                return fallback_factory()
-            return cast(_HookT, raw_hook)
+            raw_hook = _get_declared_callable(iface, attr_name)
+            return fallback_factory() if raw_hook is None else cast(_HookT, raw_hook)
 
         def _fallback_is_closing() -> Callable[[], bool]:
             def is_closing() -> bool:

--- a/meshtastic/interfaces/ble/lifecycle_controller_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_controller_runtime.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, TypeVar, cast
 
 from bleak import BleakClient as BleakRootClient
 
+from meshtastic.interfaces.ble.compat_adapter import (_get_declared_callable)
 from meshtastic.interfaces.ble.lifecycle_compat_service import (
     _ORIGINAL_FINALIZE_CONNECTION_GATES,
     _ORIGINAL_GET_CONNECTED_CLIENT_STATUS,
@@ -28,7 +29,6 @@ from meshtastic.interfaces.ble.lifecycle_shutdown_runtime import (
 )
 from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.state import ConnectionState
-from meshtastic.interfaces.ble.utils import _get_declared_callable
 
 if TYPE_CHECKING:
     from meshtastic.interfaces.ble.client import BLEClient

--- a/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
@@ -466,7 +466,8 @@ class BLEDisconnectLifecycleCoordinator:
                 return True
 
         logger.debug("BLE client %s disconnected (source: %s).", plan.address, source)
-        self._session.last_disconnect_source = f"ble.{source}"
+        with self._session.lock:
+            self._session.last_disconnect_source = f"ble.{source}"
 
         close_previous(plan.previous_client)
         stale_after_close = False

--- a/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from bleak import BleakClient as BleakRootClient
 
+from meshtastic.interfaces.ble.compat_adapter import _resolve_declared_callable
 from meshtastic.interfaces.ble.ports import _BLESessionStatePort
 from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.constants import (
@@ -41,7 +42,21 @@ class BLEDisconnectLifecycleCoordinator:
     def __init__(
         self, iface: "BLEInterface", *, session_state: _BLESessionStatePort | None = None
     ) -> None:
-        """Bind disconnect orchestration ownership to a specific interface."""
+        """Bind disconnect orchestration ownership to a specific interface.
+
+        Parameters
+        ----------
+        iface : BLEInterface
+            Interface instance whose disconnect orchestration is managed.
+        session_state : _BLESessionStatePort | None
+            Optional shared lifecycle state. When ``None``, resolve the
+            interface-owned state or use the legacy adapter.
+
+        Returns
+        -------
+        None
+            Initializes bound disconnect-orchestration collaborator state.
+        """
         self._iface = iface
         self._session = _session_state_for(iface, session_state)
         self._state_access = _LifecycleStateAccess(iface)
@@ -70,14 +85,10 @@ class BLEDisconnectLifecycleCoordinator:
                 )
                 return
             iface._shutdown_event.clear()
-        schedule_reconnect = getattr(
-            iface._reconnect_scheduler, "schedule_reconnect", None
+        schedule_reconnect = _resolve_declared_callable(
+            iface._reconnect_scheduler, "schedule_reconnect", "_schedule_reconnect"
         )
-        if not callable(schedule_reconnect):
-            schedule_reconnect = getattr(
-                iface._reconnect_scheduler, "_schedule_reconnect", None
-            )
-        if not callable(schedule_reconnect):
+        if schedule_reconnect is None:
             raise AttributeError(RECONNECT_SCHEDULER_MISSING_MSG)
         schedule_reconnect(iface.auto_reconnect, iface._shutdown_event)
 

--- a/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
@@ -74,15 +74,21 @@ class BLEDisconnectLifecycleCoordinator:
         """Schedule background auto-reconnect work when reconnect is enabled."""
         iface = self._iface
         get_is_closing = is_closing_getter or self._state_access.is_closing
+        if not iface.auto_reconnect:
+            return
         with self._session.lock:
-            if not iface.auto_reconnect:
-                return
             if self._session.closed:
                 logger.debug(
                     "Skipping auto-reconnect scheduling because interface is closed."
                 )
                 return
-            if get_is_closing():
+        compatibility_is_closing = get_is_closing()
+        with self._session.lock:
+            # Revalidate terminal/session state after the lock-free compatibility
+            # probe before clearing the shutdown event and scheduling work.
+            if not iface.auto_reconnect or self._session.closed:
+                return
+            if compatibility_is_closing:
                 logger.debug(
                     "Skipping auto-reconnect scheduling because interface is closing."
                 )
@@ -130,7 +136,9 @@ class BLEDisconnectLifecycleCoordinator:
     ) -> tuple[list[str], bool]:
         """Compute disconnect registry keys and reconnect scheduling intent."""
         iface = self._iface
-        should_schedule_reconnect = should_reconnect and not self._session.closed
+        with self._session.lock:
+            session_closed = self._session.closed
+        should_schedule_reconnect = should_reconnect and not session_closed
         if should_reconnect:
             if previous_client is not None:
                 previous_address = (
@@ -191,10 +199,20 @@ class BLEDisconnectLifecycleCoordinator:
             self._state_access.reset_to_disconnected
         )
         target_client = client
+
+        # Compatibility closing probes may execute collaborator code. Shutdown
+        # claims ``session.closed`` under this same lock, so combining the
+        # lock-free compatibility snapshot with the locked terminal flag avoids
+        # holding shared lifecycle state around that probe.
+        compatibility_is_closing = get_is_closing()
         with self._session.lock:
+            # Connection state and session ownership share this RLock on the real
+            # interface. Keep the state transition atomic with clearing the owned
+            # client/session fields; only non-owner address/registry work is
+            # deferred until after the critical section.
             current_state = get_current_state()
             current_client = iface.client
-            is_closing = get_is_closing() or self._session.closed
+            is_closing = compatibility_is_closing or self._session.closed
             was_publish_pending = self._session.client_publish_pending
             was_replacement_pending = self._session.client_replacement_pending
 
@@ -254,6 +272,7 @@ class BLEDisconnectLifecycleCoordinator:
             previous_client = current_client
             client_at_start = current_client
             alias_key = self._session.connection_alias_key
+            session_epoch = self._session.connection_session_epoch
             iface.client = None
             self._session.client_publish_pending = False
             self._session.client_replacement_pending = False
@@ -276,45 +295,43 @@ class BLEDisconnectLifecycleCoordinator:
                     )
             should_reconnect = iface.auto_reconnect
 
-            def _normalize_disconnect_address(value: object | None) -> str:
-                if isinstance(value, str) and value:
-                    return value
-                return iface.address or "unknown"
+        def _normalize_disconnect_address(value: object | None) -> str:
+            if isinstance(value, str) and value:
+                return value
+            return iface.address or "unknown"
 
-            address = iface.address or "unknown"
-            if target_client is not None:
-                address = _normalize_disconnect_address(
-                    iface._extract_client_address(target_client)
-                    or getattr(target_client, "address", None)
-                )
-            elif bleak_client is not None:
-                address = _normalize_disconnect_address(
-                    getattr(bleak_client, "address", None)
-                )
-            elif previous_client is not None:
-                address = _normalize_disconnect_address(
-                    iface._extract_client_address(previous_client)
-                    or getattr(previous_client, "address", None)
-                )
+        address = iface.address or "unknown"
+        if target_client is not None:
+            address = _normalize_disconnect_address(
+                iface._extract_client_address(target_client)
+                or getattr(target_client, "address", None)
+            )
+        elif bleak_client is not None:
+            address = _normalize_disconnect_address(getattr(bleak_client, "address", None))
+        elif previous_client is not None:
+            address = _normalize_disconnect_address(
+                iface._extract_client_address(previous_client)
+                or getattr(previous_client, "address", None)
+            )
 
-            disconnect_keys, should_schedule_reconnect = self._compute_disconnect_keys(
-                previous_client=previous_client,
-                alias_key=alias_key,
-                should_reconnect=should_reconnect,
-                address=address,
-            )
-            return _DisconnectPlan(
-                early_return=None,
-                previous_client=previous_client,
-                client_at_start=client_at_start,
-                session_epoch=self._session.connection_session_epoch,
-                address=address,
-                disconnect_keys=tuple(disconnect_keys),
-                should_reconnect=should_reconnect,
-                should_schedule_reconnect=should_schedule_reconnect,
-                was_publish_pending=was_publish_pending,
-                was_replacement_pending=was_replacement_pending,
-            )
+        disconnect_keys, should_schedule_reconnect = self._compute_disconnect_keys(
+            previous_client=previous_client,
+            alias_key=alias_key,
+            should_reconnect=should_reconnect,
+            address=address,
+        )
+        return _DisconnectPlan(
+            early_return=None,
+            previous_client=previous_client,
+            client_at_start=client_at_start,
+            session_epoch=session_epoch,
+            address=address,
+            disconnect_keys=tuple(disconnect_keys),
+            should_reconnect=should_reconnect,
+            should_schedule_reconnect=should_schedule_reconnect,
+            was_publish_pending=was_publish_pending,
+            was_replacement_pending=was_replacement_pending,
+        )
 
     def _close_previous_client_async(
         self,
@@ -392,6 +409,7 @@ class BLEDisconnectLifecycleCoordinator:
         disconnect_keys: list[str],
         active_client: "BLEClient | None",
         client_at_start: "BLEClient | None",
+        active_alias_key: str | None,
     ) -> tuple[list[str], bool]:
         """Return stale disconnect keys and whether active client differs."""
         iface = self._iface
@@ -401,7 +419,7 @@ class BLEDisconnectLifecycleCoordinator:
             active_keys = set(
                 iface._sorted_address_keys(
                     _addr_key(active_address) if active_address else None,
-                    self._session.connection_alias_key,
+                    active_alias_key,
                 )
             )
             return (
@@ -438,23 +456,25 @@ class BLEDisconnectLifecycleCoordinator:
             stale_disconnect_keys: list[str] = []
             close_stale_client = False
             still_stale = False
+            active_alias_key: str | None = None
             with self._session.lock:
                 active_client = iface.client
                 active_session_epoch = self._session.connection_session_epoch
+                active_alias_key = self._session.connection_alias_key
                 still_stale = active_session_epoch != plan.session_epoch or (
                     active_client is not None
                     and active_client is not plan.client_at_start
                 )
-                if still_stale:
-                    stale_disconnect_keys, active_client_differs = (
-                        self._compute_stale_disconnect_keys(
-                            disconnect_keys=disconnect_keys,
-                            active_client=active_client,
-                            client_at_start=plan.client_at_start,
-                        )
-                    )
-                    close_stale_client = active_client_differs
             if still_stale:
+                stale_disconnect_keys, active_client_differs = (
+                    self._compute_stale_disconnect_keys(
+                        disconnect_keys=disconnect_keys,
+                        active_client=active_client,
+                        client_at_start=plan.client_at_start,
+                        active_alias_key=active_alias_key,
+                    )
+                )
+                close_stale_client = active_client_differs
                 if stale_disconnect_keys:
                     iface._mark_address_keys_disconnected(*stale_disconnect_keys)
                 if close_stale_client:
@@ -480,9 +500,11 @@ class BLEDisconnectLifecycleCoordinator:
         if stale_after_close:
             still_stale_after_close = False
             rechecked_stale_disconnect_keys_after_close: list[str] = []
+            active_alias_key = None
             with self._session.lock:
                 active_client = iface.client
                 active_session_epoch = self._session.connection_session_epoch
+                active_alias_key = self._session.connection_alias_key
                 still_stale_after_close = (
                     active_session_epoch != plan.session_epoch
                     or (
@@ -490,15 +512,15 @@ class BLEDisconnectLifecycleCoordinator:
                         and active_client is not plan.client_at_start
                     )
                 )
-                if still_stale_after_close:
-                    rechecked_stale_disconnect_keys_after_close, _ = (
-                        self._compute_stale_disconnect_keys(
-                            disconnect_keys=disconnect_keys,
-                            active_client=active_client,
-                            client_at_start=plan.client_at_start,
-                        )
-                    )
             if still_stale_after_close:
+                rechecked_stale_disconnect_keys_after_close, _ = (
+                    self._compute_stale_disconnect_keys(
+                        disconnect_keys=disconnect_keys,
+                        active_client=active_client,
+                        client_at_start=plan.client_at_start,
+                        active_alias_key=active_alias_key,
+                    )
+                )
                 if rechecked_stale_disconnect_keys_after_close:
                     iface._mark_address_keys_disconnected(
                         *rechecked_stale_disconnect_keys_after_close
@@ -548,10 +570,11 @@ class BLEDisconnectLifecycleCoordinator:
                 "Disconnect from %s skipped: another disconnect handler is active.",
                 source,
             )
+            compatibility_is_closing = get_is_closing()
             with self._session.lock:
                 return (
                     not self._session.closed
-                    and not get_is_closing()
+                    and not compatibility_is_closing
                     and (
                         iface.auto_reconnect
                         or self._session.want_receive

--- a/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
@@ -2,7 +2,7 @@
 
 import threading
 from collections.abc import Callable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from bleak import BleakClient as BleakRootClient
 
@@ -26,7 +26,7 @@ from meshtastic.interfaces.ble.lifecycle_primitives import (
     _LifecycleStateAccess,
     _LifecycleThreadAccess,
 )
-from meshtastic.interfaces.ble.state import ConnectionState
+from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
 from meshtastic.interfaces.ble.utils import (
     _sleep,
     _thread_start_probe,
@@ -199,18 +199,39 @@ class BLEDisconnectLifecycleCoordinator:
             self._state_access.reset_to_disconnected
         )
         target_client = client
+        should_reconnect = False
+
+        state_manager = _get_declared_member(iface, "_state_manager")
+        canonical_state_manager = (
+            state_manager
+            if type(state_manager) is BLEStateManager  # pylint: disable=unidiomatic-typecheck
+            and state_manager.lock is self._session.lock
+            and current_state_getter is None
+            and transition_to_disconnected is None
+            and reset_to_disconnected is None
+            else None
+        )
 
         # Compatibility closing probes may execute collaborator code. Shutdown
         # claims ``session.closed`` under this same lock, so combining the
         # lock-free compatibility snapshot with the locked terminal flag avoids
         # holding shared lifecycle state around that probe.
         compatibility_is_closing = get_is_closing()
+        compatibility_current_state = (
+            None if canonical_state_manager is not None else get_current_state()
+        )
         with self._session.lock:
             # Connection state and session ownership share this RLock on the real
             # interface. Keep the state transition atomic with clearing the owned
-            # client/session fields; only non-owner address/registry work is
-            # deferred until after the critical section.
-            current_state = get_current_state()
+            # client/session fields. Compatibility probes/callbacks are excluded
+            # from this critical section; the exact BLEStateManager uses its
+            # lock-owned primitive instead.
+            current_state = cast(
+                ConnectionState,
+                BLEStateManager._current_state_unlocked(canonical_state_manager)
+                if canonical_state_manager is not None
+                else compatibility_current_state,
+            )
             current_client = iface.client
             is_closing = compatibility_is_closing or self._session.closed
             was_publish_pending = self._session.client_publish_pending
@@ -278,6 +299,33 @@ class BLEDisconnectLifecycleCoordinator:
             self._session.client_replacement_pending = False
             self._session.disconnect_notified = True
             self._session.connection_alias_key = None
+            if canonical_state_manager is not None:
+                transitioned = BLEStateManager._transition_to_unlocked(
+                    canonical_state_manager, ConnectionState.DISCONNECTED
+                )
+                if not transitioned:
+                    logger.error(
+                        "Failed state transition to %s during disconnect target resolution (alias=%s current=%s); forcing reset.",
+                        ConnectionState.DISCONNECTED.value,
+                        alias_key,
+                        getattr(current_state, "value", current_state),
+                    )
+                    reset_succeeded = BLEStateManager._reset_to_disconnected_unlocked(
+                        canonical_state_manager
+                    )
+                    if not reset_succeeded:
+                        fallback_state = BLEStateManager._current_state_unlocked(
+                            canonical_state_manager
+                        )
+                        logger.error(
+                            "Failed forced reset to %s during disconnect target resolution (alias=%s current=%s).",
+                            ConnectionState.DISCONNECTED.value,
+                            alias_key,
+                            getattr(fallback_state, "value", fallback_state),
+                        )
+                should_reconnect = iface.auto_reconnect
+
+        if canonical_state_manager is None:
             if not do_transition_to_disconnected():
                 logger.error(
                     "Failed state transition to %s during disconnect target resolution (alias=%s current=%s); forcing reset.",

--- a/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
@@ -44,7 +44,7 @@ class BLEDisconnectLifecycleCoordinator:
         """Bind disconnect orchestration ownership to a specific interface."""
         self._iface = iface
         self._session = _session_state_for(iface, session_state)
-        self._state_access = _LifecycleStateAccess(getattr(iface, "_state_manager", iface))
+        self._state_access = _LifecycleStateAccess(iface)
         self._thread_access = _LifecycleThreadAccess(iface)
         self._error_access = _LifecycleErrorAccess(iface)
 
@@ -292,7 +292,7 @@ class BLEDisconnectLifecycleCoordinator:
                 early_return=None,
                 previous_client=previous_client,
                 client_at_start=client_at_start,
-                session_epoch=getattr(iface, "_connection_session_epoch", 0),
+                session_epoch=self._session.connection_session_epoch,
                 address=address,
                 disconnect_keys=tuple(disconnect_keys),
                 should_reconnect=should_reconnect,
@@ -413,7 +413,7 @@ class BLEDisconnectLifecycleCoordinator:
         skip_side_effects = False
         with self._session.lock:
             active_client = iface.client
-            active_session_epoch = getattr(iface, "_connection_session_epoch", 0)
+            active_session_epoch = self._session.connection_session_epoch
             if active_session_epoch != plan.session_epoch or (
                 active_client is not None and active_client is not plan.client_at_start
             ):
@@ -425,7 +425,7 @@ class BLEDisconnectLifecycleCoordinator:
             still_stale = False
             with self._session.lock:
                 active_client = iface.client
-                active_session_epoch = getattr(iface, "_connection_session_epoch", 0)
+                active_session_epoch = self._session.connection_session_epoch
                 still_stale = active_session_epoch != plan.session_epoch or (
                     active_client is not None
                     and active_client is not plan.client_at_start
@@ -457,7 +457,7 @@ class BLEDisconnectLifecycleCoordinator:
         stale_after_close = False
         with self._session.lock:
             active_client = iface.client
-            active_session_epoch = getattr(iface, "_connection_session_epoch", 0)
+            active_session_epoch = self._session.connection_session_epoch
             stale_after_close = active_session_epoch != plan.session_epoch or (
                 active_client is not None and active_client is not plan.client_at_start
             )
@@ -466,7 +466,7 @@ class BLEDisconnectLifecycleCoordinator:
             rechecked_stale_disconnect_keys_after_close: list[str] = []
             with self._session.lock:
                 active_client = iface.client
-                active_session_epoch = getattr(iface, "_connection_session_epoch", 0)
+                active_session_epoch = self._session.connection_session_epoch
                 still_stale_after_close = (
                     active_session_epoch != plan.session_epoch
                     or (

--- a/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
@@ -24,7 +24,6 @@ from meshtastic.interfaces.ble.lifecycle_primitives import (
 )
 from meshtastic.interfaces.ble.state import ConnectionState
 from meshtastic.interfaces.ble.utils import (
-    _is_unconfigured_mock_callable,
     _sleep,
     _thread_start_probe,
 )
@@ -74,15 +73,11 @@ class BLEDisconnectLifecycleCoordinator:
         schedule_reconnect = getattr(
             iface._reconnect_scheduler, "schedule_reconnect", None
         )
-        if not callable(schedule_reconnect) or _is_unconfigured_mock_callable(
-            schedule_reconnect
-        ):
+        if not callable(schedule_reconnect):
             schedule_reconnect = getattr(
                 iface._reconnect_scheduler, "_schedule_reconnect", None
             )
-        if not callable(schedule_reconnect) or _is_unconfigured_mock_callable(
-            schedule_reconnect
-        ):
+        if not callable(schedule_reconnect):
             raise AttributeError(RECONNECT_SCHEDULER_MISSING_MSG)
         schedule_reconnect(iface.auto_reconnect, iface._shutdown_event)
 

--- a/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 
 from bleak import BleakClient as BleakRootClient
 
+from meshtastic.interfaces.ble.ports import _BLESessionStatePort
+from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.constants import (
     READ_TRIGGER_EVENT,
     RECONNECTED_EVENT,
@@ -37,10 +39,13 @@ CLOSE_THREAD_START_PROBE_DELAY_SEC = 0.001
 class BLEDisconnectLifecycleCoordinator:
     """Own disconnect orchestration and reconnect scheduling behavior."""
 
-    def __init__(self, iface: "BLEInterface") -> None:
+    def __init__(
+        self, iface: "BLEInterface", *, session_state: _BLESessionStatePort | None = None
+    ) -> None:
         """Bind disconnect orchestration ownership to a specific interface."""
         self._iface = iface
-        self._state_access = _LifecycleStateAccess(iface)
+        self._session = _session_state_for(iface, session_state)
+        self._state_access = _LifecycleStateAccess(getattr(iface, "_state_manager", iface))
         self._thread_access = _LifecycleThreadAccess(iface)
         self._error_access = _LifecycleErrorAccess(iface)
 
@@ -52,10 +57,10 @@ class BLEDisconnectLifecycleCoordinator:
         """Schedule background auto-reconnect work when reconnect is enabled."""
         iface = self._iface
         get_is_closing = is_closing_getter or self._state_access.is_closing
-        with iface._state_lock:
+        with self._session.lock:
             if not iface.auto_reconnect:
                 return
-            if iface._closed:
+            if self._session.closed:
                 logger.debug(
                     "Skipping auto-reconnect scheduling because interface is closed."
                 )
@@ -115,7 +120,7 @@ class BLEDisconnectLifecycleCoordinator:
     ) -> tuple[list[str], bool]:
         """Compute disconnect registry keys and reconnect scheduling intent."""
         iface = self._iface
-        should_schedule_reconnect = should_reconnect and not iface._closed
+        should_schedule_reconnect = should_reconnect and not self._session.closed
         if should_reconnect:
             if previous_client is not None:
                 previous_address = (
@@ -176,12 +181,12 @@ class BLEDisconnectLifecycleCoordinator:
             self._state_access.reset_to_disconnected
         )
         target_client = client
-        with iface._state_lock:
+        with self._session.lock:
             current_state = get_current_state()
             current_client = iface.client
-            is_closing = get_is_closing() or iface._closed
-            was_publish_pending = iface._client_publish_pending
-            was_replacement_pending = iface._client_replacement_pending
+            is_closing = get_is_closing() or self._session.closed
+            was_publish_pending = self._session.client_publish_pending
+            was_replacement_pending = self._session.client_replacement_pending
 
             if current_state == ConnectionState.CONNECTING:
                 disconnect_from_owned_client = current_client is not None and (
@@ -232,18 +237,18 @@ class BLEDisconnectLifecycleCoordinator:
                 logger.debug("Ignoring stale disconnect from %s.", source)
                 return _DisconnectPlan(early_return=True)
 
-            if iface._disconnect_notified:
+            if self._session.disconnect_notified:
                 logger.debug("Ignoring duplicate disconnect from %s.", source)
                 return _DisconnectPlan(early_return=True)
 
             previous_client = current_client
             client_at_start = current_client
-            alias_key = iface._connection_alias_key
+            alias_key = self._session.connection_alias_key
             iface.client = None
-            iface._client_publish_pending = False
-            iface._client_replacement_pending = False
-            iface._disconnect_notified = True
-            iface._connection_alias_key = None
+            self._session.client_publish_pending = False
+            self._session.client_replacement_pending = False
+            self._session.disconnect_notified = True
+            self._session.connection_alias_key = None
             if not do_transition_to_disconnected():
                 logger.error(
                     "Failed state transition to %s during disconnect target resolution (alias=%s current=%s); forcing reset.",
@@ -386,7 +391,7 @@ class BLEDisconnectLifecycleCoordinator:
             active_keys = set(
                 iface._sorted_address_keys(
                     _addr_key(active_address) if active_address else None,
-                    iface._connection_alias_key,
+                    self._session.connection_alias_key,
                 )
             )
             return (
@@ -411,7 +416,7 @@ class BLEDisconnectLifecycleCoordinator:
         clear_runtime_events = clear_events or self._thread_access.clear_events
         disconnect_keys = list(plan.disconnect_keys)
         skip_side_effects = False
-        with iface._state_lock:
+        with self._session.lock:
             active_client = iface.client
             active_session_epoch = getattr(iface, "_connection_session_epoch", 0)
             if active_session_epoch != plan.session_epoch or (
@@ -423,7 +428,7 @@ class BLEDisconnectLifecycleCoordinator:
             stale_disconnect_keys: list[str] = []
             close_stale_client = False
             still_stale = False
-            with iface._state_lock:
+            with self._session.lock:
                 active_client = iface.client
                 active_session_epoch = getattr(iface, "_connection_session_epoch", 0)
                 still_stale = active_session_epoch != plan.session_epoch or (
@@ -451,11 +456,11 @@ class BLEDisconnectLifecycleCoordinator:
                 return True
 
         logger.debug("BLE client %s disconnected (source: %s).", plan.address, source)
-        iface._last_disconnect_source = f"ble.{source}"
+        self._session.last_disconnect_source = f"ble.{source}"
 
         close_previous(plan.previous_client)
         stale_after_close = False
-        with iface._state_lock:
+        with self._session.lock:
             active_client = iface.client
             active_session_epoch = getattr(iface, "_connection_session_epoch", 0)
             stale_after_close = active_session_epoch != plan.session_epoch or (
@@ -464,7 +469,7 @@ class BLEDisconnectLifecycleCoordinator:
         if stale_after_close:
             still_stale_after_close = False
             rechecked_stale_disconnect_keys_after_close: list[str] = []
-            with iface._state_lock:
+            with self._session.lock:
                 active_client = iface.client
                 active_session_epoch = getattr(iface, "_connection_session_epoch", 0)
                 still_stale_after_close = (
@@ -532,16 +537,16 @@ class BLEDisconnectLifecycleCoordinator:
                 "Disconnect from %s skipped: another disconnect handler is active.",
                 source,
             )
-            with iface._state_lock:
+            with self._session.lock:
                 return (
-                    not iface._closed
+                    not self._session.closed
                     and not get_is_closing()
                     and (
                         iface.auto_reconnect
-                        or iface._want_receive
+                        or self._session.want_receive
                         or iface.client is not None
-                        or iface._client_publish_pending
-                        or iface._client_replacement_pending
+                        or self._session.client_publish_pending
+                        or self._session.client_replacement_pending
                     )
                 )
 

--- a/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
@@ -6,7 +6,10 @@ from typing import TYPE_CHECKING
 
 from bleak import BleakClient as BleakRootClient
 
-from meshtastic.interfaces.ble.compat_adapter import _resolve_declared_callable
+from meshtastic.interfaces.ble.compat_adapter import (
+    _get_declared_member,
+    _resolve_declared_callable,
+)
 from meshtastic.interfaces.ble.ports import _BLESessionStatePort
 from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.constants import (
@@ -85,8 +88,9 @@ class BLEDisconnectLifecycleCoordinator:
                 )
                 return
             iface._shutdown_event.clear()
+        reconnect_scheduler = _get_declared_member(iface, "_reconnect_scheduler")
         schedule_reconnect = _resolve_declared_callable(
-            iface._reconnect_scheduler, "schedule_reconnect", "_schedule_reconnect"
+            reconnect_scheduler, "schedule_reconnect", "_schedule_reconnect"
         )
         if schedule_reconnect is None:
             raise AttributeError(RECONNECT_SCHEDULER_MISSING_MSG)

--- a/meshtastic/interfaces/ble/lifecycle_ownership_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_ownership_runtime.py
@@ -59,6 +59,9 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         ----------
         iface : BLEInterface
             Interface instance whose ownership lifecycle is managed.
+        session_state : _BLESessionStatePort | None
+            Optional shared lifecycle state. When ``None``, resolve the
+            interface-owned state or use the legacy adapter.
 
         Returns
         -------

--- a/meshtastic/interfaces/ble/lifecycle_ownership_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_ownership_runtime.py
@@ -3,6 +3,8 @@
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+from meshtastic.interfaces.ble.ports import _BLESessionStatePort
+from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.constants import RECONNECTED_EVENT, logger
 from meshtastic.interfaces.ble.lifecycle_primitives import (
     _LifecycleErrorAccess,
@@ -39,7 +41,9 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         coordinated by this collaborator.
     """
 
-    def __init__(self, iface: "BLEInterface") -> None:
+    def __init__(
+        self, iface: "BLEInterface", *, session_state: _BLESessionStatePort | None = None
+    ) -> None:
         """Bind connection ownership coordination to a specific interface.
 
         Parameters
@@ -53,7 +57,8 @@ class BLEConnectionOwnershipLifecycleCoordinator:
             Initializes bound collaborator state.
         """
         self._iface = iface
-        self._state_access = _LifecycleStateAccess(iface)
+        self._session = _session_state_for(iface, session_state)
+        self._state_access = _LifecycleStateAccess(getattr(iface, "_state_manager", iface))
         self._thread_access = _LifecycleThreadAccess(iface)
         self._error_access = _LifecycleErrorAccess(iface)
 
@@ -98,8 +103,8 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                 "is_closing",
                 "_is_closing",
             )
-        is_closing = is_closing or iface._closed
-        if iface._closed or iface.client is not client:
+        is_closing = is_closing or self._session.closed
+        if self._session.closed or iface.client is not client:
             return False, is_closing
         if state_connected_getter is not None:
             state_connected_result = state_connected_getter()
@@ -190,7 +195,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         tuple[bool, bool]
             ``(is_owned, is_closing)`` for ``client``.
         """
-        with self._iface._state_lock:
+        with self._session.lock:
             return self._get_connected_client_status_locked(
                 client,
                 is_closing_getter=is_closing_getter,
@@ -235,7 +240,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
             connected_device_key,
             connection_alias_key,
         )
-        with iface._state_lock:
+        with self._session.lock:
             still_owned, is_closing = get_connected_status_locked(connected_client)
             prior_ever_connected = self._has_ever_connected_session()
         return _OwnershipSnapshot(
@@ -269,9 +274,9 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         """
         iface = self._iface
         coordinator = getattr(iface, "thread_coordinator", None)
-        with iface._state_lock:
-            should_emit_reconnected = bool(iface._prior_publish_was_reconnect)
-            iface._prior_publish_was_reconnect = False
+        with self._session.lock:
+            should_emit_reconnected = bool(self._session.prior_publish_was_reconnect)
+            self._session.prior_publish_was_reconnect = False
         if should_emit_reconnected and coordinator is not None:
             self._thread_access.set_event(RECONNECTED_EVENT)
         normalized_device_address = sanitize_address(
@@ -296,8 +301,8 @@ class BLEConnectionOwnershipLifecycleCoordinator:
             getattr(connected_client, "address", "unknown"),
         )
 
-    @staticmethod
     def _apply_owned_client_invalidation(
+        self,
         iface: "BLEInterface",
         *,
         get_is_closing: Callable[[], bool],
@@ -316,24 +321,24 @@ class BLEConnectionOwnershipLifecycleCoordinator:
             whether a disconnect event should be emitted, and ``is_closing``
             indicates whether shutdown is active.
         """
-        replacement_pending = bool(getattr(iface, "_client_replacement_pending", False))
-        already_notified = bool(getattr(iface, "_disconnect_notified", False))
-        is_closing = get_is_closing() or iface._closed
+        replacement_pending = bool(self._session.client_replacement_pending)
+        already_notified = bool(self._session.disconnect_notified)
+        is_closing = get_is_closing() or self._session.closed
         iface.client = None
-        iface._client_publish_pending = False
-        iface._client_replacement_pending = False
-        iface._disconnect_notified = True
+        self._session.client_publish_pending = False
+        self._session.client_replacement_pending = False
+        self._session.disconnect_notified = True
         should_publish_disconnect = replacement_pending and not already_notified
         if not is_closing:
             iface.address = restored_address
             iface._last_connection_request = restore_last_connection_request
-            iface._connection_alias_key = None
+            self._session.connection_alias_key = None
             return True, should_publish_disconnect, is_closing
         iface._last_connection_request = None
         return False, should_publish_disconnect, is_closing
 
-    @staticmethod
     def _apply_publish_pending_invalidation(
+        self,
         iface: "BLEInterface",
         *,
         get_is_closing: Callable[[], bool],
@@ -348,25 +353,24 @@ class BLEConnectionOwnershipLifecycleCoordinator:
             ``(should_reset_state, should_publish_disconnect, is_closing)``
             using the same semantics as `_apply_owned_client_invalidation`.
         """
-        replacement_pending = bool(getattr(iface, "_client_replacement_pending", False))
-        already_notified = bool(getattr(iface, "_disconnect_notified", False))
-        iface._client_publish_pending = False
-        iface._client_replacement_pending = False
+        replacement_pending = bool(self._session.client_replacement_pending)
+        already_notified = bool(self._session.disconnect_notified)
+        self._session.client_publish_pending = False
+        self._session.client_replacement_pending = False
         should_publish_disconnect = replacement_pending and not already_notified
         if should_publish_disconnect:
-            iface._disconnect_notified = True
-        is_closing = get_is_closing() or iface._closed
+            self._session.disconnect_notified = True
+        is_closing = get_is_closing() or self._session.closed
         if not is_closing:
             iface.address = restored_address
             iface._last_connection_request = restore_last_connection_request
-            iface._connection_alias_key = None
+            self._session.connection_alias_key = None
             return True, should_publish_disconnect, is_closing
         iface._last_connection_request = None
         return False, should_publish_disconnect, is_closing
 
-    @staticmethod
     def _apply_post_cleanup_state_correction(
-        iface: "BLEInterface",
+        self,
         *,
         should_reset_state: bool,
         do_reset_to_disconnected: Callable[[], bool],
@@ -377,8 +381,6 @@ class BLEConnectionOwnershipLifecycleCoordinator:
 
         Parameters
         ----------
-        iface : BLEInterface
-            Interface whose state manager is being corrected.
         should_reset_state : bool
             Whether state correction should be attempted.
         do_reset_to_disconnected : Callable[[], bool]
@@ -399,7 +401,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
             current_state = get_current_state()
             logger.error(
                 "Failed to reset state after invalidated connect result (alias=%s current=%s); forcing transition to %s.",
-                iface._connection_alias_key,
+                self._session.connection_alias_key,
                 getattr(current_state, "value", current_state),
                 ConnectionState.DISCONNECTED.value,
             )
@@ -408,7 +410,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                 logger.error(
                     "Failed forced transition to %s after invalidated connect result (alias=%s current=%s).",
                     ConnectionState.DISCONNECTED.value,
-                    iface._connection_alias_key,
+                    self._session.connection_alias_key,
                     getattr(fallback_state, "value", fallback_state),
                 )
 
@@ -469,12 +471,12 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         should_publish_disconnect = False
         is_closing = False
         disconnect_session_epoch = 0
-        with iface._state_lock:
+        with self._session.lock:
             disconnect_session_epoch = getattr(iface, "_connection_session_epoch", 0)
             inflight_client = getattr(iface, "_connected_publish_inflight_client", None)
             if iface.client is client:
                 if inflight_client is client:
-                    iface._connected_publish_inflight_client = None
+                    self._session.connected_publish_inflight_client = None
                 (
                     should_reset_state,
                     should_publish_disconnect,
@@ -490,7 +492,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                 and bool(getattr(iface, "_client_publish_pending", False))
                 and inflight_client is client
             ):
-                iface._connected_publish_inflight_client = None
+                self._session.connected_publish_inflight_client = None
                 (
                     should_reset_state,
                     should_publish_disconnect,
@@ -508,21 +510,20 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                 "BLE client close for invalidated connection result",
             )
         finally:
-            with iface._state_lock:
+            with self._session.lock:
                 same_session = (
                     getattr(iface, "_connection_session_epoch", 0)
                     == disconnect_session_epoch
                 )
             if same_session:
                 self._apply_post_cleanup_state_correction(
-                    iface,
                     should_reset_state=should_reset_state,
                     do_reset_to_disconnected=do_reset_to_disconnected,
                     get_current_state=get_current_state,
                     do_transition_to_disconnected=do_transition_to_disconnected,
                 )
         if should_publish_disconnect and not is_closing:
-            with iface._state_lock:
+            with self._session.lock:
                 publish_disconnect = (
                     getattr(iface, "_connection_session_epoch", 0)
                     == disconnect_session_epoch
@@ -611,7 +612,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         should_publish_connected = False
         publish_claimed = False
         duplicate_publish_request = False
-        with iface._state_lock:
+        with self._session.lock:
             still_owned, is_closing = get_connected_status_locked(connected_client)
             if still_owned and not is_closing:
                 publish_pending = bool(getattr(iface, "_client_publish_pending", False))
@@ -619,14 +620,14 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                     iface, "_connected_publish_inflight_client", None
                 )
                 if not publish_pending:
-                    iface._client_publish_pending = True
-                    iface._connected_publish_inflight_client = connected_client
+                    self._session.client_publish_pending = True
+                    self._session.connected_publish_inflight_client = connected_client
                     publish_claimed = True
                     should_publish_connected = True
                 elif iface.client is connected_client and inflight_client is None:
                     # The connect flow may have already claimed publish-pending
                     # for this exact client before reaching verification.
-                    iface._connected_publish_inflight_client = connected_client
+                    self._session.connected_publish_inflight_client = connected_client
                     publish_claimed = True
                     should_publish_connected = True
                 elif (
@@ -648,7 +649,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
             _raise_invalidated(snapshot)
         publish_committed = False
         if should_publish_connected:
-            with iface._state_lock:
+            with self._session.lock:
                 still_owned, is_closing = get_connected_status_locked(connected_client)
                 if (
                     publish_claimed
@@ -672,12 +673,12 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                 return
 
         if publish_claimed:
-            with iface._state_lock:
+            with self._session.lock:
                 if (
                     getattr(iface, "_connected_publish_inflight_client", None)
                     is connected_client
                 ):
-                    iface._connected_publish_inflight_client = None
+                    self._session.connected_publish_inflight_client = None
         post_check_snapshot = snapshot_provider(
             connected_client,
             connected_device_key,
@@ -741,7 +742,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
             ):
                 raise_invalidated(post_commit_snapshot)
             publish_allowed = False
-            with iface._state_lock:
+            with self._session.lock:
                 published_session_epoch = getattr(iface, "_connection_session_epoch", 0)
                 publish_allowed = iface.client is connected_client
             if not publish_allowed:
@@ -751,7 +752,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                     connection_alias_key,
                 )
                 raise_invalidated(stale_snapshot)
-            with iface._state_lock:
+            with self._session.lock:
                 publish_allowed = (
                     iface.client is connected_client
                     and getattr(iface, "_connection_session_epoch", 0)
@@ -774,7 +775,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                     or "expected_session_epoch" not in error_message
                 ):
                     raise
-                with iface._state_lock:
+                with self._session.lock:
                     fallback_allowed = (
                         iface.client is connected_client
                         and getattr(iface, "_connection_session_epoch", 0)
@@ -788,32 +789,32 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                     )
                     raise_invalidated(stale_snapshot)
                 connected_notifier()
-            with iface._state_lock:
+            with self._session.lock:
                 publish_completed = (
                     iface.client is connected_client
                     and getattr(iface, "_connection_session_epoch", 0)
                     == published_session_epoch
                 )
                 if publish_completed:
-                    iface._ever_connected = True
-                    iface._prior_publish_was_reconnect = prior_ever_connected
+                    self._session.ever_connected = True
+                    self._session.prior_publish_was_reconnect = prior_ever_connected
             if publish_completed:
                 self._emit_verified_connection_side_effects(connected_client)
         finally:
-            with iface._state_lock:
+            with self._session.lock:
                 if (
                     getattr(iface, "_connected_publish_inflight_client", None)
                     is connected_client
                 ):
-                    iface._connected_publish_inflight_client = None
+                    self._session.connected_publish_inflight_client = None
                 if iface.client is connected_client:
-                    iface._client_publish_pending = False
+                    self._session.client_publish_pending = False
                     if publish_completed:
-                        iface._client_replacement_pending = False
+                        self._session.client_replacement_pending = False
                 still_owned_after, is_closing_after = get_connected_status_locked(
                     connected_client
                 )
-                disconnect_notified = iface._disconnect_notified
+                disconnect_notified = self._session.disconnect_notified
         if (
             publish_completed
             and not still_owned_after
@@ -823,7 +824,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
             logger.debug(
                 "Connected publication raced with disconnect; emitting compensating disconnect event."
             )
-            with iface._state_lock:
+            with self._session.lock:
                 same_session = (
                     getattr(iface, "_connection_session_epoch", 0)
                     == published_session_epoch
@@ -874,18 +875,18 @@ class BLEConnectionOwnershipLifecycleCoordinator:
 
         if still_active:
             should_clear_gate_keys = False
-            with iface._state_lock:
+            with self._session.lock:
                 still_active, is_closing = get_status_locked(connected_client)
                 if still_active:
-                    iface._connection_alias_key = connection_alias_key
+                    self._session.connection_alias_key = connection_alias_key
                 else:
                     active_client = iface.client
-                    owns_alias = iface._connection_alias_key == connection_alias_key
+                    owns_alias = self._session.connection_alias_key == connection_alias_key
                     should_clear_gate_keys = owns_alias and (
                         active_client is connected_client or active_client is None
                     )
                     if should_clear_gate_keys:
-                        iface._connection_alias_key = None
+                        self._session.connection_alias_key = None
             if not still_active:
                 self._log_gate_cleanup(connected_client, is_closing=is_closing)
                 if should_clear_gate_keys:
@@ -899,17 +900,17 @@ class BLEConnectionOwnershipLifecycleCoordinator:
             )
             needs_cleanup = False
             should_clear_gate_keys = False
-            with iface._state_lock:
+            with self._session.lock:
                 still_active, is_closing = get_status_locked(connected_client)
                 if not still_active:
                     self._log_gate_cleanup(connected_client, is_closing=is_closing)
                     active_client = iface.client
-                    owns_alias = iface._connection_alias_key == connection_alias_key
+                    owns_alias = self._session.connection_alias_key == connection_alias_key
                     should_clear_gate_keys = owns_alias and (
                         active_client is connected_client or active_client is None
                     )
                     if should_clear_gate_keys:
-                        iface._connection_alias_key = None
+                        self._session.connection_alias_key = None
                     needs_cleanup = True
             if needs_cleanup and should_clear_gate_keys:
                 iface._mark_address_keys_disconnected(

--- a/meshtastic/interfaces/ble/lifecycle_ownership_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_ownership_runtime.py
@@ -310,7 +310,6 @@ class BLEConnectionOwnershipLifecycleCoordinator:
 
     def _apply_owned_client_invalidation(
         self,
-        iface: "BLEInterface",
         *,
         get_is_closing: Callable[[], bool],
         restored_address: str | None,
@@ -328,6 +327,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
             whether a disconnect event should be emitted, and ``is_closing``
             indicates whether shutdown is active.
         """
+        iface = self._iface
         replacement_pending = bool(self._session.client_replacement_pending)
         already_notified = bool(self._session.disconnect_notified)
         is_closing = get_is_closing() or self._session.closed
@@ -346,7 +346,6 @@ class BLEConnectionOwnershipLifecycleCoordinator:
 
     def _apply_publish_pending_invalidation(
         self,
-        iface: "BLEInterface",
         *,
         get_is_closing: Callable[[], bool],
         restored_address: str | None,
@@ -360,6 +359,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
             ``(should_reset_state, should_publish_disconnect, is_closing)``
             using the same semantics as `_apply_owned_client_invalidation`.
         """
+        iface = self._iface
         replacement_pending = bool(self._session.client_replacement_pending)
         already_notified = bool(self._session.disconnect_notified)
         self._session.client_publish_pending = False
@@ -489,7 +489,6 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                     should_publish_disconnect,
                     is_closing,
                 ) = self._apply_owned_client_invalidation(
-                    iface,
                     get_is_closing=get_is_closing,
                     restored_address=restored_address,
                     restore_last_connection_request=restore_last_connection_request,
@@ -505,7 +504,6 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                     should_publish_disconnect,
                     is_closing,
                 ) = self._apply_publish_pending_invalidation(
-                    iface,
                     get_is_closing=get_is_closing,
                     restored_address=restored_address,
                     restore_last_connection_request=restore_last_connection_request,

--- a/meshtastic/interfaces/ble/lifecycle_ownership_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_ownership_runtime.py
@@ -3,8 +3,6 @@
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
-from meshtastic.interfaces.ble.ports import _BLESessionStatePort
-from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.compat_adapter import (
     _get_declared_member,
     _iter_declared_members,
@@ -20,6 +18,8 @@ from meshtastic.interfaces.ble.lifecycle_primitives import (
     _LifecycleThreadAccess,
     _OwnershipSnapshot,
 )
+from meshtastic.interfaces.ble.ports import _BLESessionStatePort
+from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.state import ConnectionState
 from meshtastic.interfaces.ble.utils import (
     sanitize_address,
@@ -48,7 +48,10 @@ class BLEConnectionOwnershipLifecycleCoordinator:
     """
 
     def __init__(
-        self, iface: "BLEInterface", *, session_state: _BLESessionStatePort | None = None
+        self,
+        iface: "BLEInterface",
+        *,
+        session_state: _BLESessionStatePort | None = None,
     ) -> None:
         """Bind connection ownership coordination to a specific interface.
 
@@ -476,8 +479,8 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         is_closing = False
         disconnect_session_epoch = 0
         with self._session.lock:
-            disconnect_session_epoch = getattr(iface, "_connection_session_epoch", 0)
-            inflight_client = getattr(iface, "_connected_publish_inflight_client", None)
+            disconnect_session_epoch = self._session.connection_session_epoch
+            inflight_client = self._session.connected_publish_inflight_client
             if iface.client is client:
                 if inflight_client is client:
                     self._session.connected_publish_inflight_client = None
@@ -493,7 +496,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                 )
             elif (
                 iface.client is None
-                and bool(getattr(iface, "_client_publish_pending", False))
+                and self._session.client_publish_pending
                 and inflight_client is client
             ):
                 self._session.connected_publish_inflight_client = None
@@ -516,8 +519,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         finally:
             with self._session.lock:
                 same_session = (
-                    getattr(iface, "_connection_session_epoch", 0)
-                    == disconnect_session_epoch
+                    self._session.connection_session_epoch == disconnect_session_epoch
                 )
             if same_session:
                 self._apply_post_cleanup_state_correction(
@@ -529,8 +531,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         if should_publish_disconnect and not is_closing:
             with self._session.lock:
                 publish_disconnect = (
-                    getattr(iface, "_connection_session_epoch", 0)
-                    == disconnect_session_epoch
+                    self._session.connection_session_epoch == disconnect_session_epoch
                 )
             if publish_disconnect:
                 iface._disconnected()
@@ -619,10 +620,8 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         with self._session.lock:
             still_owned, is_closing = get_connected_status_locked(connected_client)
             if still_owned and not is_closing:
-                publish_pending = bool(getattr(iface, "_client_publish_pending", False))
-                inflight_client = getattr(
-                    iface, "_connected_publish_inflight_client", None
-                )
+                publish_pending = self._session.client_publish_pending
+                inflight_client = self._session.connected_publish_inflight_client
                 if not publish_pending:
                     self._session.client_publish_pending = True
                     self._session.connected_publish_inflight_client = connected_client
@@ -678,10 +677,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
 
         if publish_claimed:
             with self._session.lock:
-                if (
-                    getattr(iface, "_connected_publish_inflight_client", None)
-                    is connected_client
-                ):
+                if self._session.connected_publish_inflight_client is connected_client:
                     self._session.connected_publish_inflight_client = None
         post_check_snapshot = snapshot_provider(
             connected_client,
@@ -747,7 +743,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                 raise_invalidated(post_commit_snapshot)
             publish_allowed = False
             with self._session.lock:
-                published_session_epoch = getattr(iface, "_connection_session_epoch", 0)
+                published_session_epoch = self._session.connection_session_epoch
                 publish_allowed = iface.client is connected_client
             if not publish_allowed:
                 stale_snapshot = snapshot_provider(
@@ -759,7 +755,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
             with self._session.lock:
                 publish_allowed = (
                     iface.client is connected_client
-                    and getattr(iface, "_connection_session_epoch", 0)
+                    and self._session.connection_session_epoch
                     == published_session_epoch
                 )
             if not publish_allowed:
@@ -782,7 +778,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                 with self._session.lock:
                     fallback_allowed = (
                         iface.client is connected_client
-                        and getattr(iface, "_connection_session_epoch", 0)
+                        and self._session.connection_session_epoch
                         == published_session_epoch
                     )
                 if not fallback_allowed:
@@ -796,7 +792,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
             with self._session.lock:
                 publish_completed = (
                     iface.client is connected_client
-                    and getattr(iface, "_connection_session_epoch", 0)
+                    and self._session.connection_session_epoch
                     == published_session_epoch
                 )
                 if publish_completed:
@@ -806,10 +802,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                 self._emit_verified_connection_side_effects(connected_client)
         finally:
             with self._session.lock:
-                if (
-                    getattr(iface, "_connected_publish_inflight_client", None)
-                    is connected_client
-                ):
+                if self._session.connected_publish_inflight_client is connected_client:
                     self._session.connected_publish_inflight_client = None
                 if iface.client is connected_client:
                     self._session.client_publish_pending = False
@@ -830,8 +823,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
             )
             with self._session.lock:
                 same_session = (
-                    getattr(iface, "_connection_session_epoch", 0)
-                    == published_session_epoch
+                    self._session.connection_session_epoch == published_session_epoch
                 )
             if same_session:
                 iface._disconnected()
@@ -885,7 +877,9 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                     self._session.connection_alias_key = connection_alias_key
                 else:
                     active_client = iface.client
-                    owns_alias = self._session.connection_alias_key == connection_alias_key
+                    owns_alias = (
+                        self._session.connection_alias_key == connection_alias_key
+                    )
                     should_clear_gate_keys = owns_alias and (
                         active_client is connected_client or active_client is None
                     )
@@ -909,7 +903,9 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                 if not still_active:
                     self._log_gate_cleanup(connected_client, is_closing=is_closing)
                     active_client = iface.client
-                    owns_alias = self._session.connection_alias_key == connection_alias_key
+                    owns_alias = (
+                        self._session.connection_alias_key == connection_alias_key
+                    )
                     should_clear_gate_keys = owns_alias and (
                         active_client is connected_client or active_client is None
                     )

--- a/meshtastic/interfaces/ble/lifecycle_ownership_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_ownership_runtime.py
@@ -5,6 +5,10 @@ from typing import TYPE_CHECKING
 
 from meshtastic.interfaces.ble.ports import _BLESessionStatePort
 from meshtastic.interfaces.ble.session_state import _session_state_for
+from meshtastic.interfaces.ble.compat_adapter import (
+    _get_declared_member,
+    _iter_declared_members,
+)
 from meshtastic.interfaces.ble.constants import RECONNECTED_EVENT, logger
 from meshtastic.interfaces.ble.lifecycle_primitives import (
     _LifecycleErrorAccess,
@@ -56,7 +60,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         """
         self._iface = iface
         self._session = _session_state_for(iface, session_state)
-        self._state_access = _LifecycleStateAccess(getattr(iface, "_state_manager", iface))
+        self._state_access = _LifecycleStateAccess(iface)
         self._thread_access = _LifecycleThreadAccess(iface)
         self._error_access = _LifecycleErrorAccess(iface)
 
@@ -89,7 +93,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
             close/shutdown state.
         """
         iface = self._iface
-        state_manager = getattr(iface, "_state_manager", None)
+        state_manager = _get_declared_member(iface, "_state_manager")
         if is_closing_getter is not None:
             is_closing_result = is_closing_getter()
             is_closing = (
@@ -151,20 +155,16 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         bool
             First authoritative bool probe result; otherwise ``False``.
         """
-        if owner is None:
-            return False
-        for member_name in member_names:
-            member = getattr(owner, member_name, None)
+        for _member_name, member in _iter_declared_members(owner, *member_names):
             if callable(member):
                 try:
                     result = member()
                 except Exception:  # noqa: BLE001 - probe remains best effort
                     continue
-                if isinstance(result, bool):
-                    return result
-                continue
-            if isinstance(member, bool):
-                return member
+            else:
+                result = member
+            if isinstance(result, bool):
+                return result
         return False
 
     def _get_connected_client_status(
@@ -268,7 +268,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
             Always returns ``None``.
         """
         iface = self._iface
-        coordinator = getattr(iface, "thread_coordinator", None)
+        coordinator = _get_declared_member(iface, "thread_coordinator")
         with self._session.lock:
             should_emit_reconnected = bool(self._session.prior_publish_was_reconnect)
             self._session.prior_publish_was_reconnect = False

--- a/meshtastic/interfaces/ble/lifecycle_ownership_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_ownership_runtime.py
@@ -20,7 +20,7 @@ from meshtastic.interfaces.ble.lifecycle_primitives import (
 )
 from meshtastic.interfaces.ble.ports import _BLESessionStatePort
 from meshtastic.interfaces.ble.session_state import _session_state_for
-from meshtastic.interfaces.ble.state import ConnectionState
+from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
 from meshtastic.interfaces.ble.utils import (
     sanitize_address,
 )
@@ -70,9 +70,112 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         """
         self._iface = iface
         self._session = _session_state_for(iface, session_state)
+        self._state_manager = _get_declared_member(iface, "_state_manager")
         self._state_access = _LifecycleStateAccess(iface)
         self._thread_access = _LifecycleThreadAccess(iface)
         self._error_access = _LifecycleErrorAccess(iface)
+
+    def _canonical_connection_state_locked(self) -> ConnectionState | None:
+        """Return canonical state when it shares the session lock.
+
+        Returns
+        -------
+        ConnectionState | None
+            Raw state for the exact ``BLEStateManager`` owner when it shares the
+            session lock; otherwise ``None`` for compatibility managers.
+        """
+        state_manager = self._state_manager
+        if (
+            type(state_manager) is BLEStateManager  # pylint: disable=unidiomatic-typecheck
+            and state_manager.lock is self._session.lock
+        ):
+            return BLEStateManager._current_state_unlocked(state_manager)
+        return None
+
+    def _revalidate_connected_client_status_locked(
+        self,
+        client: "BLEClient",
+        *,
+        probed_owned: bool,
+        probed_is_closing: bool,
+        enforce_canonical_state: bool = True,
+    ) -> tuple[bool, bool]:
+        """Revalidate a lock-free ownership probe against authoritative state.
+
+        Parameters
+        ----------
+        client : BLEClient
+            Candidate client whose probe result is being committed.
+        probed_owned : bool
+            Point-in-time result from compatibility and client probes performed
+            without the shared session lock.
+        probed_is_closing : bool
+            Point-in-time compatibility closing result.
+
+        Returns
+        -------
+        tuple[bool, bool]
+            Revalidated ``(is_owned, is_closing)`` snapshot.
+        """
+        iface = self._iface
+        canonical_state = (
+            self._canonical_connection_state_locked()
+            if enforce_canonical_state
+            else None
+        )
+        is_closing = probed_is_closing or self._session.closed
+        if canonical_state is not None:
+            is_closing = is_closing or canonical_state == ConnectionState.DISCONNECTING
+        if self._session.closed or iface.client is not client:
+            return False, is_closing
+        if canonical_state is not None and canonical_state != ConnectionState.CONNECTED:
+            return False, is_closing
+        return probed_owned, is_closing
+
+    def _probe_connected_client_status(
+        self,
+        client: "BLEClient",
+        *,
+        is_closing_getter: Callable[[], bool] | None = None,
+        state_connected_getter: Callable[[], bool] | None = None,
+        client_connected_getter: Callable[["BLEClient"], bool] | None = None,
+    ) -> tuple[bool, bool]:
+        """Run compatibility/client ownership probes without the session lock."""
+        state_manager = self._state_manager
+        canonical_state_owned = (
+            is_closing_getter is None
+            and state_connected_getter is None
+            and type(state_manager) is BLEStateManager  # pylint: disable=unidiomatic-typecheck
+            and state_manager.lock is self._session.lock
+        )
+        if is_closing_getter is not None:
+            result = is_closing_getter()
+            is_closing = result if isinstance(result, bool) else False
+        elif canonical_state_owned:
+            is_closing = False
+        else:
+            is_closing = self._probe_bool_member(
+                state_manager, "is_closing", "_is_closing"
+            )
+
+        if state_connected_getter is not None:
+            result = state_connected_getter()
+            state_connected = result if isinstance(result, bool) else False
+        elif canonical_state_owned:
+            state_connected = True
+        else:
+            state_connected = self._probe_bool_member(
+                state_manager, "is_connected", "_is_connected"
+            )
+
+        if client_connected_getter is not None:
+            result = client_connected_getter(client)
+            client_connected = result if isinstance(result, bool) else False
+        else:
+            client_connected = self._probe_bool_member(
+                client, "isConnected", "is_connected", "_is_connected"
+            )
+        return state_connected and client_connected, is_closing
 
     def _get_connected_client_status_locked(
         self,
@@ -82,72 +185,60 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         state_connected_getter: Callable[[], bool] | None = None,
         client_connected_getter: Callable[["BLEClient"], bool] | None = None,
     ) -> tuple[bool, bool]:
-        """Return ownership and closing flags for ``client`` while holding lock.
+        """Compatibility shim returning a safely revalidated ownership status.
 
-        Parameters
-        ----------
-        client : BLEClient
-            Client candidate whose owned/connected status is being evaluated.
-        is_closing_getter : Callable[[], bool] | None
-            Optional closure-state probe override.
-        state_connected_getter : Callable[[], bool] | None
-            Optional state-manager connected probe override.
-        client_connected_getter : Callable[[BLEClient], bool] | None
-            Optional per-client connected probe override.
-
-        Returns
-        -------
-        tuple[bool, bool]
-            ``(is_owned, is_closing)`` where ``is_owned`` indicates active
-            ownership of ``client`` and ``is_closing`` reflects interface
-            close/shutdown state.
+        Despite the historical ``_locked`` suffix, compatibility and client
+        probes are deliberately evaluated before this method acquires the shared
+        session lock. Internal lifecycle code must not call this shim while
+        already holding that lock.
         """
-        iface = self._iface
-        state_manager = _get_declared_member(iface, "_state_manager")
-        if is_closing_getter is not None:
-            is_closing_result = is_closing_getter()
-            is_closing = (
-                is_closing_result if isinstance(is_closing_result, bool) else False
+        return self._get_connected_client_status(
+            client,
+            is_closing_getter=is_closing_getter,
+            state_connected_getter=state_connected_getter,
+            client_connected_getter=client_connected_getter,
+        )
+
+    def _probe_status_provider(
+        self,
+        client: "BLEClient",
+        provider: Callable[["BLEClient"], tuple[bool, bool]],
+    ) -> tuple[bool, bool, int]:
+        """Run an ownership provider unlocked and retain its session generation."""
+        with self._session.lock:
+            expected_epoch = self._session.connection_session_epoch
+        probed_owned, probed_is_closing = provider(client)
+        return probed_owned, probed_is_closing, expected_epoch
+
+    def _revalidate_status_probe_locked(
+        self,
+        client: "BLEClient",
+        *,
+        probed_owned: bool,
+        probed_is_closing: bool,
+        expected_epoch: int,
+        enforce_canonical_state: bool,
+    ) -> tuple[bool, bool]:
+        """Revalidate a provider result before mutating shared lifecycle state."""
+        if self._session.connection_session_epoch != expected_epoch:
+            canonical_state = (
+                self._canonical_connection_state_locked()
+                if enforce_canonical_state
+                else None
             )
-        else:
-            is_closing = self._probe_bool_member(
-                state_manager,
-                "is_closing",
-                "_is_closing",
+            is_closing = probed_is_closing or self._session.closed or (
+                canonical_state == ConnectionState.DISCONNECTING
             )
-        is_closing = is_closing or self._session.closed
-        if self._session.closed or iface.client is not client:
             return False, is_closing
-        if state_connected_getter is not None:
-            state_connected_result = state_connected_getter()
-            state_connected = (
-                state_connected_result
-                if isinstance(state_connected_result, bool)
-                else False
-            )
-        else:
-            state_connected = self._probe_bool_member(
-                state_manager,
-                "is_connected",
-                "_is_connected",
-            )
-        if not state_connected:
-            return False, is_closing
-        if client_connected_getter is not None:
-            client_connected_result = client_connected_getter(client)
-            client_connected = (
-                client_connected_result
-                if isinstance(client_connected_result, bool)
-                else False
-            )
-        else:
-            client_connected = self._probe_bool_member(
-                client,
-                "isConnected",
-                "is_connected",
-                "_is_connected",
-            )
-        return client_connected, is_closing
+        if not enforce_canonical_state:
+            is_closing = probed_is_closing or self._session.closed
+            return probed_owned and not self._session.closed, is_closing
+        return self._revalidate_connected_client_status_locked(
+            client,
+            probed_owned=probed_owned,
+            probed_is_closing=probed_is_closing,
+            enforce_canonical_state=True,
+        )
 
     @staticmethod
     def _probe_bool_member(owner: object | None, *member_names: str) -> bool:
@@ -190,30 +281,38 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         state_connected_getter: Callable[[], bool] | None = None,
         client_connected_getter: Callable[["BLEClient"], bool] | None = None,
     ) -> tuple[bool, bool]:
-        """Return ownership and closing flags with internal state locking.
-
-        Parameters
-        ----------
-        client : BLEClient
-            Candidate connected client to evaluate.
-        is_closing_getter : Callable[[], bool] | None, optional
-            Optional closing-state probe used while lock is held.
-        state_connected_getter : Callable[[], bool] | None, optional
-            Optional connection-state probe used while lock is held.
-        client_connected_getter : Callable[[BLEClient], bool] | None, optional
-            Optional client-connected probe used while lock is held.
-
-        Returns
-        -------
-        tuple[bool, bool]
-            ``(is_owned, is_closing)`` for ``client``.
-        """
+        """Return ownership and closing flags without probing under the lock."""
         with self._session.lock:
-            return self._get_connected_client_status_locked(
+            baseline_epoch = self._session.connection_session_epoch
+            if self._session.closed or self._iface.client is not client:
+                canonical_state = self._canonical_connection_state_locked()
+                is_closing = self._session.closed or (
+                    canonical_state == ConnectionState.DISCONNECTING
+                )
+                return False, is_closing
+
+        probed_owned, probed_is_closing = self._probe_connected_client_status(
+            client,
+            is_closing_getter=is_closing_getter,
+            state_connected_getter=state_connected_getter,
+            client_connected_getter=client_connected_getter,
+        )
+        with self._session.lock:
+            if self._session.connection_session_epoch != baseline_epoch:
+                canonical_state = self._canonical_connection_state_locked()
+                is_closing = probed_is_closing or self._session.closed or (
+                    canonical_state == ConnectionState.DISCONNECTING
+                )
+                return False, is_closing
+            return self._revalidate_connected_client_status_locked(
                 client,
-                is_closing_getter=is_closing_getter,
-                state_connected_getter=state_connected_getter,
-                client_connected_getter=client_connected_getter,
+                probed_owned=probed_owned,
+                probed_is_closing=probed_is_closing,
+                enforce_canonical_state=(
+                    is_closing_getter is None
+                    and state_connected_getter is None
+                    and client_connected_getter is None
+                ),
             )
 
     def _verify_ownership_snapshot(
@@ -237,7 +336,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         connection_alias_key : str | None
             Alias gate key used during connect orchestration.
         get_connected_client_status_locked : Callable[[BLEClient], tuple[bool, bool]] | None, optional
-            Optional lock-held ownership/closing probe.
+            Historical ownership/closing status provider. It is invoked without the shared session lock and revalidated under that lock.
 
         Returns
         -------
@@ -245,6 +344,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
             Snapshot used to decide whether connected publication is still safe.
         """
         iface = self._iface
+        enforce_canonical_state = get_connected_client_status_locked is None
         get_connected_status_locked = (
             get_connected_client_status_locked
             or self._get_connected_client_status_locked
@@ -253,8 +353,17 @@ class BLEConnectionOwnershipLifecycleCoordinator:
             connected_device_key,
             connection_alias_key,
         )
+        probed_owned, probed_is_closing, expected_epoch = self._probe_status_provider(
+            connected_client, get_connected_status_locked
+        )
         with self._session.lock:
-            still_owned, is_closing = get_connected_status_locked(connected_client)
+            still_owned, is_closing = self._revalidate_status_probe_locked(
+                connected_client,
+                probed_owned=probed_owned,
+                probed_is_closing=probed_is_closing,
+                expected_epoch=expected_epoch,
+                enforce_canonical_state=enforce_canonical_state,
+            )
             prior_ever_connected = self._has_ever_connected_session()
         return _OwnershipSnapshot(
             still_owned=still_owned,
@@ -583,7 +692,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         verify_ownership_snapshot : Callable[[BLEClient, str | None, str | None], _OwnershipSnapshot] | None, optional
             Optional snapshot provider override.
         get_connected_client_status_locked : Callable[[BLEClient], tuple[bool, bool]] | None, optional
-            Optional lock-held ownership probe override.
+            Historical ownership status-provider override. It is invoked without the shared session lock and revalidated before mutation.
 
         Returns
         -------
@@ -611,6 +720,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                 get_connected_client_status_locked=get_connected_client_status_locked,
             )
         )
+        enforce_canonical_state = get_connected_client_status_locked is None
         get_connected_status_locked = (
             get_connected_client_status_locked
             or self._get_connected_client_status_locked
@@ -632,8 +742,17 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         should_publish_connected = False
         publish_claimed = False
         duplicate_publish_request = False
+        probed_owned, probed_is_closing, expected_epoch = self._probe_status_provider(
+            connected_client, get_connected_status_locked
+        )
         with self._session.lock:
-            still_owned, is_closing = get_connected_status_locked(connected_client)
+            still_owned, is_closing = self._revalidate_status_probe_locked(
+                connected_client,
+                probed_owned=probed_owned,
+                probed_is_closing=probed_is_closing,
+                expected_epoch=expected_epoch,
+                enforce_canonical_state=enforce_canonical_state,
+            )
             if still_owned and not is_closing:
                 publish_pending = self._session.client_publish_pending
                 inflight_client = self._session.connected_publish_inflight_client
@@ -667,8 +786,17 @@ class BLEConnectionOwnershipLifecycleCoordinator:
             _raise_invalidated(snapshot)
         publish_committed = False
         if should_publish_connected:
+            probed_owned, probed_is_closing, expected_epoch = self._probe_status_provider(
+                connected_client, get_connected_status_locked
+            )
             with self._session.lock:
-                still_owned, is_closing = get_connected_status_locked(connected_client)
+                still_owned, is_closing = self._revalidate_status_probe_locked(
+                    connected_client,
+                    probed_owned=probed_owned,
+                    probed_is_closing=probed_is_closing,
+                    expected_epoch=expected_epoch,
+                    enforce_canonical_state=enforce_canonical_state,
+                )
                 if (
                     publish_claimed
                     and snapshot.still_owned
@@ -685,6 +813,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                     connection_alias_key=connection_alias_key,
                     snapshot_provider=snapshot_provider,
                     get_connected_status_locked=get_connected_status_locked,
+                    enforce_canonical_state=enforce_canonical_state,
                     prior_ever_connected=prior_ever_connected,
                     raise_invalidated=_raise_invalidated,
                 )
@@ -711,6 +840,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
             ["BLEClient", str | None, str | None], _OwnershipSnapshot
         ],
         get_connected_status_locked: Callable[["BLEClient"], tuple[bool, bool]],
+        enforce_canonical_state: bool,
         prior_ever_connected: bool,
         raise_invalidated: Callable[[_OwnershipSnapshot], None],
     ) -> None:
@@ -727,7 +857,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         snapshot_provider : Callable[[BLEClient, str | None, str | None], _OwnershipSnapshot]
             Provider used for ownership snapshot verification.
         get_connected_status_locked : Callable[[BLEClient], tuple[bool, bool]]
-            Lock-held ownership/closing status probe.
+            Ownership/closing status provider invoked outside the shared session lock.
         prior_ever_connected : bool
             Prior session publication marker used for reconnect side effects.
         raise_invalidated : Callable[[_OwnershipSnapshot], None]
@@ -823,8 +953,18 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                     self._session.client_publish_pending = False
                     if publish_completed:
                         self._session.client_replacement_pending = False
-                still_owned_after, is_closing_after = get_connected_status_locked(
-                    connected_client
+            probed_owned, probed_is_closing, expected_epoch = self._probe_status_provider(
+                connected_client, get_connected_status_locked
+            )
+            with self._session.lock:
+                still_owned_after, is_closing_after = (
+                    self._revalidate_status_probe_locked(
+                        connected_client,
+                        probed_owned=probed_owned,
+                        probed_is_closing=probed_is_closing,
+                        expected_epoch=expected_epoch,
+                        enforce_canonical_state=enforce_canonical_state,
+                    )
                 )
                 disconnect_notified = self._session.disconnect_notified
         if (
@@ -869,7 +1009,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         get_connected_client_status : Callable[[BLEClient], tuple[bool, bool]] | None, optional
             Optional unlocked ownership probe override.
         get_connected_client_status_locked : Callable[[BLEClient], tuple[bool, bool]] | None, optional
-            Optional lock-held ownership probe override.
+            Historical ownership status-provider override. It is invoked without the shared session lock and revalidated before mutation.
 
         Returns
         -------
@@ -878,6 +1018,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         """
         iface = self._iface
         get_status = get_connected_client_status or self._get_connected_client_status
+        enforce_canonical_state = get_connected_client_status_locked is None
         get_status_locked = (
             get_connected_client_status_locked
             or self._get_connected_client_status_locked
@@ -886,8 +1027,17 @@ class BLEConnectionOwnershipLifecycleCoordinator:
 
         if still_active:
             should_clear_gate_keys = False
+            probed_owned, probed_is_closing, expected_epoch = self._probe_status_provider(
+                connected_client, get_status_locked
+            )
             with self._session.lock:
-                still_active, is_closing = get_status_locked(connected_client)
+                still_active, is_closing = self._revalidate_status_probe_locked(
+                    connected_client,
+                    probed_owned=probed_owned,
+                    probed_is_closing=probed_is_closing,
+                    expected_epoch=expected_epoch,
+                    enforce_canonical_state=enforce_canonical_state,
+                )
                 if still_active:
                     self._session.connection_alias_key = connection_alias_key
                 else:
@@ -913,10 +1063,18 @@ class BLEConnectionOwnershipLifecycleCoordinator:
             )
             needs_cleanup = False
             should_clear_gate_keys = False
+            probed_owned, probed_is_closing, expected_epoch = self._probe_status_provider(
+                connected_client, get_status_locked
+            )
             with self._session.lock:
-                still_active, is_closing = get_status_locked(connected_client)
+                still_active, is_closing = self._revalidate_status_probe_locked(
+                    connected_client,
+                    probed_owned=probed_owned,
+                    probed_is_closing=probed_is_closing,
+                    expected_epoch=expected_epoch,
+                    enforce_canonical_state=enforce_canonical_state,
+                )
                 if not still_active:
-                    self._log_gate_cleanup(connected_client, is_closing=is_closing)
                     active_client = iface.client
                     owns_alias = (
                         self._session.connection_alias_key == connection_alias_key
@@ -927,10 +1085,12 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                     if should_clear_gate_keys:
                         self._session.connection_alias_key = None
                     needs_cleanup = True
-            if needs_cleanup and should_clear_gate_keys:
-                iface._mark_address_keys_disconnected(
-                    connected_device_key, connection_alias_key
-                )
+            if needs_cleanup:
+                self._log_gate_cleanup(connected_client, is_closing=is_closing)
+                if should_clear_gate_keys:
+                    iface._mark_address_keys_disconnected(
+                        connected_device_key, connection_alias_key
+                    )
         elif is_closing:
             logger.debug(
                 "Skipping connect gate marking during shutdown for stale client result (%s).",

--- a/meshtastic/interfaces/ble/lifecycle_ownership_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_ownership_runtime.py
@@ -264,7 +264,13 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         )
 
     def _has_ever_connected_session(self) -> bool:
-        """Return `True` when this interface published a connection."""
+        """Return ``True`` when this interface published a connection.
+
+        Notes
+        -----
+        This method must not acquire ``self._session.lock``. Callers such as
+        ``_verify_ownership_snapshot`` invoke it while already holding that lock.
+        """
         return self._session.ever_connected is True
 
     def _emit_verified_connection_side_effects(

--- a/meshtastic/interfaces/ble/lifecycle_ownership_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_ownership_runtime.py
@@ -10,6 +10,10 @@ from meshtastic.interfaces.ble.compat_adapter import (
     _iter_declared_members,
 )
 from meshtastic.interfaces.ble.constants import RECONNECTED_EVENT, logger
+from meshtastic.interfaces.ble.failure_policy import (
+    _BLEFailureDisposition,
+    _log_ble_failure,
+)
 from meshtastic.interfaces.ble.lifecycle_primitives import (
     _LifecycleErrorAccess,
     _LifecycleStateAccess,
@@ -160,6 +164,11 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                 try:
                     result = member()
                 except Exception:  # noqa: BLE001 - probe remains best effort
+                    _log_ble_failure(
+                        _BLEFailureDisposition.COMPATIBILITY_FALLBACK,
+                        "Error probing ownership member %s()",
+                        _member_name,
+                    )
                     continue
             else:
                 result = member

--- a/meshtastic/interfaces/ble/lifecycle_ownership_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_ownership_runtime.py
@@ -14,8 +14,6 @@ from meshtastic.interfaces.ble.lifecycle_primitives import (
 )
 from meshtastic.interfaces.ble.state import ConnectionState
 from meshtastic.interfaces.ble.utils import (
-    _is_unconfigured_mock_callable,
-    _is_unconfigured_mock_member,
     sanitize_address,
 )
 
@@ -157,7 +155,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
             return False
         for member_name in member_names:
             member = getattr(owner, member_name, None)
-            if callable(member) and not _is_unconfigured_mock_callable(member):
+            if callable(member):
                 try:
                     result = member()
                 except Exception:  # noqa: BLE001 - probe remains best effort
@@ -165,7 +163,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                 if isinstance(result, bool):
                     return result
                 continue
-            if isinstance(member, bool) and not _is_unconfigured_mock_member(member):
+            if isinstance(member, bool):
                 return member
         return False
 
@@ -251,11 +249,8 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         )
 
     def _has_ever_connected_session(self) -> bool:
-        """Return mock-safe `True` when this interface published a connection."""
-        raw_ever_connected = getattr(self._iface, "_ever_connected", False)
-        if _is_unconfigured_mock_member(raw_ever_connected):
-            return False
-        return raw_ever_connected is True
+        """Return `True` when this interface published a connection."""
+        return self._session.ever_connected is True
 
     def _emit_verified_connection_side_effects(
         self, connected_client: "BLEClient"

--- a/meshtastic/interfaces/ble/lifecycle_ownership_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_ownership_runtime.py
@@ -320,7 +320,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
     def _apply_owned_client_invalidation(
         self,
         *,
-        get_is_closing: Callable[[], bool],
+        compatibility_is_closing: bool,
         restored_address: str | None,
         restore_last_connection_request: str | None,
     ) -> tuple[bool, bool, bool]:
@@ -339,7 +339,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         iface = self._iface
         replacement_pending = bool(self._session.client_replacement_pending)
         already_notified = bool(self._session.disconnect_notified)
-        is_closing = get_is_closing() or self._session.closed
+        is_closing = compatibility_is_closing or self._session.closed
         iface.client = None
         self._session.client_publish_pending = False
         self._session.client_replacement_pending = False
@@ -356,7 +356,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
     def _apply_publish_pending_invalidation(
         self,
         *,
-        get_is_closing: Callable[[], bool],
+        compatibility_is_closing: bool,
         restored_address: str | None,
         restore_last_connection_request: str | None,
     ) -> tuple[bool, bool, bool]:
@@ -376,7 +376,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         should_publish_disconnect = replacement_pending and not already_notified
         if should_publish_disconnect:
             self._session.disconnect_notified = True
-        is_closing = get_is_closing() or self._session.closed
+        is_closing = compatibility_is_closing or self._session.closed
         if not is_closing:
             iface.address = restored_address
             iface._last_connection_request = restore_last_connection_request
@@ -488,6 +488,14 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         is_closing = False
         disconnect_session_epoch = 0
         with self._session.lock:
+            session_already_closed = self._session.closed
+        # Compatibility probes can execute caller-owned code. Run the probe
+        # outside the shared session lock, and avoid it entirely after the
+        # terminal closed flag is already authoritative.
+        compatibility_is_closing = (
+            True if session_already_closed else get_is_closing()
+        )
+        with self._session.lock:
             disconnect_session_epoch = self._session.connection_session_epoch
             inflight_client = self._session.connected_publish_inflight_client
             if iface.client is client:
@@ -498,7 +506,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                     should_publish_disconnect,
                     is_closing,
                 ) = self._apply_owned_client_invalidation(
-                    get_is_closing=get_is_closing,
+                    compatibility_is_closing=compatibility_is_closing,
                     restored_address=restored_address,
                     restore_last_connection_request=restore_last_connection_request,
                 )
@@ -513,7 +521,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                     should_publish_disconnect,
                     is_closing,
                 ) = self._apply_publish_pending_invalidation(
-                    get_is_closing=get_is_closing,
+                    compatibility_is_closing=compatibility_is_closing,
                     restored_address=restored_address,
                     restore_last_connection_request=restore_last_connection_request,
                 )

--- a/meshtastic/interfaces/ble/lifecycle_primitives.py
+++ b/meshtastic/interfaces/ble/lifecycle_primitives.py
@@ -11,6 +11,10 @@ from meshtastic.interfaces.ble.compat_adapter import (
     _resolve_declared_callable,
 )
 from meshtastic.interfaces.ble.constants import logger
+from meshtastic.interfaces.ble.failure_policy import (
+    _BLEFailureDisposition,
+    _log_ble_failure,
+)
 from meshtastic.interfaces.ble.coordination import ThreadLike
 from meshtastic.interfaces.ble.ports import _BLEStateManagerPort
 from meshtastic.interfaces.ble.state import ConnectionState
@@ -78,10 +82,10 @@ def _client_is_connected_compat(client: "BLEClient") -> bool:
             try:
                 connected = candidate()
             except Exception:  # noqa: BLE001 - connectivity probes stay best effort
-                logger.debug(
+                _log_ble_failure(
+                    _BLEFailureDisposition.COMPATIBILITY_FALLBACK,
                     "Error probing BLE client connectivity via %s",
                     candidate_name,
-                    exc_info=True,
                 )
                 continue
         else:
@@ -111,10 +115,10 @@ class _LifecycleStateAccess:
                 try:
                     result = candidate()
                 except Exception:  # noqa: BLE001 - compatibility probe must fall through
-                    logger.debug(
+                    _log_ble_failure(
+                        _BLEFailureDisposition.COMPATIBILITY_FALLBACK,
                         "Error probing state manager %s()",
                         member_name,
-                        exc_info=True,
                     )
                     continue
             else:
@@ -133,10 +137,10 @@ class _LifecycleStateAccess:
             try:
                 result = candidate(*args)
             except Exception:  # noqa: BLE001 - compatibility probe must fall through
-                logger.debug(
+                _log_ble_failure(
+                    _BLEFailureDisposition.COMPATIBILITY_FALLBACK,
                     "Error calling state manager %s()",
                     member_name,
-                    exc_info=True,
                 )
                 continue
             if isinstance(result, bool):
@@ -236,10 +240,10 @@ class _LifecycleThreadAccess:
             try:
                 hook(*args, **kwargs)
             except Exception:  # noqa: BLE001 - non-critical lifecycle hook
-                logger.debug(
+                _log_ble_failure(
+                    _BLEFailureDisposition.BEST_EFFORT,
                     "Error in thread_coordinator.%s",
                     member_name,
-                    exc_info=True,
                 )
                 continue
             return True
@@ -282,7 +286,11 @@ class _LifecycleThreadAccess:
             try:
                 thread_join(timeout=timeout)
             except Exception:  # noqa: BLE001 - non-critical join stays best effort
-                logger.debug("Error in thread.join for %r", thread, exc_info=True)
+                _log_ble_failure(
+                    _BLEFailureDisposition.BEST_EFFORT,
+                    "Error in thread.join for %r",
+                    thread,
+                )
             return
         logger.debug("Thread coordinator is missing join_thread/_join_thread")
 
@@ -318,11 +326,11 @@ class _LifecycleThreadAccess:
                 try:
                     set_event(event_name)
                 except Exception:  # noqa: BLE001 - non-critical wake stays best effort
-                    logger.debug(
+                    _log_ble_failure(
+                        _BLEFailureDisposition.BEST_EFFORT,
                         "Error in thread_coordinator.%s fallback for %s",
                         member_name,
                         event_name,
-                        exc_info=True,
                     )
                     failed.append(event_name)
             if not failed:
@@ -378,17 +386,21 @@ class _LifecycleErrorAccess:
                 if cleanup_ran or bool(hook_result):
                     return
             except Exception:  # noqa: BLE001 - hook failure must not abort shutdown
-                logger.debug(
+                _log_ble_failure(
+                    _BLEFailureDisposition.BEST_EFFORT,
                     "Error running safe_cleanup hook for %s",
                     operation_name,
-                    exc_info=True,
                 )
                 if cleanup_ran:
                     return
         try:
             cleanup()
         except Exception:  # noqa: BLE001 - shutdown cleanup must remain best effort
-            logger.debug("Error during %s", operation_name, exc_info=True)
+            _log_ble_failure(
+                _BLEFailureDisposition.BEST_EFFORT,
+                "Error during %s",
+                operation_name,
+            )
 
     @staticmethod
     def _try_safe_execute_variants(
@@ -409,7 +421,10 @@ class _LifecycleErrorAccess:
             return did_run(), result
         except TypeError as exc:
             if not _is_unexpected_keyword_error(exc, "error_msg"):
-                logger.debug(error_msg, exc_info=True)
+                _log_ble_failure(
+                _BLEFailureDisposition.BEST_EFFORT,
+                error_msg,
+            )
                 return did_run(), None
             if did_run():
                 return True, None
@@ -418,7 +433,10 @@ class _LifecycleErrorAccess:
                 if did_run():
                     return True, result
             except Exception:  # noqa: BLE001 - hook failures must not abort shutdown
-                logger.debug(error_msg, exc_info=True)
+                _log_ble_failure(
+                _BLEFailureDisposition.BEST_EFFORT,
+                error_msg,
+            )
                 if did_run():
                     return True, None
             try:
@@ -426,11 +444,17 @@ class _LifecycleErrorAccess:
                 if did_run():
                     return True, result
             except Exception:  # noqa: BLE001 - hook failures must not abort shutdown
-                logger.debug(error_msg, exc_info=True)
+                _log_ble_failure(
+                _BLEFailureDisposition.BEST_EFFORT,
+                error_msg,
+            )
                 if did_run():
                     return True, None
         except Exception:  # noqa: BLE001 - hook failures must not abort shutdown
-            logger.debug(error_msg, exc_info=True)
+            _log_ble_failure(
+                _BLEFailureDisposition.BEST_EFFORT,
+                error_msg,
+            )
             if did_run():
                 return True, None
         return False, None
@@ -462,5 +486,8 @@ class _LifecycleErrorAccess:
         try:
             return func()
         except Exception:  # noqa: BLE001 - shutdown execution must remain best effort
-            logger.debug(error_msg, exc_info=True)
+            _log_ble_failure(
+                _BLEFailureDisposition.BEST_EFFORT,
+                error_msg,
+            )
             return None

--- a/meshtastic/interfaces/ble/lifecycle_primitives.py
+++ b/meshtastic/interfaces/ble/lifecycle_primitives.py
@@ -11,11 +11,11 @@ from meshtastic.interfaces.ble.compat_adapter import (
     _resolve_declared_callable,
 )
 from meshtastic.interfaces.ble.constants import logger
+from meshtastic.interfaces.ble.coordination import ThreadLike
 from meshtastic.interfaces.ble.failure_policy import (
     _BLEFailureDisposition,
     _log_ble_failure,
 )
-from meshtastic.interfaces.ble.coordination import ThreadLike
 from meshtastic.interfaces.ble.ports import _BLEStateManagerPort
 from meshtastic.interfaces.ble.state import ConnectionState
 from meshtastic.interfaces.ble.utils import (
@@ -27,6 +27,10 @@ if TYPE_CHECKING:
     from meshtastic.interfaces.ble.interface import BLEInterface
 
 THREAD_COORDINATOR_MISSING_FMT = "Thread coordinator is missing %s/%s"
+THREAD_COORDINATOR_MISSING_WAKE_MSG = (
+    "Thread coordinator is missing "
+    "wake_waiting_threads/_wake_waiting_threads/set_event/_set_event"
+)
 RECONNECT_SCHEDULER_MISSING_MSG = (
     "Reconnect scheduler is missing schedule_reconnect/_schedule_reconnect"
 )
@@ -114,7 +118,9 @@ class _LifecycleStateAccess:
             if callable(candidate):
                 try:
                     result = candidate()
-                except Exception:  # noqa: BLE001 - compatibility probe must fall through
+                except (
+                    Exception
+                ):  # noqa: BLE001 - compatibility probe must fall through
                     _log_ble_failure(
                         _BLEFailureDisposition.COMPATIBILITY_FALLBACK,
                         "Error probing state manager %s()",
@@ -214,9 +220,7 @@ class _LifecycleThreadAccess:
     ) -> Callable[..., object]:
         """Resolve a required current/legacy coordinator callable."""
         coordinator = self._coordinator()
-        resolved = _resolve_declared_callable(
-            coordinator, public_name, legacy_name
-        )
+        resolved = _resolve_declared_callable(coordinator, public_name, legacy_name)
         if resolved is None:
             raise AttributeError(
                 THREAD_COORDINATOR_MISSING_FMT % (public_name, legacy_name)
@@ -292,25 +296,25 @@ class _LifecycleThreadAccess:
                     thread,
                 )
             return
-        logger.debug("Thread coordinator is missing join_thread/_join_thread")
+        logger.debug(THREAD_COORDINATOR_MISSING_FMT, "join_thread", "_join_thread")
 
     def set_event(self, event_name: str) -> None:
         """Set a coordinator event using current/legacy hooks."""
         if not self._best_effort_call("set_event", "_set_event", event_name):
-            logger.debug("Thread coordinator is missing set_event/_set_event")
+            logger.debug(THREAD_COORDINATOR_MISSING_FMT, "set_event", "_set_event")
 
     def clear_events(self, *event_names: str) -> None:
         """Clear coordinator events using current/legacy hooks."""
         if not self._best_effort_call("clear_events", "_clear_events", *event_names):
-            logger.debug("Thread coordinator is missing clear_events/_clear_events")
+            logger.debug(
+                THREAD_COORDINATOR_MISSING_FMT, "clear_events", "_clear_events"
+            )
 
     def wake_waiting_threads(self, *event_names: str) -> None:
         """Wake waiters with bulk hooks, then fall back to per-event hooks."""
         coordinator = self._coordinator()
         if coordinator is None:
-            logger.debug(
-                "Thread coordinator is missing wake_waiting_threads/_wake_waiting_threads/set_event/_set_event"
-            )
+            logger.debug(THREAD_COORDINATOR_MISSING_WAKE_MSG)
             return
         if self._best_effort_call(
             "wake_waiting_threads", "_wake_waiting_threads", *event_names
@@ -336,9 +340,7 @@ class _LifecycleThreadAccess:
             if not failed:
                 return
             remaining = failed
-        logger.debug(
-            "Thread coordinator is missing wake_waiting_threads/_wake_waiting_threads/set_event/_set_event"
-        )
+        logger.debug(THREAD_COORDINATOR_MISSING_WAKE_MSG)
 
 
 class _LifecycleErrorAccess:

--- a/meshtastic/interfaces/ble/lifecycle_primitives.py
+++ b/meshtastic/interfaces/ble/lifecycle_primitives.py
@@ -207,7 +207,7 @@ class _LifecycleThreadAccess:
     to legacy hook names before logging a missing-hook message.
     """
 
-    def __init__(self, iface: "BLEInterface") -> None:
+    def __init__(self, iface: "BLEInterface | object") -> None:
         """Bind thread-coordinator access to a specific interface."""
         self._iface = iface
 

--- a/meshtastic/interfaces/ble/lifecycle_primitives.py
+++ b/meshtastic/interfaces/ble/lifecycle_primitives.py
@@ -9,8 +9,7 @@ from meshtastic.interfaces.ble.coordination import ThreadLike
 from meshtastic.interfaces.ble.ports import _BLEStateManagerPort
 from meshtastic.interfaces.ble.state import ConnectionState
 from meshtastic.interfaces.ble.utils import (
-    _is_unconfigured_mock_callable,
-    _is_unconfigured_mock_member,
+    _get_declared_member,
     _is_unexpected_keyword_error,
 )
 
@@ -68,10 +67,8 @@ class _OwnershipSnapshot:
 def _client_is_connected_compat(client: "BLEClient") -> bool:
     """Return connected-state flag from public/legacy BLEClient members."""
     for candidate_name in ("isConnected", "is_connected", "_is_connected"):
-        candidate = getattr(client, candidate_name, None)
+        candidate = _get_declared_member(client, candidate_name)
         if callable(candidate):
-            if _is_unconfigured_mock_callable(candidate):
-                continue
             try:
                 connected = candidate()
             except Exception:  # noqa: BLE001 - connectivity probes stay best effort
@@ -84,7 +81,7 @@ def _client_is_connected_compat(client: "BLEClient") -> bool:
             if isinstance(connected, bool):
                 return connected
             continue
-        if isinstance(candidate, bool) and not _is_unconfigured_mock_member(candidate):
+        if isinstance(candidate, bool):
             return candidate
     raise AttributeError(CLIENT_MISSING_CONNECTED_MSG)
 
@@ -98,10 +95,8 @@ class _LifecycleStateAccess:
 
     def is_connected(self) -> bool:
         """Return connected-state flag from public-first state-manager members."""
-        public_is_connected = getattr(self._state_manager, "is_connected", None)
-        if callable(public_is_connected) and not _is_unconfigured_mock_callable(
-            public_is_connected
-        ):
+        public_is_connected = _get_declared_member(self._state_manager, "is_connected")
+        if callable(public_is_connected):
             try:
                 result = public_is_connected()
             except Exception:  # noqa: BLE001 - compatibility probe must fall through
@@ -112,14 +107,12 @@ class _LifecycleStateAccess:
             else:
                 if isinstance(result, bool):
                     return result
-        if not _is_unconfigured_mock_member(public_is_connected) and isinstance(
+        if isinstance(
             public_is_connected, bool
         ):
             return public_is_connected
-        legacy_is_connected = getattr(self._state_manager, "_is_connected", None)
-        if callable(legacy_is_connected) and not _is_unconfigured_mock_callable(
-            legacy_is_connected
-        ):
+        legacy_is_connected = _get_declared_member(self._state_manager, "_is_connected")
+        if callable(legacy_is_connected):
             try:
                 result = legacy_is_connected()
             except Exception:  # noqa: BLE001 - compatibility probe must fall through
@@ -130,7 +123,7 @@ class _LifecycleStateAccess:
             else:
                 if isinstance(result, bool):
                     return result
-        if not _is_unconfigured_mock_member(legacy_is_connected) and isinstance(
+        if isinstance(
             legacy_is_connected, bool
         ):
             return legacy_is_connected
@@ -138,8 +131,8 @@ class _LifecycleStateAccess:
 
     def current_state(self) -> ConnectionState:
         """Return current connection state from public-first state-manager members."""
-        public_state = getattr(self._state_manager, "current_state", None)
-        if callable(public_state) and not _is_unconfigured_mock_callable(public_state):
+        public_state = _get_declared_member(self._state_manager, "current_state")
+        if callable(public_state):
             try:
                 result = public_state()
             except Exception:  # noqa: BLE001 - compatibility probe must fall through
@@ -150,12 +143,12 @@ class _LifecycleStateAccess:
             else:
                 if isinstance(result, ConnectionState):
                     return result
-        if not _is_unconfigured_mock_member(public_state) and isinstance(
+        if isinstance(
             public_state, ConnectionState
         ):
             return public_state
-        legacy_state = getattr(self._state_manager, "_current_state", None)
-        if callable(legacy_state) and not _is_unconfigured_mock_callable(legacy_state):
+        legacy_state = _get_declared_member(self._state_manager, "_current_state")
+        if callable(legacy_state):
             try:
                 result = legacy_state()
             except Exception:  # noqa: BLE001 - compatibility probe must fall through
@@ -166,7 +159,7 @@ class _LifecycleStateAccess:
             else:
                 if isinstance(result, ConnectionState):
                     return result
-        if not _is_unconfigured_mock_member(legacy_state) and isinstance(
+        if isinstance(
             legacy_state, ConnectionState
         ):
             return legacy_state
@@ -174,10 +167,8 @@ class _LifecycleStateAccess:
 
     def transition_to(self, new_state: ConnectionState) -> bool:
         """Transition state manager using public-first compatibility dispatch."""
-        public_transition = getattr(self._state_manager, "transition_to", None)
-        if callable(public_transition) and not _is_unconfigured_mock_callable(
-            public_transition
-        ):
+        public_transition = _get_declared_member(self._state_manager, "transition_to")
+        if callable(public_transition):
             try:
                 result = public_transition(new_state)
             except Exception:  # noqa: BLE001 - compatibility probe must fall through
@@ -188,10 +179,8 @@ class _LifecycleStateAccess:
             else:
                 if isinstance(result, bool):
                     return result
-        legacy_transition = getattr(self._state_manager, "_transition_to", None)
-        if callable(legacy_transition) and not _is_unconfigured_mock_callable(
-            legacy_transition
-        ):
+        legacy_transition = _get_declared_member(self._state_manager, "_transition_to")
+        if callable(legacy_transition):
             try:
                 result = legacy_transition(new_state)
             except Exception:  # noqa: BLE001 - compatibility probe must fall through
@@ -209,7 +198,7 @@ class _LifecycleStateAccess:
         public_reset = getattr(
             self._state_manager, "reset_to_disconnected", None
         )
-        if callable(public_reset) and not _is_unconfigured_mock_callable(public_reset):
+        if callable(public_reset):
             try:
                 result = public_reset()
             except Exception:  # noqa: BLE001 - compatibility probe must fall through
@@ -223,7 +212,7 @@ class _LifecycleStateAccess:
         legacy_reset = getattr(
             self._state_manager, "_reset_to_disconnected", None
         )
-        if callable(legacy_reset) and not _is_unconfigured_mock_callable(legacy_reset):
+        if callable(legacy_reset):
             try:
                 result = legacy_reset()
             except Exception:  # noqa: BLE001 - compatibility probe must fall through
@@ -238,10 +227,8 @@ class _LifecycleStateAccess:
 
     def is_closing(self) -> bool:
         """Return closing-state flag from public-first state-manager members."""
-        public_is_closing = getattr(self._state_manager, "is_closing", None)
-        if callable(public_is_closing) and not _is_unconfigured_mock_callable(
-            public_is_closing
-        ):
+        public_is_closing = _get_declared_member(self._state_manager, "is_closing")
+        if callable(public_is_closing):
             try:
                 result = public_is_closing()
             except Exception:  # noqa: BLE001 - compatibility probe must fall through
@@ -252,14 +239,12 @@ class _LifecycleStateAccess:
             else:
                 if isinstance(result, bool):
                     return result
-        if not _is_unconfigured_mock_member(public_is_closing) and isinstance(
+        if isinstance(
             public_is_closing, bool
         ):
             return public_is_closing
-        legacy_is_closing = getattr(self._state_manager, "_is_closing", None)
-        if callable(legacy_is_closing) and not _is_unconfigured_mock_callable(
-            legacy_is_closing
-        ):
+        legacy_is_closing = _get_declared_member(self._state_manager, "_is_closing")
+        if callable(legacy_is_closing):
             try:
                 result = legacy_is_closing()
             except Exception:  # noqa: BLE001 - compatibility probe must fall through
@@ -270,7 +255,7 @@ class _LifecycleStateAccess:
             else:
                 if isinstance(result, bool):
                     return result
-        if not _is_unconfigured_mock_member(legacy_is_closing) and isinstance(
+        if isinstance(
             legacy_is_closing, bool
         ):
             return legacy_is_closing
@@ -306,15 +291,13 @@ class _LifecycleThreadAccess:
         kwargs: dict[str, object] | None = None,
     ) -> ThreadLike:
         """Create thread via public-first coordinator compatibility dispatch."""
-        coordinator = getattr(self._iface, "thread_coordinator", None)
-        if coordinator is None or _is_unconfigured_mock_member(coordinator):
+        coordinator = _get_declared_member(self._iface, "thread_coordinator")
+        if coordinator is None:
             raise AttributeError(
                 THREAD_COORDINATOR_MISSING_FMT % ("create_thread", "_create_thread")
             )
-        create_thread = getattr(coordinator, "create_thread", None)
-        if callable(create_thread) and not _is_unconfigured_mock_callable(
-            create_thread
-        ):
+        create_thread = _get_declared_member(coordinator, "create_thread")
+        if callable(create_thread):
             return cast(
                 ThreadLike,
                 create_thread(
@@ -325,10 +308,8 @@ class _LifecycleThreadAccess:
                     kwargs=kwargs,
                 ),
             )
-        legacy_create_thread = getattr(coordinator, "_create_thread", None)
-        if callable(legacy_create_thread) and not _is_unconfigured_mock_callable(
-            legacy_create_thread
-        ):
+        legacy_create_thread = _get_declared_member(coordinator, "_create_thread")
+        if callable(legacy_create_thread):
             return cast(
                 ThreadLike,
                 legacy_create_thread(
@@ -345,19 +326,17 @@ class _LifecycleThreadAccess:
 
     def start_thread(self, thread: object) -> None:
         """Start thread via public-first coordinator compatibility dispatch."""
-        coordinator = getattr(self._iface, "thread_coordinator", None)
-        if coordinator is None or _is_unconfigured_mock_member(coordinator):
+        coordinator = _get_declared_member(self._iface, "thread_coordinator")
+        if coordinator is None:
             raise AttributeError(
                 THREAD_COORDINATOR_MISSING_FMT % ("start_thread", "_start_thread")
             )
-        start_thread = getattr(coordinator, "start_thread", None)
-        if callable(start_thread) and not _is_unconfigured_mock_callable(start_thread):
+        start_thread = _get_declared_member(coordinator, "start_thread")
+        if callable(start_thread):
             start_thread(thread)
             return
-        legacy_start_thread = getattr(coordinator, "_start_thread", None)
-        if callable(legacy_start_thread) and not _is_unconfigured_mock_callable(
-            legacy_start_thread
-        ):
+        legacy_start_thread = _get_declared_member(coordinator, "_start_thread")
+        if callable(legacy_start_thread):
             legacy_start_thread(thread)
             return
         raise AttributeError(
@@ -366,14 +345,12 @@ class _LifecycleThreadAccess:
 
     def join_thread(self, thread: object, *, timeout: float | None) -> None:
         """Join thread via public-first coordinator compatibility dispatch."""
-        coordinator = getattr(self._iface, "thread_coordinator", None)
-        if coordinator is None or _is_unconfigured_mock_member(coordinator):
+        coordinator = _get_declared_member(self._iface, "thread_coordinator")
+        if coordinator is None:
             logger.debug("Thread coordinator is missing join_thread/_join_thread")
         else:
-            join_thread = getattr(coordinator, "join_thread", None)
-            if callable(join_thread) and not _is_unconfigured_mock_callable(
-                join_thread
-            ):
+            join_thread = _get_declared_member(coordinator, "join_thread")
+            if callable(join_thread):
                 try:
                     join_thread(thread, timeout=timeout)
                 except Exception:  # noqa: BLE001 - non-critical join stays best effort
@@ -384,10 +361,8 @@ class _LifecycleThreadAccess:
                     )
                 else:
                     return
-            legacy_join_thread = getattr(coordinator, "_join_thread", None)
-            if callable(legacy_join_thread) and not _is_unconfigured_mock_callable(
-                legacy_join_thread
-            ):
+            legacy_join_thread = _get_declared_member(coordinator, "_join_thread")
+            if callable(legacy_join_thread):
                 try:
                     legacy_join_thread(thread, timeout=timeout)
                 except Exception:  # noqa: BLE001 - non-critical join stays best effort
@@ -399,7 +374,7 @@ class _LifecycleThreadAccess:
                 else:
                     return
         thread_join = getattr(thread, "join", None)
-        if callable(thread_join) and not _is_unconfigured_mock_callable(thread_join):
+        if callable(thread_join):
             try:
                 thread_join(timeout=timeout)
             except Exception:  # noqa: BLE001 - non-critical join stays best effort
@@ -409,12 +384,12 @@ class _LifecycleThreadAccess:
 
     def set_event(self, event_name: str) -> None:
         """Set event via public-first coordinator compatibility dispatch."""
-        coordinator = getattr(self._iface, "thread_coordinator", None)
-        if coordinator is None or _is_unconfigured_mock_member(coordinator):
+        coordinator = _get_declared_member(self._iface, "thread_coordinator")
+        if coordinator is None:
             logger.debug("Thread coordinator is missing set_event/_set_event")
             return
-        set_event = getattr(coordinator, "set_event", None)
-        if callable(set_event) and not _is_unconfigured_mock_callable(set_event):
+        set_event = _get_declared_member(coordinator, "set_event")
+        if callable(set_event):
             try:
                 set_event(event_name)
             except Exception:  # noqa: BLE001 - non-critical event set stays best effort
@@ -425,10 +400,8 @@ class _LifecycleThreadAccess:
                 )
             else:
                 return
-        legacy_set_event = getattr(coordinator, "_set_event", None)
-        if callable(legacy_set_event) and not _is_unconfigured_mock_callable(
-            legacy_set_event
-        ):
+        legacy_set_event = _get_declared_member(coordinator, "_set_event")
+        if callable(legacy_set_event):
             try:
                 legacy_set_event(event_name)
             except Exception:  # noqa: BLE001 - non-critical event set stays best effort
@@ -443,12 +416,12 @@ class _LifecycleThreadAccess:
 
     def clear_events(self, *event_names: str) -> None:
         """Clear events via public-first coordinator compatibility dispatch."""
-        coordinator = getattr(self._iface, "thread_coordinator", None)
-        if coordinator is None or _is_unconfigured_mock_member(coordinator):
+        coordinator = _get_declared_member(self._iface, "thread_coordinator")
+        if coordinator is None:
             logger.debug("Thread coordinator is missing clear_events/_clear_events")
             return
-        clear_events = getattr(coordinator, "clear_events", None)
-        if callable(clear_events) and not _is_unconfigured_mock_callable(clear_events):
+        clear_events = _get_declared_member(coordinator, "clear_events")
+        if callable(clear_events):
             try:
                 clear_events(*event_names)
             except Exception:  # noqa: BLE001 - non-critical clear stays best effort
@@ -459,10 +432,8 @@ class _LifecycleThreadAccess:
                 )
             else:
                 return
-        legacy_clear_events = getattr(coordinator, "_clear_events", None)
-        if callable(legacy_clear_events) and not _is_unconfigured_mock_callable(
-            legacy_clear_events
-        ):
+        legacy_clear_events = _get_declared_member(coordinator, "_clear_events")
+        if callable(legacy_clear_events):
             try:
                 legacy_clear_events(*event_names)
             except Exception:  # noqa: BLE001 - non-critical clear stays best effort
@@ -477,16 +448,14 @@ class _LifecycleThreadAccess:
 
     def wake_waiting_threads(self, *event_names: str) -> None:
         """Wake waiters via public-first coordinator compatibility dispatch."""
-        coordinator = getattr(self._iface, "thread_coordinator", None)
-        if coordinator is None or _is_unconfigured_mock_member(coordinator):
+        coordinator = _get_declared_member(self._iface, "thread_coordinator")
+        if coordinator is None:
             logger.debug(
                 "Thread coordinator is missing wake_waiting_threads/_wake_waiting_threads/set_event/_set_event"
             )
             return
-        wake_waiting_threads = getattr(coordinator, "wake_waiting_threads", None)
-        if callable(wake_waiting_threads) and not _is_unconfigured_mock_callable(
-            wake_waiting_threads
-        ):
+        wake_waiting_threads = _get_declared_member(coordinator, "wake_waiting_threads")
+        if callable(wake_waiting_threads):
             try:
                 wake_waiting_threads(*event_names)
                 return
@@ -499,9 +468,7 @@ class _LifecycleThreadAccess:
         legacy_wake_waiting_threads = getattr(
             coordinator, "_wake_waiting_threads", None
         )
-        if callable(legacy_wake_waiting_threads) and not _is_unconfigured_mock_callable(
-            legacy_wake_waiting_threads
-        ):
+        if callable(legacy_wake_waiting_threads):
             try:
                 legacy_wake_waiting_threads(*event_names)
                 return
@@ -511,8 +478,8 @@ class _LifecycleThreadAccess:
                     event_names,
                     exc_info=True,
                 )
-        set_event = getattr(coordinator, "set_event", None)
-        if callable(set_event) and not _is_unconfigured_mock_callable(set_event):
+        set_event = _get_declared_member(coordinator, "set_event")
+        if callable(set_event):
             failed_events: list[str] = []
             for event_name in event_names:
                 try:
@@ -527,10 +494,8 @@ class _LifecycleThreadAccess:
             if not failed_events:
                 return
             event_names = tuple(failed_events)
-        legacy_set_event = getattr(coordinator, "_set_event", None)
-        if callable(legacy_set_event) and not _is_unconfigured_mock_callable(
-            legacy_set_event
-        ):
+        legacy_set_event = _get_declared_member(coordinator, "_set_event")
+        if callable(legacy_set_event):
             failed_events = []
             for event_name in event_names:
                 try:
@@ -560,12 +525,12 @@ class _LifecycleErrorAccess:
         self, public_name: str, legacy_name: str
     ) -> Callable[..., object] | None:
         """Resolve an error-handler hook with public-first fallback behavior."""
-        error_handler = getattr(self._iface, "error_handler", None)
-        hook = getattr(error_handler, public_name, None)
-        if callable(hook) and not _is_unconfigured_mock_callable(hook):
+        error_handler = _get_declared_member(self._iface, "error_handler")
+        hook = _get_declared_member(error_handler, public_name)
+        if callable(hook):
             return cast(Callable[..., object], hook)
-        legacy_hook = getattr(error_handler, legacy_name, None)
-        if callable(legacy_hook) and not _is_unconfigured_mock_callable(legacy_hook):
+        legacy_hook = _get_declared_member(error_handler, legacy_name)
+        if callable(legacy_hook):
             return cast(Callable[..., object], legacy_hook)
         return None
 

--- a/meshtastic/interfaces/ble/lifecycle_primitives.py
+++ b/meshtastic/interfaces/ble/lifecycle_primitives.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, cast
 
 from meshtastic.interfaces.ble.constants import logger
 from meshtastic.interfaces.ble.coordination import ThreadLike
+from meshtastic.interfaces.ble.ports import _BLEStateManagerPort
 from meshtastic.interfaces.ble.state import ConnectionState
 from meshtastic.interfaces.ble.utils import (
     _is_unconfigured_mock_callable,
@@ -91,13 +92,13 @@ def _client_is_connected_compat(client: "BLEClient") -> bool:
 class _LifecycleStateAccess:
     """Runtime state-manager access owned by lifecycle collaborators."""
 
-    def __init__(self, iface: "BLEInterface") -> None:
-        """Bind state-manager access to a specific interface."""
-        self._iface = iface
+    def __init__(self, target: _BLEStateManagerPort | object) -> None:
+        """Bind compatibility access to a state manager or legacy interface."""
+        self._state_manager = getattr(target, "_state_manager", target)
 
     def is_connected(self) -> bool:
         """Return connected-state flag from public-first state-manager members."""
-        public_is_connected = getattr(self._iface._state_manager, "is_connected", None)
+        public_is_connected = getattr(self._state_manager, "is_connected", None)
         if callable(public_is_connected) and not _is_unconfigured_mock_callable(
             public_is_connected
         ):
@@ -115,7 +116,7 @@ class _LifecycleStateAccess:
             public_is_connected, bool
         ):
             return public_is_connected
-        legacy_is_connected = getattr(self._iface._state_manager, "_is_connected", None)
+        legacy_is_connected = getattr(self._state_manager, "_is_connected", None)
         if callable(legacy_is_connected) and not _is_unconfigured_mock_callable(
             legacy_is_connected
         ):
@@ -137,7 +138,7 @@ class _LifecycleStateAccess:
 
     def current_state(self) -> ConnectionState:
         """Return current connection state from public-first state-manager members."""
-        public_state = getattr(self._iface._state_manager, "current_state", None)
+        public_state = getattr(self._state_manager, "current_state", None)
         if callable(public_state) and not _is_unconfigured_mock_callable(public_state):
             try:
                 result = public_state()
@@ -153,7 +154,7 @@ class _LifecycleStateAccess:
             public_state, ConnectionState
         ):
             return public_state
-        legacy_state = getattr(self._iface._state_manager, "_current_state", None)
+        legacy_state = getattr(self._state_manager, "_current_state", None)
         if callable(legacy_state) and not _is_unconfigured_mock_callable(legacy_state):
             try:
                 result = legacy_state()
@@ -173,7 +174,7 @@ class _LifecycleStateAccess:
 
     def transition_to(self, new_state: ConnectionState) -> bool:
         """Transition state manager using public-first compatibility dispatch."""
-        public_transition = getattr(self._iface._state_manager, "transition_to", None)
+        public_transition = getattr(self._state_manager, "transition_to", None)
         if callable(public_transition) and not _is_unconfigured_mock_callable(
             public_transition
         ):
@@ -187,7 +188,7 @@ class _LifecycleStateAccess:
             else:
                 if isinstance(result, bool):
                     return result
-        legacy_transition = getattr(self._iface._state_manager, "_transition_to", None)
+        legacy_transition = getattr(self._state_manager, "_transition_to", None)
         if callable(legacy_transition) and not _is_unconfigured_mock_callable(
             legacy_transition
         ):
@@ -206,7 +207,7 @@ class _LifecycleStateAccess:
     def reset_to_disconnected(self) -> bool:
         """Reset state manager to disconnected using public-first dispatch."""
         public_reset = getattr(
-            self._iface._state_manager, "reset_to_disconnected", None
+            self._state_manager, "reset_to_disconnected", None
         )
         if callable(public_reset) and not _is_unconfigured_mock_callable(public_reset):
             try:
@@ -220,7 +221,7 @@ class _LifecycleStateAccess:
                 if isinstance(result, bool):
                     return result
         legacy_reset = getattr(
-            self._iface._state_manager, "_reset_to_disconnected", None
+            self._state_manager, "_reset_to_disconnected", None
         )
         if callable(legacy_reset) and not _is_unconfigured_mock_callable(legacy_reset):
             try:
@@ -237,7 +238,7 @@ class _LifecycleStateAccess:
 
     def is_closing(self) -> bool:
         """Return closing-state flag from public-first state-manager members."""
-        public_is_closing = getattr(self._iface._state_manager, "is_closing", None)
+        public_is_closing = getattr(self._state_manager, "is_closing", None)
         if callable(public_is_closing) and not _is_unconfigured_mock_callable(
             public_is_closing
         ):
@@ -255,7 +256,7 @@ class _LifecycleStateAccess:
             public_is_closing, bool
         ):
             return public_is_closing
-        legacy_is_closing = getattr(self._iface._state_manager, "_is_closing", None)
+        legacy_is_closing = getattr(self._state_manager, "_is_closing", None)
         if callable(legacy_is_closing) and not _is_unconfigured_mock_callable(
             legacy_is_closing
         ):

--- a/meshtastic/interfaces/ble/lifecycle_primitives.py
+++ b/meshtastic/interfaces/ble/lifecycle_primitives.py
@@ -4,12 +4,17 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
+from meshtastic.interfaces.ble.compat_adapter import (
+    _get_declared_member,
+    _iter_declared_callables,
+    _iter_declared_members,
+    _resolve_declared_callable,
+)
 from meshtastic.interfaces.ble.constants import logger
 from meshtastic.interfaces.ble.coordination import ThreadLike
 from meshtastic.interfaces.ble.ports import _BLEStateManagerPort
 from meshtastic.interfaces.ble.state import ConnectionState
 from meshtastic.interfaces.ble.utils import (
-    _get_declared_member,
     _is_unexpected_keyword_error,
 )
 
@@ -66,8 +71,9 @@ class _OwnershipSnapshot:
 
 def _client_is_connected_compat(client: "BLEClient") -> bool:
     """Return connected-state flag from public/legacy BLEClient members."""
-    for candidate_name in ("isConnected", "is_connected", "_is_connected"):
-        candidate = _get_declared_member(client, candidate_name)
+    for candidate_name, candidate in _iter_declared_members(
+        client, "isConnected", "is_connected", "_is_connected"
+    ):
         if callable(candidate):
             try:
                 connected = candidate()
@@ -78,11 +84,10 @@ def _client_is_connected_compat(client: "BLEClient") -> bool:
                     exc_info=True,
                 )
                 continue
-            if isinstance(connected, bool):
-                return connected
-            continue
-        if isinstance(candidate, bool):
-            return candidate
+        else:
+            connected = candidate
+        if isinstance(connected, bool):
+            return connected
     raise AttributeError(CLIENT_MISSING_CONNECTED_MSG)
 
 
@@ -91,195 +96,154 @@ class _LifecycleStateAccess:
 
     def __init__(self, target: _BLEStateManagerPort | object) -> None:
         """Bind compatibility access to a state manager or legacy interface."""
-        self._state_manager = getattr(target, "_state_manager", target)
+        self._state_manager = _get_declared_member(target, "_state_manager", target)
+
+    def _read_typed(
+        self,
+        expected_type: type[object],
+        *names: str,
+    ) -> object:
+        """Read a typed value from public/legacy members in precedence order."""
+        for member_name, candidate in _iter_declared_members(
+            self._state_manager, *names
+        ):
+            if callable(candidate):
+                try:
+                    result = candidate()
+                except Exception:  # noqa: BLE001 - compatibility probe must fall through
+                    logger.debug(
+                        "Error probing state manager %s()",
+                        member_name,
+                        exc_info=True,
+                    )
+                    continue
+            else:
+                result = candidate
+            if isinstance(result, expected_type):
+                return result
+        raise AttributeError
+
+    def _call_bool(
+        self, missing_message: str, names: tuple[str, ...], *args: object
+    ) -> bool:
+        """Call public/legacy state-manager members until one returns ``bool``."""
+        for member_name, candidate in _iter_declared_callables(
+            self._state_manager, *names
+        ):
+            try:
+                result = candidate(*args)
+            except Exception:  # noqa: BLE001 - compatibility probe must fall through
+                logger.debug(
+                    "Error calling state manager %s()",
+                    member_name,
+                    exc_info=True,
+                )
+                continue
+            if isinstance(result, bool):
+                return result
+        raise AttributeError(missing_message)
 
     def is_connected(self) -> bool:
         """Return connected-state flag from public-first state-manager members."""
-        public_is_connected = _get_declared_member(self._state_manager, "is_connected")
-        if callable(public_is_connected):
-            try:
-                result = public_is_connected()
-            except Exception:  # noqa: BLE001 - compatibility probe must fall through
-                logger.debug(
-                    "Error probing state manager is_connected()",
-                    exc_info=True,
-                )
-            else:
-                if isinstance(result, bool):
-                    return result
-        if isinstance(
-            public_is_connected, bool
-        ):
-            return public_is_connected
-        legacy_is_connected = _get_declared_member(self._state_manager, "_is_connected")
-        if callable(legacy_is_connected):
-            try:
-                result = legacy_is_connected()
-            except Exception:  # noqa: BLE001 - compatibility probe must fall through
-                logger.debug(
-                    "Error probing state manager _is_connected()",
-                    exc_info=True,
-                )
-            else:
-                if isinstance(result, bool):
-                    return result
-        if isinstance(
-            legacy_is_connected, bool
-        ):
-            return legacy_is_connected
-        raise AttributeError(STATE_MANAGER_MISSING_CONNECTED_MSG)
+        try:
+            return cast(bool, self._read_typed(bool, "is_connected", "_is_connected"))
+        except AttributeError as exc:
+            raise AttributeError(STATE_MANAGER_MISSING_CONNECTED_MSG) from exc
 
     def current_state(self) -> ConnectionState:
         """Return current connection state from public-first state-manager members."""
-        public_state = _get_declared_member(self._state_manager, "current_state")
-        if callable(public_state):
-            try:
-                result = public_state()
-            except Exception:  # noqa: BLE001 - compatibility probe must fall through
-                logger.debug(
-                    "Error probing state manager current_state()",
-                    exc_info=True,
-                )
-            else:
-                if isinstance(result, ConnectionState):
-                    return result
-        if isinstance(
-            public_state, ConnectionState
-        ):
-            return public_state
-        legacy_state = _get_declared_member(self._state_manager, "_current_state")
-        if callable(legacy_state):
-            try:
-                result = legacy_state()
-            except Exception:  # noqa: BLE001 - compatibility probe must fall through
-                logger.debug(
-                    "Error probing state manager _current_state()",
-                    exc_info=True,
-                )
-            else:
-                if isinstance(result, ConnectionState):
-                    return result
-        if isinstance(
-            legacy_state, ConnectionState
-        ):
-            return legacy_state
-        raise AttributeError(STATE_MANAGER_MISSING_CURRENT_STATE_MSG)
+        try:
+            return cast(
+                ConnectionState,
+                self._read_typed(ConnectionState, "current_state", "_current_state"),
+            )
+        except AttributeError as exc:
+            raise AttributeError(STATE_MANAGER_MISSING_CURRENT_STATE_MSG) from exc
 
     def transition_to(self, new_state: ConnectionState) -> bool:
         """Transition state manager using public-first compatibility dispatch."""
-        public_transition = _get_declared_member(self._state_manager, "transition_to")
-        if callable(public_transition):
-            try:
-                result = public_transition(new_state)
-            except Exception:  # noqa: BLE001 - compatibility probe must fall through
-                logger.debug(
-                    "Error calling state manager transition_to()",
-                    exc_info=True,
-                )
-            else:
-                if isinstance(result, bool):
-                    return result
-        legacy_transition = _get_declared_member(self._state_manager, "_transition_to")
-        if callable(legacy_transition):
-            try:
-                result = legacy_transition(new_state)
-            except Exception:  # noqa: BLE001 - compatibility probe must fall through
-                logger.debug(
-                    "Error calling state manager _transition_to()",
-                    exc_info=True,
-                )
-            else:
-                if isinstance(result, bool):
-                    return result
-        raise AttributeError(STATE_MANAGER_MISSING_TRANSITION_MSG)
+        return self._call_bool(
+            STATE_MANAGER_MISSING_TRANSITION_MSG,
+            ("transition_to", "_transition_to"),
+            new_state,
+        )
 
     def reset_to_disconnected(self) -> bool:
         """Reset state manager to disconnected using public-first dispatch."""
-        public_reset = getattr(
-            self._state_manager, "reset_to_disconnected", None
+        return self._call_bool(
+            STATE_MANAGER_MISSING_RESET_MSG,
+            ("reset_to_disconnected", "_reset_to_disconnected"),
         )
-        if callable(public_reset):
-            try:
-                result = public_reset()
-            except Exception:  # noqa: BLE001 - compatibility probe must fall through
-                logger.debug(
-                    "Error calling state manager reset_to_disconnected()",
-                    exc_info=True,
-                )
-            else:
-                if isinstance(result, bool):
-                    return result
-        legacy_reset = getattr(
-            self._state_manager, "_reset_to_disconnected", None
-        )
-        if callable(legacy_reset):
-            try:
-                result = legacy_reset()
-            except Exception:  # noqa: BLE001 - compatibility probe must fall through
-                logger.debug(
-                    "Error calling state manager _reset_to_disconnected()",
-                    exc_info=True,
-                )
-            else:
-                if isinstance(result, bool):
-                    return result
-        raise AttributeError(STATE_MANAGER_MISSING_RESET_MSG)
 
     def is_closing(self) -> bool:
         """Return closing-state flag from public-first state-manager members."""
-        public_is_closing = _get_declared_member(self._state_manager, "is_closing")
-        if callable(public_is_closing):
-            try:
-                result = public_is_closing()
-            except Exception:  # noqa: BLE001 - compatibility probe must fall through
-                logger.debug(
-                    "Error probing state manager is_closing()",
-                    exc_info=True,
-                )
-            else:
-                if isinstance(result, bool):
-                    return result
-        if isinstance(
-            public_is_closing, bool
-        ):
-            return public_is_closing
-        legacy_is_closing = _get_declared_member(self._state_manager, "_is_closing")
-        if callable(legacy_is_closing):
-            try:
-                result = legacy_is_closing()
-            except Exception:  # noqa: BLE001 - compatibility probe must fall through
-                logger.debug(
-                    "Error probing state manager _is_closing()",
-                    exc_info=True,
-                )
-            else:
-                if isinstance(result, bool):
-                    return result
-        if isinstance(
-            legacy_is_closing, bool
-        ):
-            return legacy_is_closing
-        # Deliberate graceful-degradation asymmetry: close/shutdown paths should
-        # not raise when optional state-manager hooks are absent.
-        return False
+        try:
+            return cast(bool, self._read_typed(bool, "is_closing", "_is_closing"))
+        except AttributeError:
+            # Close/shutdown paths deliberately degrade when optional state hooks
+            # are absent on legacy or partial collaborators.
+            return False
 
     def client_is_connected(self, client: "BLEClient") -> bool:
-        """Return connected-state flag from public/legacy BLEClient members."""
+        """Return client connectivity using compatibility member probing."""
         return _client_is_connected_compat(client)
 
 
 class _LifecycleThreadAccess:
     """Thread/event compatibility access owned by lifecycle collaborators.
 
-    Contract: critical operations (`create_thread`, `start_thread`) raise
-    `AttributeError` when required hooks are missing; non-critical operations
-    (`join_thread`, `set_event`, `clear_events`, `wake_waiting_threads`) log and
-    return to keep shutdown/recovery paths best effort.
+    Critical operations (thread creation/start) propagate collaborator failures.
+    Shutdown/recovery operations are best effort and fall through from current
+    to legacy hook names before logging a missing-hook message.
     """
 
     def __init__(self, iface: "BLEInterface") -> None:
         """Bind thread-coordinator access to a specific interface."""
         self._iface = iface
+
+    def _coordinator(self) -> object | None:
+        """Return the explicitly declared thread coordinator when available."""
+        return _get_declared_member(self._iface, "thread_coordinator")
+
+    def _required_callable(
+        self, public_name: str, legacy_name: str
+    ) -> Callable[..., object]:
+        """Resolve a required current/legacy coordinator callable."""
+        coordinator = self._coordinator()
+        resolved = _resolve_declared_callable(
+            coordinator, public_name, legacy_name
+        )
+        if resolved is None:
+            raise AttributeError(
+                THREAD_COORDINATOR_MISSING_FMT % (public_name, legacy_name)
+            )
+        return cast(Callable[..., object], resolved)
+
+    def _best_effort_call(
+        self,
+        public_name: str,
+        legacy_name: str,
+        *args: object,
+        **kwargs: object,
+    ) -> bool:
+        """Try current/legacy coordinator hooks, logging and falling through."""
+        coordinator = self._coordinator()
+        if coordinator is None:
+            return False
+        for member_name, hook in _iter_declared_callables(
+            coordinator, public_name, legacy_name
+        ):
+            try:
+                hook(*args, **kwargs)
+            except Exception:  # noqa: BLE001 - non-critical lifecycle hook
+                logger.debug(
+                    "Error in thread_coordinator.%s",
+                    member_name,
+                    exc_info=True,
+                )
+                continue
+            return True
+        return False
 
     def create_thread(
         self,
@@ -290,91 +254,31 @@ class _LifecycleThreadAccess:
         args: tuple[object, ...] = (),
         kwargs: dict[str, object] | None = None,
     ) -> ThreadLike:
-        """Create thread via public-first coordinator compatibility dispatch."""
-        coordinator = _get_declared_member(self._iface, "thread_coordinator")
-        if coordinator is None:
-            raise AttributeError(
-                THREAD_COORDINATOR_MISSING_FMT % ("create_thread", "_create_thread")
-            )
-        create_thread = _get_declared_member(coordinator, "create_thread")
-        if callable(create_thread):
-            return cast(
-                ThreadLike,
-                create_thread(
-                    target=target,
-                    name=name,
-                    daemon=daemon,
-                    args=args,
-                    kwargs=kwargs,
-                ),
-            )
-        legacy_create_thread = _get_declared_member(coordinator, "_create_thread")
-        if callable(legacy_create_thread):
-            return cast(
-                ThreadLike,
-                legacy_create_thread(
-                    target=target,
-                    name=name,
-                    daemon=daemon,
-                    args=args,
-                    kwargs=kwargs,
-                ),
-            )
-        raise AttributeError(
-            THREAD_COORDINATOR_MISSING_FMT % ("create_thread", "_create_thread")
+        """Create a thread through the current/legacy coordinator contract."""
+        create_thread = self._required_callable("create_thread", "_create_thread")
+        return cast(
+            ThreadLike,
+            create_thread(
+                target=target,
+                name=name,
+                daemon=daemon,
+                args=args,
+                kwargs=kwargs,
+            ),
         )
 
     def start_thread(self, thread: object) -> None:
-        """Start thread via public-first coordinator compatibility dispatch."""
-        coordinator = _get_declared_member(self._iface, "thread_coordinator")
-        if coordinator is None:
-            raise AttributeError(
-                THREAD_COORDINATOR_MISSING_FMT % ("start_thread", "_start_thread")
-            )
-        start_thread = _get_declared_member(coordinator, "start_thread")
-        if callable(start_thread):
-            start_thread(thread)
-            return
-        legacy_start_thread = _get_declared_member(coordinator, "_start_thread")
-        if callable(legacy_start_thread):
-            legacy_start_thread(thread)
-            return
-        raise AttributeError(
-            THREAD_COORDINATOR_MISSING_FMT % ("start_thread", "_start_thread")
-        )
+        """Start a thread through the current/legacy coordinator contract."""
+        self._required_callable("start_thread", "_start_thread")(thread)
 
     def join_thread(self, thread: object, *, timeout: float | None) -> None:
-        """Join thread via public-first coordinator compatibility dispatch."""
-        coordinator = _get_declared_member(self._iface, "thread_coordinator")
-        if coordinator is None:
-            logger.debug("Thread coordinator is missing join_thread/_join_thread")
-        else:
-            join_thread = _get_declared_member(coordinator, "join_thread")
-            if callable(join_thread):
-                try:
-                    join_thread(thread, timeout=timeout)
-                except Exception:  # noqa: BLE001 - non-critical join stays best effort
-                    logger.debug(
-                        "Error in thread_coordinator.join_thread for %r",
-                        thread,
-                        exc_info=True,
-                    )
-                else:
-                    return
-            legacy_join_thread = _get_declared_member(coordinator, "_join_thread")
-            if callable(legacy_join_thread):
-                try:
-                    legacy_join_thread(thread, timeout=timeout)
-                except Exception:  # noqa: BLE001 - non-critical join stays best effort
-                    logger.debug(
-                        "Error in thread_coordinator._join_thread for %r",
-                        thread,
-                        exc_info=True,
-                    )
-                else:
-                    return
-        thread_join = getattr(thread, "join", None)
-        if callable(thread_join):
+        """Join a thread through coordinator hooks with direct-thread fallback."""
+        if self._best_effort_call(
+            "join_thread", "_join_thread", thread, timeout=timeout
+        ):
+            return
+        thread_join = _resolve_declared_callable(thread, "join")
+        if thread_join is not None:
             try:
                 thread_join(timeout=timeout)
             except Exception:  # noqa: BLE001 - non-critical join stays best effort
@@ -383,132 +287,47 @@ class _LifecycleThreadAccess:
         logger.debug("Thread coordinator is missing join_thread/_join_thread")
 
     def set_event(self, event_name: str) -> None:
-        """Set event via public-first coordinator compatibility dispatch."""
-        coordinator = _get_declared_member(self._iface, "thread_coordinator")
-        if coordinator is None:
+        """Set a coordinator event using current/legacy hooks."""
+        if not self._best_effort_call("set_event", "_set_event", event_name):
             logger.debug("Thread coordinator is missing set_event/_set_event")
-            return
-        set_event = _get_declared_member(coordinator, "set_event")
-        if callable(set_event):
-            try:
-                set_event(event_name)
-            except Exception:  # noqa: BLE001 - non-critical event set stays best effort
-                logger.debug(
-                    "Error in thread_coordinator.set_event for %s",
-                    event_name,
-                    exc_info=True,
-                )
-            else:
-                return
-        legacy_set_event = _get_declared_member(coordinator, "_set_event")
-        if callable(legacy_set_event):
-            try:
-                legacy_set_event(event_name)
-            except Exception:  # noqa: BLE001 - non-critical event set stays best effort
-                logger.debug(
-                    "Error in thread_coordinator._set_event for %s",
-                    event_name,
-                    exc_info=True,
-                )
-            else:
-                return
-        logger.debug("Thread coordinator is missing set_event/_set_event")
 
     def clear_events(self, *event_names: str) -> None:
-        """Clear events via public-first coordinator compatibility dispatch."""
-        coordinator = _get_declared_member(self._iface, "thread_coordinator")
-        if coordinator is None:
+        """Clear coordinator events using current/legacy hooks."""
+        if not self._best_effort_call("clear_events", "_clear_events", *event_names):
             logger.debug("Thread coordinator is missing clear_events/_clear_events")
-            return
-        clear_events = _get_declared_member(coordinator, "clear_events")
-        if callable(clear_events):
-            try:
-                clear_events(*event_names)
-            except Exception:  # noqa: BLE001 - non-critical clear stays best effort
-                logger.debug(
-                    "Error in thread_coordinator.clear_events for %s",
-                    event_names,
-                    exc_info=True,
-                )
-            else:
-                return
-        legacy_clear_events = _get_declared_member(coordinator, "_clear_events")
-        if callable(legacy_clear_events):
-            try:
-                legacy_clear_events(*event_names)
-            except Exception:  # noqa: BLE001 - non-critical clear stays best effort
-                logger.debug(
-                    "Error in thread_coordinator._clear_events for %s",
-                    event_names,
-                    exc_info=True,
-                )
-            else:
-                return
-        logger.debug("Thread coordinator is missing clear_events/_clear_events")
 
     def wake_waiting_threads(self, *event_names: str) -> None:
-        """Wake waiters via public-first coordinator compatibility dispatch."""
-        coordinator = _get_declared_member(self._iface, "thread_coordinator")
+        """Wake waiters with bulk hooks, then fall back to per-event hooks."""
+        coordinator = self._coordinator()
         if coordinator is None:
             logger.debug(
                 "Thread coordinator is missing wake_waiting_threads/_wake_waiting_threads/set_event/_set_event"
             )
             return
-        wake_waiting_threads = _get_declared_member(coordinator, "wake_waiting_threads")
-        if callable(wake_waiting_threads):
-            try:
-                wake_waiting_threads(*event_names)
-                return
-            except Exception:  # noqa: BLE001 - non-critical wake stays best effort
-                logger.debug(
-                    "Error in thread_coordinator.wake_waiting_threads for %s",
-                    event_names,
-                    exc_info=True,
-                )
-        legacy_wake_waiting_threads = getattr(
-            coordinator, "_wake_waiting_threads", None
-        )
-        if callable(legacy_wake_waiting_threads):
-            try:
-                legacy_wake_waiting_threads(*event_names)
-                return
-            except Exception:  # noqa: BLE001 - non-critical wake stays best effort
-                logger.debug(
-                    "Error in thread_coordinator._wake_waiting_threads for %s",
-                    event_names,
-                    exc_info=True,
-                )
-        set_event = _get_declared_member(coordinator, "set_event")
-        if callable(set_event):
-            failed_events: list[str] = []
-            for event_name in event_names:
+        if self._best_effort_call(
+            "wake_waiting_threads", "_wake_waiting_threads", *event_names
+        ):
+            return
+
+        remaining = list(event_names)
+        for member_name, set_event in _iter_declared_callables(
+            coordinator, "set_event", "_set_event"
+        ):
+            failed: list[str] = []
+            for event_name in remaining:
                 try:
                     set_event(event_name)
                 except Exception:  # noqa: BLE001 - non-critical wake stays best effort
                     logger.debug(
-                        "Error in thread_coordinator.set_event fallback for %s",
+                        "Error in thread_coordinator.%s fallback for %s",
+                        member_name,
                         event_name,
                         exc_info=True,
                     )
-                    failed_events.append(event_name)
-            if not failed_events:
+                    failed.append(event_name)
+            if not failed:
                 return
-            event_names = tuple(failed_events)
-        legacy_set_event = _get_declared_member(coordinator, "_set_event")
-        if callable(legacy_set_event):
-            failed_events = []
-            for event_name in event_names:
-                try:
-                    legacy_set_event(event_name)
-                except Exception:  # noqa: BLE001 - non-critical wake stays best effort
-                    logger.debug(
-                        "Error in thread_coordinator._set_event fallback for %s",
-                        event_name,
-                        exc_info=True,
-                    )
-                    failed_events.append(event_name)
-            if not failed_events:
-                return
+            remaining = failed
         logger.debug(
             "Thread coordinator is missing wake_waiting_threads/_wake_waiting_threads/set_event/_set_event"
         )
@@ -526,13 +345,8 @@ class _LifecycleErrorAccess:
     ) -> Callable[..., object] | None:
         """Resolve an error-handler hook with public-first fallback behavior."""
         error_handler = _get_declared_member(self._iface, "error_handler")
-        hook = _get_declared_member(error_handler, public_name)
-        if callable(hook):
-            return cast(Callable[..., object], hook)
-        legacy_hook = _get_declared_member(error_handler, legacy_name)
-        if callable(legacy_hook):
-            return cast(Callable[..., object], legacy_hook)
-        return None
+        hook = _resolve_declared_callable(error_handler, public_name, legacy_name)
+        return cast(Callable[..., object], hook) if hook is not None else None
 
     def safe_cleanup(self, cleanup: Callable[[], object], operation_name: str) -> None:
         """Run cleanup via resolved error-handler hook with best-effort fallback."""

--- a/meshtastic/interfaces/ble/lifecycle_primitives.py
+++ b/meshtastic/interfaces/ble/lifecycle_primitives.py
@@ -73,7 +73,7 @@ class _OwnershipSnapshot:
     prior_ever_connected: bool
 
 
-def _client_is_connected_compat(client: "BLEClient") -> bool:
+def _client_is_connected_compat(client: object) -> bool:
     """Return connected-state flag from public/legacy BLEClient members."""
     for candidate_name, candidate in _iter_declared_members(
         client, "isConnected", "is_connected", "_is_connected"
@@ -422,9 +422,9 @@ class _LifecycleErrorAccess:
         except TypeError as exc:
             if not _is_unexpected_keyword_error(exc, "error_msg"):
                 _log_ble_failure(
-                _BLEFailureDisposition.BEST_EFFORT,
-                error_msg,
-            )
+                    _BLEFailureDisposition.BEST_EFFORT,
+                    error_msg,
+                )
                 return did_run(), None
             if did_run():
                 return True, None
@@ -434,9 +434,9 @@ class _LifecycleErrorAccess:
                     return True, result
             except Exception:  # noqa: BLE001 - hook failures must not abort shutdown
                 _log_ble_failure(
-                _BLEFailureDisposition.BEST_EFFORT,
-                error_msg,
-            )
+                    _BLEFailureDisposition.BEST_EFFORT,
+                    error_msg,
+                )
                 if did_run():
                     return True, None
             try:
@@ -445,9 +445,9 @@ class _LifecycleErrorAccess:
                     return True, result
             except Exception:  # noqa: BLE001 - hook failures must not abort shutdown
                 _log_ble_failure(
-                _BLEFailureDisposition.BEST_EFFORT,
-                error_msg,
-            )
+                    _BLEFailureDisposition.BEST_EFFORT,
+                    error_msg,
+                )
                 if did_run():
                     return True, None
         except Exception:  # noqa: BLE001 - hook failures must not abort shutdown

--- a/meshtastic/interfaces/ble/lifecycle_primitives.py
+++ b/meshtastic/interfaces/ble/lifecycle_primitives.py
@@ -78,10 +78,41 @@ class _OwnershipSnapshot:
 
 
 def _client_is_connected_compat(client: object) -> bool:
-    """Return connected-state flag from public/legacy BLEClient members."""
-    for candidate_name, candidate in _iter_declared_members(
-        client, "isConnected", "is_connected", "_is_connected"
-    ):
+    """Return connected-state flag from public/legacy BLEClient members.
+
+    Parameters
+    ----------
+    client : object
+        Client-like object exposing current or legacy connectivity members.
+
+    Returns
+    -------
+    bool
+        First declared connectivity probe that yields a real boolean.
+
+    Raises
+    ------
+    AttributeError
+        If no declared compatibility candidate yields a boolean result.
+
+    Notes
+    -----
+    Declared-member resolution and callable probes are best effort. Failures
+    are reported as compatibility fallbacks and probing continues, so callers
+    share one explicit exception contract.
+    """
+    for candidate_name in ("isConnected", "is_connected", "_is_connected"):
+        try:
+            candidate = _get_declared_member(client, candidate_name)
+        except Exception:  # noqa: BLE001 - connectivity probes stay best effort
+            _log_ble_failure(
+                _BLEFailureDisposition.COMPATIBILITY_FALLBACK,
+                "Error resolving BLE client connectivity member %s",
+                candidate_name,
+            )
+            continue
+        if candidate is None:
+            continue
         if callable(candidate):
             try:
                 connected = candidate()

--- a/meshtastic/interfaces/ble/lifecycle_primitives.py
+++ b/meshtastic/interfaces/ble/lifecycle_primitives.py
@@ -167,7 +167,13 @@ class _LifecycleStateAccess:
     def _call_bool(
         self, missing_message: str, names: tuple[str, ...], *args: object
     ) -> bool:
-        """Call public/legacy state-manager members until one returns ``bool``."""
+        """Call the first successful public/legacy mutating state hook.
+
+        A successful mutation is authoritative even when a legacy-compatible
+        hook returns ``None`` or another non-boolean value. Falling through to
+        the next hook after such a call can apply the same transition twice.
+        Exceptions still fall through to the next declared compatibility hook.
+        """
         for member_name, candidate in _iter_declared_callables(
             self._state_manager, *names
         ):
@@ -182,6 +188,7 @@ class _LifecycleStateAccess:
                 continue
             if isinstance(result, bool):
                 return result
+            return True
         raise AttributeError(missing_message)
 
     def is_connected(self) -> bool:

--- a/meshtastic/interfaces/ble/lifecycle_receive_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_receive_runtime.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from meshtastic.interfaces.ble.interface import BLEInterface
 
 RECEIVE_START_PENDING_TIMEOUT_SECONDS = 1.0
+RECEIVE_START_SNAPSHOT_MAX_ATTEMPTS = 16
 
 
 class BLEReceiveLifecycleCoordinator:
@@ -237,7 +238,7 @@ class BLEReceiveLifecycleCoordinator:
         schedule_deferred_restart_for: ThreadLike | None = None
         inconclusive_probe_thread: ThreadLike | None = None
 
-        while True:
+        for _snapshot_attempt in range(RECEIVE_START_SNAPSHOT_MAX_ATTEMPTS):
             with self._session.lock:
                 if self._session.closed or not self._session.want_receive:
                     logger.debug(
@@ -402,6 +403,13 @@ class BLEReceiveLifecycleCoordinator:
                         else None
                     )
                 break
+        else:
+            logger.debug(
+                "Skipping receive thread start (%s): lifecycle state changed during %d consecutive liveness snapshots.",
+                name,
+                RECEIVE_START_SNAPSHOT_MAX_ATTEMPTS,
+            )
+            return None, None
 
         if inconclusive_probe_thread is not None:
             self._schedule_deferred_receive_restart(

--- a/meshtastic/interfaces/ble/lifecycle_receive_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_receive_runtime.py
@@ -247,6 +247,21 @@ class BLEReceiveLifecycleCoordinator:
         session lock.  The state snapshot is revalidated before any mutation so
         arbitrary collaborator code cannot extend the critical section without
         allowing a stale probe result to overwrite newer lifecycle state.
+
+        Parameters
+        ----------
+        name : str
+            Thread name used for diagnostics and deferred restart helpers.
+        reset_recovery : bool
+            Whether recovery attempts should reset after a successful start.
+        create_runtime_thread : Callable[..., ThreadLike]
+            Factory used to create the staged receive thread.
+
+        Returns
+        -------
+        tuple[ThreadLike | None, int | None]
+            Staged thread and the pre-start recovery-attempt snapshot, or
+            ``(None, None)`` when no thread should start.
         """
         iface = self._iface
         expected_existing: ThreadLike | None = None

--- a/meshtastic/interfaces/ble/lifecycle_receive_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_receive_runtime.py
@@ -229,6 +229,7 @@ class BLEReceiveLifecycleCoordinator:
         deferred_current_thread: ThreadLike | None = None
         deferred_current_thread_waiting = False
         schedule_deferred_restart_for: ThreadLike | None = None
+        inconclusive_probe_thread: ThreadLike | None = None
         with self._session.lock:
             if self._session.closed or not self._session.want_receive:
                 logger.debug(
@@ -344,25 +345,28 @@ class BLEReceiveLifecycleCoordinator:
                         if not isinstance(pending_since, (float, int)):
                             self._session.receive_start_pending_since = time.monotonic()
                         self._session.receive_start_pending = True
-                        self._schedule_deferred_receive_restart(
-                            existing_thread=existing,
-                            name=name,
-                            reset_recovery=reset_recovery,
-                            enforce_pending_timeout=True,
-                        )
+                        inconclusive_probe_thread = existing
                         logger.debug(
                             "Skipping receive thread start (%s): %s liveness probe inconclusive.",
                             name,
                             existing.name,
                         )
-                        return None, None
-                    self._session.receive_start_pending = False
-                    self._session.receive_start_pending_since = None
-            if deferred_current_thread is None:
+                    else:
+                        self._session.receive_start_pending = False
+                        self._session.receive_start_pending_since = None
+            if deferred_current_thread is None and inconclusive_probe_thread is None:
                 expected_existing = existing
                 recovery_attempts_before_start = (
                     self._session.receive_recovery_attempts if reset_recovery else None
                 )
+        if inconclusive_probe_thread is not None:
+            self._schedule_deferred_receive_restart(
+                existing_thread=inconclusive_probe_thread,
+                name=name,
+                reset_recovery=reset_recovery,
+                enforce_pending_timeout=True,
+            )
+            return None, None
         if deferred_current_thread_waiting:
             if schedule_deferred_restart_for is not None:
                 self._schedule_deferred_receive_restart(

--- a/meshtastic/interfaces/ble/lifecycle_receive_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_receive_runtime.py
@@ -19,6 +19,24 @@ RECEIVE_START_PENDING_TIMEOUT_SECONDS = 1.0
 RECEIVE_START_SNAPSHOT_MAX_ATTEMPTS = 16
 
 
+def _thread_display_name(thread: object) -> str:
+    """Return a defensive display name for a thread-like collaborator.
+
+    Attribute access and ``repr`` may execute collaborator-owned code, so this
+    helper is called only outside the shared session lock.
+    """
+    try:
+        raw_name = getattr(thread, "name")
+    except Exception:  # noqa: BLE001 - diagnostics must never disrupt lifecycle
+        raw_name = None
+    if isinstance(raw_name, str) and raw_name:
+        return raw_name
+    try:
+        return repr(thread)
+    except Exception:  # noqa: BLE001 - diagnostics must remain best effort
+        return f"<{type(thread).__name__}>"
+
+
 class BLEReceiveLifecycleCoordinator:
     """Own receive-loop intent and receive-thread lifecycle behavior.
 
@@ -254,8 +272,10 @@ class BLEReceiveLifecycleCoordinator:
             existing_is_alive = False
             existing_is_current = False
             start_failure_confirmed = False
+            existing_display_name = "<no receive thread>"
             if existing is not None:
                 existing_ident, existing_is_alive = _thread_start_probe(existing)
+                existing_display_name = _thread_display_name(existing)
                 existing_is_current = existing is threading.current_thread() or (
                     isinstance(existing_ident, int)
                     and existing_ident == threading.get_ident()
@@ -335,14 +355,14 @@ class BLEReceiveLifecycleCoordinator:
                         logger.debug(
                             "Skipping receive thread start (%s): %s is already running.",
                             name,
-                            existing.name,
+                            existing_display_name,
                         )
                         return None, None
                     if existing_start_pending:
                         if existing_ident is not None or start_failure_confirmed:
                             logger.debug(
                                 "Replacing stale pending receive-thread start reference for %s: worker is no longer alive.",
-                                getattr(existing, "name", repr(existing)),
+                                existing_display_name,
                             )
                             self._session.receive_thread = None
                             existing = None
@@ -360,12 +380,12 @@ class BLEReceiveLifecycleCoordinator:
                                 logger.debug(
                                     "Skipping receive thread start (%s): %s start still pending.",
                                     name,
-                                    existing.name,
+                                    existing_display_name,
                                 )
                                 return None, None
                             logger.debug(
                                 "Receive thread start pending timed out for %s after %.3fs; replacing stale pending reference.",
-                                existing.name,
+                                existing_display_name,
                                 pending_age,
                             )
                             self._session.receive_start_pending = False
@@ -374,7 +394,7 @@ class BLEReceiveLifecycleCoordinator:
                         if existing_ident is not None:
                             logger.debug(
                                 "Replacing dead receive thread reference for %s before restart.",
-                                getattr(existing, "name", repr(existing)),
+                                existing_display_name,
                             )
                             self._session.receive_thread = None
                             existing = None
@@ -389,7 +409,7 @@ class BLEReceiveLifecycleCoordinator:
                             logger.debug(
                                 "Skipping receive thread start (%s): %s liveness probe inconclusive.",
                                 name,
-                                existing.name,
+                                existing_display_name,
                             )
                         else:
                             self._session.receive_start_pending = False

--- a/meshtastic/interfaces/ble/lifecycle_receive_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_receive_runtime.py
@@ -222,7 +222,13 @@ class BLEReceiveLifecycleCoordinator:
         reset_recovery: bool,
         create_runtime_thread: Callable[..., ThreadLike],
     ) -> tuple[ThreadLike | None, int | None]:
-        """Validate start preconditions and create a staged receive thread."""
+        """Validate start preconditions and create a staged receive thread.
+
+        Thread-like liveness/start probes deliberately run outside the shared
+        session lock.  The state snapshot is revalidated before any mutation so
+        arbitrary collaborator code cannot extend the critical section without
+        allowing a stale probe result to overwrite newer lifecycle state.
+        """
         iface = self._iface
         expected_existing: ThreadLike | None = None
         recovery_attempts_before_start: int | None = None
@@ -230,135 +236,173 @@ class BLEReceiveLifecycleCoordinator:
         deferred_current_thread_waiting = False
         schedule_deferred_restart_for: ThreadLike | None = None
         inconclusive_probe_thread: ThreadLike | None = None
-        with self._session.lock:
-            if self._session.closed or not self._session.want_receive:
-                logger.debug(
-                    "Skipping receive thread start (%s): interface is closing/stopped.",
-                    name,
-                )
-                return None, None
-            existing = self._session.receive_thread
-            existing_start_pending = self._session.receive_start_pending
-            existing_ident: int | None = None
-            existing_is_alive = False
-            if existing is not None:
-                existing_ident, existing_is_alive = _thread_start_probe(existing)
-            if self._is_current_receive_thread(existing):
-                now = time.monotonic()
-                pending_since = self._session.receive_start_pending_since
-                if not existing_start_pending or not isinstance(
-                    pending_since, (float, int)
-                ):
-                    pending_age = 0.0
-                else:
-                    pending_age = now - float(pending_since)
-                    if pending_age >= RECEIVE_START_PENDING_TIMEOUT_SECONDS:
-                        self._session.receive_start_pending = False
-                        self._session.receive_start_pending_since = None
-                        deferred_current_thread = existing
-                        logger.debug(
-                            "Receive-thread deferral timeout reached (%s): scheduling deferred restart.",
-                            name,
-                        )
-                if deferred_current_thread is None:
-                    deferred_current_thread_waiting = True
-                    self._session.receive_start_pending = True
-                    if not isinstance(pending_since, (float, int)):
-                        self._session.receive_start_pending_since = now
-                        schedule_deferred_restart_for = existing
-                    elif not existing_start_pending:
-                        schedule_deferred_restart_for = existing
-                    if not reset_recovery:
-                        logger.debug(
-                            "Deferring replacement receive thread start (%s): current receive thread is still unwinding (pending %.3fs).",
-                            name,
-                            pending_age,
-                        )
-                    else:
-                        logger.debug(
-                            "Deferring receive thread start (%s): current receive thread is still unwinding (pending %.3fs).",
-                            name,
-                            pending_age,
-                        )
-                else:
+
+        while True:
+            with self._session.lock:
+                if self._session.closed or not self._session.want_receive:
                     logger.debug(
-                        "Deferring receive thread start (%s) and queueing restart after current thread unwind.",
+                        "Skipping receive thread start (%s): interface is closing/stopped.",
                         name,
-                    )
-            if existing is not None and not self._is_current_receive_thread(existing):
-                if existing_is_alive:
-                    self._session.receive_start_pending = False
-                    self._session.receive_start_pending_since = None
-                    logger.debug(
-                        "Skipping receive thread start (%s): %s is already running.",
-                        name,
-                        existing.name,
                     )
                     return None, None
-                if existing_start_pending:
-                    if not existing_is_alive and (
-                        existing_ident is not None
-                        or self._is_thread_start_failure_confirmed(existing)
+                existing = self._session.receive_thread
+                existing_start_pending = self._session.receive_start_pending
+                existing_pending_since = self._session.receive_start_pending_since
+
+            existing_ident: int | None = None
+            existing_is_alive = False
+            existing_is_current = False
+            start_failure_confirmed = False
+            if existing is not None:
+                existing_ident, existing_is_alive = _thread_start_probe(existing)
+                existing_is_current = existing is threading.current_thread() or (
+                    isinstance(existing_ident, int)
+                    and existing_ident == threading.get_ident()
+                )
+                if (
+                    not existing_is_alive
+                    and not existing_is_current
+                    and existing_ident is None
+                ):
+                    start_failure_confirmed = self._is_thread_start_failure_confirmed(
+                        existing
+                    )
+
+            with self._session.lock:
+                if self._session.closed or not self._session.want_receive:
+                    # The lifecycle changed while the lock was released for
+                    # thread probes. Re-enter through the snapshot check so the
+                    # stop-path logging and return remain centralized above.
+                    continue
+                if (
+                    self._session.receive_thread is not existing
+                    or self._session.receive_start_pending != existing_start_pending
+                    or self._session.receive_start_pending_since
+                    != existing_pending_since
+                ):
+                    # State changed while thread-like probes ran without the
+                    # lock. Re-snapshot rather than applying stale observations.
+                    continue
+
+                if existing_is_current:
+                    now = time.monotonic()
+                    pending_since = existing_pending_since
+                    if not existing_start_pending or not isinstance(
+                        pending_since, (float, int)
                     ):
-                        logger.debug(
-                            "Replacing stale pending receive-thread start reference for %s: worker is no longer alive.",
-                            getattr(existing, "name", repr(existing)),
-                        )
-                        self._session.receive_thread = None
-                        existing = None
-                        self._session.receive_start_pending = False
-                        self._session.receive_start_pending_since = None
+                        pending_age = 0.0
                     else:
-                        pending_since = self._session.receive_start_pending_since
-                        now = time.monotonic()
+                        pending_age = now - float(pending_since)
+                        if pending_age >= RECEIVE_START_PENDING_TIMEOUT_SECONDS:
+                            self._session.receive_start_pending = False
+                            self._session.receive_start_pending_since = None
+                            deferred_current_thread = existing
+                            logger.debug(
+                                "Receive-thread deferral timeout reached (%s): scheduling deferred restart.",
+                                name,
+                            )
+                    if deferred_current_thread is None:
+                        deferred_current_thread_waiting = True
+                        self._session.receive_start_pending = True
                         if not isinstance(pending_since, (float, int)):
                             self._session.receive_start_pending_since = now
-                            pending_age = 0.0
-                        else:
-                            pending_age = now - float(pending_since)
-                        if pending_age < RECEIVE_START_PENDING_TIMEOUT_SECONDS:
+                            schedule_deferred_restart_for = existing
+                        elif not existing_start_pending:
+                            schedule_deferred_restart_for = existing
+                        if not reset_recovery:
                             logger.debug(
-                                "Skipping receive thread start (%s): %s start still pending.",
+                                "Deferring replacement receive thread start (%s): current receive thread is still unwinding (pending %.3fs).",
+                                name,
+                                pending_age,
+                            )
+                        else:
+                            logger.debug(
+                                "Deferring receive thread start (%s): current receive thread is still unwinding (pending %.3fs).",
+                                name,
+                                pending_age,
+                            )
+                    else:
+                        logger.debug(
+                            "Deferring receive thread start (%s) and queueing restart after current thread unwind.",
+                            name,
+                        )
+
+                if existing is not None and not existing_is_current:
+                    if existing_is_alive:
+                        self._session.receive_start_pending = False
+                        self._session.receive_start_pending_since = None
+                        logger.debug(
+                            "Skipping receive thread start (%s): %s is already running.",
+                            name,
+                            existing.name,
+                        )
+                        return None, None
+                    if existing_start_pending:
+                        if existing_ident is not None or start_failure_confirmed:
+                            logger.debug(
+                                "Replacing stale pending receive-thread start reference for %s: worker is no longer alive.",
+                                getattr(existing, "name", repr(existing)),
+                            )
+                            self._session.receive_thread = None
+                            existing = None
+                            self._session.receive_start_pending = False
+                            self._session.receive_start_pending_since = None
+                        else:
+                            pending_since = existing_pending_since
+                            now = time.monotonic()
+                            if not isinstance(pending_since, (float, int)):
+                                self._session.receive_start_pending_since = now
+                                pending_age = 0.0
+                            else:
+                                pending_age = now - float(pending_since)
+                            if pending_age < RECEIVE_START_PENDING_TIMEOUT_SECONDS:
+                                logger.debug(
+                                    "Skipping receive thread start (%s): %s start still pending.",
+                                    name,
+                                    existing.name,
+                                )
+                                return None, None
+                            logger.debug(
+                                "Receive thread start pending timed out for %s after %.3fs; replacing stale pending reference.",
+                                existing.name,
+                                pending_age,
+                            )
+                            self._session.receive_start_pending = False
+                            self._session.receive_start_pending_since = None
+                    else:
+                        if existing_ident is not None:
+                            logger.debug(
+                                "Replacing dead receive thread reference for %s before restart.",
+                                getattr(existing, "name", repr(existing)),
+                            )
+                            self._session.receive_thread = None
+                            existing = None
+                            self._session.receive_start_pending = False
+                            self._session.receive_start_pending_since = None
+                        elif not start_failure_confirmed:
+                            pending_since = existing_pending_since
+                            if not isinstance(pending_since, (float, int)):
+                                self._session.receive_start_pending_since = time.monotonic()
+                            self._session.receive_start_pending = True
+                            inconclusive_probe_thread = existing
+                            logger.debug(
+                                "Skipping receive thread start (%s): %s liveness probe inconclusive.",
                                 name,
                                 existing.name,
                             )
-                            return None, None
-                        logger.debug(
-                            "Receive thread start pending timed out for %s after %.3fs; replacing stale pending reference.",
-                            existing.name,
-                            pending_age,
-                        )
-                        self._session.receive_start_pending = False
-                        self._session.receive_start_pending_since = None
-                else:
-                    if existing_ident is not None:
-                        logger.debug(
-                            "Replacing dead receive thread reference for %s before restart.",
-                            getattr(existing, "name", repr(existing)),
-                        )
-                        self._session.receive_thread = None
-                        existing = None
-                        self._session.receive_start_pending = False
-                        self._session.receive_start_pending_since = None
-                    elif not self._is_thread_start_failure_confirmed(existing):
-                        pending_since = self._session.receive_start_pending_since
-                        if not isinstance(pending_since, (float, int)):
-                            self._session.receive_start_pending_since = time.monotonic()
-                        self._session.receive_start_pending = True
-                        inconclusive_probe_thread = existing
-                        logger.debug(
-                            "Skipping receive thread start (%s): %s liveness probe inconclusive.",
-                            name,
-                            existing.name,
-                        )
-                    else:
-                        self._session.receive_start_pending = False
-                        self._session.receive_start_pending_since = None
-            if deferred_current_thread is None and inconclusive_probe_thread is None:
-                expected_existing = existing
-                recovery_attempts_before_start = (
-                    self._session.receive_recovery_attempts if reset_recovery else None
-                )
+                        else:
+                            self._session.receive_start_pending = False
+                            self._session.receive_start_pending_since = None
+
+                if deferred_current_thread is None and inconclusive_probe_thread is None:
+                    expected_existing = existing
+                    recovery_attempts_before_start = (
+                        self._session.receive_recovery_attempts
+                        if reset_recovery
+                        else None
+                    )
+                break
+
         if inconclusive_probe_thread is not None:
             self._schedule_deferred_receive_restart(
                 existing_thread=inconclusive_probe_thread,
@@ -383,10 +427,16 @@ class BLEReceiveLifecycleCoordinator:
                 reset_recovery=reset_recovery,
             )
             return None, None
+
         thread = create_runtime_thread(
             target=iface._receive_from_radio_impl,
             name=name,
             daemon=True,
+        )
+        expected_existing_is_alive = (
+            _thread_start_probe(expected_existing)[1]
+            if expected_existing is not None
+            else False
         )
         with self._session.lock:
             if self._session.closed or not self._session.want_receive:
@@ -397,10 +447,7 @@ class BLEReceiveLifecycleCoordinator:
                     name,
                 )
                 return None, None
-            if (
-                expected_existing is not None
-                and _thread_start_probe(expected_existing)[1]
-            ):
+            if expected_existing is not None and expected_existing_is_alive:
                 self._session.receive_start_pending = False
                 self._session.receive_start_pending_since = None
                 logger.debug(
@@ -501,12 +548,14 @@ class BLEReceiveLifecycleCoordinator:
         """Reset recovery attempts after successful start when still applicable."""
         if recovery_attempts_before_start is None:
             return
+        thread_is_alive = _thread_start_probe(thread)[1]
+        if not thread_is_alive:
+            return
         with self._session.lock:
             if (
                 self._session.receive_thread is thread
                 and self._session.receive_recovery_attempts
                 == recovery_attempts_before_start
-                and _thread_start_probe(thread)[1]
             ):
                 self._session.receive_recovery_attempts = 0
 

--- a/meshtastic/interfaces/ble/lifecycle_receive_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_receive_runtime.py
@@ -5,6 +5,8 @@ import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+from meshtastic.interfaces.ble.ports import _BLESessionStatePort
+from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.constants import logger
 from meshtastic.interfaces.ble.coordination import ThreadLike
 from meshtastic.interfaces.ble.lifecycle_primitives import _LifecycleThreadAccess
@@ -26,7 +28,9 @@ class BLEReceiveLifecycleCoordinator:
         this collaborator.
     """
 
-    def __init__(self, iface: "BLEInterface") -> None:
+    def __init__(
+        self, iface: "BLEInterface", *, session_state: _BLESessionStatePort | None = None
+    ) -> None:
         """Bind receive lifecycle ownership to a specific interface.
 
         Parameters
@@ -40,6 +44,7 @@ class BLEReceiveLifecycleCoordinator:
             Initializes bound collaborator state.
         """
         self._iface = iface
+        self._session = _session_state_for(iface, session_state)
         self._thread_access = _LifecycleThreadAccess(iface)
         self._deferred_restart_lock = threading.Lock()
         self._deferred_restart_inflight = False
@@ -82,7 +87,6 @@ class BLEReceiveLifecycleCoordinator:
         deferred thread to unwind (or for the wait window to elapse), then
         re-enters ``start_receive_thread``.
         """
-        iface = self._iface
         with self._deferred_restart_lock:
             if self._deferred_restart_inflight:
                 return
@@ -93,10 +97,10 @@ class BLEReceiveLifecycleCoordinator:
             try:
                 wait_deadline = time.monotonic() + RECEIVE_START_PENDING_TIMEOUT_SECONDS
                 while True:
-                    with iface._state_lock:
-                        if iface._closed or not iface._want_receive:
+                    with self._session.lock:
+                        if self._session.closed or not self._session.want_receive:
                             return
-                        current = iface._receiveThread
+                        current = self._session.receive_thread
                     if enforce_pending_timeout and time.monotonic() < wait_deadline:
                         time.sleep(0.01)
                         continue
@@ -107,10 +111,10 @@ class BLEReceiveLifecycleCoordinator:
                     _, current_is_alive = _thread_start_probe(existing_thread)
                     if clear_pending_if_alive:
                         if current_is_alive:
-                            with iface._state_lock:
-                                if iface._receiveThread is existing_thread:
-                                    iface._receive_start_pending = False
-                                    iface._receive_start_pending_since = None
+                            with self._session.lock:
+                                if self._session.receive_thread is existing_thread:
+                                    self._session.receive_start_pending = False
+                                    self._session.receive_start_pending_since = None
                             return
                         if time.monotonic() >= wait_deadline:
                             break
@@ -168,13 +172,13 @@ class BLEReceiveLifecycleCoordinator:
 
     def set_receive_wanted(self, *, want_receive: bool) -> None:
         """Request or clear receive-loop intent."""
-        with self._iface._state_lock:
-            self._iface._want_receive = want_receive
+        with self._session.lock:
+            self._session.want_receive = want_receive
 
     def should_run_receive_loop(self) -> bool:
         """Return whether receive loop should continue running."""
-        with self._iface._state_lock:
-            return self._iface._want_receive and not self._iface._closed
+        with self._session.lock:
+            return self._session.want_receive and not self._session.closed
 
     @staticmethod
     def _is_thread_start_failure_confirmed(thread: ThreadLike) -> bool:
@@ -219,14 +223,14 @@ class BLEReceiveLifecycleCoordinator:
         deferred_current_thread: ThreadLike | None = None
         deferred_current_thread_waiting = False
         schedule_deferred_restart_for: ThreadLike | None = None
-        with iface._state_lock:
-            if iface._closed or not iface._want_receive:
+        with self._session.lock:
+            if self._session.closed or not self._session.want_receive:
                 logger.debug(
                     "Skipping receive thread start (%s): interface is closing/stopped.",
                     name,
                 )
                 return None, None
-            existing = iface._receiveThread
+            existing = self._session.receive_thread
             existing_start_pending = bool(
                 getattr(iface, "_receive_start_pending", False)
             )
@@ -244,8 +248,8 @@ class BLEReceiveLifecycleCoordinator:
                 else:
                     pending_age = now - float(pending_since)
                     if pending_age >= RECEIVE_START_PENDING_TIMEOUT_SECONDS:
-                        iface._receive_start_pending = False
-                        iface._receive_start_pending_since = None
+                        self._session.receive_start_pending = False
+                        self._session.receive_start_pending_since = None
                         deferred_current_thread = existing
                         logger.debug(
                             "Receive-thread deferral timeout reached (%s): scheduling deferred restart.",
@@ -253,9 +257,9 @@ class BLEReceiveLifecycleCoordinator:
                         )
                 if deferred_current_thread is None:
                     deferred_current_thread_waiting = True
-                    iface._receive_start_pending = True
+                    self._session.receive_start_pending = True
                     if not isinstance(pending_since, (float, int)):
-                        iface._receive_start_pending_since = now
+                        self._session.receive_start_pending_since = now
                         schedule_deferred_restart_for = existing
                     elif not existing_start_pending:
                         schedule_deferred_restart_for = existing
@@ -278,8 +282,8 @@ class BLEReceiveLifecycleCoordinator:
                     )
             if existing is not None and not self._is_current_receive_thread(existing):
                 if existing_is_alive:
-                    iface._receive_start_pending = False
-                    iface._receive_start_pending_since = None
+                    self._session.receive_start_pending = False
+                    self._session.receive_start_pending_since = None
                     logger.debug(
                         "Skipping receive thread start (%s): %s is already running.",
                         name,
@@ -295,17 +299,17 @@ class BLEReceiveLifecycleCoordinator:
                             "Replacing stale pending receive-thread start reference for %s: worker is no longer alive.",
                             getattr(existing, "name", repr(existing)),
                         )
-                        iface._receiveThread = None
+                        self._session.receive_thread = None
                         existing = None
-                        iface._receive_start_pending = False
-                        iface._receive_start_pending_since = None
+                        self._session.receive_start_pending = False
+                        self._session.receive_start_pending_since = None
                     else:
                         pending_since = getattr(
                             iface, "_receive_start_pending_since", None
                         )
                         now = time.monotonic()
                         if not isinstance(pending_since, (float, int)):
-                            iface._receive_start_pending_since = now
+                            self._session.receive_start_pending_since = now
                             pending_age = 0.0
                         else:
                             pending_age = now - float(pending_since)
@@ -321,25 +325,25 @@ class BLEReceiveLifecycleCoordinator:
                             existing.name,
                             pending_age,
                         )
-                        iface._receive_start_pending = False
-                        iface._receive_start_pending_since = None
+                        self._session.receive_start_pending = False
+                        self._session.receive_start_pending_since = None
                 else:
                     if existing_ident is not None:
                         logger.debug(
                             "Replacing dead receive thread reference for %s before restart.",
                             getattr(existing, "name", repr(existing)),
                         )
-                        iface._receiveThread = None
+                        self._session.receive_thread = None
                         existing = None
-                        iface._receive_start_pending = False
-                        iface._receive_start_pending_since = None
+                        self._session.receive_start_pending = False
+                        self._session.receive_start_pending_since = None
                     elif not self._is_thread_start_failure_confirmed(existing):
                         pending_since = getattr(
                             iface, "_receive_start_pending_since", None
                         )
                         if not isinstance(pending_since, (float, int)):
-                            iface._receive_start_pending_since = time.monotonic()
-                        iface._receive_start_pending = True
+                            self._session.receive_start_pending_since = time.monotonic()
+                        self._session.receive_start_pending = True
                         self._schedule_deferred_receive_restart(
                             existing_thread=existing,
                             name=name,
@@ -352,12 +356,12 @@ class BLEReceiveLifecycleCoordinator:
                             existing.name,
                         )
                         return None, None
-                    iface._receive_start_pending = False
-                    iface._receive_start_pending_since = None
+                    self._session.receive_start_pending = False
+                    self._session.receive_start_pending_since = None
             if deferred_current_thread is None:
                 expected_existing = existing
                 recovery_attempts_before_start = (
-                    iface._receive_recovery_attempts if reset_recovery else None
+                    self._session.receive_recovery_attempts if reset_recovery else None
                 )
         if deferred_current_thread_waiting:
             if schedule_deferred_restart_for is not None:
@@ -379,10 +383,10 @@ class BLEReceiveLifecycleCoordinator:
             name=name,
             daemon=True,
         )
-        with iface._state_lock:
-            if iface._closed or not iface._want_receive:
+        with self._session.lock:
+            if self._session.closed or not self._session.want_receive:
                 return None, None
-            if iface._receiveThread is not expected_existing:
+            if self._session.receive_thread is not expected_existing:
                 logger.debug(
                     "Skipping receive thread publish (%s): receive thread reference changed concurrently.",
                     name,
@@ -392,16 +396,16 @@ class BLEReceiveLifecycleCoordinator:
                 expected_existing is not None
                 and _thread_start_probe(expected_existing)[1]
             ):
-                iface._receive_start_pending = False
-                iface._receive_start_pending_since = None
+                self._session.receive_start_pending = False
+                self._session.receive_start_pending_since = None
                 logger.debug(
                     "Skipping receive thread start (%s): existing thread became active while staging replacement.",
                     name,
                 )
                 return None, None
-            iface._receiveThread = thread
-            iface._receive_start_pending = True
-            iface._receive_start_pending_since = time.monotonic()
+            self._session.receive_thread = thread
+            self._session.receive_start_pending = True
+            self._session.receive_start_pending_since = time.monotonic()
             return thread, recovery_attempts_before_start
 
     def _create_and_start_receive_thread(
@@ -411,29 +415,28 @@ class BLEReceiveLifecycleCoordinator:
         start_runtime_thread: Callable[[ThreadLike], None],
     ) -> bool:
         """Start staged receive thread and clear stale reference on failure."""
-        iface = self._iface
-        with iface._state_lock:
-            if iface._receiveThread is not thread:
+        with self._session.lock:
+            if self._session.receive_thread is not thread:
                 return False
-            if iface._closed or not iface._want_receive:
+            if self._session.closed or not self._session.want_receive:
                 return False
         try:
             start_runtime_thread(thread)
         except (SystemExit, KeyboardInterrupt):  # pylint: disable=W0706
-            with iface._state_lock:
-                if iface._receiveThread is thread:
-                    iface._receiveThread = None
-                    iface._receive_start_pending = False
-                    iface._receive_start_pending_since = None
+            with self._session.lock:
+                if self._session.receive_thread is thread:
+                    self._session.receive_thread = None
+                    self._session.receive_start_pending = False
+                    self._session.receive_start_pending_since = None
             raise
         except (
             Exception
         ):  # noqa: BLE001 - start failure must clear stale thread reference
-            with iface._state_lock:
-                if iface._receiveThread is thread:
-                    iface._receiveThread = None
-                    iface._receive_start_pending = False
-                    iface._receive_start_pending_since = None
+            with self._session.lock:
+                if self._session.receive_thread is thread:
+                    self._session.receive_thread = None
+                    self._session.receive_start_pending = False
+                    self._session.receive_start_pending_since = None
             raise
         return True
 
@@ -448,30 +451,30 @@ class BLEReceiveLifecycleCoordinator:
         iface = self._iface
         _, thread_is_alive = _thread_start_probe(thread)
         if thread_is_alive:
-            with iface._state_lock:
-                if iface._receiveThread is thread:
-                    iface._receive_start_pending = False
-                    iface._receive_start_pending_since = None
+            with self._session.lock:
+                if self._session.receive_thread is thread:
+                    self._session.receive_start_pending = False
+                    self._session.receive_start_pending_since = None
             return True
         start_failure_confirmed = self._is_thread_start_failure_confirmed(thread)
 
         if start_failure_confirmed:
-            with iface._state_lock:
-                if iface._receiveThread is thread:
-                    iface._receiveThread = None
-                    iface._receive_start_pending = False
-                    iface._receive_start_pending_since = None
+            with self._session.lock:
+                if self._session.receive_thread is thread:
+                    self._session.receive_thread = None
+                    self._session.receive_start_pending = False
+                    self._session.receive_start_pending_since = None
             logger.debug(
                 "Receive thread %s did not start; cleared stale thread reference.",
                 name,
             )
         else:
-            with iface._state_lock:
-                if iface._receiveThread is thread:
-                    iface._receive_start_pending = True
+            with self._session.lock:
+                if self._session.receive_thread is thread:
+                    self._session.receive_start_pending = True
                     pending_since = getattr(iface, "_receive_start_pending_since", None)
                     if not isinstance(pending_since, (float, int)):
-                        iface._receive_start_pending_since = time.monotonic()
+                        self._session.receive_start_pending_since = time.monotonic()
             logger.debug(
                 "Receive thread %s start probe inconclusive; keeping thread reference.",
                 name,
@@ -492,16 +495,15 @@ class BLEReceiveLifecycleCoordinator:
         recovery_attempts_before_start: int | None,
     ) -> None:
         """Reset recovery attempts after successful start when still applicable."""
-        iface = self._iface
         if recovery_attempts_before_start is None:
             return
-        with iface._state_lock:
+        with self._session.lock:
             if (
-                iface._receiveThread is thread
-                and iface._receive_recovery_attempts == recovery_attempts_before_start
+                self._session.receive_thread is thread
+                and self._session.receive_recovery_attempts == recovery_attempts_before_start
                 and _thread_start_probe(thread)[1]
             ):
-                iface._receive_recovery_attempts = 0
+                self._session.receive_recovery_attempts = 0
 
     def start_receive_thread(
         self,

--- a/meshtastic/interfaces/ble/lifecycle_receive_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_receive_runtime.py
@@ -5,11 +5,11 @@ import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
-from meshtastic.interfaces.ble.ports import _BLESessionStatePort
-from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.constants import logger
 from meshtastic.interfaces.ble.coordination import ThreadLike
 from meshtastic.interfaces.ble.lifecycle_primitives import _LifecycleThreadAccess
+from meshtastic.interfaces.ble.ports import _BLESessionStatePort
+from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.utils import _thread_start_probe
 
 if TYPE_CHECKING:
@@ -29,7 +29,10 @@ class BLEReceiveLifecycleCoordinator:
     """
 
     def __init__(
-        self, iface: "BLEInterface", *, session_state: _BLESessionStatePort | None = None
+        self,
+        iface: "BLEInterface",
+        *,
+        session_state: _BLESessionStatePort | None = None,
     ) -> None:
         """Bind receive lifecycle ownership to a specific interface.
 
@@ -37,6 +40,9 @@ class BLEReceiveLifecycleCoordinator:
         ----------
         iface : BLEInterface
             Interface instance owning receive state and thread references.
+        session_state : _BLESessionStatePort | None
+            Optional shared lifecycle state. When ``None``, resolve the
+            interface-owned state or use the legacy adapter.
 
         Returns
         -------
@@ -493,7 +499,8 @@ class BLEReceiveLifecycleCoordinator:
         with self._session.lock:
             if (
                 self._session.receive_thread is thread
-                and self._session.receive_recovery_attempts == recovery_attempts_before_start
+                and self._session.receive_recovery_attempts
+                == recovery_attempts_before_start
                 and _thread_start_probe(thread)[1]
             ):
                 self._session.receive_recovery_attempts = 0

--- a/meshtastic/interfaces/ble/lifecycle_receive_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_receive_runtime.py
@@ -231,16 +231,14 @@ class BLEReceiveLifecycleCoordinator:
                 )
                 return None, None
             existing = self._session.receive_thread
-            existing_start_pending = bool(
-                getattr(iface, "_receive_start_pending", False)
-            )
+            existing_start_pending = self._session.receive_start_pending
             existing_ident: int | None = None
             existing_is_alive = False
             if existing is not None:
                 existing_ident, existing_is_alive = _thread_start_probe(existing)
             if self._is_current_receive_thread(existing):
                 now = time.monotonic()
-                pending_since = getattr(iface, "_receive_start_pending_since", None)
+                pending_since = self._session.receive_start_pending_since
                 if not existing_start_pending or not isinstance(
                     pending_since, (float, int)
                 ):
@@ -304,9 +302,7 @@ class BLEReceiveLifecycleCoordinator:
                         self._session.receive_start_pending = False
                         self._session.receive_start_pending_since = None
                     else:
-                        pending_since = getattr(
-                            iface, "_receive_start_pending_since", None
-                        )
+                        pending_since = self._session.receive_start_pending_since
                         now = time.monotonic()
                         if not isinstance(pending_since, (float, int)):
                             self._session.receive_start_pending_since = now
@@ -338,9 +334,7 @@ class BLEReceiveLifecycleCoordinator:
                         self._session.receive_start_pending = False
                         self._session.receive_start_pending_since = None
                     elif not self._is_thread_start_failure_confirmed(existing):
-                        pending_since = getattr(
-                            iface, "_receive_start_pending_since", None
-                        )
+                        pending_since = self._session.receive_start_pending_since
                         if not isinstance(pending_since, (float, int)):
                             self._session.receive_start_pending_since = time.monotonic()
                         self._session.receive_start_pending = True
@@ -448,7 +442,6 @@ class BLEReceiveLifecycleCoordinator:
         reset_recovery: bool,
     ) -> bool:
         """Probe receive-thread startup and clear stale references on failure."""
-        iface = self._iface
         _, thread_is_alive = _thread_start_probe(thread)
         if thread_is_alive:
             with self._session.lock:
@@ -472,7 +465,7 @@ class BLEReceiveLifecycleCoordinator:
             with self._session.lock:
                 if self._session.receive_thread is thread:
                     self._session.receive_start_pending = True
-                    pending_since = getattr(iface, "_receive_start_pending_since", None)
+                    pending_since = self._session.receive_start_pending_since
                     if not isinstance(pending_since, (float, int)):
                         self._session.receive_start_pending_since = time.monotonic()
             logger.debug(

--- a/meshtastic/interfaces/ble/lifecycle_receive_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_receive_runtime.py
@@ -364,6 +364,7 @@ class BLEReceiveLifecycleCoordinator:
                 existing_thread=inconclusive_probe_thread,
                 name=name,
                 reset_recovery=reset_recovery,
+                clear_pending_if_alive=True,
                 enforce_pending_timeout=True,
             )
             return None, None

--- a/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
@@ -442,10 +442,13 @@ class BLEShutdownLifecycleCoordinator:
                 )
             thread_ident = post_join_ident
             thread_is_alive = post_join_is_alive
+        # Thread-like liveness probes can execute collaborator code. Keep them
+        # outside the shared session lock and reserve the critical section for
+        # the identity-checked compare-and-clear below.
+        probe_confirms_stopped = not thread_is_alive
+        if not probe_confirms_stopped:
+            probe_confirms_stopped = _explicitly_not_alive(receive_thread)
         with self._session.lock:
-            probe_confirms_stopped = not thread_is_alive
-            if not probe_confirms_stopped:
-                probe_confirms_stopped = _explicitly_not_alive(receive_thread)
             if self._session.receive_thread is receive_thread and (
                 start_failure_confirmed or probe_confirms_stopped
             ):

--- a/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
@@ -61,6 +61,9 @@ class BLEShutdownLifecycleCoordinator:
         ----------
         iface : BLEInterface
             Interface instance providing state/thread/error collaborators.
+        session_state : _BLESessionStatePort | None
+            Optional shared lifecycle state. When ``None``, resolve the
+            interface-owned state or use the legacy adapter.
 
         Returns
         -------
@@ -107,12 +110,14 @@ class BLEShutdownLifecycleCoordinator:
             Cleanup is best effort and intentionally suppresses hook failures.
         """
         iface = self._iface
-        cleanup_hook = getattr(iface.thread_coordinator, "cleanup", None)
-        if callable(cleanup_hook):
+        cleanup_hook = _get_declared_callable(iface.thread_coordinator, "cleanup")
+        if cleanup_hook is not None:
             hook_name = "cleanup"
         else:
-            legacy_cleanup = getattr(iface.thread_coordinator, "_cleanup", None)
-            if callable(legacy_cleanup):
+            legacy_cleanup = _get_declared_callable(
+                iface.thread_coordinator, "_cleanup"
+            )
+            if legacy_cleanup is not None:
                 cleanup_hook = legacy_cleanup
                 hook_name = "_cleanup"
             else:

--- a/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
@@ -88,8 +88,10 @@ class BLEShutdownLifecycleCoordinator:
             ``True`` when the interface is in closing/closed state; otherwise
             ``False``.
         """
+        if self._state_access.is_closing():
+            return True
         with self._session.lock:
-            return self._state_access.is_closing() or self._session.closed
+            return self._session.closed
 
     def _cleanup_thread_coordinator(
         self,
@@ -234,6 +236,17 @@ class BLEShutdownLifecycleCoordinator:
         should_transition_to_disconnecting = False
         disconnect_alias_key: str | None = None
         management_wait_started = time.monotonic()
+        with self._session.lock:
+            if self._session.closed:
+                logger.debug(
+                    "BLEInterface.close called on already closed interface; ignoring"
+                )
+                return None
+        # Compatibility/state-manager probes may execute collaborator code. They
+        # do not participate in the atomic closed-state claim below, so evaluate
+        # closing state without interface/session locks, then revalidate closed
+        # state after acquiring the normal shutdown lock order.
+        was_closing = get_is_closing()
         with iface._management_lock:
             with self._session.lock:
                 if self._session.closed:
@@ -241,7 +254,6 @@ class BLEShutdownLifecycleCoordinator:
                         "BLEInterface.close called on already closed interface; ignoring"
                     )
                     return None
-                was_closing = get_is_closing()
                 self._session.closed = True
                 if was_closing:
                     logger.debug(

--- a/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
@@ -9,6 +9,7 @@ import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, cast
 
+from meshtastic.interfaces.ble.compat_adapter import (_get_declared_callable)
 from meshtastic.interfaces.ble.ports import _BLESessionStatePort
 from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.constants import (
@@ -27,7 +28,6 @@ from meshtastic.interfaces.ble.lifecycle_primitives import (
 )
 from meshtastic.interfaces.ble.state import ConnectionState
 from meshtastic.interfaces.ble.utils import (
-    _get_declared_callable,
     _is_unexpected_keyword_error,
     _thread_start_probe,
 )

--- a/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
@@ -27,8 +27,7 @@ from meshtastic.interfaces.ble.lifecycle_primitives import (
 )
 from meshtastic.interfaces.ble.state import ConnectionState
 from meshtastic.interfaces.ble.utils import (
-    _is_unconfigured_mock_callable,
-    _is_unconfigured_mock_member,
+    _get_declared_callable,
     _is_unexpected_keyword_error,
     _thread_start_probe,
 )
@@ -105,13 +104,11 @@ class BLEShutdownLifecycleCoordinator:
         """
         iface = self._iface
         cleanup_hook = getattr(iface.thread_coordinator, "cleanup", None)
-        if callable(cleanup_hook) and not _is_unconfigured_mock_callable(cleanup_hook):
+        if callable(cleanup_hook):
             hook_name = "cleanup"
         else:
             legacy_cleanup = getattr(iface.thread_coordinator, "_cleanup", None)
-            if callable(legacy_cleanup) and not _is_unconfigured_mock_callable(
-                legacy_cleanup
-            ):
+            if callable(legacy_cleanup):
                 cleanup_hook = legacy_cleanup
                 hook_name = "_cleanup"
             else:
@@ -541,7 +538,6 @@ class BLEShutdownLifecycleCoordinator:
 
     def _consume_disconnect_notification_state(self) -> bool:
         """Consume publish flags and decide disconnect notification emission."""
-        iface = self._iface
         notify = False
         with self._session.lock:
             if self._session.client_publish_pending:
@@ -560,11 +556,7 @@ class BLEShutdownLifecycleCoordinator:
                     notify = True
             elif not self._session.disconnect_notified:
                 self._session.disconnect_notified = True
-                raw_ever_connected = getattr(iface, "_ever_connected", False)
-                if _is_unconfigured_mock_member(raw_ever_connected):
-                    notify = False
-                else:
-                    notify = raw_ever_connected is True
+                notify = self._session.ever_connected is True
         return notify
 
     def _shutdown_client(
@@ -632,8 +624,8 @@ class BLEShutdownLifecycleCoordinator:
             elif method_name == "_cleanup_all":
                 candidate_names.append("cleanup_all")
             for candidate_name in candidate_names:
-                method = getattr(notification_manager, candidate_name, None)
-                if callable(method) and not _is_unconfigured_mock_callable(method):
+                method = _get_declared_callable(notification_manager, candidate_name)
+                if callable(method):
                     return cast(Callable[..., object], method)
             return None
 

--- a/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
@@ -9,6 +9,8 @@ import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, cast
 
+from meshtastic.interfaces.ble.ports import _BLESessionStatePort
+from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.constants import (
     DISCONNECT_TIMEOUT_SECONDS,
     NOTIFICATION_START_TIMEOUT,
@@ -47,7 +49,9 @@ class BLEShutdownLifecycleCoordinator:
         by this collaborator.
     """
 
-    def __init__(self, iface: "BLEInterface") -> None:
+    def __init__(
+        self, iface: "BLEInterface", *, session_state: _BLESessionStatePort | None = None
+    ) -> None:
         """Bind shutdown ownership to a specific interface.
 
         Parameters
@@ -61,7 +65,8 @@ class BLEShutdownLifecycleCoordinator:
             Initializes bound shutdown-collaborator state.
         """
         self._iface = iface
-        self._state_access = _LifecycleStateAccess(iface)
+        self._session = _session_state_for(iface, session_state)
+        self._state_access = _LifecycleStateAccess(getattr(iface, "_state_manager", iface))
         self._thread_access = _LifecycleThreadAccess(iface)
         self._error_access = _LifecycleErrorAccess(iface)
         self._bounded_cleanup_thread: threading.Thread | None = None
@@ -77,9 +82,8 @@ class BLEShutdownLifecycleCoordinator:
             ``True`` when the interface is in closing/closed state; otherwise
             ``False``.
         """
-        iface = self._iface
-        with iface._state_lock:
-            return self._state_access.is_closing() or iface._closed
+        with self._session.lock:
+            return self._state_access.is_closing() or self._session.closed
 
     def _cleanup_thread_coordinator(
         self,
@@ -225,20 +229,20 @@ class BLEShutdownLifecycleCoordinator:
         disconnect_alias_key: str | None = None
         management_wait_started = time.monotonic()
         with iface._management_lock:
-            with iface._state_lock:
-                if iface._closed:
+            with self._session.lock:
+                if self._session.closed:
                     logger.debug(
                         "BLEInterface.close called on already closed interface; ignoring"
                     )
                     return None
                 was_closing = get_is_closing()
-                iface._closed = True
+                self._session.closed = True
                 if was_closing:
                     logger.debug(
                         "BLEInterface.close called while another shutdown is in progress; continuing with cleanup"
                     )
                 current_state = get_current_state()
-                disconnect_alias_key = iface._connection_alias_key
+                disconnect_alias_key = self._session.connection_alias_key
                 should_transition_to_disconnecting = current_state not in (
                     ConnectionState.DISCONNECTED,
                     ConnectionState.DISCONNECTING,
@@ -327,7 +331,6 @@ class BLEShutdownLifecycleCoordinator:
         None
             Always returns ``None``.
         """
-        iface = self._iface
         wake_waiters = wake_waiting_threads or self._thread_access.wake_waiting_threads
         if join_thread is None:
             join_runtime_thread = self._thread_access.join_thread
@@ -363,7 +366,7 @@ class BLEShutdownLifecycleCoordinator:
                 "Error waking BLE receive-thread waiters during close",
                 exc_info=True,
             )
-        receive_thread = iface._receiveThread
+        receive_thread = self._session.receive_thread
         if receive_thread is None:
             return
         thread_ident, thread_is_alive = _thread_start_probe(receive_thread)
@@ -391,11 +394,11 @@ class BLEShutdownLifecycleCoordinator:
             elif _explicitly_not_alive(receive_thread):
                 start_failure_confirmed = True
             if start_failure_confirmed:
-                with iface._state_lock:
-                    if iface._receiveThread is receive_thread:
-                        iface._receiveThread = None
-                        iface._receive_start_pending = False
-                        iface._receive_start_pending_since = None
+                with self._session.lock:
+                    if self._session.receive_thread is receive_thread:
+                        self._session.receive_thread = None
+                        self._session.receive_start_pending = False
+                        self._session.receive_start_pending_since = None
                 logger.debug(
                     "Skipping receive thread join during close: worker never started."
                 )
@@ -424,16 +427,16 @@ class BLEShutdownLifecycleCoordinator:
                 )
             thread_ident = post_join_ident
             thread_is_alive = post_join_is_alive
-        with iface._state_lock:
+        with self._session.lock:
             probe_confirms_stopped = not thread_is_alive
             if not probe_confirms_stopped:
                 probe_confirms_stopped = _explicitly_not_alive(receive_thread)
-            if iface._receiveThread is receive_thread and (
+            if self._session.receive_thread is receive_thread and (
                 start_failure_confirmed or probe_confirms_stopped
             ):
-                iface._receiveThread = None
-                iface._receive_start_pending = False
-                iface._receive_start_pending_since = None
+                self._session.receive_thread = None
+                self._session.receive_start_pending = False
+                self._session.receive_start_pending_since = None
 
     def _close_mesh_interface(
         self,
@@ -529,9 +532,9 @@ class BLEShutdownLifecycleCoordinator:
             Detached client plus the publish-pending flag captured at detach.
         """
         iface = self._iface
-        with iface._state_lock:
+        with self._session.lock:
             client = iface.client
-            publish_pending = iface._client_publish_pending
+            publish_pending = self._session.client_publish_pending
             if client is not None:
                 iface.client = None
         return client, publish_pending
@@ -540,23 +543,23 @@ class BLEShutdownLifecycleCoordinator:
         """Consume publish flags and decide disconnect notification emission."""
         iface = self._iface
         notify = False
-        with iface._state_lock:
-            if iface._client_publish_pending:
-                replacement_pending = iface._client_replacement_pending
-                iface._client_publish_pending = False
-                iface._client_replacement_pending = False
-                if replacement_pending and not iface._disconnect_notified:
-                    iface._disconnect_notified = True
+        with self._session.lock:
+            if self._session.client_publish_pending:
+                replacement_pending = self._session.client_replacement_pending
+                self._session.client_publish_pending = False
+                self._session.client_replacement_pending = False
+                if replacement_pending and not self._session.disconnect_notified:
+                    self._session.disconnect_notified = True
                     notify = True
                 else:
-                    iface._disconnect_notified = True
-            elif iface._client_replacement_pending:
-                iface._client_replacement_pending = False
-                if not iface._disconnect_notified:
-                    iface._disconnect_notified = True
+                    self._session.disconnect_notified = True
+            elif self._session.client_replacement_pending:
+                self._session.client_replacement_pending = False
+                if not self._session.disconnect_notified:
+                    self._session.disconnect_notified = True
                     notify = True
-            elif not iface._disconnect_notified:
-                iface._disconnect_notified = True
+            elif not self._session.disconnect_notified:
+                self._session.disconnect_notified = True
                 raw_ever_connected = getattr(iface, "_ever_connected", False)
                 if _is_unconfigured_mock_member(raw_ever_connected):
                     notify = False
@@ -754,9 +757,9 @@ class BLEShutdownLifecycleCoordinator:
             reset_to_disconnected or self._state_access.reset_to_disconnected
         )
         alias_key: str | None = None
-        with iface._state_lock:
-            alias_key = iface._connection_alias_key
-            iface._connection_alias_key = None
+        with self._session.lock:
+            alias_key = self._session.connection_alias_key
+            self._session.connection_alias_key = None
         # Record final state as DISCONNECTED for observers; instance remains closed.
         if not do_transition_to(ConnectionState.DISCONNECTED):
             current_state = get_current_state()

--- a/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
@@ -372,7 +372,8 @@ class BLEShutdownLifecycleCoordinator:
                 _BLEFailureDisposition.BEST_EFFORT,
                 "Error waking BLE receive-thread waiters during close",
             )
-        receive_thread = self._session.receive_thread
+        with self._session.lock:
+            receive_thread = self._session.receive_thread
         if receive_thread is None:
             return
         thread_ident, thread_is_alive = _thread_start_probe(receive_thread)

--- a/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
@@ -259,12 +259,16 @@ class BLEShutdownLifecycleCoordinator:
                     logger.debug(
                         "BLEInterface.close called while another shutdown is in progress; continuing with cleanup"
                     )
-                current_state = get_current_state()
                 disconnect_alias_key = self._session.connection_alias_key
-                should_transition_to_disconnecting = current_state not in (
-                    ConnectionState.DISCONNECTED,
-                    ConnectionState.DISCONNECTING,
-                )
+            # State-manager compatibility access may dispatch through a
+            # collaborator hook. Preserve the management-before-state lock
+            # ordering, but never execute that hook while the session lock is
+            # held.
+            current_state = get_current_state()
+            should_transition_to_disconnecting = current_state not in (
+                ConnectionState.DISCONNECTED,
+                ConnectionState.DISCONNECTING,
+            )
             if should_transition_to_disconnecting and not do_transition_to(
                 ConnectionState.DISCONNECTING
             ):

--- a/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
@@ -9,7 +9,10 @@ import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, cast
 
-from meshtastic.interfaces.ble.compat_adapter import (_get_declared_callable)
+from meshtastic.interfaces.ble.compat_adapter import (
+    _get_declared_callable,
+    _get_declared_member,
+)
 from meshtastic.interfaces.ble.ports import _BLESessionStatePort
 from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.constants import (
@@ -112,13 +115,15 @@ class BLEShutdownLifecycleCoordinator:
             Cleanup is best effort and intentionally suppresses hook failures.
         """
         iface = self._iface
-        cleanup_hook = _get_declared_callable(iface.thread_coordinator, "cleanup")
+        coordinator = _get_declared_member(iface, "thread_coordinator")
+        if coordinator is None:
+            logger.debug("Thread coordinator is unavailable; skipping cleanup")
+            return
+        cleanup_hook = _get_declared_callable(coordinator, "cleanup")
         if cleanup_hook is not None:
             hook_name = "cleanup"
         else:
-            legacy_cleanup = _get_declared_callable(
-                iface.thread_coordinator, "_cleanup"
-            )
+            legacy_cleanup = _get_declared_callable(coordinator, "_cleanup")
             if legacy_cleanup is not None:
                 cleanup_hook = legacy_cleanup
                 hook_name = "_cleanup"

--- a/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
@@ -20,6 +20,10 @@ from meshtastic.interfaces.ble.constants import (
     RECONNECTED_EVENT,
     logger,
 )
+from meshtastic.interfaces.ble.failure_policy import (
+    _BLEFailureDisposition,
+    _log_ble_failure,
+)
 from meshtastic.interfaces.ble.gating import _addr_key
 from meshtastic.interfaces.ble.lifecycle_primitives import (
     _LifecycleErrorAccess,
@@ -119,10 +123,10 @@ class BLEShutdownLifecycleCoordinator:
             try:
                 cleanup_hook()
             except Exception:  # noqa: BLE001 - shutdown cleanup is best effort
-                logger.debug(
+                _log_ble_failure(
+                    _BLEFailureDisposition.BEST_EFFORT,
                     "Error running thread coordinator %s()",
                     hook_name,
-                    exc_info=True,
                 )
             return
 
@@ -137,10 +141,10 @@ class BLEShutdownLifecycleCoordinator:
             try:
                 cleanup_hook()
             except Exception:  # noqa: BLE001 - shutdown cleanup is best effort
-                logger.debug(
+                _log_ble_failure(
+                    _BLEFailureDisposition.BEST_EFFORT,
                     "Error running thread coordinator %s()",
                     hook_name,
-                    exc_info=True,
                 )
             finally:
                 with self._bounded_thread_lock:
@@ -359,9 +363,9 @@ class BLEShutdownLifecycleCoordinator:
         try:
             wake_waiters(READ_TRIGGER_EVENT, RECONNECTED_EVENT)
         except Exception:  # noqa: BLE001 - close must remain best effort
-            logger.debug(
+            _log_ble_failure(
+                _BLEFailureDisposition.BEST_EFFORT,
                 "Error waking BLE receive-thread waiters during close",
-                exc_info=True,
             )
         receive_thread = self._session.receive_thread
         if receive_thread is None:
@@ -374,7 +378,11 @@ class BLEShutdownLifecycleCoordinator:
                 return False
             try:
                 return is_alive_probe() is False
-            except Exception:  # noqa: BLE001 - probe remains best effort
+            except Exception:  # noqa: BLE001 - shutdown probe is best effort
+                _log_ble_failure(
+                    _BLEFailureDisposition.BEST_EFFORT,
+                    "Unable to probe BLE receive-thread liveness during close",
+                )
                 return False
 
         start_failure_confirmed = False
@@ -384,7 +392,11 @@ class BLEShutdownLifecycleCoordinator:
             if callable(is_started):
                 try:
                     start_failure_confirmed = not bool(is_started())
-                except Exception:  # noqa: BLE001 - probe remains best effort
+                except Exception:  # noqa: BLE001 - shutdown probe is best effort
+                    _log_ble_failure(
+                        _BLEFailureDisposition.BEST_EFFORT,
+                        "Unable to probe BLE receive-thread start state during close",
+                    )
                     start_failure_confirmed = False
             elif isinstance(receive_thread, threading.Thread):
                 start_failure_confirmed = True
@@ -412,9 +424,9 @@ class BLEShutdownLifecycleCoordinator:
                     timeout=join_timeout,
                 )
             except Exception:  # noqa: BLE001 - close must remain best effort
-                logger.debug(
+                _log_ble_failure(
+                    _BLEFailureDisposition.BEST_EFFORT,
                     "Error joining BLE receive thread during close",
-                    exc_info=True,
                 )
             post_join_ident, post_join_is_alive = _thread_start_probe(receive_thread)
             if post_join_is_alive:

--- a/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
@@ -69,7 +69,7 @@ class BLEShutdownLifecycleCoordinator:
         """
         self._iface = iface
         self._session = _session_state_for(iface, session_state)
-        self._state_access = _LifecycleStateAccess(getattr(iface, "_state_manager", iface))
+        self._state_access = _LifecycleStateAccess(iface)
         self._thread_access = _LifecycleThreadAccess(iface)
         self._error_access = _LifecycleErrorAccess(iface)
         self._bounded_cleanup_thread: threading.Thread | None = None

--- a/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
@@ -45,6 +45,11 @@ if TYPE_CHECKING:
     from meshtastic.interfaces.ble.interface import BLEInterface
 
 
+SHUTDOWN_ALREADY_CLOSED_MSG = (
+    "BLEInterface.close called on already closed interface; ignoring"
+)
+
+
 class BLEShutdownLifecycleCoordinator:
     """Own interface shutdown orchestration and terminal cleanup behavior.
 
@@ -243,9 +248,7 @@ class BLEShutdownLifecycleCoordinator:
         management_wait_started = time.monotonic()
         with self._session.lock:
             if self._session.closed:
-                logger.debug(
-                    "BLEInterface.close called on already closed interface; ignoring"
-                )
+                logger.debug(SHUTDOWN_ALREADY_CLOSED_MSG)
                 return None
         # Compatibility/state-manager probes may execute collaborator code. They
         # do not participate in the atomic closed-state claim below, so evaluate
@@ -255,9 +258,7 @@ class BLEShutdownLifecycleCoordinator:
         with iface._management_lock:
             with self._session.lock:
                 if self._session.closed:
-                    logger.debug(
-                        "BLEInterface.close called on already closed interface; ignoring"
-                    )
+                    logger.debug(SHUTDOWN_ALREADY_CLOSED_MSG)
                     return None
                 self._session.closed = True
                 if was_closing:

--- a/meshtastic/interfaces/ble/management_compat_service.py
+++ b/meshtastic/interfaces/ble/management_compat_service.py
@@ -107,7 +107,7 @@ class BLEManagementCommandsService:
             ble_client_factory is None and connected_elsewhere is None
         )
         if use_iface_owned_handler:
-            get_handler: object | None = None
+            get_handler: Callable[..., object] | None = None
             try:
                 get_handler = _get_declared_callable(
                     iface, "_get_management_command_handler"

--- a/meshtastic/interfaces/ble/management_compat_service.py
+++ b/meshtastic/interfaces/ble/management_compat_service.py
@@ -107,16 +107,9 @@ class BLEManagementCommandsService:
             ble_client_factory is None and connected_elsewhere is None
         )
         if use_iface_owned_handler:
-            get_handler: Callable[..., object] | None = None
-            try:
-                get_handler = _get_declared_callable(
-                    iface, "_get_management_command_handler"
-                )
-            except AttributeError:
-                logger.debug(
-                    "Error resolving _get_management_command_handler; falling back to direct handler field.",
-                    exc_info=True,
-                )
+            get_handler: Callable[..., object] | None = _get_declared_callable(
+                iface, "_get_management_command_handler"
+            )
             if get_handler is not None:
                 try:
                     resolved = get_handler()

--- a/meshtastic/interfaces/ble/management_compat_service.py
+++ b/meshtastic/interfaces/ble/management_compat_service.py
@@ -96,7 +96,7 @@ class BLEManagementCommandsService:
 
     @staticmethod
     def _handler_for_shim(
-        iface: "BLEInterface | object",
+        iface: object,
         *,
         expected_method: str | None = None,
         ble_client_factory: Callable[..., BLEClient] | None = None,

--- a/meshtastic/interfaces/ble/management_compat_service.py
+++ b/meshtastic/interfaces/ble/management_compat_service.py
@@ -20,8 +20,8 @@ from meshtastic.interfaces.ble.management_runtime import (
     _ManagementStartContext,
 )
 from meshtastic.interfaces.ble.utils import (
-    _is_unconfigured_mock_callable,
-    _is_unconfigured_mock_member,
+    _get_declared_callable,
+    _get_declared_member,
 )
 
 if TYPE_CHECKING:
@@ -44,11 +44,8 @@ class BLEManagementCommandsService:
         as soon as it finds any callable/non-mock method from the compatibility
         entrypoint list.
         """
-        if _is_unconfigured_mock_member(candidate):
-            return False
         if expected_method is not None:
-            expected = getattr(candidate, expected_method, None)
-            return callable(expected) and not _is_unconfigured_mock_callable(expected)
+            return _get_declared_callable(candidate, expected_method) is not None
         required_entrypoints = (
             "execute_management_command",
             "start_management_phase",
@@ -64,16 +61,14 @@ class BLEManagementCommandsService:
             "run_bluetoothctl_trust_command",
         )
         for method_name in required_entrypoints:
-            method = getattr(candidate, method_name, None)
-            if callable(method) and not _is_unconfigured_mock_callable(method):
+            method = _get_declared_callable(candidate, method_name)
+            if method is not None:
                 return True
         return False
 
     @staticmethod
     def _is_handler_like(candidate: object) -> bool:
         """Return whether ``candidate`` exposes the management handler API surface."""
-        if _is_unconfigured_mock_member(candidate):
-            return False
         required_methods = (
             "resolve_target_address_for_management",
             "management_target_gate",
@@ -98,8 +93,7 @@ class BLEManagementCommandsService:
             "trust",
         )
         for method_name in required_methods:
-            method = getattr(candidate, method_name, None)
-            if not callable(method) or _is_unconfigured_mock_callable(method):
+            if _get_declared_callable(candidate, method_name) is None:
                 return False
         return True
 
@@ -118,15 +112,15 @@ class BLEManagementCommandsService:
         if use_iface_owned_handler:
             get_handler: object | None = None
             try:
-                get_handler = getattr(iface, "_get_management_command_handler", None)
+                get_handler = _get_declared_callable(
+                    iface, "_get_management_command_handler"
+                )
             except AttributeError:
                 logger.debug(
                     "Error resolving _get_management_command_handler; falling back to direct handler field.",
                     exc_info=True,
                 )
-            if callable(get_handler) and not _is_unconfigured_mock_callable(
-                get_handler
-            ):
+            if get_handler is not None:
                 try:
                     resolved = get_handler()
                 except (AttributeError, TypeError):
@@ -137,7 +131,6 @@ class BLEManagementCommandsService:
                 else:
                     if (
                         resolved is not None
-                        and not _is_unconfigured_mock_member(resolved)
                         and (
                             BLEManagementCommandsService._is_handler_like(resolved)
                             # COMPAT_STABLE_SHIM: preserve iface-owned partial
@@ -149,10 +142,9 @@ class BLEManagementCommandsService:
                         )
                     ):
                         return cast(BLEManagementCommandHandler, resolved)
-            direct_handler = getattr(iface, "_management_command_handler", None)
+            direct_handler = _get_declared_member(iface, "_management_command_handler")
             if (
                 direct_handler is not None
-                and not _is_unconfigured_mock_member(direct_handler)
                 and (
                     BLEManagementCommandsService._is_handler_like(direct_handler)
                     # COMPAT_STABLE_SHIM: preserve iface-owned partial
@@ -167,12 +159,10 @@ class BLEManagementCommandsService:
         if ble_client_factory is None:
             ble_client_factory = BLEClient
         if connected_elsewhere is None:
-            iface_connected_elsewhere = getattr(
-                iface, "_connected_elsewhere_late_bound", None
+            iface_connected_elsewhere = _get_declared_callable(
+                iface, "_connected_elsewhere_late_bound"
             )
-            if callable(
-                iface_connected_elsewhere
-            ) and not _is_unconfigured_mock_callable(iface_connected_elsewhere):
+            if iface_connected_elsewhere is not None:
                 connected_elsewhere = cast(
                     Callable[[str | None, object | None], bool],
                     iface_connected_elsewhere,

--- a/meshtastic/interfaces/ble/management_compat_service.py
+++ b/meshtastic/interfaces/ble/management_compat_service.py
@@ -7,6 +7,7 @@ import sys as sys_stdlib
 from collections.abc import Callable
 from typing import TYPE_CHECKING, cast
 
+from meshtastic.interfaces.ble.compat_adapter import (_get_declared_callable, _get_declared_member)
 from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.constants import logger
 from meshtastic.interfaces.ble.gating import _is_currently_connected_elsewhere
@@ -18,10 +19,6 @@ from meshtastic.interfaces.ble.management_runtime import (
     BLEManagementCommandHandler,
     T,
     _ManagementStartContext,
-)
-from meshtastic.interfaces.ble.utils import (
-    _get_declared_callable,
-    _get_declared_member,
 )
 
 if TYPE_CHECKING:
@@ -40,8 +37,8 @@ class BLEManagementCommandsService:
         """Return whether ``candidate`` exposes usable shim entrypoint(s).
 
         When ``expected_method`` is provided, this requires that specific
-        delegated method to be callable/non-mock. Otherwise, it returns ``True``
-        as soon as it finds any callable/non-mock method from the compatibility
+        delegated method to be explicitly declared callable. Otherwise, it returns ``True``
+        as soon as it finds any explicitly declared callable method from the compatibility
         entrypoint list.
         """
         if expected_method is not None:

--- a/meshtastic/interfaces/ble/management_compat_service.py
+++ b/meshtastic/interfaces/ble/management_compat_service.py
@@ -96,7 +96,7 @@ class BLEManagementCommandsService:
 
     @staticmethod
     def _handler_for_shim(
-        iface: "BLEInterface",
+        iface: "BLEInterface | object",
         *,
         expected_method: str | None = None,
         ble_client_factory: Callable[..., BLEClient] | None = None,
@@ -173,7 +173,7 @@ class BLEManagementCommandsService:
 
                 connected_elsewhere = _default_connected_elsewhere
         return BLEManagementCommandHandler(
-            iface,
+            cast("BLEInterface", iface),
             ble_client_factory=ble_client_factory,
             connected_elsewhere=connected_elsewhere,
         )

--- a/meshtastic/interfaces/ble/management_runtime.py
+++ b/meshtastic/interfaces/ble/management_runtime.py
@@ -1,5 +1,6 @@
 """Management command helpers for BLE interface orchestration."""
 
+import inspect
 import math
 import numbers
 import re
@@ -11,6 +12,10 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, TypeVar, cast
 
 from meshtastic.interfaces.ble.client import BLEClient
+from meshtastic.interfaces.ble.compat_adapter import (
+    _get_declared_callable,
+    _get_declared_member,
+)
 from meshtastic.interfaces.ble.connection import ConnectionOrchestrator
 from meshtastic.interfaces.ble.constants import (
     ERROR_CONNECTION_SUPPRESSED,
@@ -273,8 +278,8 @@ class BLEManagementCommandHandler:
         if method_name in active_dispatches:
             return fallback(*args, **kwargs)
 
-        override = getattr(self._iface, method_name, None)
-        if callable(override):
+        override = _get_declared_callable(self._iface, method_name)
+        if override is not None:
 
             def _invoke_override() -> T:
                 active_dispatches.add(method_name)
@@ -283,14 +288,16 @@ class BLEManagementCommandHandler:
                 finally:
                     active_dispatches.discard(method_name)
 
-            instance_dict = getattr(self._iface, "__dict__", {})
+            instance_dict = _get_declared_member(self._iface, "__dict__", {})
             if isinstance(instance_dict, dict) and method_name in instance_dict:
                 return _invoke_override()
             try:
                 from meshtastic.interfaces.ble.interface import BLEInterface
 
-                base_method = getattr(BLEInterface, method_name, None)
-                class_method = getattr(type(self._iface), method_name, None)
+                base_method = inspect.getattr_static(BLEInterface, method_name, None)
+                class_method = inspect.getattr_static(
+                    type(self._iface), method_name, None
+                )
                 if class_method is not None and class_method is not base_method:
                     return _invoke_override()
             except Exception:  # noqa: BLE001 - lookup fallback

--- a/meshtastic/interfaces/ble/management_runtime.py
+++ b/meshtastic/interfaces/ble/management_runtime.py
@@ -501,7 +501,7 @@ class BLEManagementCommandHandler:
                 self.begin_management_operation_locked()
                 operation_started = True
                 existing_client = self._call_iface_override(
-                    "_get_management_client_if_available",
+                    "_get_management_client_if_available_locked",
                     self.get_management_client_if_available_locked,
                     address,
                 )
@@ -540,7 +540,7 @@ class BLEManagementCommandHandler:
             with iface._connect_lock, iface._management_lock, iface._state_lock:
                 iface._validate_management_preconditions()
                 refreshed_existing_client = self._call_iface_override(
-                    "_get_management_client_if_available",
+                    "_get_management_client_if_available_locked",
                     self.get_management_client_if_available_locked,
                     address,
                 )
@@ -563,7 +563,7 @@ class BLEManagementCommandHandler:
             with iface._connect_lock, iface._management_lock, iface._state_lock:
                 iface._validate_management_preconditions()
                 refreshed_existing_client = self._call_iface_override(
-                    "_get_management_client_if_available",
+                    "_get_management_client_if_available_locked",
                     self.get_management_client_if_available_locked,
                     address,
                 )
@@ -659,7 +659,7 @@ class BLEManagementCommandHandler:
                     expected_binding=expected_implicit_binding,
                 )
             client_to_use = self._call_iface_override(
-                "_get_management_client_for_target",
+                "_get_management_client_for_target_locked",
                 self.get_management_client_for_target_locked,
                 target_address,
                 prefer_current_client=address is None,

--- a/meshtastic/interfaces/ble/management_runtime.py
+++ b/meshtastic/interfaces/ble/management_runtime.py
@@ -33,7 +33,6 @@ from meshtastic.interfaces.ble.gating import (
 )
 from meshtastic.interfaces.ble.utils import (
     _call_factory_with_optional_kwarg,
-    _is_unconfigured_mock_callable,
     sanitize_address,
 )
 
@@ -274,7 +273,7 @@ class BLEManagementCommandHandler:
             return fallback(*args, **kwargs)
 
         override = getattr(self._iface, method_name, None)
-        if callable(override) and not _is_unconfigured_mock_callable(override):
+        if callable(override):
 
             def _invoke_override() -> T:
                 active_dispatches.add(method_name)
@@ -420,9 +419,7 @@ class BLEManagementCommandHandler:
         callable_probe_seen = False
         for attr_name in ("isConnected", "is_connected", "_is_connected"):
             is_connected = getattr(client, attr_name, None)
-            if callable(is_connected) and not _is_unconfigured_mock_callable(
-                is_connected
-            ):
+            if callable(is_connected):
                 try:
                     connected_result = is_connected()
                 except (

--- a/meshtastic/interfaces/ble/management_runtime.py
+++ b/meshtastic/interfaces/ble/management_runtime.py
@@ -31,6 +31,7 @@ from meshtastic.interfaces.ble.gating import (
     _addr_key,
     _addr_lock_context,
 )
+from meshtastic.interfaces.ble.lifecycle_primitives import _client_is_connected_compat
 from meshtastic.interfaces.ble.utils import (
     _call_factory_with_optional_kwarg,
     sanitize_address,
@@ -414,35 +415,10 @@ class BLEManagementCommandHandler:
     @staticmethod
     def _is_client_connected(client: BLEClient | None) -> bool:
         """Return whether a candidate client appears currently connected."""
-        if client is None:
+        try:
+            return _client_is_connected_compat(client)
+        except AttributeError:
             return False
-        callable_probe_seen = False
-        for attr_name in ("isConnected", "is_connected", "_is_connected"):
-            is_connected = getattr(client, attr_name, None)
-            if callable(is_connected):
-                try:
-                    connected_result = is_connected()
-                except (
-                    Exception
-                ):  # noqa: BLE001 - connectivity probe must remain best effort
-                    callable_probe_seen = True
-                    logger.debug(
-                        "Error probing BLE client connectivity via %s",
-                        attr_name,
-                        exc_info=True,
-                    )
-                    continue
-                callable_probe_seen = True
-                if isinstance(connected_result, bool):
-                    return connected_result
-                continue
-            if isinstance(is_connected, bool):
-                if callable_probe_seen:
-                    continue
-                return is_connected
-        if callable_probe_seen:
-            return False
-        return False
 
     def get_current_implicit_management_binding_locked(self) -> str | None:
         """Return current implicit management binding while holding state lock."""

--- a/meshtastic/interfaces/ble/notifications.py
+++ b/meshtastic/interfaces/ble/notifications.py
@@ -11,7 +11,10 @@ from typing import TYPE_CHECKING, Any, cast
 from bleak.exc import BleakDBusError, BleakError
 
 from meshtastic.interfaces.ble.client import BLEClient
-from meshtastic.interfaces.ble.compat_adapter import _resolve_declared_callable
+from meshtastic.interfaces.ble.compat_adapter import (
+    _iter_declared_callables,
+    _resolve_declared_callable,
+)
 from meshtastic.interfaces.ble.constants import (
     BLECLIENT_ERROR_SUBSCRIPTION_TOKEN_EXHAUSTED,
     FROMNUM_UUID,
@@ -693,20 +696,13 @@ class BLENotificationDispatcher:
                         return False
                     return True
 
-                report_notification_error = getattr(
+                for _member_name, reporter in _iter_declared_callables(
                     iface,
                     "report_notification_handler_error",
-                    None,
-                )
-                if _try_report(report_notification_error):
-                    return
-                legacy_report_notification_error = getattr(
-                    iface,
                     "_report_notification_handler_error",
-                    None,
-                )
-                if _try_report(legacy_report_notification_error):
-                    return
+                ):
+                    if _try_report(reporter):
+                        return
                 self.report_notification_handler_error(error_msg)
 
             def _invoke_handler() -> None:

--- a/meshtastic/interfaces/ble/notifications.py
+++ b/meshtastic/interfaces/ble/notifications.py
@@ -22,8 +22,7 @@ from meshtastic.interfaces.ble.constants import (
 )
 from meshtastic.interfaces.ble.errors import DecodeError
 from meshtastic.interfaces.ble.utils import (
-    _is_unconfigured_mock_callable,
-    _is_unconfigured_mock_member,
+    _get_declared_callable,
     _is_unexpected_keyword_error,
     _sleep,
 )
@@ -363,7 +362,7 @@ class BLENotificationDispatcher:
         -------
         object | None
             Resolved error-handler object, or ``None`` when provider lookup
-            fails or returns an unconfigured mock placeholder.
+            fails or returns no handler.
         """
         try:
             error_handler = self._error_handler_provider()
@@ -372,8 +371,6 @@ class BLENotificationDispatcher:
                 "Error resolving notification error-handler provider.",
                 exc_info=True,
             )
-            return None
-        if _is_unconfigured_mock_member(error_handler):
             return None
         return error_handler
 
@@ -386,9 +383,7 @@ class BLENotificationDispatcher:
         report_exception: Callable[[str], Any] | None = None
         for hook_name in ("safe_execute", "_safe_execute"):
             safe_execute_hook = getattr(error_handler, hook_name, None)
-            if callable(safe_execute_hook) and not _is_unconfigured_mock_callable(
-                safe_execute_hook
-            ):
+            if callable(safe_execute_hook):
                 safe_execute_callable = cast(Callable[..., Any], safe_execute_hook)
 
                 def _report_via_safe_execute(
@@ -415,7 +410,7 @@ class BLENotificationDispatcher:
             if report_exception is not None:
                 break
             hook = getattr(error_handler, hook_name, None)
-            if callable(hook) and not _is_unconfigured_mock_callable(hook):
+            if callable(hook):
                 report_exception = hook
                 break
         if report_exception is not None:
@@ -690,7 +685,7 @@ class BLENotificationDispatcher:
         ) -> None:
             def _report_notification_error() -> None:
                 def _try_report(hook: object | None) -> bool:
-                    if not callable(hook) or _is_unconfigured_mock_callable(hook):
+                    if not callable(hook):
                         return False
                     try:
                         hook(error_msg)
@@ -730,14 +725,10 @@ class BLENotificationDispatcher:
                     _report_notification_error()
 
             error_handler = self._resolve_error_handler()
-            safe_execute = getattr(error_handler, "safe_execute", None)
-            if not callable(safe_execute) or _is_unconfigured_mock_callable(
-                safe_execute
-            ):
-                safe_execute = getattr(error_handler, "_safe_execute", None)
-            if not callable(safe_execute) or _is_unconfigured_mock_callable(
-                safe_execute
-            ):
+            safe_execute = _get_declared_callable(error_handler, "safe_execute")
+            if not callable(safe_execute):
+                safe_execute = _get_declared_callable(error_handler, "_safe_execute")
+            if not callable(safe_execute):
                 try:
                     _invoke_handler()
                 except (

--- a/meshtastic/interfaces/ble/notifications.py
+++ b/meshtastic/interfaces/ble/notifications.py
@@ -893,12 +893,28 @@ class BLENotificationDispatcher:
             cache_attr="_safe_from_num_handler",
             factory=lambda: _safe_from_num_handler,
         )
-        if FROMNUM_UUID in self._started_notify_characteristics:
-            current_ingress_handler = self._notification_manager._get_callback(
-                FROMNUM_UUID
-            )
-            if current_ingress_handler is not ingress_handler:
+
+        def _track_fromnum_handler() -> bool:
+            try:
+                current_ingress_handler = self._notification_manager._get_callback(
+                    FROMNUM_UUID
+                )
+                if current_ingress_handler is ingress_handler:
+                    return True
                 self._notification_manager._subscribe(FROMNUM_UUID, ingress_handler)
+            except Exception as err:  # noqa: BLE001 - local/backend state must converge
+                logger.warning(
+                    "Unable to track FROMNUM notification callback for %s: %s; rolling back backend notifications and falling back to polling reads.",
+                    FROMNUM_UUID,
+                    err,
+                )
+                _rollback_registration_state(stop_client=client)
+                return False
+            return True
+
+        if FROMNUM_UUID in self._started_notify_characteristics:
+            if not _track_fromnum_handler():
+                return
             if not _registration_still_current():
                 _rollback_registration_state(stop_client=client)
                 return
@@ -958,11 +974,8 @@ class BLENotificationDispatcher:
                 # can then unwind through the single centralized rollback path exactly
                 # once per started characteristic.
                 self._started_notify_characteristics.add(FROMNUM_UUID)
-                current_ingress_handler = self._notification_manager._get_callback(
-                    FROMNUM_UUID
-                )
-                if current_ingress_handler is not ingress_handler:
-                    self._notification_manager._subscribe(FROMNUM_UUID, ingress_handler)
+                if not _track_fromnum_handler():
+                    return
                 if not _registration_still_current():
                     _rollback_registration_state(stop_client=client)
                     return

--- a/meshtastic/interfaces/ble/notifications.py
+++ b/meshtastic/interfaces/ble/notifications.py
@@ -302,7 +302,7 @@ class BLENotificationDispatcher:
         self._fromnum_notify_enabled = False
         self._malformed_notification_count = 0
         self._malformed_notification_lock = RLock()
-        self._malformed_notification_state_lock = Lock()
+        self._notification_state_lock = Lock()
         self._malformed_notification_handling_started = False
         self._current_legacy_log_handler: Callable[[Any, Any], None] | None = None
         self._current_log_handler: Callable[[Any, Any], None] | None = None
@@ -316,14 +316,15 @@ class BLENotificationDispatcher:
     @property
     def fromnum_notify_enabled(self) -> bool:
         """Return whether FROMNUM notifications are currently active."""
-        with self._registration_lock:
+        with self._notification_state_lock:
             return self._fromnum_notify_enabled
 
     @fromnum_notify_enabled.setter
     def fromnum_notify_enabled(self, enabled: bool) -> None:
         """Set FROMNUM notification-active flag."""
         with self._registration_lock:
-            self._fromnum_notify_enabled = enabled
+            with self._notification_state_lock:
+                self._fromnum_notify_enabled = enabled
 
     @property
     def malformed_notification_count(self) -> int:
@@ -345,7 +346,7 @@ class BLENotificationDispatcher:
     @malformed_notification_lock.setter
     def malformed_notification_lock(self, lock: RLock) -> None:
         """Set malformed-notification lock for compatibility callers."""
-        with self._malformed_notification_state_lock:
+        with self._notification_state_lock:
             if self._malformed_notification_handling_started:
                 raise RuntimeError(
                     "Cannot replace malformed_notification_lock after notification handling starts."
@@ -354,7 +355,7 @@ class BLENotificationDispatcher:
 
     def handle_malformed_fromnum(self, reason: str, exc_info: bool = False) -> None:
         """Track malformed FROMNUM notifications and emit threshold warnings."""
-        with self._malformed_notification_state_lock:
+        with self._notification_state_lock:
             self._malformed_notification_handling_started = True
         with self._malformed_notification_lock:
             self._malformed_notification_count += 1
@@ -595,7 +596,7 @@ class BLENotificationDispatcher:
 
     def from_num_handler(self, _: Any, b: bytes | bytearray) -> None:
         """Parse FROMNUM payload, reset malformed counter, and wake read loop."""
-        with self._malformed_notification_state_lock:
+        with self._notification_state_lock:
             self._malformed_notification_handling_started = True
         try:
             if len(b) != 4:

--- a/meshtastic/interfaces/ble/notifications.py
+++ b/meshtastic/interfaces/ble/notifications.py
@@ -298,6 +298,7 @@ class BLENotificationDispatcher:
         self._error_handler_provider = error_handler_provider
         self._trigger_read_event = trigger_read_event
         self._registration_current_provider = registration_current_provider
+        self._registration_lock = RLock()
         self._fromnum_notify_enabled = False
         self._malformed_notification_count = 0
         self._malformed_notification_lock = RLock()
@@ -315,12 +316,14 @@ class BLENotificationDispatcher:
     @property
     def fromnum_notify_enabled(self) -> bool:
         """Return whether FROMNUM notifications are currently active."""
-        return self._fromnum_notify_enabled
+        with self._registration_lock:
+            return self._fromnum_notify_enabled
 
     @fromnum_notify_enabled.setter
     def fromnum_notify_enabled(self, enabled: bool) -> None:
         """Set FROMNUM notification-active flag."""
-        self._fromnum_notify_enabled = enabled
+        with self._registration_lock:
+            self._fromnum_notify_enabled = enabled
 
     @property
     def malformed_notification_count(self) -> int:
@@ -627,7 +630,26 @@ class BLENotificationDispatcher:
         log_handler: Callable[[Any, bytes | bytearray], None],
         from_num_handler: Callable[[Any, bytes], None],
     ) -> None:
-        """Register BLE characteristic notification handlers on ``client``."""
+        """Serialize one complete notification-registration transaction."""
+        with self._registration_lock:
+            self._register_notifications_locked(
+                iface,
+                client,
+                legacy_log_handler=legacy_log_handler,
+                log_handler=log_handler,
+                from_num_handler=from_num_handler,
+            )
+
+    def _register_notifications_locked(
+        self,
+        iface: "BLEInterface",
+        client: BLEClient,
+        *,
+        legacy_log_handler: Callable[[Any, bytes | bytearray], None],
+        log_handler: Callable[[Any, bytes | bytearray], None],
+        from_num_handler: Callable[[Any, bytes], None],
+    ) -> None:
+        """Register notification handlers while registration ownership is held."""
         self._current_legacy_log_handler = legacy_log_handler
         self._current_log_handler = log_handler
         self._current_from_num_handler = from_num_handler

--- a/meshtastic/interfaces/ble/notifications.py
+++ b/meshtastic/interfaces/ble/notifications.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from bleak.exc import BleakDBusError, BleakError
 
+from meshtastic.interfaces.ble.compat_adapter import (_get_declared_callable)
 from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.constants import (
     BLECLIENT_ERROR_SUBSCRIPTION_TOKEN_EXHAUSTED,
@@ -22,7 +23,6 @@ from meshtastic.interfaces.ble.constants import (
 )
 from meshtastic.interfaces.ble.errors import DecodeError
 from meshtastic.interfaces.ble.utils import (
-    _get_declared_callable,
     _is_unexpected_keyword_error,
     _sleep,
 )

--- a/meshtastic/interfaces/ble/notifications.py
+++ b/meshtastic/interfaces/ble/notifications.py
@@ -668,21 +668,6 @@ class BLENotificationDispatcher:
                 )
                 return False
 
-        def _rollback_stale_registration(*characteristics: str) -> None:
-            for characteristic in characteristics:
-                try:
-                    client.stop_notify(
-                        characteristic,
-                        timeout=NOTIFICATION_START_TIMEOUT,
-                    )
-                except Exception:  # noqa: BLE001 - stale rollback must stay best effort
-                    logger.debug(
-                        "Error stopping stale notification subscription for %s",
-                        characteristic,
-                        exc_info=True,
-                    )
-            _rollback_registration_state(stop_client=client)
-
         if self._registered_notification_session_epoch != current_session_epoch:
             _rollback_registration_state(stop_client=client)
             self._registered_notification_session_epoch = current_session_epoch
@@ -865,7 +850,7 @@ class BLENotificationDispatcher:
                 else:
                     self._started_notify_characteristics.add(LEGACY_LOGRADIO_UUID)
                     if not _registration_still_current():
-                        _rollback_stale_registration(LEGACY_LOGRADIO_UUID)
+                        _rollback_registration_state(stop_client=client)
                         return
 
         try:
@@ -901,7 +886,7 @@ class BLENotificationDispatcher:
                 else:
                     self._started_notify_characteristics.add(LOGRADIO_UUID)
                     if not _registration_still_current():
-                        _rollback_stale_registration(LOGRADIO_UUID)
+                        _rollback_registration_state(stop_client=client)
                         return
 
         ingress_handler = _get_or_create_cached_handler(
@@ -968,15 +953,19 @@ class BLENotificationDispatcher:
                 _rollback_fromnum_registration_state()
                 return
             else:
+                # Track the active backend subscription immediately after start_notify
+                # succeeds. Any later validation or local callback-registration failure
+                # can then unwind through the single centralized rollback path exactly
+                # once per started characteristic.
+                self._started_notify_characteristics.add(FROMNUM_UUID)
                 current_ingress_handler = self._notification_manager._get_callback(
                     FROMNUM_UUID
                 )
                 if current_ingress_handler is not ingress_handler:
                     self._notification_manager._subscribe(FROMNUM_UUID, ingress_handler)
                 if not _registration_still_current():
-                    _rollback_stale_registration(FROMNUM_UUID)
+                    _rollback_registration_state(stop_client=client)
                     return
-                self._started_notify_characteristics.add(FROMNUM_UUID)
                 self.fromnum_notify_enabled = True
                 self._registered_notification_session_epoch = current_session_epoch
                 logger.debug(

--- a/meshtastic/interfaces/ble/notifications.py
+++ b/meshtastic/interfaces/ble/notifications.py
@@ -278,6 +278,7 @@ class BLENotificationDispatcher:
         notification_manager: NotificationManager,
         error_handler_provider: Callable[[], object],
         trigger_read_event: Callable[[], None],
+        registration_current_provider: Callable[[BLEClient, int], bool],
     ) -> None:
         """Create a notification-dispatch collaborator.
 
@@ -289,10 +290,14 @@ class BLENotificationDispatcher:
             Function returning the current interface error-handler object.
         trigger_read_event : Callable[[], None]
             Callback that wakes the receive loop after FROMNUM handling.
+        registration_current_provider : Callable[[BLEClient, int], bool]
+            Interface-owned lifecycle predicate that validates whether notification
+            registration still belongs to the current connection attempt.
         """
         self._notification_manager = notification_manager
         self._error_handler_provider = error_handler_provider
         self._trigger_read_event = trigger_read_event
+        self._registration_current_provider = registration_current_provider
         self._fromnum_notify_enabled = False
         self._malformed_notification_count = 0
         self._malformed_notification_lock = RLock()
@@ -651,11 +656,17 @@ class BLENotificationDispatcher:
             self.malformed_notification_count = 0
 
         def _registration_still_current() -> bool:
-            return (
-                int(getattr(iface, "_connection_session_epoch", 0))
-                == current_session_epoch
-                and getattr(iface, "client", None) is client
-            )
+            try:
+                return (
+                    self._registration_current_provider(client, current_session_epoch)
+                    is True
+                )
+            except Exception:  # noqa: BLE001 - stale registration must fail closed
+                logger.debug(
+                    "Error validating BLE notification registration ownership.",
+                    exc_info=True,
+                )
+                return False
 
         def _rollback_stale_registration(*characteristics: str) -> None:
             for characteristic in characteristics:
@@ -968,6 +979,10 @@ class BLENotificationDispatcher:
                 self._started_notify_characteristics.add(FROMNUM_UUID)
                 self.fromnum_notify_enabled = True
                 self._registered_notification_session_epoch = current_session_epoch
+                logger.debug(
+                    "FROMNUM notifications active for BLE session %d; receive loop using notification-driven reads.",
+                    current_session_epoch,
+                )
                 return
 
     def log_radio_handler(self, _: Any, b: bytes | bytearray) -> str | None:

--- a/meshtastic/interfaces/ble/notifications.py
+++ b/meshtastic/interfaces/ble/notifications.py
@@ -10,8 +10,8 @@ from typing import TYPE_CHECKING, Any, cast
 
 from bleak.exc import BleakDBusError, BleakError
 
-from meshtastic.interfaces.ble.compat_adapter import (_get_declared_callable)
 from meshtastic.interfaces.ble.client import BLEClient
+from meshtastic.interfaces.ble.compat_adapter import _resolve_declared_callable
 from meshtastic.interfaces.ble.constants import (
     BLECLIENT_ERROR_SUBSCRIPTION_TOKEN_EXHAUSTED,
     FROMNUM_UUID,
@@ -381,38 +381,34 @@ class BLENotificationDispatcher:
             logger.debug(error_msg)
             return
         report_exception: Callable[[str], Any] | None = None
-        for hook_name in ("safe_execute", "_safe_execute"):
-            safe_execute_hook = getattr(error_handler, hook_name, None)
-            if callable(safe_execute_hook):
-                safe_execute_callable = cast(Callable[..., Any], safe_execute_hook)
+        safe_execute_hook = _resolve_declared_callable(
+            error_handler, "safe_execute", "_safe_execute"
+        )
+        if safe_execute_hook is not None:
+            safe_execute_callable = cast(Callable[..., Any], safe_execute_hook)
 
-                def _report_via_safe_execute(
-                    message: str,
-                    *,
-                    _safe_execute_callable: Callable[..., Any] = safe_execute_callable,
-                ) -> None:
-                    def _raise_handler_error() -> None:
-                        raise RuntimeError(message)
+            def _report_via_safe_execute(
+                message: str,
+                *,
+                _safe_execute_callable: Callable[..., Any] = safe_execute_callable,
+            ) -> None:
+                def _raise_handler_error() -> None:
+                    raise RuntimeError(message)
 
-                    BLENotificationDispatcher.invoke_safe_execute_compat(
-                        _safe_execute_callable,
-                        _raise_handler_error,
-                        error_msg=message,
-                        fallback=lambda: logger.debug(message),
-                    )
+                BLENotificationDispatcher.invoke_safe_execute_compat(
+                    _safe_execute_callable,
+                    _raise_handler_error,
+                    error_msg=message,
+                    fallback=lambda: logger.debug(message),
+                )
 
-                report_exception = _report_via_safe_execute
-                break
-        for hook_name in (
-            "handle_unhandled_exception",
-            "_handle_unhandled_exception",
-        ):
-            if report_exception is not None:
-                break
-            hook = getattr(error_handler, hook_name, None)
-            if callable(hook):
-                report_exception = hook
-                break
+            report_exception = _report_via_safe_execute
+        if report_exception is None:
+            report_exception = _resolve_declared_callable(
+                error_handler,
+                "handle_unhandled_exception",
+                "_handle_unhandled_exception",
+            )
         if report_exception is not None:
             try:
                 report_exception(error_msg)
@@ -725,10 +721,10 @@ class BLENotificationDispatcher:
                     _report_notification_error()
 
             error_handler = self._resolve_error_handler()
-            safe_execute = _get_declared_callable(error_handler, "safe_execute")
-            if not callable(safe_execute):
-                safe_execute = _get_declared_callable(error_handler, "_safe_execute")
-            if not callable(safe_execute):
+            safe_execute = _resolve_declared_callable(
+                error_handler, "safe_execute", "_safe_execute"
+            )
+            if safe_execute is None:
                 try:
                     _invoke_handler()
                 except (

--- a/meshtastic/interfaces/ble/ports.py
+++ b/meshtastic/interfaces/ble/ports.py
@@ -1,0 +1,62 @@
+"""Narrow internal protocols for BLE runtime collaborators."""
+
+from __future__ import annotations
+
+from threading import RLock
+from typing import TYPE_CHECKING, Protocol
+
+from meshtastic.interfaces.ble.coordination import ThreadLike
+from meshtastic.interfaces.ble.state import ConnectionState
+
+if TYPE_CHECKING:
+    from meshtastic.interfaces.ble.client import BLEClient
+
+
+class _BLEStateManagerPort(Protocol):
+    """Connection-state operations required by lifecycle collaborators."""
+
+    @property
+    def current_state(self) -> ConnectionState:
+        """Return the current connection state."""
+
+    @property
+    def is_connected(self) -> bool:
+        """Return whether the state is connected."""
+
+    @property
+    def is_closing(self) -> bool:
+        """Return whether the state is disconnecting."""
+
+    def transition_to(self, new_state: ConnectionState) -> bool:
+        """Attempt a validated state transition."""
+
+    def reset_to_disconnected(self) -> bool:
+        """Force the state machine back to disconnected."""
+
+
+class _BLESessionStatePort(Protocol):  # pylint: disable=too-many-instance-attributes
+    """Mutable lifecycle state required by BLE coordinators."""
+
+    lock: RLock
+    closed: bool
+    disconnect_notified: bool
+    client_publish_pending: bool
+    connected_publish_inflight_client: BLEClient | None
+    client_replacement_pending: bool
+    last_disconnect_source: str
+    connection_alias_key: str | None
+    prior_publish_was_reconnect: bool
+    last_connect_pair_override: bool | None
+    last_connect_timeout_override: float | None
+    publishing_thread_override: object | None
+    ever_connected: bool
+    connection_session_epoch: int
+    receive_recovery_attempts: int
+    last_recovery_time: float
+    read_retry_count: int
+    last_empty_read_warning: float
+    suppressed_empty_read_warnings: int
+    want_receive: bool
+    receive_start_pending: bool
+    receive_start_pending_since: float | None
+    receive_thread: ThreadLike | None

--- a/meshtastic/interfaces/ble/ports.py
+++ b/meshtastic/interfaces/ble/ports.py
@@ -76,11 +76,11 @@ class _BLESessionStatePort(Protocol):  # pylint: disable=too-many-instance-attri
     receive_start_pending_since: float | None
     receive_thread: ThreadLike | None
 
-    def reset_read_retry_count(self) -> None:
+    def _reset_read_retry_count(self) -> None:
         """Reset only the transient read retry counter."""
 
-    def reset_receive_retry_state(self) -> None:
+    def _reset_receive_retry_state(self) -> None:
         """Reset transient read retry and warning counters."""
 
-    def reset_recovery_state(self) -> None:
+    def _reset_recovery_state(self) -> None:
         """Reset receive-recovery attempt bookkeeping."""

--- a/meshtastic/interfaces/ble/ports.py
+++ b/meshtastic/interfaces/ble/ports.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from threading import RLock
+from types import TracebackType
 from typing import TYPE_CHECKING, Protocol
 
 from meshtastic.interfaces.ble.coordination import ThreadLike
@@ -10,6 +10,21 @@ from meshtastic.interfaces.ble.state import ConnectionState
 
 if TYPE_CHECKING:
     from meshtastic.interfaces.ble.client import BLEClient
+
+
+class _LockPort(Protocol):
+    """Context-manager contract required from the BLE lifecycle lock."""
+
+    def __enter__(self) -> object:
+        """Acquire the lock and return its context value."""
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        """Release the lock context."""
 
 
 class _BLEStateManagerPort(Protocol):
@@ -37,13 +52,13 @@ class _BLEStateManagerPort(Protocol):
 class _BLESessionStatePort(Protocol):  # pylint: disable=too-many-instance-attributes
     """Mutable lifecycle state required by BLE coordinators."""
 
-    lock: RLock
+    lock: _LockPort
     closed: bool
     disconnect_notified: bool
     client_publish_pending: bool
     connected_publish_inflight_client: BLEClient | None
     client_replacement_pending: bool
-    last_disconnect_source: str
+    last_disconnect_source: str | None
     connection_alias_key: str | None
     prior_publish_was_reconnect: bool
     last_connect_pair_override: bool | None
@@ -60,3 +75,12 @@ class _BLESessionStatePort(Protocol):  # pylint: disable=too-many-instance-attri
     receive_start_pending: bool
     receive_start_pending_since: float | None
     receive_thread: ThreadLike | None
+
+    def reset_read_retry_count(self) -> None:
+        """Reset only the transient read retry counter."""
+
+    def reset_receive_retry_state(self) -> None:
+        """Reset transient read retry and warning counters."""
+
+    def reset_recovery_state(self) -> None:
+        """Reset receive-recovery attempt bookkeeping."""

--- a/meshtastic/interfaces/ble/receive_compat_service.py
+++ b/meshtastic/interfaces/ble/receive_compat_service.py
@@ -9,8 +9,8 @@ from bleak.exc import BleakError
 
 from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.utils import (
-    _is_unconfigured_mock_callable,
-    _is_unconfigured_mock_member,
+    _get_declared_callable,
+    _get_declared_member,
 )
 
 if TYPE_CHECKING:
@@ -51,11 +51,8 @@ class BLEReceiveRecoveryService:
         bool
             True if candidate has the required method(s).
         """
-        if _is_unconfigured_mock_member(candidate):
-            return False
         if required_method is not None:
-            method = getattr(candidate, required_method, None)
-            return callable(method) and not _is_unconfigured_mock_callable(method)
+            return _get_declared_callable(candidate, required_method) is not None
         # Full compatibility surface check
         required_methods = (
             "handle_read_loop_disconnect",
@@ -77,8 +74,7 @@ class BLEReceiveRecoveryService:
             "_start_receive_thread",
         )
         for method_name in required_methods:
-            method = getattr(candidate, method_name, None)
-            if not callable(method) or _is_unconfigured_mock_callable(method):
+            if _get_declared_callable(candidate, method_name) is None:
                 return False
         return True
 
@@ -90,12 +86,11 @@ class BLEReceiveRecoveryService:
         iface: "BLEInterface | None" = None,
     ) -> "BLEReceiveRecoveryController | None":
         """Resolve concrete controller instances from eager or lazy candidates."""
-        if candidate is None or _is_unconfigured_mock_member(candidate):
+        if candidate is None:
             return None
         resolved = candidate
         should_invoke_factory = (
             callable(resolved)
-            and not _is_unconfigured_mock_callable(resolved)
             and (
                 inspect.isclass(resolved)
                 or not BLEReceiveRecoveryService._is_controller_like(
@@ -119,7 +114,6 @@ class BLEReceiveRecoveryService:
             return None
         if (
             resolved is not None
-            and not _is_unconfigured_mock_member(resolved)
             and BLEReceiveRecoveryService._is_controller_like(resolved, required_method)
         ):
             return cast("BLEReceiveRecoveryController", resolved)
@@ -144,10 +138,8 @@ class BLEReceiveRecoveryService:
             Controller bound to ``iface``.
         """
         controller_cls = BLEReceiveRecoveryService._controller_class()
-        get_controller = getattr(iface, "_get_receive_recovery_controller", None)
-        if callable(get_controller) and not _is_unconfigured_mock_callable(
-            get_controller
-        ):
+        get_controller = _get_declared_callable(iface, "_get_receive_recovery_controller")
+        if callable(get_controller):
             with contextlib.suppress(
                 Exception
             ):  # noqa: BLE001 - shim resolution stays best effort
@@ -159,7 +151,7 @@ class BLEReceiveRecoveryService:
                 )
                 if resolved_controller is not None:
                     return resolved_controller
-        cached = getattr(iface, "_receive_recovery_controller", None)
+        cached = _get_declared_member(iface, "_receive_recovery_controller")
         cached_controller = BLEReceiveRecoveryService._resolve_controller_candidate(
             cached,
             required_method,
@@ -168,8 +160,8 @@ class BLEReceiveRecoveryService:
         if cached_controller is not None:
             return cached_controller
         controller = controller_cls(iface)
-        state_lock = getattr(iface, "_state_lock", None)
-        if state_lock is None or _is_unconfigured_mock_member(state_lock):
+        state_lock = _get_declared_member(iface, "_state_lock")
+        if state_lock is None:
             with contextlib.suppress(
                 Exception
             ):  # noqa: BLE001 - best-effort cache attach
@@ -178,7 +170,7 @@ class BLEReceiveRecoveryService:
         with contextlib.suppress(
             Exception
         ), state_lock:  # noqa: BLE001 - best-effort cache attach
-            cached = getattr(iface, "_receive_recovery_controller", None)
+            cached = _get_declared_member(iface, "_receive_recovery_controller")
             cached_controller = BLEReceiveRecoveryService._resolve_controller_candidate(
                 cached,
                 required_method,
@@ -234,9 +226,7 @@ class BLEReceiveRecoveryService:
         """
         with iface._state_lock:
             notify_enabled = getattr(iface, "_fromnum_notify_enabled", False)
-            if _is_unconfigured_mock_member(notify_enabled):
-                notify_enabled = False
-            return not bool(notify_enabled)
+            return not (notify_enabled if isinstance(notify_enabled, bool) else False)
 
     @staticmethod
     def _coordinator_wait_for_event(

--- a/meshtastic/interfaces/ble/receive_compat_service.py
+++ b/meshtastic/interfaces/ble/receive_compat_service.py
@@ -9,6 +9,7 @@ from bleak.exc import BleakError
 
 from meshtastic.interfaces.ble.compat_adapter import (
     _get_declared_callable,
+    _get_declared_lock,
     _get_declared_member,
 )
 from meshtastic.interfaces.ble.client import BLEClient
@@ -160,7 +161,7 @@ class BLEReceiveRecoveryService:
         if cached_controller is not None:
             return cached_controller
         controller = controller_cls(iface)
-        state_lock = _get_declared_member(iface, "_state_lock")
+        state_lock = _get_declared_lock(iface, "_state_lock")
         if state_lock is None:
             with contextlib.suppress(
                 Exception

--- a/meshtastic/interfaces/ble/receive_compat_service.py
+++ b/meshtastic/interfaces/ble/receive_compat_service.py
@@ -7,11 +7,11 @@ from typing import TYPE_CHECKING, Any, cast
 
 from bleak.exc import BleakError
 
-from meshtastic.interfaces.ble.client import BLEClient
-from meshtastic.interfaces.ble.utils import (
+from meshtastic.interfaces.ble.compat_adapter import (
     _get_declared_callable,
     _get_declared_member,
 )
+from meshtastic.interfaces.ble.client import BLEClient
 
 if TYPE_CHECKING:
     from meshtastic.interfaces.ble.coordination import ThreadCoordinator
@@ -139,7 +139,7 @@ class BLEReceiveRecoveryService:
         """
         controller_cls = BLEReceiveRecoveryService._controller_class()
         get_controller = _get_declared_callable(iface, "_get_receive_recovery_controller")
-        if callable(get_controller):
+        if get_controller is not None:
             with contextlib.suppress(
                 Exception
             ):  # noqa: BLE001 - shim resolution stays best effort
@@ -225,7 +225,7 @@ class BLEReceiveRecoveryService:
             otherwise ``False``.
         """
         with iface._state_lock:
-            notify_enabled = getattr(iface, "_fromnum_notify_enabled", False)
+            notify_enabled = _get_declared_member(iface, "_fromnum_notify_enabled", False)
             return not (notify_enabled if isinstance(notify_enabled, bool) else False)
 
     @staticmethod

--- a/meshtastic/interfaces/ble/receive_compat_service.py
+++ b/meshtastic/interfaces/ble/receive_compat_service.py
@@ -225,9 +225,8 @@ class BLEReceiveRecoveryService:
             ``True`` when polling without notify callbacks should proceed,
             otherwise ``False``.
         """
-        with iface._state_lock:
-            notify_enabled = _get_declared_member(iface, "_fromnum_notify_enabled", False)
-            return not (notify_enabled if isinstance(notify_enabled, bool) else False)
+        notify_enabled = _get_declared_member(iface, "_fromnum_notify_enabled", False)
+        return not (notify_enabled if isinstance(notify_enabled, bool) else False)
 
     @staticmethod
     def _coordinator_wait_for_event(

--- a/meshtastic/interfaces/ble/receive_service.py
+++ b/meshtastic/interfaces/ble/receive_service.py
@@ -10,15 +10,13 @@ from typing import TYPE_CHECKING, cast
 
 from bleak.exc import BleakDBusError, BleakError, BleakGATTProtocolError
 
+from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.compat_adapter import (
     _get_declared_callable,
     _get_declared_member,
     _iter_declared_members,
     _resolve_declared_callable,
 )
-from meshtastic.interfaces.ble.ports import _BLESessionStatePort
-from meshtastic.interfaces.ble.session_state import _session_state_for
-from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.constants import (
     ERROR_READING_BLE,
     FROMRADIO_UUID,
@@ -36,6 +34,8 @@ from meshtastic.interfaces.ble.failure_policy import (
     _BLEFailureDisposition,
     _log_ble_failure,
 )
+from meshtastic.interfaces.ble.ports import _BLESessionStatePort
+from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.utils import (
     _sleep,
 )
@@ -77,7 +77,10 @@ class BLEReceiveRecoveryController:
     """
 
     def __init__(
-        self, iface: "BLEInterface", *, session_state: _BLESessionStatePort | None = None
+        self,
+        iface: "BLEInterface",
+        *,
+        session_state: _BLESessionStatePort | None = None,
     ) -> None:
         """Bind receive/recovery helpers to a specific interface instance.
 
@@ -282,9 +285,7 @@ class BLEReceiveRecoveryController:
         legacy_check_and_clear_event = getattr(
             coordinator, "_check_and_clear_event", None
         )
-        if callable(
-            legacy_check_and_clear_event
-        ):
+        if callable(legacy_check_and_clear_event):
             result = legacy_check_and_clear_event(event_name)
             return result if isinstance(result, bool) else False
         return False
@@ -548,7 +549,7 @@ class BLEReceiveRecoveryController:
             f"read_loop: {error_message}",
             client=previous_client,
         )
-        self._session.reset_read_retry_count()
+        self._session._reset_read_retry_count()
         if not should_continue:
             self._set_receive_wanted(want_receive=False)
         return should_continue
@@ -556,11 +557,8 @@ class BLEReceiveRecoveryController:
     def _should_poll_without_notify(self) -> bool:
         """Return whether fallback polling is allowed without notify callbacks."""
         iface = self._iface
-        with self._session.lock:
-            notify_enabled: object = getattr(iface, "_fromnum_notify_enabled", False)
-            return not (
-                notify_enabled if isinstance(notify_enabled, bool) else False
-            )
+        notify_enabled = _get_declared_member(iface, "_fromnum_notify_enabled", False)
+        return not (notify_enabled if isinstance(notify_enabled, bool) else False)
 
     def _resolve_wait_for_runtime_event(
         self,
@@ -767,17 +765,17 @@ class BLEReceiveRecoveryController:
             retry_on_empty=not poll_without_notify,
         )
         if not payload:
-            self._session.reset_read_retry_count()
+            self._session._reset_read_retry_count()
             return False
         logger.debug("FROMRADIO read: %s", payload.hex())
         try:
             iface._handle_from_radio(payload)
         except DecodeError as exc:
             logger.warning("Failed to parse FromRadio packet, discarding: %s", exc)
-            self._session.reset_read_retry_count()
+            self._session._reset_read_retry_count()
             return True
         self._reset_recovery_after_stability()
-        self._session.reset_read_retry_count()
+        self._session._reset_read_retry_count()
         return True
 
     def _handle_payload_read(
@@ -960,7 +958,7 @@ class BLEReceiveRecoveryController:
         with self._session.lock:
             self._session.last_recovery_time = time.monotonic()
             updated_last_recovery_time = self._session.last_recovery_time
-        self._session.reset_read_retry_count()
+        self._session._reset_read_retry_count()
         logger.debug(
             "BLE receive recovery timestamp updated: attempts=%d last_recovery_time=%.3f",
             attempts,

--- a/meshtastic/interfaces/ble/receive_service.py
+++ b/meshtastic/interfaces/ble/receive_service.py
@@ -209,8 +209,8 @@ class BLEReceiveRecoveryController:
             return False
         return result if isinstance(result, bool) else False
 
-    def _is_connection_closing_locked(self) -> bool:
-        """Return whether connection-closing probes indicate closing while lock is held."""
+    def _probe_connection_closing_compat(self) -> bool:
+        """Return best-effort compatibility closing state without holding session lock."""
         iface = self._iface
         state_manager = _get_declared_member(iface, "_state_manager")
         state_is_closing: bool | None = None
@@ -239,8 +239,11 @@ class BLEReceiveRecoveryController:
             if state_is_closing is None:
                 legacy_is_closing = _get_declared_member(state_manager, "_is_closing")
                 state_is_closing = self._normalize_bool_probe(legacy_is_closing)
+        return bool(state_is_closing)
 
-        return bool(state_is_closing or self._session.closed)
+    def _is_connection_closing_locked(self, *, compatibility_is_closing: bool) -> bool:
+        """Combine a compatibility snapshot with session-owned closing state."""
+        return bool(compatibility_is_closing or self._session.closed)
 
     def _is_connection_closing(self) -> bool:
         """Return whether receive-loop behavior should treat the interface as closing."""
@@ -267,8 +270,11 @@ class BLEReceiveRecoveryController:
                         "Probe is_connection_closing_fn returned non-bool result",
                         exc_info=False,
                     )
+        compatibility_is_closing = self._probe_connection_closing_compat()
         with self._session.lock:
-            return self._is_connection_closing_locked()
+            return self._is_connection_closing_locked(
+                compatibility_is_closing=compatibility_is_closing
+            )
 
     @staticmethod
     def _coordinator_wait_for_event(
@@ -669,30 +675,33 @@ class BLEReceiveRecoveryController:
     def _snapshot_client_state(self) -> tuple[BLEClient | None, bool, bool, bool]:
         """Snapshot client and gating flags needed by the read loop."""
         iface = self._iface
+        state_manager = _get_declared_member(iface, "_state_manager")
+        is_connecting = False
+        for member_name, candidate in _iter_declared_members(
+            state_manager, "is_connecting", "_is_connecting"
+        ):
+            if callable(candidate):
+                try:
+                    connecting_result = candidate()
+                except Exception:  # noqa: BLE001 - snapshot probe stays best effort
+                    _log_ble_failure(
+                        _BLEFailureDisposition.COMPATIBILITY_FALLBACK,
+                        "Error probing state manager %s()",
+                        member_name,
+                    )
+                    continue
+            else:
+                connecting_result = candidate
+            if isinstance(connecting_result, bool):
+                is_connecting = connecting_result
+                break
+        compatibility_is_closing = self._probe_connection_closing_compat()
         with self._session.lock:
             client = iface.client
-            state_manager = _get_declared_member(iface, "_state_manager")
-            is_connecting = False
-            for member_name, candidate in _iter_declared_members(
-                state_manager, "is_connecting", "_is_connecting"
-            ):
-                if callable(candidate):
-                    try:
-                        connecting_result = candidate()
-                    except Exception:  # noqa: BLE001 - snapshot probe stays best effort
-                        _log_ble_failure(
-                            _BLEFailureDisposition.COMPATIBILITY_FALLBACK,
-                            "Error probing state manager %s()",
-                            member_name,
-                        )
-                        continue
-                else:
-                    connecting_result = candidate
-                if isinstance(connecting_result, bool):
-                    is_connecting = connecting_result
-                    break
             publish_pending = self._session.client_publish_pending
-            is_closing = self._is_connection_closing_locked()
+            is_closing = self._is_connection_closing_locked(
+                compatibility_is_closing=compatibility_is_closing
+            )
         return client, is_connecting, publish_pending, is_closing
 
     def _process_client_state(

--- a/meshtastic/interfaces/ble/receive_service.py
+++ b/meshtastic/interfaces/ble/receive_service.py
@@ -1,5 +1,6 @@
 """Receive-loop and recovery helpers for BLE interface orchestration."""
 
+import logging
 import math
 import threading
 import time
@@ -26,6 +27,10 @@ from meshtastic.interfaces.ble.constants import (
     logger,
 )
 from meshtastic.interfaces.ble.errors import DecodeError
+from meshtastic.interfaces.ble.failure_policy import (
+    _BLEFailureDisposition,
+    _log_ble_failure,
+)
 from meshtastic.interfaces.ble.utils import (
     _sleep,
 )
@@ -165,7 +170,11 @@ class BLEReceiveRecoveryController:
         if get_lifecycle_controller_fn is not None:
             try:
                 controller = get_lifecycle_controller_fn()
-            except Exception:  # noqa: BLE001 - probe remains best effort
+            except Exception:  # noqa: BLE001 - compatibility probe falls back
+                _log_ble_failure(
+                    _BLEFailureDisposition.COMPATIBILITY_FALLBACK,
+                    "BLE lifecycle controller probe failed",
+                )
                 return None
             if self._is_unusable_probe_value(controller):
                 return None
@@ -185,9 +194,9 @@ class BLEReceiveRecoveryController:
                 try:
                     result = has_ever_connected_session_fn()
                 except Exception:  # noqa: BLE001 - probe remains best effort
-                    logger.debug(
+                    _log_ble_failure(
+                        _BLEFailureDisposition.COMPATIBILITY_FALLBACK,
                         "Probe has_ever_connected_session_fn failed",
-                        exc_info=True,
                     )
                 else:
                     return result if isinstance(result, bool) else False
@@ -201,7 +210,11 @@ class BLEReceiveRecoveryController:
             try:
                 result = raw_value()
                 return result if isinstance(result, bool) else False
-            except Exception:  # noqa: BLE001 - probe remains best effort
+            except Exception:  # noqa: BLE001 - compatibility probe falls back
+                _log_ble_failure(
+                    _BLEFailureDisposition.COMPATIBILITY_FALLBACK,
+                    "BLE boolean compatibility probe failed",
+                )
                 return False
         if isinstance(raw_value, bool):
             return raw_value
@@ -214,7 +227,11 @@ class BLEReceiveRecoveryController:
         """Call a hook and return True only if result is a real bool True."""
         try:
             result = hook(*args, **kwargs)
-        except Exception:  # noqa: BLE001 - hook probes remain best effort
+        except Exception:  # noqa: BLE001 - compatibility probe falls back
+            _log_ble_failure(
+                _BLEFailureDisposition.COMPATIBILITY_FALLBACK,
+                "BLE compatibility boolean hook failed",
+            )
             return False
         return result if isinstance(result, bool) else False
 
@@ -260,9 +277,9 @@ class BLEReceiveRecoveryController:
                 try:
                     result = is_connection_closing_fn()
                 except Exception:  # noqa: BLE001 - probe remains best effort
-                    logger.debug(
+                    _log_ble_failure(
+                        _BLEFailureDisposition.COMPATIBILITY_FALLBACK,
                         "Probe is_connection_closing_fn failed",
-                        exc_info=True,
                     )
                 else:
                     return result if isinstance(result, bool) else False
@@ -340,9 +357,10 @@ class BLEReceiveRecoveryController:
             try:
                 result = override_should_run_receive_loop()
             except Exception:
-                logger.error(
+                _log_ble_failure(
+                    _BLEFailureDisposition.TERMINAL,
                     "Receive-loop override should_run_receive_loop raised",
-                    exc_info=True,
+                    level=logging.ERROR,
                 )
                 raise
             return result if isinstance(result, bool) else False
@@ -357,9 +375,10 @@ class BLEReceiveRecoveryController:
                 try:
                     result = should_run_receive_loop_fn()
                 except Exception:
-                    logger.error(
+                    _log_ble_failure(
+                        _BLEFailureDisposition.TERMINAL,
                         "Lifecycle should_run_receive_loop raised",
-                        exc_info=True,
+                        level=logging.ERROR,
                     )
                     raise
                 return result if isinstance(result, bool) else False
@@ -400,9 +419,10 @@ class BLEReceiveRecoveryController:
                     client=client,
                 )
             except Exception:  # noqa: BLE001 - disconnect hook must surface failures
-                logger.warning(
+                _log_ble_failure(
+                    _BLEFailureDisposition.TERMINAL,
                     "Disconnect handler override raised",
-                    exc_info=True,
+                    level=logging.WARNING,
                 )
                 raise
             return result if isinstance(result, bool) else False
@@ -421,9 +441,10 @@ class BLEReceiveRecoveryController:
                     client=client,
                 )
             except Exception:  # noqa: BLE001 - disconnect hook must surface failures
-                logger.warning(
+                _log_ble_failure(
+                    _BLEFailureDisposition.TERMINAL,
                     "Lifecycle disconnect handler raised",
-                    exc_info=True,
+                    level=logging.WARNING,
                 )
                 raise
             return result if isinstance(result, bool) else False
@@ -553,9 +574,10 @@ class BLEReceiveRecoveryController:
                     previous_client,
                 )
             except Exception:  # noqa: BLE001 - disconnect hook must surface failures
-                logger.warning(
+                _log_ble_failure(
+                    _BLEFailureDisposition.TERMINAL,
                     "Read-loop disconnect override raised",
-                    exc_info=True,
+                    level=logging.WARNING,
                 )
                 raise
             return result if isinstance(result, bool) else False
@@ -613,7 +635,11 @@ class BLEReceiveRecoveryController:
                         event_name,
                         timeout,
                     )
-                except Exception:  # noqa: BLE001 - wait probe remains best effort
+                except Exception:  # noqa: BLE001 - compatibility wait probe falls back
+                    _log_ble_failure(
+                        _BLEFailureDisposition.COMPATIBILITY_FALLBACK,
+                        "BLE wait-event compatibility probe failed",
+                    )
                     return False
                 return result if isinstance(result, bool) else False
 
@@ -855,7 +881,11 @@ class BLEReceiveRecoveryController:
                 self._close_after_fatal_read()
             return True, True
         except Exception as exc:  # noqa: BLE001  # pragma: no cover
-            logger.exception("Unexpected error in BLE read loop")
+            _log_ble_failure(
+                _BLEFailureDisposition.RETRYABLE,
+                "Unexpected error in BLE read loop",
+                level=logging.ERROR,
+            )
             if self.handle_read_loop_disconnect(repr(exc), client):
                 return True, False
             return True, True
@@ -928,7 +958,11 @@ class BLEReceiveRecoveryController:
             logger.exception("Fatal error in BLE receive thread")
             self.recover_receive_thread(RECEIVE_THREAD_FATAL_REASON)
         except Exception:  # noqa: BLE001
-            logger.exception("Unexpected fatal error in BLE receive thread")
+            _log_ble_failure(
+                _BLEFailureDisposition.RETRYABLE,
+                "Unexpected fatal error in BLE receive thread",
+                level=logging.ERROR,
+            )
             self.recover_receive_thread(RECEIVE_THREAD_FATAL_REASON)
 
     def recover_receive_thread(self, disconnect_reason: str) -> None:
@@ -1010,10 +1044,11 @@ class BLEReceiveRecoveryController:
                     name="BLEReceiveRecovery", reset_recovery=False
                 )
             except Exception:  # noqa: BLE001 - preserve existing failure behavior
-                logger.warning(
+                _log_ble_failure(
+                    _BLEFailureDisposition.RETRYABLE,
                     "BLE receive recovery restart failed (attempt %d)",
                     attempts,
-                    exc_info=True,
+                    level=logging.WARNING,
                 )
                 raise
             logger.debug(

--- a/meshtastic/interfaces/ble/receive_service.py
+++ b/meshtastic/interfaces/ble/receive_service.py
@@ -1078,7 +1078,7 @@ class BLEReceiveRecoveryController:
                     next_retry_count = 0
                 break
         else:
-            logger.debug(
+            logger.warning(
                 "Transient BLE read error decision superseded by concurrent retry-state changes after %d attempts; ignoring stale error.",
                 TRANSIENT_RETRY_POLICY_REVALIDATION_MAX_ATTEMPTS,
             )

--- a/meshtastic/interfaces/ble/receive_service.py
+++ b/meshtastic/interfaces/ble/receive_service.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, cast
 
 from bleak.exc import BleakDBusError, BleakError, BleakGATTProtocolError
 
+from meshtastic.interfaces.ble.compat_adapter import (_get_declared_member)
 from meshtastic.interfaces.ble.ports import _BLESessionStatePort
 from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.client import BLEClient
@@ -26,7 +27,6 @@ from meshtastic.interfaces.ble.constants import (
 )
 from meshtastic.interfaces.ble.errors import DecodeError
 from meshtastic.interfaces.ble.utils import (
-    _get_declared_member,
     _sleep,
 )
 

--- a/meshtastic/interfaces/ble/receive_service.py
+++ b/meshtastic/interfaces/ble/receive_service.py
@@ -1071,7 +1071,9 @@ class BLEReceiveRecoveryController:
             return
         now = time.monotonic()
         cooldown = BLEConfig.EMPTY_READ_WARNING_COOLDOWN
-        raw_notify_enabled: object = getattr(iface, "_fromnum_notify_enabled", False)
+        raw_notify_enabled: object = _get_declared_member(
+            iface, "_fromnum_notify_enabled", False
+        )
         notify_enabled = (
             raw_notify_enabled if isinstance(raw_notify_enabled, bool) else False
         )

--- a/meshtastic/interfaces/ble/receive_service.py
+++ b/meshtastic/interfaces/ble/receive_service.py
@@ -228,6 +228,10 @@ class BLEReceiveRecoveryController:
                 except (
                     Exception
                 ):  # noqa: BLE001 - closing probe must remain best effort
+                    _log_ble_failure(
+                        _BLEFailureDisposition.COMPATIBILITY_FALLBACK,
+                        "State manager is_closing() probe failed",
+                    )
                     state_is_closing = None
             elif isinstance(raw_is_closing, bool):
                 state_is_closing = raw_is_closing

--- a/meshtastic/interfaces/ble/receive_service.py
+++ b/meshtastic/interfaces/ble/receive_service.py
@@ -675,10 +675,10 @@ class BLEReceiveRecoveryController:
                     try:
                         connecting_result = candidate()
                     except Exception:  # noqa: BLE001 - snapshot probe stays best effort
-                        logger.debug(
+                        _log_ble_failure(
+                            _BLEFailureDisposition.COMPATIBILITY_FALLBACK,
                             "Error probing state manager %s()",
                             member_name,
-                            exc_info=True,
                         )
                         continue
                 else:
@@ -1039,9 +1039,10 @@ class BLEReceiveRecoveryController:
         transient_policy = iface._transient_read_policy
         with self._session.lock:
             retry_count = self._session.read_retry_count
-            should_retry = iface._retry_policy_should_retry(
-                transient_policy, retry_count
-            )
+        should_retry = iface._retry_policy_should_retry(transient_policy, retry_count)
+        attempt_index = 0
+        next_retry_count = 0
+        with self._session.lock:
             if should_retry:
                 attempt_index = retry_count
                 self._session.read_retry_count = retry_count + 1

--- a/meshtastic/interfaces/ble/receive_service.py
+++ b/meshtastic/interfaces/ble/receive_service.py
@@ -167,7 +167,13 @@ class BLEReceiveRecoveryController:
                         "Probe has_ever_connected_session_fn failed",
                     )
                 else:
-                    return result if isinstance(result, bool) else False
+                    if isinstance(result, bool):
+                        return result
+                    _log_ble_failure(
+                        _BLEFailureDisposition.COMPATIBILITY_FALLBACK,
+                        "Probe has_ever_connected_session_fn returned non-bool result",
+                        exc_info=False,
+                    )
         return self._session.ever_connected is True
 
     @staticmethod
@@ -208,7 +214,9 @@ class BLEReceiveRecoveryController:
         state_manager = _get_declared_member(iface, "_state_manager")
         state_is_closing: bool | None = None
         if state_manager is None:
-            raw_is_closing = getattr(iface, "_is_connection_closing", False)
+            raw_is_closing = _get_declared_member(
+                iface, "_is_connection_closing", False
+            )
             state_is_closing = self._normalize_bool_probe(raw_is_closing)
         else:
             raw_is_closing = _get_declared_member(state_manager, "is_closing")
@@ -247,7 +255,13 @@ class BLEReceiveRecoveryController:
                         "Probe is_connection_closing_fn failed",
                     )
                 else:
-                    return result if isinstance(result, bool) else False
+                    if isinstance(result, bool):
+                        return result
+                    _log_ble_failure(
+                        _BLEFailureDisposition.COMPATIBILITY_FALLBACK,
+                        "Probe is_connection_closing_fn returned non-bool result",
+                        exc_info=False,
+                    )
         with self._session.lock:
             return self._is_connection_closing_locked()
 
@@ -258,13 +272,11 @@ class BLEReceiveRecoveryController:
         timeout: float | None,
     ) -> bool:
         """Wait for a coordinator event using compatibility dispatch."""
-        wait_for_event = getattr(coordinator, "wait_for_event", None)
-        if callable(wait_for_event):
+        wait_for_event = _resolve_declared_callable(
+            coordinator, "wait_for_event", "_wait_for_event"
+        )
+        if wait_for_event is not None:
             result = wait_for_event(event_name, timeout=timeout)
-            return result if isinstance(result, bool) else False
-        legacy_wait_for_event = getattr(coordinator, "_wait_for_event", None)
-        if callable(legacy_wait_for_event):
-            result = legacy_wait_for_event(event_name, timeout=timeout)
             return result if isinstance(result, bool) else False
         if timeout is None:
             _sleep(COORDINATOR_WAIT_FALLBACK_SLEEP_SEC)
@@ -278,15 +290,11 @@ class BLEReceiveRecoveryController:
         event_name: str,
     ) -> bool:
         """Check and clear a coordinator event using compatibility dispatch."""
-        check_and_clear_event = getattr(coordinator, "check_and_clear_event", None)
-        if callable(check_and_clear_event):
-            result = check_and_clear_event(event_name)
-            return result if isinstance(result, bool) else False
-        legacy_check_and_clear_event = getattr(
-            coordinator, "_check_and_clear_event", None
+        check_and_clear_event = _resolve_declared_callable(
+            coordinator, "check_and_clear_event", "_check_and_clear_event"
         )
-        if callable(legacy_check_and_clear_event):
-            result = legacy_check_and_clear_event(event_name)
+        if check_and_clear_event is not None:
+            result = check_and_clear_event(event_name)
             return result if isinstance(result, bool) else False
         return False
 
@@ -295,21 +303,17 @@ class BLEReceiveRecoveryController:
         coordinator: "ThreadCoordinator", event_name: str
     ) -> None:
         """Clear a coordinator event using compatibility dispatch."""
-        clear_events = getattr(coordinator, "clear_events", None)
-        if callable(clear_events):
+        clear_events = _resolve_declared_callable(
+            coordinator, "clear_events", "_clear_events"
+        )
+        if clear_events is not None:
             clear_events(event_name)
             return
-        legacy_clear_events = getattr(coordinator, "_clear_events", None)
-        if callable(legacy_clear_events):
-            legacy_clear_events(event_name)
-            return
-        clear_event = getattr(coordinator, "clear_event", None)
-        if callable(clear_event):
+        clear_event = _resolve_declared_callable(
+            coordinator, "clear_event", "_clear_event"
+        )
+        if clear_event is not None:
             clear_event(event_name)
-            return
-        legacy_clear_event = getattr(coordinator, "_clear_event", None)
-        if callable(legacy_clear_event):
-            legacy_clear_event(event_name)
 
     def _should_run_receive_loop(self) -> bool:
         """Return whether the lifecycle currently wants receive-loop execution."""

--- a/meshtastic/interfaces/ble/receive_service.py
+++ b/meshtastic/interfaces/ble/receive_service.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, cast
 
 from bleak.exc import BleakDBusError, BleakError, BleakGATTProtocolError
 
+from meshtastic.interfaces.ble.ports import _BLESessionStatePort
+from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.constants import (
     ERROR_READING_BLE,
@@ -65,7 +67,9 @@ class BLEReceiveRecoveryController:
         Per-thread recursion guard storage for interface receive-hook overrides.
     """
 
-    def __init__(self, iface: "BLEInterface") -> None:
+    def __init__(
+        self, iface: "BLEInterface", *, session_state: _BLESessionStatePort | None = None
+    ) -> None:
         """Bind receive/recovery helpers to a specific interface instance.
 
         Parameters
@@ -79,6 +83,7 @@ class BLEReceiveRecoveryController:
             Initializes bound controller state.
         """
         self._iface = iface
+        self._session = _session_state_for(iface, session_state)
         self._dispatching_iface_receive_hooks = threading.local()
 
     def _dispatching_hooks(self) -> set[str]:
@@ -271,8 +276,7 @@ class BLEReceiveRecoveryController:
                     )
                 else:
                     return result if isinstance(result, bool) else False
-        iface = self._iface
-        with iface._state_lock:
+        with self._session.lock:
             return self._is_connection_closing_locked()
 
     @staticmethod
@@ -563,7 +567,6 @@ class BLEReceiveRecoveryController:
         self, error_message: str, previous_client: BLEClient
     ) -> bool:
         """Handle read-loop disconnect logic for the bound interface."""
-        iface = self._iface
         override_handle_read_loop_disconnect = (
             self._resolve_iface_receive_hook_override("_handle_read_loop_disconnect")
         )
@@ -585,7 +588,7 @@ class BLEReceiveRecoveryController:
             f"read_loop: {error_message}",
             client=previous_client,
         )
-        iface._read_retry_count = 0
+        self._session.read_retry_count = 0
         if not should_continue:
             self._set_receive_wanted(want_receive=False)
         return should_continue
@@ -593,7 +596,7 @@ class BLEReceiveRecoveryController:
     def _should_poll_without_notify(self) -> bool:
         """Return whether fallback polling is allowed without notify callbacks."""
         iface = self._iface
-        with iface._state_lock:
+        with self._session.lock:
             notify_enabled: object = getattr(iface, "_fromnum_notify_enabled", False)
             is_unconfigured_member = getattr(
                 iface, "_is_unconfigured_mock_member", None
@@ -708,7 +711,7 @@ class BLEReceiveRecoveryController:
     def _snapshot_client_state(self) -> tuple[BLEClient | None, bool, bool, bool]:
         """Snapshot client and gating flags needed by the read loop."""
         iface = self._iface
-        with iface._state_lock:
+        with self._session.lock:
             client = iface.client
             state_is_connecting = getattr(iface._state_manager, "is_connecting", None)
             if callable(state_is_connecting) and not _is_unconfigured_mock_callable(
@@ -763,7 +766,7 @@ class BLEReceiveRecoveryController:
                     is_connecting = legacy_is_connecting
                 else:
                     is_connecting = False
-            publish_pending = iface._client_publish_pending
+            publish_pending = self._session.client_publish_pending
             is_closing = self._is_connection_closing_locked()
         return client, is_connecting, publish_pending, is_closing
 
@@ -820,19 +823,18 @@ class BLEReceiveRecoveryController:
 
     def _reset_recovery_after_stability(self) -> None:
         """Reset recovery-attempt counter after sustained stable reads."""
-        iface = self._iface
         now = time.monotonic()
-        with iface._state_lock:
+        with self._session.lock:
             if (
-                iface._receive_recovery_attempts > 0
-                and now - iface._last_recovery_time
+                self._session.receive_recovery_attempts > 0
+                and now - self._session.last_recovery_time
                 >= RECEIVE_RECOVERY_STABILITY_RESET_SEC
             ):
                 logger.debug(
                     "Resetting receive recovery attempts after %.1fs of stability.",
-                    now - iface._last_recovery_time,
+                    now - self._session.last_recovery_time,
                 )
-                iface._receive_recovery_attempts = 0
+                self._session.receive_recovery_attempts = 0
 
     def _read_and_handle_payload(
         self,
@@ -847,17 +849,17 @@ class BLEReceiveRecoveryController:
             retry_on_empty=not poll_without_notify,
         )
         if not payload:
-            iface._read_retry_count = 0
+            self._session.read_retry_count = 0
             return False
         logger.debug("FROMRADIO read: %s", payload.hex())
         try:
             iface._handle_from_radio(payload)
         except DecodeError as exc:
             logger.warning("Failed to parse FromRadio packet, discarding: %s", exc)
-            iface._read_retry_count = 0
+            self._session.read_retry_count = 0
             return True
         self._reset_recovery_after_stability()
-        iface._read_retry_count = 0
+        self._session.read_retry_count = 0
         return True
 
     def _handle_payload_read(
@@ -977,7 +979,7 @@ class BLEReceiveRecoveryController:
         iface = self._iface
         if self._is_connection_closing():
             return
-        with iface._state_lock:
+        with self._session.lock:
             current_client = iface.client
         should_continue = self._handle_disconnect(
             disconnect_reason,
@@ -987,10 +989,10 @@ class BLEReceiveRecoveryController:
             self._set_receive_wanted(want_receive=False)
             return
         now = time.monotonic()
-        with iface._state_lock:
-            iface._receive_recovery_attempts += 1
-            attempts = iface._receive_recovery_attempts
-            last_recovery = iface._last_recovery_time
+        with self._session.lock:
+            self._session.receive_recovery_attempts += 1
+            attempts = self._session.receive_recovery_attempts
+            last_recovery = self._session.last_recovery_time
         logger.debug(
             "BLE receive recovery attempt scheduled: attempts=%d last_recovery_time=%.3f",
             attempts,
@@ -1029,10 +1031,10 @@ class BLEReceiveRecoveryController:
                     "BLE receive recovery backoff wait elapsed; retrying restart (attempt %d)",
                     attempts,
                 )
-        with iface._state_lock:
-            iface._last_recovery_time = time.monotonic()
-            updated_last_recovery_time = iface._last_recovery_time
-        iface._read_retry_count = 0
+        with self._session.lock:
+            self._session.last_recovery_time = time.monotonic()
+            updated_last_recovery_time = self._session.last_recovery_time
+        self._session.read_retry_count = 0
         logger.debug(
             "BLE receive recovery timestamp updated: attempts=%d last_recovery_time=%.3f",
             attempts,
@@ -1085,7 +1087,7 @@ class BLEReceiveRecoveryController:
         for attempt in range(max_retries + 1):
             payload = client.read_gatt_char(FROMRADIO_UUID, timeout=read_timeout)
             if payload:
-                iface._suppressed_empty_read_warnings = 0
+                self._session.suppressed_empty_read_warnings = 0
                 return payload
             if attempt < max_retries:
                 _sleep(iface._retry_policy_get_delay(iface._empty_read_policy, attempt))
@@ -1105,17 +1107,17 @@ class BLEReceiveRecoveryController:
             override_handle_transient_read_error(error)
             return
         transient_policy = iface._transient_read_policy
-        if iface._retry_policy_should_retry(transient_policy, iface._read_retry_count):
-            attempt_index = iface._read_retry_count
-            iface._read_retry_count += 1
+        if iface._retry_policy_should_retry(transient_policy, self._session.read_retry_count):
+            attempt_index = self._session.read_retry_count
+            self._session.read_retry_count += 1
             logger.debug(
                 "Transient BLE read error, retrying (%d/%d)",
-                iface._read_retry_count,
+                self._session.read_retry_count,
                 BLEConfig.TRANSIENT_READ_MAX_RETRIES,
             )
             _sleep(iface._retry_policy_get_delay(transient_policy, attempt_index))
             return
-        iface._read_retry_count = 0
+        self._session.read_retry_count = 0
         raise iface.BLEError(ERROR_READING_BLE) from error
 
     def log_empty_read_warning(self) -> None:
@@ -1135,8 +1137,8 @@ class BLEReceiveRecoveryController:
             if _is_unconfigured_mock_member(raw_notify_enabled)
             else bool(raw_notify_enabled)
         )
-        if now - iface._last_empty_read_warning >= cooldown:
-            suppressed = iface._suppressed_empty_read_warnings
+        if now - self._session.last_empty_read_warning >= cooldown:
+            suppressed = self._session.suppressed_empty_read_warnings
             message = f"Exceeded max retries for empty BLE read from {FROMRADIO_UUID}"
             if suppressed:
                 message = (
@@ -1150,14 +1152,14 @@ class BLEReceiveRecoveryController:
                     "%s (polling mode without FROMNUM notifications)",
                     message,
                 )
-            iface._last_empty_read_warning = now
-            iface._suppressed_empty_read_warnings = 0
+            self._session.last_empty_read_warning = now
+            self._session.suppressed_empty_read_warnings = 0
             return
 
-        iface._suppressed_empty_read_warnings += 1
+        self._session.suppressed_empty_read_warnings += 1
         logger.debug(
             "Suppressed repeated empty BLE read warning (%d within %.0fs window)",
-            iface._suppressed_empty_read_warnings,
+            self._session.suppressed_empty_read_warnings,
             cooldown,
         )
 

--- a/meshtastic/interfaces/ble/receive_service.py
+++ b/meshtastic/interfaces/ble/receive_service.py
@@ -26,8 +26,7 @@ from meshtastic.interfaces.ble.constants import (
 )
 from meshtastic.interfaces.ble.errors import DecodeError
 from meshtastic.interfaces.ble.utils import (
-    _is_unconfigured_mock_callable,
-    _is_unconfigured_mock_member,
+    _get_declared_member,
     _sleep,
 )
 
@@ -114,10 +113,10 @@ class BLEReceiveRecoveryController:
         Returns
         -------
         Callable[..., object] | None
-            Callable candidate when it is not an unconfigured mock; otherwise
+            Callable candidate when explicitly usable; otherwise
             ``None``.
         """
-        if callable(candidate) and not _is_unconfigured_mock_callable(candidate):
+        if callable(candidate):
             return cast(Callable[..., object], candidate)
         return None
 
@@ -146,17 +145,16 @@ class BLEReceiveRecoveryController:
             First usable callable hook, preferring private then public; else
             ``None``.
         """
-        private_hook = self._as_usable_callable(getattr(owner, private_name, None))
+        private_hook = self._as_usable_callable(_get_declared_member(owner, private_name))
         if private_hook is not None:
             return private_hook
-        return self._as_usable_callable(getattr(owner, public_name, None))
+        return self._as_usable_callable(_get_declared_member(owner, public_name))
 
     @classmethod
-    def _is_unusable_mock_value(cls, value: object | None) -> bool:
-        """Return whether value is absent or an unconfigured mock placeholder."""
-        if value is None or _is_unconfigured_mock_member(value):
-            return True
-        return callable(value) and _is_unconfigured_mock_callable(value)
+    def _is_unusable_probe_value(cls, value: object | None) -> bool:
+        """Return whether a probe value is absent or has an unsupported shape."""
+        _ = cls
+        return value is None
 
     def _get_lifecycle_controller(self) -> object | None:
         """Return lifecycle controller when available on the bound interface."""
@@ -169,13 +167,13 @@ class BLEReceiveRecoveryController:
                 controller = get_lifecycle_controller_fn()
             except Exception:  # noqa: BLE001 - probe remains best effort
                 return None
-            if self._is_unusable_mock_value(controller):
+            if self._is_unusable_probe_value(controller):
                 return None
             return controller
         return None
 
     def _has_ever_connected_session(self) -> bool:
-        """Return mock-safe ever-connected state for receive-loop behavior."""
+        """Return strict ever-connected state for receive-loop behavior."""
         lifecycle_controller = self._get_lifecycle_controller()
         if lifecycle_controller is not None:
             has_ever_connected_session_fn = self._resolve_private_public_callable(
@@ -193,17 +191,13 @@ class BLEReceiveRecoveryController:
                     )
                 else:
                     return result if isinstance(result, bool) else False
-        raw_ever_connected = getattr(self._iface, "_ever_connected", False)
-        if _is_unconfigured_mock_member(raw_ever_connected):
-            return False
+        raw_ever_connected = _get_declared_member(self._iface, "_ever_connected", False)
         return raw_ever_connected is True
 
     @staticmethod
     def _normalize_bool_probe(raw_value: object) -> bool:
-        """Normalize a bool-like probe while filtering mock placeholders."""
-        if _is_unconfigured_mock_member(raw_value):
-            return False
-        if callable(raw_value) and not _is_unconfigured_mock_callable(raw_value):
+        """Normalize a bool-like compatibility probe."""
+        if callable(raw_value):
             try:
                 result = raw_value()
                 return result if isinstance(result, bool) else False
@@ -233,10 +227,8 @@ class BLEReceiveRecoveryController:
             raw_is_closing = getattr(iface, "_is_connection_closing", False)
             state_is_closing = self._normalize_bool_probe(raw_is_closing)
         else:
-            raw_is_closing = getattr(state_manager, "is_closing", None)
-            if callable(raw_is_closing) and not _is_unconfigured_mock_callable(
-                raw_is_closing
-            ):
+            raw_is_closing = _get_declared_member(state_manager, "is_closing")
+            if callable(raw_is_closing):
                 try:
                     result = raw_is_closing()
                     if isinstance(result, bool):
@@ -245,12 +237,10 @@ class BLEReceiveRecoveryController:
                     Exception
                 ):  # noqa: BLE001 - closing probe must remain best effort
                     state_is_closing = None
-            elif not _is_unconfigured_mock_member(raw_is_closing) and isinstance(
-                raw_is_closing, bool
-            ):
+            elif isinstance(raw_is_closing, bool):
                 state_is_closing = raw_is_closing
             if state_is_closing is None:
-                legacy_is_closing = getattr(state_manager, "_is_closing", None)
+                legacy_is_closing = _get_declared_member(state_manager, "_is_closing")
                 state_is_closing = self._normalize_bool_probe(legacy_is_closing)
 
         raw_closed = getattr(iface, "_closed", False)
@@ -287,15 +277,11 @@ class BLEReceiveRecoveryController:
     ) -> bool:
         """Wait for a coordinator event using compatibility dispatch."""
         wait_for_event = getattr(coordinator, "wait_for_event", None)
-        if callable(wait_for_event) and not _is_unconfigured_mock_callable(
-            wait_for_event
-        ):
+        if callable(wait_for_event):
             result = wait_for_event(event_name, timeout=timeout)
             return result if isinstance(result, bool) else False
         legacy_wait_for_event = getattr(coordinator, "_wait_for_event", None)
-        if callable(legacy_wait_for_event) and not _is_unconfigured_mock_callable(
-            legacy_wait_for_event
-        ):
+        if callable(legacy_wait_for_event):
             result = legacy_wait_for_event(event_name, timeout=timeout)
             return result if isinstance(result, bool) else False
         if timeout is None:
@@ -311,9 +297,7 @@ class BLEReceiveRecoveryController:
     ) -> bool:
         """Check and clear a coordinator event using compatibility dispatch."""
         check_and_clear_event = getattr(coordinator, "check_and_clear_event", None)
-        if callable(check_and_clear_event) and not _is_unconfigured_mock_callable(
-            check_and_clear_event
-        ):
+        if callable(check_and_clear_event):
             result = check_and_clear_event(event_name)
             return result if isinstance(result, bool) else False
         legacy_check_and_clear_event = getattr(
@@ -321,7 +305,7 @@ class BLEReceiveRecoveryController:
         )
         if callable(
             legacy_check_and_clear_event
-        ) and not _is_unconfigured_mock_callable(legacy_check_and_clear_event):
+        ):
             result = legacy_check_and_clear_event(event_name)
             return result if isinstance(result, bool) else False
         return False
@@ -332,23 +316,19 @@ class BLEReceiveRecoveryController:
     ) -> None:
         """Clear a coordinator event using compatibility dispatch."""
         clear_events = getattr(coordinator, "clear_events", None)
-        if callable(clear_events) and not _is_unconfigured_mock_callable(clear_events):
+        if callable(clear_events):
             clear_events(event_name)
             return
         legacy_clear_events = getattr(coordinator, "_clear_events", None)
-        if callable(legacy_clear_events) and not _is_unconfigured_mock_callable(
-            legacy_clear_events
-        ):
+        if callable(legacy_clear_events):
             legacy_clear_events(event_name)
             return
         clear_event = getattr(coordinator, "clear_event", None)
-        if callable(clear_event) and not _is_unconfigured_mock_callable(clear_event):
+        if callable(clear_event):
             clear_event(event_name)
             return
         legacy_clear_event = getattr(coordinator, "_clear_event", None)
-        if callable(legacy_clear_event) and not _is_unconfigured_mock_callable(
-            legacy_clear_event
-        ):
+        if callable(legacy_clear_event):
             legacy_clear_event(event_name)
 
     def _should_run_receive_loop(self) -> bool:
@@ -543,16 +523,12 @@ class BLEReceiveRecoveryController:
 
         iface = self._iface
         instance_override = iface.__dict__.get(method_name)
-        if callable(instance_override) and not _is_unconfigured_mock_callable(
-            instance_override
-        ):
+        if callable(instance_override):
             if self._is_default_iface_receive_hook(method_name, instance_override):
                 return None
             return _wrap_override(cast(Callable[..., object], instance_override))
         class_or_subclass_override = getattr(iface, method_name, None)
-        if callable(class_or_subclass_override) and not _is_unconfigured_mock_callable(
-            class_or_subclass_override
-        ):
+        if callable(class_or_subclass_override):
             if self._is_default_iface_receive_hook(
                 method_name,
                 class_or_subclass_override,
@@ -598,20 +574,9 @@ class BLEReceiveRecoveryController:
         iface = self._iface
         with self._session.lock:
             notify_enabled: object = getattr(iface, "_fromnum_notify_enabled", False)
-            is_unconfigured_member = getattr(
-                iface, "_is_unconfigured_mock_member", None
+            return not (
+                notify_enabled if isinstance(notify_enabled, bool) else False
             )
-            if callable(is_unconfigured_member) and not _is_unconfigured_mock_callable(
-                is_unconfigured_member
-            ):
-                try:
-                    if bool(is_unconfigured_member("_fromnum_notify_enabled")):
-                        notify_enabled = False
-                except Exception:  # noqa: BLE001 - probe remains best effort
-                    notify_enabled = False
-            if _is_unconfigured_mock_member(notify_enabled):
-                notify_enabled = False
-            return not bool(notify_enabled)
 
     def _resolve_wait_for_runtime_event(
         self,
@@ -630,9 +595,7 @@ class BLEReceiveRecoveryController:
             The injected wait function when provided and configured; otherwise
             a wrapper that delegates to ``_coordinator_wait_for_event``.
         """
-        if callable(wait_for_event) and not _is_unconfigured_mock_callable(
-            wait_for_event
-        ):
+        if callable(wait_for_event):
             injected_wait_for_event = cast(
                 Callable[["ThreadCoordinator", str, float | None], object],
                 wait_for_event,
@@ -713,10 +676,8 @@ class BLEReceiveRecoveryController:
         iface = self._iface
         with self._session.lock:
             client = iface.client
-            state_is_connecting = getattr(iface._state_manager, "is_connecting", None)
-            if callable(state_is_connecting) and not _is_unconfigured_mock_callable(
-                state_is_connecting
-            ):
+            state_is_connecting = _get_declared_member(iface._state_manager, "is_connecting")
+            if callable(state_is_connecting):
                 try:
                     connecting_result = state_is_connecting()
                 except (
@@ -733,9 +694,7 @@ class BLEReceiveRecoveryController:
                         if isinstance(connecting_result, bool)
                         else False
                     )
-            elif not _is_unconfigured_mock_member(state_is_connecting) and isinstance(
-                state_is_connecting, bool
-            ):
+            elif isinstance(state_is_connecting, bool):
                 is_connecting = state_is_connecting
             else:
                 legacy_is_connecting = getattr(
@@ -743,7 +702,7 @@ class BLEReceiveRecoveryController:
                 )
                 if callable(
                     legacy_is_connecting
-                ) and not _is_unconfigured_mock_callable(legacy_is_connecting):
+                ):
                     try:
                         connecting_result = legacy_is_connecting()
                     except (
@@ -760,9 +719,7 @@ class BLEReceiveRecoveryController:
                             if isinstance(connecting_result, bool)
                             else False
                         )
-                elif not _is_unconfigured_mock_member(
-                    legacy_is_connecting
-                ) and isinstance(legacy_is_connecting, bool):
+                elif isinstance(legacy_is_connecting, bool):
                     is_connecting = legacy_is_connecting
                 else:
                     is_connecting = False
@@ -1133,9 +1090,7 @@ class BLEReceiveRecoveryController:
         cooldown = BLEConfig.EMPTY_READ_WARNING_COOLDOWN
         raw_notify_enabled: object = getattr(iface, "_fromnum_notify_enabled", False)
         notify_enabled = (
-            False
-            if _is_unconfigured_mock_member(raw_notify_enabled)
-            else bool(raw_notify_enabled)
+            raw_notify_enabled if isinstance(raw_notify_enabled, bool) else False
         )
         if now - self._session.last_empty_read_warning >= cooldown:
             suppressed = self._session.suppressed_empty_read_warnings

--- a/meshtastic/interfaces/ble/receive_service.py
+++ b/meshtastic/interfaces/ble/receive_service.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
     from meshtastic.interfaces.ble.interface import BLEInterface
 
 COORDINATOR_WAIT_FALLBACK_SLEEP_SEC = 0.001
+TRANSIENT_RETRY_POLICY_REVALIDATION_MAX_ATTEMPTS = 4
 RECEIVE_THREAD_FATAL_REASON = "receive_thread_fatal"
 _INTERFACE_MODULE_NAME = "meshtastic.interfaces.ble.interface"
 _DEFAULT_RECURSIVE_IFACE_RECEIVE_HOOK_QUALNAMES = {
@@ -1041,23 +1042,38 @@ class BLEReceiveRecoveryController:
             override_handle_transient_read_error(error)
             return
         transient_policy = iface._transient_read_policy
-        with self._session.lock:
-            retry_count = self._session.read_retry_count
-        should_retry = iface._retry_policy_should_retry(transient_policy, retry_count)
         attempt_index = 0
         next_retry_count = 0
-        with self._session.lock:
-            if should_retry:
-                # A successful receive/recovery path may reset the shared
-                # counter while the caller-supplied retry policy runs outside
-                # this lock. Advance from the current value so a stale snapshot
-                # cannot resurrect a reset counter.
-                attempt_index = self._session.read_retry_count
-                self._session.read_retry_count = attempt_index + 1
-                next_retry_count = self._session.read_retry_count
-            else:
-                self._session.read_retry_count = 0
-                next_retry_count = 0
+        should_retry = False
+        for _decision_attempt in range(
+            TRANSIENT_RETRY_POLICY_REVALIDATION_MAX_ATTEMPTS
+        ):
+            with self._session.lock:
+                retry_count = self._session.read_retry_count
+            should_retry = iface._retry_policy_should_retry(
+                transient_policy, retry_count
+            )
+            with self._session.lock:
+                if self._session.read_retry_count != retry_count:
+                    # Successful receive/recovery work can reset this shared
+                    # counter while the caller-supplied policy runs without the
+                    # session lock. Re-evaluate from the new state so neither a
+                    # stale retry nor a stale terminal decision is applied.
+                    continue
+                if should_retry:
+                    attempt_index = retry_count
+                    self._session.read_retry_count = retry_count + 1
+                    next_retry_count = self._session.read_retry_count
+                else:
+                    self._session.read_retry_count = 0
+                    next_retry_count = 0
+                break
+        else:
+            logger.debug(
+                "Transient BLE read error decision superseded by concurrent retry-state changes after %d attempts; ignoring stale error.",
+                TRANSIENT_RETRY_POLICY_REVALIDATION_MAX_ATTEMPTS,
+            )
+            return
         if should_retry:
             logger.debug(
                 "Transient BLE read error, retrying (%d/%d)",

--- a/meshtastic/interfaces/ble/receive_service.py
+++ b/meshtastic/interfaces/ble/receive_service.py
@@ -1048,8 +1048,12 @@ class BLEReceiveRecoveryController:
         next_retry_count = 0
         with self._session.lock:
             if should_retry:
-                attempt_index = retry_count
-                self._session.read_retry_count = retry_count + 1
+                # A successful receive/recovery path may reset the shared
+                # counter while the caller-supplied retry policy runs outside
+                # this lock. Advance from the current value so a stale snapshot
+                # cannot resurrect a reset counter.
+                attempt_index = self._session.read_retry_count
+                self._session.read_retry_count = attempt_index + 1
                 next_retry_count = self._session.read_retry_count
             else:
                 self._session.read_retry_count = 0

--- a/meshtastic/interfaces/ble/receive_service.py
+++ b/meshtastic/interfaces/ble/receive_service.py
@@ -10,7 +10,12 @@ from typing import TYPE_CHECKING, cast
 
 from bleak.exc import BleakDBusError, BleakError, BleakGATTProtocolError
 
-from meshtastic.interfaces.ble.compat_adapter import (_get_declared_member)
+from meshtastic.interfaces.ble.compat_adapter import (
+    _get_declared_callable,
+    _get_declared_member,
+    _iter_declared_members,
+    _resolve_declared_callable,
+)
 from meshtastic.interfaces.ble.ports import _BLESessionStatePort
 from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.client import BLEClient
@@ -80,6 +85,14 @@ class BLEReceiveRecoveryController:
         ----------
         iface : BLEInterface
             Interface instance whose receive/recovery lifecycle is managed.
+        session_state : _BLESessionStatePort | None
+            Optional shared lifecycle state. When ``None``, resolve the
+            interface-owned state or use the legacy adapter.
+
+        Attributes
+        ----------
+        _session : _BLESessionStatePort
+            Shared lifecycle state used by receive and recovery paths.
 
         Returns
         -------
@@ -105,68 +118,20 @@ class BLEReceiveRecoveryController:
         return hooks
 
     @staticmethod
-    def _as_usable_callable(
-        candidate: object | None,
-    ) -> Callable[..., object] | None:
-        """Return a callable hook when candidate is usable.
-
-        Parameters
-        ----------
-        candidate : object | None
-            Candidate hook object.
-
-        Returns
-        -------
-        Callable[..., object] | None
-            Callable candidate when explicitly usable; otherwise
-            ``None``.
-        """
-        if callable(candidate):
-            return cast(Callable[..., object], candidate)
-        return None
-
     def _resolve_private_public_callable(
-        self,
         owner: object,
         *,
         private_name: str,
         public_name: str,
     ) -> Callable[..., object] | None:
-        """Resolve private/public hook names to the first usable callable.
-
-        Parameters
-        ----------
-        owner : object
-            Object that may expose private/public hook variants.
-        private_name : str
-            Private hook attribute name to probe first.
-        public_name : str
-            Public hook attribute name used as fallback when private hook is
-            unavailable.
-
-        Returns
-        -------
-        Callable[..., object] | None
-            First usable callable hook, preferring private then public; else
-            ``None``.
-        """
-        private_hook = self._as_usable_callable(_get_declared_member(owner, private_name))
-        if private_hook is not None:
-            return private_hook
-        return self._as_usable_callable(_get_declared_member(owner, public_name))
-
-    @classmethod
-    def _is_unusable_probe_value(cls, value: object | None) -> bool:
-        """Return whether a probe value is absent or has an unsupported shape."""
-        _ = cls
-        return value is None
+        """Resolve declared private/public hook names in precedence order."""
+        return _resolve_declared_callable(owner, private_name, public_name)
 
     def _get_lifecycle_controller(self) -> object | None:
         """Return lifecycle controller when available on the bound interface."""
-        get_lifecycle_controller = getattr(
-            self._iface, "_get_lifecycle_controller", None
+        get_lifecycle_controller_fn = _get_declared_callable(
+            self._iface, "_get_lifecycle_controller"
         )
-        get_lifecycle_controller_fn = self._as_usable_callable(get_lifecycle_controller)
         if get_lifecycle_controller_fn is not None:
             try:
                 controller = get_lifecycle_controller_fn()
@@ -176,7 +141,7 @@ class BLEReceiveRecoveryController:
                     "BLE lifecycle controller probe failed",
                 )
                 return None
-            if self._is_unusable_probe_value(controller):
+            if controller is None:
                 return None
             return controller
         return None
@@ -200,8 +165,7 @@ class BLEReceiveRecoveryController:
                     )
                 else:
                     return result if isinstance(result, bool) else False
-        raw_ever_connected = _get_declared_member(self._iface, "_ever_connected", False)
-        return raw_ever_connected is True
+        return self._session.ever_connected is True
 
     @staticmethod
     def _normalize_bool_probe(raw_value: object) -> bool:
@@ -238,7 +202,7 @@ class BLEReceiveRecoveryController:
     def _is_connection_closing_locked(self) -> bool:
         """Return whether connection-closing probes indicate closing while lock is held."""
         iface = self._iface
-        state_manager = getattr(iface, "_state_manager", None)
+        state_manager = _get_declared_member(iface, "_state_manager")
         state_is_closing: bool | None = None
         if state_manager is None:
             raw_is_closing = getattr(iface, "_is_connection_closing", False)
@@ -260,9 +224,7 @@ class BLEReceiveRecoveryController:
                 legacy_is_closing = _get_declared_member(state_manager, "_is_closing")
                 state_is_closing = self._normalize_bool_probe(legacy_is_closing)
 
-        raw_closed = getattr(iface, "_closed", False)
-        closed = self._normalize_bool_probe(raw_closed)
-        return state_is_closing or closed
+        return bool(state_is_closing or self._session.closed)
 
     def _is_connection_closing(self) -> bool:
         """Return whether receive-loop behavior should treat the interface as closing."""
@@ -586,7 +548,7 @@ class BLEReceiveRecoveryController:
             f"read_loop: {error_message}",
             client=previous_client,
         )
-        self._session.read_retry_count = 0
+        self._session.reset_read_retry_count()
         if not should_continue:
             self._set_receive_wanted(want_receive=False)
         return should_continue
@@ -702,53 +664,26 @@ class BLEReceiveRecoveryController:
         iface = self._iface
         with self._session.lock:
             client = iface.client
-            state_is_connecting = _get_declared_member(iface._state_manager, "is_connecting")
-            if callable(state_is_connecting):
-                try:
-                    connecting_result = state_is_connecting()
-                except (
-                    Exception
-                ):  # noqa: BLE001 - snapshot probe must remain best effort
-                    logger.debug(
-                        "Error probing state manager is_connecting()",
-                        exc_info=True,
-                    )
-                    is_connecting = False
-                else:
-                    is_connecting = (
-                        connecting_result
-                        if isinstance(connecting_result, bool)
-                        else False
-                    )
-            elif isinstance(state_is_connecting, bool):
-                is_connecting = state_is_connecting
-            else:
-                legacy_is_connecting = getattr(
-                    iface._state_manager, "_is_connecting", None
-                )
-                if callable(
-                    legacy_is_connecting
-                ):
+            state_manager = _get_declared_member(iface, "_state_manager")
+            is_connecting = False
+            for member_name, candidate in _iter_declared_members(
+                state_manager, "is_connecting", "_is_connecting"
+            ):
+                if callable(candidate):
                     try:
-                        connecting_result = legacy_is_connecting()
-                    except (
-                        Exception
-                    ):  # noqa: BLE001 - snapshot probe must remain best effort
+                        connecting_result = candidate()
+                    except Exception:  # noqa: BLE001 - snapshot probe stays best effort
                         logger.debug(
-                            "Error probing state manager _is_connecting()",
+                            "Error probing state manager %s()",
+                            member_name,
                             exc_info=True,
                         )
-                        is_connecting = False
-                    else:
-                        is_connecting = (
-                            connecting_result
-                            if isinstance(connecting_result, bool)
-                            else False
-                        )
-                elif isinstance(legacy_is_connecting, bool):
-                    is_connecting = legacy_is_connecting
+                        continue
                 else:
-                    is_connecting = False
+                    connecting_result = candidate
+                if isinstance(connecting_result, bool):
+                    is_connecting = connecting_result
+                    break
             publish_pending = self._session.client_publish_pending
             is_closing = self._is_connection_closing_locked()
         return client, is_connecting, publish_pending, is_closing
@@ -832,17 +767,17 @@ class BLEReceiveRecoveryController:
             retry_on_empty=not poll_without_notify,
         )
         if not payload:
-            self._session.read_retry_count = 0
+            self._session.reset_read_retry_count()
             return False
         logger.debug("FROMRADIO read: %s", payload.hex())
         try:
             iface._handle_from_radio(payload)
         except DecodeError as exc:
             logger.warning("Failed to parse FromRadio packet, discarding: %s", exc)
-            self._session.read_retry_count = 0
+            self._session.reset_read_retry_count()
             return True
         self._reset_recovery_after_stability()
-        self._session.read_retry_count = 0
+        self._session.reset_read_retry_count()
         return True
 
     def _handle_payload_read(
@@ -1025,7 +960,7 @@ class BLEReceiveRecoveryController:
         with self._session.lock:
             self._session.last_recovery_time = time.monotonic()
             updated_last_recovery_time = self._session.last_recovery_time
-        self._session.read_retry_count = 0
+        self._session.reset_read_retry_count()
         logger.debug(
             "BLE receive recovery timestamp updated: attempts=%d last_recovery_time=%.3f",
             attempts,
@@ -1079,7 +1014,8 @@ class BLEReceiveRecoveryController:
         for attempt in range(max_retries + 1):
             payload = client.read_gatt_char(FROMRADIO_UUID, timeout=read_timeout)
             if payload:
-                self._session.suppressed_empty_read_warnings = 0
+                with self._session.lock:
+                    self._session.suppressed_empty_read_warnings = 0
                 return payload
             if attempt < max_retries:
                 _sleep(iface._retry_policy_get_delay(iface._empty_read_policy, attempt))
@@ -1099,17 +1035,26 @@ class BLEReceiveRecoveryController:
             override_handle_transient_read_error(error)
             return
         transient_policy = iface._transient_read_policy
-        if iface._retry_policy_should_retry(transient_policy, self._session.read_retry_count):
-            attempt_index = self._session.read_retry_count
-            self._session.read_retry_count += 1
+        with self._session.lock:
+            retry_count = self._session.read_retry_count
+            should_retry = iface._retry_policy_should_retry(
+                transient_policy, retry_count
+            )
+            if should_retry:
+                attempt_index = retry_count
+                self._session.read_retry_count = retry_count + 1
+                next_retry_count = self._session.read_retry_count
+            else:
+                self._session.read_retry_count = 0
+                next_retry_count = 0
+        if should_retry:
             logger.debug(
                 "Transient BLE read error, retrying (%d/%d)",
-                self._session.read_retry_count,
+                next_retry_count,
                 BLEConfig.TRANSIENT_READ_MAX_RETRIES,
             )
             _sleep(iface._retry_policy_get_delay(transient_policy, attempt_index))
             return
-        self._session.read_retry_count = 0
         raise iface.BLEError(ERROR_READING_BLE) from error
 
     def log_empty_read_warning(self) -> None:
@@ -1127,8 +1072,17 @@ class BLEReceiveRecoveryController:
         notify_enabled = (
             raw_notify_enabled if isinstance(raw_notify_enabled, bool) else False
         )
-        if now - self._session.last_empty_read_warning >= cooldown:
+        with self._session.lock:
+            should_emit = now - self._session.last_empty_read_warning >= cooldown
             suppressed = self._session.suppressed_empty_read_warnings
+            if should_emit:
+                self._session.last_empty_read_warning = now
+                self._session.suppressed_empty_read_warnings = 0
+            else:
+                self._session.suppressed_empty_read_warnings = suppressed + 1
+                suppressed = self._session.suppressed_empty_read_warnings
+
+        if should_emit:
             message = f"Exceeded max retries for empty BLE read from {FROMRADIO_UUID}"
             if suppressed:
                 message = (
@@ -1142,14 +1096,11 @@ class BLEReceiveRecoveryController:
                     "%s (polling mode without FROMNUM notifications)",
                     message,
                 )
-            self._session.last_empty_read_warning = now
-            self._session.suppressed_empty_read_warnings = 0
             return
 
-        self._session.suppressed_empty_read_warnings += 1
         logger.debug(
             "Suppressed repeated empty BLE read warning (%d within %.0fs window)",
-            self._session.suppressed_empty_read_warnings,
+            suppressed,
             cooldown,
         )
 

--- a/meshtastic/interfaces/ble/reconnection.py
+++ b/meshtastic/interfaces/ble/reconnection.py
@@ -11,6 +11,10 @@ from bleak.exc import BleakDBusError, BleakDeviceNotFoundError, BleakError
 from meshtastic.interfaces.ble.constants import DBUS_ERROR_RECONNECT_DELAY, BLEConfig
 from meshtastic.interfaces.ble.coordination import ThreadCoordinator, ThreadLike
 from meshtastic.interfaces.ble.errors import BLEDBusTransportError
+from meshtastic.interfaces.ble.failure_policy import (
+    _BLEFailureDisposition,
+    _log_ble_failure,
+)
 from meshtastic.interfaces.ble.gating import (
     _addr_key,
     _is_currently_connected_elsewhere,
@@ -598,9 +602,11 @@ class ReconnectWorker:
                 except Exception:
                     if self._should_abort_reconnect(context="unexpected error"):
                         return
-                    logger.exception(
+                    _log_ble_failure(
+                        _BLEFailureDisposition.RETRYABLE,
                         "Unexpected error during auto-reconnect attempt %d",
                         attempt_num,
+                        level=logging.ERROR,
                     )
                 else:
                     logger.info(
@@ -638,12 +644,18 @@ class ReconnectWorker:
                 self.reconnect_policy,
             )
         except Exception:
-            logger.exception(
-                "Unexpected error during reconnect loop setup; aborting reconnect"
+            _log_ble_failure(
+                _BLEFailureDisposition.TERMINAL,
+                "Unexpected error during reconnect loop setup; aborting reconnect",
+                level=logging.ERROR,
             )
         finally:
             if on_exit is not None:
                 try:
                     on_exit()
                 except Exception:
-                    logger.exception("Reconnect loop exit callback failed")
+                    _log_ble_failure(
+                        _BLEFailureDisposition.BEST_EFFORT,
+                        "Reconnect loop exit callback failed",
+                        level=logging.ERROR,
+                    )

--- a/meshtastic/interfaces/ble/reconnection.py
+++ b/meshtastic/interfaces/ble/reconnection.py
@@ -32,22 +32,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger("meshtastic.ble")
 
 
-def _camel_to_snake(name: str) -> str:
-    """Convert a lower/upper camelCase identifier to snake_case."""
-    chars: list[str] = []
-    for idx, char in enumerate(name):
-        if char.isupper() and idx > 0:
-            chars.append("_")
-        chars.append(char.lower())
-    return "".join(chars)
-
-
-def _snake_to_camel(name: str) -> str:
-    """Convert snake_case identifier to lower camelCase."""
-    head, *tail = name.split("_")
-    return head + "".join(piece.capitalize() for piece in tail)
-
-
 class ReconnectPolicyMissingMethodError(AttributeError):
     """Raised when a required reconnect-policy method is missing."""
 
@@ -309,12 +293,12 @@ class ReconnectWorker:
         self.reconnect_policy = reconnect_policy
 
     def _call_policy(self, method_name: str, *args: Any) -> Any:
-        """Call a policy method with compatibility fallbacks for legacy naming styles.
+        """Call one canonical reconnect-policy method.
 
         Parameters
         ----------
         method_name : str
-            Name of the public method to call on the policy.
+            Name of the canonical internal method to call on the policy.
         *args
             Arguments to pass to the policy method.
 
@@ -323,20 +307,8 @@ class ReconnectWorker:
         Any
             The return value from the policy method.
         """
-        candidate_names: list[str] = [method_name]
-        snake_name = _camel_to_snake(method_name)
-        if snake_name != method_name:
-            candidate_names.append(snake_name)
-        camel_name = _snake_to_camel(snake_name)
-        if camel_name not in candidate_names:
-            candidate_names.append(camel_name)
-
-        compatibility_names = [
-            *candidate_names,
-            *(f"_{candidate_name}" for candidate_name in candidate_names),
-        ]
         candidate_method = _resolve_declared_callable(
-            self.reconnect_policy, *compatibility_names
+            self.reconnect_policy, method_name
         )
         if candidate_method is not None:
             return candidate_method(*args)

--- a/meshtastic/interfaces/ble/reconnection.py
+++ b/meshtastic/interfaces/ble/reconnection.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 from bleak.exc import BleakDBusError, BleakDeviceNotFoundError, BleakError
 
+from meshtastic.interfaces.ble.compat_adapter import _resolve_declared_callable
 from meshtastic.interfaces.ble.constants import DBUS_ERROR_RECONNECT_DELAY, BLEConfig
 from meshtastic.interfaces.ble.coordination import ThreadCoordinator, ThreadLike
 from meshtastic.interfaces.ble.errors import BLEDBusTransportError
@@ -134,14 +135,11 @@ class ReconnectScheduler:
         ThreadCoordinatorMissingMethodError
             If neither hook is available and callable.
         """
-        public_hook = getattr(self.thread_coordinator, public_name, None)
-        if callable(public_hook):
-            return cast(Callable[..., object], public_hook)
-
-        legacy_hook = getattr(self.thread_coordinator, legacy_name, None)
-        if callable(legacy_hook):
-            return cast(Callable[..., object], legacy_hook)
-
+        hook = _resolve_declared_callable(
+            self.thread_coordinator, public_name, legacy_name
+        )
+        if hook is not None:
+            return cast(Callable[..., object], hook)
         raise ThreadCoordinatorMissingMethodError(f"{public_name}/{legacy_name}")
 
     def _thread_create_thread(
@@ -333,16 +331,15 @@ class ReconnectWorker:
         if camel_name not in candidate_names:
             candidate_names.append(camel_name)
 
-        for candidate_name in candidate_names:
-            candidate_method = getattr(self.reconnect_policy, candidate_name, None)
-            if callable(candidate_method):
-                return candidate_method(*args)
-
-        # Backward compatibility for test doubles that only expose underscored methods.
-        for candidate_name in candidate_names:
-            fallback = getattr(self.reconnect_policy, f"_{candidate_name}", None)
-            if callable(fallback):
-                return fallback(*args)
+        compatibility_names = [
+            *candidate_names,
+            *(f"_{candidate_name}" for candidate_name in candidate_names),
+        ]
+        candidate_method = _resolve_declared_callable(
+            self.reconnect_policy, *compatibility_names
+        )
+        if candidate_method is not None:
+            return candidate_method(*args)
         raise ReconnectPolicyMissingMethodError(method_name)
 
     def _should_abort_reconnect(

--- a/meshtastic/interfaces/ble/reconnection.py
+++ b/meshtastic/interfaces/ble/reconnection.py
@@ -18,7 +18,6 @@ from meshtastic.interfaces.ble.gating import (
 from meshtastic.interfaces.ble.policies import ReconnectPolicy
 from meshtastic.interfaces.ble.state import BLEStateManager
 from meshtastic.interfaces.ble.utils import (
-    _is_unconfigured_mock_callable,
     _thread_start_probe,
 )
 
@@ -132,11 +131,11 @@ class ReconnectScheduler:
             If neither hook is available and callable.
         """
         public_hook = getattr(self.thread_coordinator, public_name, None)
-        if callable(public_hook) and not _is_unconfigured_mock_callable(public_hook):
+        if callable(public_hook):
             return cast(Callable[..., object], public_hook)
 
         legacy_hook = getattr(self.thread_coordinator, legacy_name, None)
-        if callable(legacy_hook) and not _is_unconfigured_mock_callable(legacy_hook):
+        if callable(legacy_hook):
             return cast(Callable[..., object], legacy_hook)
 
         raise ThreadCoordinatorMissingMethodError(f"{public_name}/{legacy_name}")
@@ -332,15 +331,13 @@ class ReconnectWorker:
 
         for candidate_name in candidate_names:
             candidate_method = getattr(self.reconnect_policy, candidate_name, None)
-            if callable(candidate_method) and not _is_unconfigured_mock_callable(
-                candidate_method
-            ):
+            if callable(candidate_method):
                 return candidate_method(*args)
 
         # Backward compatibility for test doubles that only expose underscored methods.
         for candidate_name in candidate_names:
             fallback = getattr(self.reconnect_policy, f"_{candidate_name}", None)
-            if callable(fallback) and not _is_unconfigured_mock_callable(fallback):
+            if callable(fallback):
                 return fallback(*args)
         raise ReconnectPolicyMissingMethodError(method_name)
 

--- a/meshtastic/interfaces/ble/session_state.py
+++ b/meshtastic/interfaces/ble/session_state.py
@@ -421,10 +421,15 @@ class _LegacyBLESessionStateAdapter:
 def _session_state_for(
     iface: object, explicit: _BLESessionStatePort | None = None
 ) -> _BLESessionStatePort:
-    """Return explicit/owned session state or a cached legacy interface adapter."""
+    """Return explicit/owned session state or a cached legacy interface adapter.
+
+    Caches the legacy adapter only on collaborators that expose a real
+    instance ``__dict__``. Slot-based or partial test doubles get a fresh
+    adapter per call rather than silently writing into a throwaway fallback.
+    """
     if explicit is not None:
         return explicit
-    instance_dict = _get_declared_member(iface, "__dict__", {})
+    instance_dict = _get_declared_member(iface, "__dict__")
     state = (
         instance_dict.get("_session_state") if isinstance(instance_dict, dict) else None
     )

--- a/meshtastic/interfaces/ble/session_state.py
+++ b/meshtastic/interfaces/ble/session_state.py
@@ -106,20 +106,7 @@ class _BLESessionStateCompatMixin:
             Canonical session owner installed for this interface.
         """
         instance_dict = self.__dict__
-        state_manager_lock = _get_declared_lock(
-            instance_dict.get("_state_manager"), "lock"
-        )
-        raw_legacy_lock = instance_dict.get("_state_lock")
-        raw_legacy_lock_type = type(raw_legacy_lock)
-        raw_legacy_lock_is_valid = raw_legacy_lock is not None and (
-            _get_declared_callable(raw_legacy_lock_type, "__enter__") is not None
-            and _get_declared_callable(raw_legacy_lock_type, "__exit__") is not None
-        )
-        promotion_lock = state_manager_lock
-        if promotion_lock is None and raw_legacy_lock_is_valid:
-            promotion_lock = cast(_LockPort, raw_legacy_lock)
-        if promotion_lock is None:
-            promotion_lock = state._fallback_lock
+        promotion_lock = state.lock
         with promotion_lock:
             current = instance_dict.get("_session_state")
             if isinstance(current, BLESessionState):
@@ -454,6 +441,32 @@ class _LegacyBLESessionStateAdapter:
             self, "_fallback_lock", cast(_LockPort, threading.RLock())
         )
 
+    def _resolve_lock(self, mapped: str) -> _LockPort:
+        """Return the synchronization owner currently governing legacy state."""
+        iface = self._iface
+        if isinstance(iface, _BLESessionStateCompatMixin):
+            instance_dict = iface.__dict__
+            current_state = instance_dict.get("_session_state")
+            if isinstance(current_state, BLESessionState):
+                return current_state.lock
+            state_manager_lock = _get_declared_lock(
+                instance_dict.get("_state_manager"), "lock"
+            )
+            if state_manager_lock is not None:
+                return state_manager_lock
+            raw_legacy_lock = instance_dict.get(mapped)
+            if raw_legacy_lock is not None:
+                raw_lock_type = type(raw_legacy_lock)
+                if (
+                    _get_declared_callable(raw_lock_type, "__enter__") is not None
+                    and _get_declared_callable(raw_lock_type, "__exit__") is not None
+                ):
+                    return cast(_LockPort, raw_legacy_lock)
+            if current_state is self:
+                return self._fallback_lock
+        declared_lock = _get_declared_lock(iface, mapped)
+        return self._fallback_lock if declared_lock is None else declared_lock
+
     def __getattr__(self, name: str) -> Any:
         mapped = self._FIELD_MAP.get(name)
         if mapped is None:
@@ -461,14 +474,7 @@ class _LegacyBLESessionStateAdapter:
                 f"{type(self).__name__} does not proxy session field {name!r}"
             )
         if name == "lock":
-            if isinstance(self._iface, _BLESessionStateCompatMixin):
-                current_state = self._iface.__dict__.get("_session_state")
-                if current_state is self:
-                    return self._fallback_lock
-                if isinstance(current_state, BLESessionState):
-                    return current_state.lock
-            declared_lock = _get_declared_lock(self._iface, mapped)
-            return self._fallback_lock if declared_lock is None else declared_lock
+            return self._resolve_lock(mapped)
         value = _get_declared_member(self._iface, mapped, _MISSING_SESSION_FIELD)
         if value is not _MISSING_SESSION_FIELD:
             return value

--- a/meshtastic/interfaces/ble/session_state.py
+++ b/meshtastic/interfaces/ble/session_state.py
@@ -2,15 +2,17 @@
 
 from dataclasses import dataclass
 import threading
-from threading import RLock
 from typing import TYPE_CHECKING, Any, cast
 
-from meshtastic.interfaces.ble.compat_adapter import _get_declared_member
+from meshtastic.interfaces.ble.compat_adapter import _get_declared_lock, _get_declared_member
 from meshtastic.interfaces.ble.coordination import ThreadLike
-from meshtastic.interfaces.ble.ports import _BLESessionStatePort
+from meshtastic.interfaces.ble.ports import _BLESessionStatePort, _LockPort
 
 if TYPE_CHECKING:
     from meshtastic.interfaces.ble.client import BLEClient
+
+
+_MISSING_SESSION_FIELD = object()
 
 
 @dataclass(slots=True)
@@ -26,13 +28,13 @@ class BLESessionState:  # pylint: disable=too-many-instance-attributes
     introducing nested-lock behavior.
     """
 
-    lock: RLock
+    lock: _LockPort
     closed: bool = False
     disconnect_notified: bool = False
     client_publish_pending: bool = False
     connected_publish_inflight_client: "BLEClient | None" = None
     client_replacement_pending: bool = False
-    last_disconnect_source: str = ""
+    last_disconnect_source: str | None = ""
     connection_alias_key: str | None = None
     prior_publish_was_reconnect: bool = False
     last_connect_pair_override: bool | None = None
@@ -50,16 +52,23 @@ class BLESessionState:  # pylint: disable=too-many-instance-attributes
     receive_start_pending_since: float | None = None
     receive_thread: ThreadLike | None = None
 
+    def reset_read_retry_count(self) -> None:
+        """Reset only the transient read retry counter under the session lock."""
+        with self.lock:
+            self.read_retry_count = 0
+
     def reset_receive_retry_state(self) -> None:
-        """Reset transient read retry and warning counters."""
-        self.read_retry_count = 0
-        self.last_empty_read_warning = 0.0
-        self.suppressed_empty_read_warnings = 0
+        """Reset transient read retry and warning counters under the session lock."""
+        with self.lock:
+            self.read_retry_count = 0
+            self.last_empty_read_warning = 0.0
+            self.suppressed_empty_read_warnings = 0
 
     def reset_recovery_state(self) -> None:
-        """Reset receive-recovery attempt bookkeeping."""
-        self.receive_recovery_attempts = 0
-        self.last_recovery_time = 0.0
+        """Reset receive-recovery attempt bookkeeping under the session lock."""
+        with self.lock:
+            self.receive_recovery_attempts = 0
+            self.last_recovery_time = 0.0
 
 
 class _BLESessionStateCompatMixin:
@@ -74,20 +83,20 @@ class _BLESessionStateCompatMixin:
         if isinstance(state, BLESessionState):
             return state
         state_manager = self.__dict__.get("_state_manager")
-        lock = _get_declared_member(state_manager, "lock")
-        if not hasattr(lock, "acquire") or not hasattr(lock, "release"):
-            lock = threading.RLock()
+        lock = _get_declared_lock(state_manager, "lock")
+        if lock is None:
+            lock = cast(_LockPort, threading.RLock())
         state = BLESessionState(lock=lock)
         self.__dict__["_session_state"] = state
         return state
 
     @property
-    def _state_lock(self) -> threading.RLock:
+    def _state_lock(self) -> _LockPort:
         """Compatibility view of the owned lifecycle lock."""
         return self._get_session_state().lock
 
     @_state_lock.setter
-    def _state_lock(self, value: threading.RLock) -> None:
+    def _state_lock(self, value: _LockPort) -> None:
         self._get_session_state().lock = value
 
     @property
@@ -101,6 +110,7 @@ class _BLESessionStateCompatMixin:
 
     @property
     def _disconnect_notified(self) -> bool:
+        """Compatibility view of the disconnect-notified flag."""
         return self._get_session_state().disconnect_notified
 
     @_disconnect_notified.setter
@@ -109,6 +119,7 @@ class _BLESessionStateCompatMixin:
 
     @property
     def _client_publish_pending(self) -> bool:
+        """Compatibility view of the client-publication pending flag."""
         return self._get_session_state().client_publish_pending
 
     @_client_publish_pending.setter
@@ -117,6 +128,7 @@ class _BLESessionStateCompatMixin:
 
     @property
     def _connected_publish_inflight_client(self) -> "BLEClient | None":
+        """Compatibility view of the client currently being published."""
         return self._get_session_state().connected_publish_inflight_client
 
     @_connected_publish_inflight_client.setter
@@ -125,6 +137,7 @@ class _BLESessionStateCompatMixin:
 
     @property
     def _client_replacement_pending(self) -> bool:
+        """Compatibility view of the client-replacement pending flag."""
         return self._get_session_state().client_replacement_pending
 
     @_client_replacement_pending.setter
@@ -132,15 +145,17 @@ class _BLESessionStateCompatMixin:
         self._get_session_state().client_replacement_pending = value
 
     @property
-    def _last_disconnect_source(self) -> str:
+    def _last_disconnect_source(self) -> str | None:
+        """Compatibility view of the latest disconnect source."""
         return self._get_session_state().last_disconnect_source
 
     @_last_disconnect_source.setter
-    def _last_disconnect_source(self, value: str) -> None:
+    def _last_disconnect_source(self, value: str | None) -> None:
         self._get_session_state().last_disconnect_source = value
 
     @property
     def _connection_alias_key(self) -> str | None:
+        """Compatibility view of the active connection alias key."""
         return self._get_session_state().connection_alias_key
 
     @_connection_alias_key.setter
@@ -149,6 +164,7 @@ class _BLESessionStateCompatMixin:
 
     @property
     def _prior_publish_was_reconnect(self) -> bool:
+        """Compatibility view of whether the prior publication was a reconnect."""
         return self._get_session_state().prior_publish_was_reconnect
 
     @_prior_publish_was_reconnect.setter
@@ -157,6 +173,7 @@ class _BLESessionStateCompatMixin:
 
     @property
     def _last_connect_pair_override(self) -> bool | None:
+        """Compatibility view of the last pairing override."""
         return self._get_session_state().last_connect_pair_override
 
     @_last_connect_pair_override.setter
@@ -165,6 +182,7 @@ class _BLESessionStateCompatMixin:
 
     @property
     def _last_connect_timeout_override(self) -> float | None:
+        """Compatibility view of the last connect-timeout override."""
         return self._get_session_state().last_connect_timeout_override
 
     @_last_connect_timeout_override.setter
@@ -173,6 +191,7 @@ class _BLESessionStateCompatMixin:
 
     @property
     def _publishing_thread_override(self) -> object | None:
+        """Compatibility view of the publishing-thread override."""
         return self._get_session_state().publishing_thread_override
 
     @_publishing_thread_override.setter
@@ -181,6 +200,7 @@ class _BLESessionStateCompatMixin:
 
     @property
     def _ever_connected(self) -> bool:
+        """Compatibility view of whether this session has ever connected."""
         return self._get_session_state().ever_connected
 
     @_ever_connected.setter
@@ -189,6 +209,7 @@ class _BLESessionStateCompatMixin:
 
     @property
     def _connection_session_epoch(self) -> int:
+        """Compatibility view of the connection-session epoch."""
         return self._get_session_state().connection_session_epoch
 
     @_connection_session_epoch.setter
@@ -197,6 +218,7 @@ class _BLESessionStateCompatMixin:
 
     @property
     def _receive_recovery_attempts(self) -> int:
+        """Compatibility view of receive-recovery attempts."""
         return self._get_session_state().receive_recovery_attempts
 
     @_receive_recovery_attempts.setter
@@ -205,6 +227,7 @@ class _BLESessionStateCompatMixin:
 
     @property
     def _last_recovery_time(self) -> float:
+        """Compatibility view of the last receive-recovery timestamp."""
         return self._get_session_state().last_recovery_time
 
     @_last_recovery_time.setter
@@ -213,6 +236,7 @@ class _BLESessionStateCompatMixin:
 
     @property
     def _read_retry_count(self) -> int:
+        """Compatibility view of the transient read-retry count."""
         return self._get_session_state().read_retry_count
 
     @_read_retry_count.setter
@@ -221,6 +245,7 @@ class _BLESessionStateCompatMixin:
 
     @property
     def _last_empty_read_warning(self) -> float:
+        """Compatibility view of the last empty-read warning timestamp."""
         return self._get_session_state().last_empty_read_warning
 
     @_last_empty_read_warning.setter
@@ -229,6 +254,7 @@ class _BLESessionStateCompatMixin:
 
     @property
     def _suppressed_empty_read_warnings(self) -> int:
+        """Compatibility view of suppressed empty-read warnings."""
         return self._get_session_state().suppressed_empty_read_warnings
 
     @_suppressed_empty_read_warnings.setter
@@ -237,6 +263,7 @@ class _BLESessionStateCompatMixin:
 
     @property
     def _want_receive(self) -> bool:
+        """Compatibility view of receive-loop intent."""
         return self._get_session_state().want_receive
 
     @_want_receive.setter
@@ -245,6 +272,7 @@ class _BLESessionStateCompatMixin:
 
     @property
     def _receive_start_pending(self) -> bool:
+        """Compatibility view of the receive-start pending flag."""
         return self._get_session_state().receive_start_pending
 
     @_receive_start_pending.setter
@@ -253,6 +281,7 @@ class _BLESessionStateCompatMixin:
 
     @property
     def _receive_start_pending_since(self) -> float | None:
+        """Compatibility view of when receive-start became pending."""
         return self._get_session_state().receive_start_pending_since
 
     @_receive_start_pending_since.setter
@@ -261,6 +290,7 @@ class _BLESessionStateCompatMixin:
 
     @property
     def _receiveThread(self) -> ThreadLike | None:  # noqa: N802 - compatibility name
+        """Compatibility view of the receive thread."""
         return self._get_session_state().receive_thread
 
     @_receiveThread.setter
@@ -269,9 +299,15 @@ class _BLESessionStateCompatMixin:
 
 
 class _LegacyBLESessionStateAdapter:
-    """Adapt historical interface-private fields to the session-state port."""
+    """Adapt historical interface-private fields to the session-state port.
 
-    __slots__ = ("_iface",)
+    Partial legacy interfaces are allowed to omit lifecycle fields that historically
+    had implicit defaults.  The adapter preserves those defaults and owns a stable
+    fallback lock when ``_state_lock`` is absent, so every session-state operation
+    still has one synchronization primitive for the adapter lifetime.
+    """
+
+    __slots__ = ("_iface", "_fallback_lock")
     _FIELD_MAP = {
         "lock": "_state_lock",
         "closed": "_closed",
@@ -297,31 +333,90 @@ class _LegacyBLESessionStateAdapter:
         "receive_start_pending_since": "_receive_start_pending_since",
         "receive_thread": "_receiveThread",
     }
+    _FIELD_DEFAULTS: dict[str, object] = {
+        "closed": False,
+        "disconnect_notified": False,
+        "client_publish_pending": False,
+        "connected_publish_inflight_client": None,
+        "client_replacement_pending": False,
+        "last_disconnect_source": "",
+        "connection_alias_key": None,
+        "prior_publish_was_reconnect": False,
+        "last_connect_pair_override": None,
+        "last_connect_timeout_override": None,
+        "publishing_thread_override": None,
+        "ever_connected": False,
+        "connection_session_epoch": 0,
+        "receive_recovery_attempts": 0,
+        "last_recovery_time": 0.0,
+        "read_retry_count": 0,
+        "last_empty_read_warning": 0.0,
+        "suppressed_empty_read_warnings": 0,
+        "want_receive": True,
+        "receive_start_pending": False,
+        "receive_start_pending_since": None,
+        "receive_thread": None,
+    }
 
     def __init__(self, iface: object) -> None:
         object.__setattr__(self, "_iface", iface)
+        lock = _get_declared_lock(iface, "_state_lock")
+        if lock is None:
+            lock = cast(_LockPort, threading.RLock())
+        object.__setattr__(self, "_fallback_lock", lock)
 
     def __getattr__(self, name: str) -> Any:
         mapped = self._FIELD_MAP.get(name)
         if mapped is None:
             raise AttributeError(name)
-        return getattr(self._iface, mapped)
+        if name == "lock":
+            return self._fallback_lock
+        value = _get_declared_member(self._iface, mapped, _MISSING_SESSION_FIELD)
+        if value is not _MISSING_SESSION_FIELD:
+            return value
+        if name in self._FIELD_DEFAULTS:
+            return self._FIELD_DEFAULTS[name]
+        raise AttributeError(name)
 
     def __setattr__(self, name: str, value: object) -> None:
         mapped = self._FIELD_MAP.get(name)
         if mapped is None:
             raise AttributeError(name)
+        if name == "lock":
+            object.__setattr__(self, "_fallback_lock", cast(_LockPort, value))
         setattr(self._iface, mapped, value)
+
+    def reset_read_retry_count(self) -> None:
+        """Reset only the legacy transient read retry counter."""
+        with self._fallback_lock:
+            self.read_retry_count = 0
+
+    def reset_receive_retry_state(self) -> None:
+        """Reset legacy transient read retry and warning counters."""
+        with self._fallback_lock:
+            self.read_retry_count = 0
+            self.last_empty_read_warning = 0.0
+            self.suppressed_empty_read_warnings = 0
+
+    def reset_recovery_state(self) -> None:
+        """Reset legacy receive-recovery bookkeeping."""
+        with self._fallback_lock:
+            self.receive_recovery_attempts = 0
+            self.last_recovery_time = 0.0
 
 
 def _session_state_for(
     iface: object, explicit: _BLESessionStatePort | None = None
 ) -> _BLESessionStatePort:
-    """Return explicit/owned session state or a legacy interface adapter."""
+    """Return explicit/owned session state or a cached legacy interface adapter."""
     if explicit is not None:
         return explicit
     instance_dict = _get_declared_member(iface, "__dict__", {})
     state = instance_dict.get("_session_state") if isinstance(instance_dict, dict) else None
-    if isinstance(state, BLESessionState):
-        return state
-    return cast(_BLESessionStatePort, _LegacyBLESessionStateAdapter(iface))
+    if isinstance(state, (BLESessionState, _LegacyBLESessionStateAdapter)):
+        return cast(_BLESessionStatePort, state)
+
+    legacy_state = _LegacyBLESessionStateAdapter(iface)
+    if isinstance(instance_dict, dict):
+        instance_dict["_session_state"] = legacy_state
+    return cast(_BLESessionStatePort, legacy_state)

--- a/meshtastic/interfaces/ble/session_state.py
+++ b/meshtastic/interfaces/ble/session_state.py
@@ -5,6 +5,7 @@ import threading
 from threading import RLock
 from typing import TYPE_CHECKING, Any, cast
 
+from meshtastic.interfaces.ble.compat_adapter import _get_declared_member
 from meshtastic.interfaces.ble.coordination import ThreadLike
 from meshtastic.interfaces.ble.ports import _BLESessionStatePort
 
@@ -73,7 +74,7 @@ class _BLESessionStateCompatMixin:
         if isinstance(state, BLESessionState):
             return state
         state_manager = self.__dict__.get("_state_manager")
-        lock = getattr(state_manager, "lock", None)
+        lock = _get_declared_member(state_manager, "lock")
         if not hasattr(lock, "acquire") or not hasattr(lock, "release"):
             lock = threading.RLock()
         state = BLESessionState(lock=lock)
@@ -319,7 +320,7 @@ def _session_state_for(
     """Return explicit/owned session state or a legacy interface adapter."""
     if explicit is not None:
         return explicit
-    instance_dict = getattr(iface, "__dict__", {})
+    instance_dict = _get_declared_member(iface, "__dict__", {})
     state = instance_dict.get("_session_state") if isinstance(instance_dict, dict) else None
     if isinstance(state, BLESessionState):
         return state

--- a/meshtastic/interfaces/ble/session_state.py
+++ b/meshtastic/interfaces/ble/session_state.py
@@ -1,10 +1,13 @@
 """Owned mutable lifecycle state for a BLE interface session."""
 
-from dataclasses import dataclass
 import threading
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
-from meshtastic.interfaces.ble.compat_adapter import _get_declared_lock, _get_declared_member
+from meshtastic.interfaces.ble.compat_adapter import (
+    _get_declared_lock,
+    _get_declared_member,
+)
 from meshtastic.interfaces.ble.coordination import ThreadLike
 from meshtastic.interfaces.ble.ports import _BLESessionStatePort, _LockPort
 
@@ -52,19 +55,19 @@ class BLESessionState:  # pylint: disable=too-many-instance-attributes
     receive_start_pending_since: float | None = None
     receive_thread: ThreadLike | None = None
 
-    def reset_read_retry_count(self) -> None:
+    def _reset_read_retry_count(self) -> None:
         """Reset only the transient read retry counter under the session lock."""
         with self.lock:
             self.read_retry_count = 0
 
-    def reset_receive_retry_state(self) -> None:
+    def _reset_receive_retry_state(self) -> None:
         """Reset transient read retry and warning counters under the session lock."""
         with self.lock:
             self.read_retry_count = 0
             self.last_empty_read_warning = 0.0
             self.suppressed_empty_read_warnings = 0
 
-    def reset_recovery_state(self) -> None:
+    def _reset_recovery_state(self) -> None:
         """Reset receive-recovery attempt bookkeeping under the session lock."""
         with self.lock:
             self.receive_recovery_attempts = 0
@@ -75,17 +78,23 @@ class _BLESessionStateCompatMixin:
     """Preserve historical private lifecycle attributes over owned session state."""
 
     _state_manager: Any
-    _session_state: BLESessionState
+    _session_state: _BLESessionStatePort
 
     def _get_session_state(self) -> BLESessionState:
         """Return owned lifecycle state, lazily supporting partial interfaces."""
         state = self.__dict__.get("_session_state")
         if isinstance(state, BLESessionState):
             return state
-        state_manager = self.__dict__.get("_state_manager")
-        lock = _get_declared_lock(state_manager, "lock")
-        if lock is None:
-            lock = cast(_LockPort, threading.RLock())
+        if isinstance(state, _LegacyBLESessionStateAdapter):
+            # A legacy adapter can be cached before a partial interface first
+            # reaches a mixin property. Promote it without changing the shared
+            # lock; the adapter continues to proxy fields into this owner.
+            lock = state.lock
+        else:
+            state_manager = self.__dict__.get("_state_manager")
+            lock = _get_declared_lock(state_manager, "lock")
+            if lock is None:
+                lock = cast(_LockPort, threading.RLock())
         state = BLESessionState(lock=lock)
         self.__dict__["_session_state"] = state
         return state
@@ -386,19 +395,19 @@ class _LegacyBLESessionStateAdapter:
             object.__setattr__(self, "_fallback_lock", cast(_LockPort, value))
         setattr(self._iface, mapped, value)
 
-    def reset_read_retry_count(self) -> None:
+    def _reset_read_retry_count(self) -> None:
         """Reset only the legacy transient read retry counter."""
         with self._fallback_lock:
             self.read_retry_count = 0
 
-    def reset_receive_retry_state(self) -> None:
+    def _reset_receive_retry_state(self) -> None:
         """Reset legacy transient read retry and warning counters."""
         with self._fallback_lock:
             self.read_retry_count = 0
             self.last_empty_read_warning = 0.0
             self.suppressed_empty_read_warnings = 0
 
-    def reset_recovery_state(self) -> None:
+    def _reset_recovery_state(self) -> None:
         """Reset legacy receive-recovery bookkeeping."""
         with self._fallback_lock:
             self.receive_recovery_attempts = 0
@@ -412,9 +421,14 @@ def _session_state_for(
     if explicit is not None:
         return explicit
     instance_dict = _get_declared_member(iface, "__dict__", {})
-    state = instance_dict.get("_session_state") if isinstance(instance_dict, dict) else None
+    state = (
+        instance_dict.get("_session_state") if isinstance(instance_dict, dict) else None
+    )
     if isinstance(state, (BLESessionState, _LegacyBLESessionStateAdapter)):
         return cast(_BLESessionStatePort, state)
+
+    if isinstance(iface, _BLESessionStateCompatMixin):
+        return iface._get_session_state()
 
     legacy_state = _LegacyBLESessionStateAdapter(iface)
     if isinstance(instance_dict, dict):

--- a/meshtastic/interfaces/ble/session_state.py
+++ b/meshtastic/interfaces/ble/session_state.py
@@ -311,9 +311,9 @@ class _LegacyBLESessionStateAdapter:
     """Adapt historical interface-private fields to the session-state port.
 
     Partial legacy interfaces are allowed to omit lifecycle fields that historically
-    had implicit defaults.  The adapter preserves those defaults and owns a stable
-    fallback lock when ``_state_lock`` is absent, so every session-state operation
-    still has one synchronization primitive for the adapter lifetime.
+    had implicit defaults. The adapter preserves those defaults, follows the
+    interface's currently declared ``_state_lock`` when present, and retains one
+    stable fallback lock for intervals where no declared lock exists.
     """
 
     __slots__ = ("_iface", "_fallback_lock")
@@ -369,17 +369,23 @@ class _LegacyBLESessionStateAdapter:
 
     def __init__(self, iface: object) -> None:
         object.__setattr__(self, "_iface", iface)
-        lock = _get_declared_lock(iface, "_state_lock")
-        if lock is None:
-            lock = cast(_LockPort, threading.RLock())
-        object.__setattr__(self, "_fallback_lock", lock)
+        object.__setattr__(
+            self, "_fallback_lock", cast(_LockPort, threading.RLock())
+        )
 
     def __getattr__(self, name: str) -> Any:
         mapped = self._FIELD_MAP.get(name)
         if mapped is None:
             raise AttributeError(name)
         if name == "lock":
-            return self._fallback_lock
+            if isinstance(self._iface, _BLESessionStateCompatMixin):
+                current_state = self._iface.__dict__.get("_session_state")
+                if current_state is self:
+                    return self._fallback_lock
+                if isinstance(current_state, BLESessionState):
+                    return current_state.lock
+            declared_lock = _get_declared_lock(self._iface, mapped)
+            return self._fallback_lock if declared_lock is None else declared_lock
         value = _get_declared_member(self._iface, mapped, _MISSING_SESSION_FIELD)
         if value is not _MISSING_SESSION_FIELD:
             return value
@@ -391,25 +397,23 @@ class _LegacyBLESessionStateAdapter:
         mapped = self._FIELD_MAP.get(name)
         if mapped is None:
             raise AttributeError(name)
-        if name == "lock":
-            object.__setattr__(self, "_fallback_lock", cast(_LockPort, value))
         setattr(self._iface, mapped, value)
 
     def _reset_read_retry_count(self) -> None:
         """Reset only the legacy transient read retry counter."""
-        with self._fallback_lock:
+        with self.lock:
             self.read_retry_count = 0
 
     def _reset_receive_retry_state(self) -> None:
         """Reset legacy transient read retry and warning counters."""
-        with self._fallback_lock:
+        with self.lock:
             self.read_retry_count = 0
             self.last_empty_read_warning = 0.0
             self.suppressed_empty_read_warnings = 0
 
     def _reset_recovery_state(self) -> None:
         """Reset legacy receive-recovery bookkeeping."""
-        with self._fallback_lock:
+        with self.lock:
             self.receive_recovery_attempts = 0
             self.last_recovery_time = 0.0
 

--- a/meshtastic/interfaces/ble/session_state.py
+++ b/meshtastic/interfaces/ble/session_state.py
@@ -3,9 +3,10 @@
 from dataclasses import dataclass
 import threading
 from threading import RLock
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from meshtastic.interfaces.ble.coordination import ThreadLike
+from meshtastic.interfaces.ble.ports import _BLESessionStatePort
 
 if TYPE_CHECKING:
     from meshtastic.interfaces.ble.client import BLEClient
@@ -264,3 +265,62 @@ class _BLESessionStateCompatMixin:
     @_receiveThread.setter
     def _receiveThread(self, value: ThreadLike | None) -> None:  # noqa: N802
         self._get_session_state().receive_thread = value
+
+
+class _LegacyBLESessionStateAdapter:
+    """Adapt historical interface-private fields to the session-state port."""
+
+    __slots__ = ("_iface",)
+    _FIELD_MAP = {
+        "lock": "_state_lock",
+        "closed": "_closed",
+        "disconnect_notified": "_disconnect_notified",
+        "client_publish_pending": "_client_publish_pending",
+        "connected_publish_inflight_client": "_connected_publish_inflight_client",
+        "client_replacement_pending": "_client_replacement_pending",
+        "last_disconnect_source": "_last_disconnect_source",
+        "connection_alias_key": "_connection_alias_key",
+        "prior_publish_was_reconnect": "_prior_publish_was_reconnect",
+        "last_connect_pair_override": "_last_connect_pair_override",
+        "last_connect_timeout_override": "_last_connect_timeout_override",
+        "publishing_thread_override": "_publishing_thread_override",
+        "ever_connected": "_ever_connected",
+        "connection_session_epoch": "_connection_session_epoch",
+        "receive_recovery_attempts": "_receive_recovery_attempts",
+        "last_recovery_time": "_last_recovery_time",
+        "read_retry_count": "_read_retry_count",
+        "last_empty_read_warning": "_last_empty_read_warning",
+        "suppressed_empty_read_warnings": "_suppressed_empty_read_warnings",
+        "want_receive": "_want_receive",
+        "receive_start_pending": "_receive_start_pending",
+        "receive_start_pending_since": "_receive_start_pending_since",
+        "receive_thread": "_receiveThread",
+    }
+
+    def __init__(self, iface: object) -> None:
+        object.__setattr__(self, "_iface", iface)
+
+    def __getattr__(self, name: str) -> Any:
+        mapped = self._FIELD_MAP.get(name)
+        if mapped is None:
+            raise AttributeError(name)
+        return getattr(self._iface, mapped)
+
+    def __setattr__(self, name: str, value: object) -> None:
+        mapped = self._FIELD_MAP.get(name)
+        if mapped is None:
+            raise AttributeError(name)
+        setattr(self._iface, mapped, value)
+
+
+def _session_state_for(
+    iface: object, explicit: _BLESessionStatePort | None = None
+) -> _BLESessionStatePort:
+    """Return explicit/owned session state or a legacy interface adapter."""
+    if explicit is not None:
+        return explicit
+    instance_dict = getattr(iface, "__dict__", {})
+    state = instance_dict.get("_session_state") if isinstance(instance_dict, dict) else None
+    if isinstance(state, BLESessionState):
+        return state
+    return cast(_BLESessionStatePort, _LegacyBLESessionStateAdapter(iface))

--- a/meshtastic/interfaces/ble/session_state.py
+++ b/meshtastic/interfaces/ble/session_state.py
@@ -8,6 +8,7 @@ from meshtastic.interfaces.ble.compat_adapter import (
     _get_declared_lock,
     _get_declared_member,
 )
+from meshtastic.interfaces.ble.constants import logger
 from meshtastic.interfaces.ble.coordination import ThreadLike
 from meshtastic.interfaces.ble.ports import _BLESessionStatePort, _LockPort
 
@@ -28,11 +29,14 @@ class BLESessionState:  # pylint: disable=too-many-instance-attributes
 
     Synchronization policy
     ----------------------
-    ``lock`` is the same reentrant lock used by ``BLEStateManager``. Callers that
-    perform check-and-act sequences across these fields and connection-state
-    transitions must hold this lock. Simple fields intentionally remain plain
-    attributes so existing lifecycle code can migrate incrementally without
-    introducing nested-lock behavior.
+    Interface-owned construction shares ``lock`` with ``BLEStateManager`` when
+    that manager exposes its declared lock. Partial compatibility objects that
+    have no state-manager lock receive one stable independent session lock and
+    emit a diagnostic recording the degraded cross-owner atomicity guarantee.
+    Callers that perform check-and-act sequences across these fields and
+    connection-state transitions must hold the shared lock when one exists.
+    Simple fields intentionally remain plain attributes so existing lifecycle
+    code can migrate incrementally without introducing nested-lock behavior.
     """
 
     lock: _LockPort
@@ -84,24 +88,62 @@ class _BLESessionStateCompatMixin:
     _state_manager: Any
     _session_state: _BLESessionStatePort
 
+    def _promote_legacy_session_state(
+        self, state: "_LegacyBLESessionStateAdapter"
+    ) -> BLESessionState:
+        """Promote a cached legacy adapter to one canonical owned state.
+
+        Parameters
+        ----------
+        state : _LegacyBLESessionStateAdapter
+            Cached compatibility adapter currently occupying the owner slot.
+
+        Returns
+        -------
+        BLESessionState
+            Canonical session owner installed for this interface.
+        """
+        instance_dict = self.__dict__
+        with state.lock:
+            current = instance_dict.get("_session_state")
+            if isinstance(current, BLESessionState):
+                return current
+            if current is state:
+                promoted = BLESessionState(lock=state.lock)
+                instance_dict["_session_state"] = promoted
+                return promoted
+        return self._get_session_state()
+
     def _get_session_state(self) -> BLESessionState:
         """Return owned lifecycle state, lazily supporting partial interfaces."""
-        state = self.__dict__.get("_session_state")
+        instance_dict = self.__dict__
+        state = instance_dict.get("_session_state")
         if isinstance(state, BLESessionState):
             return state
         if isinstance(state, _LegacyBLESessionStateAdapter):
-            # A legacy adapter can be cached before a partial interface first
-            # reaches a mixin property. Promote it without changing the shared
-            # lock; the adapter continues to proxy fields into this owner.
-            lock = state.lock
-        else:
-            state_manager = self.__dict__.get("_state_manager")
-            lock = _get_declared_lock(state_manager, "lock")
-            if lock is None:
-                lock = cast(_LockPort, threading.RLock())
-        state = BLESessionState(lock=lock)
-        self.__dict__["_session_state"] = state
-        return state
+            return self._promote_legacy_session_state(state)
+        state_manager = self.__dict__.get("_state_manager")
+        lock = _get_declared_lock(state_manager, "lock")
+        if lock is None:
+            logger.debug(
+                "No declared BLE state-manager lock; using an independent "
+                "session lock. Session-state and connection-state updates "
+                "are not mutually atomic."
+            )
+            lock = cast(_LockPort, threading.RLock())
+        candidate = BLESessionState(lock=lock)
+        winner = instance_dict.setdefault("_session_state", candidate)
+        if isinstance(winner, BLESessionState):
+            return winner
+        if isinstance(winner, _LegacyBLESessionStateAdapter):
+            return self._promote_legacy_session_state(winner)
+        # Preserve the historical lazy-initialization behavior for partial test
+        # doubles that pre-populate this private slot with an unrelated value,
+        # while still converging concurrent callers on one replacement owner.
+        if instance_dict.get("_session_state") is winner:
+            instance_dict["_session_state"] = candidate
+            return candidate
+        return self._get_session_state()
 
     @property
     def _state_lock(self) -> _LockPort:
@@ -164,6 +206,11 @@ class _BLESessionStateCompatMixin:
 
     @_last_disconnect_source.setter
     def _last_disconnect_source(self, value: str | None) -> None:
+        if value is not None and not isinstance(value, str):
+            raise TypeError(
+                "_last_disconnect_source must be a str or None, "
+                f"got {type(value).__name__}"
+            )
         self._get_session_state().last_disconnect_source = value
 
     @property
@@ -380,7 +427,9 @@ class _LegacyBLESessionStateAdapter:
     def __getattr__(self, name: str) -> Any:
         mapped = self._FIELD_MAP.get(name)
         if mapped is None:
-            raise AttributeError(name)
+            raise AttributeError(
+                f"{type(self).__name__} does not proxy session field {name!r}"
+            )
         if name == "lock":
             if isinstance(self._iface, _BLESessionStateCompatMixin):
                 current_state = self._iface.__dict__.get("_session_state")
@@ -395,12 +444,16 @@ class _LegacyBLESessionStateAdapter:
             return value
         if name in self._FIELD_DEFAULTS:
             return self._FIELD_DEFAULTS[name]
-        raise AttributeError(name)
+        raise AttributeError(
+            f"{type(self).__name__} has no default for session field {name!r}"
+        )
 
     def __setattr__(self, name: str, value: object) -> None:
         mapped = self._FIELD_MAP.get(name)
         if mapped is None:
-            raise AttributeError(name)
+            raise AttributeError(
+                f"{type(self).__name__} does not proxy session field {name!r}"
+            )
         setattr(self._iface, mapped, value)
 
     def _reset_read_retry_count(self) -> None:
@@ -448,5 +501,13 @@ def _session_state_for(
         raise TypeError(LEGACY_SESSION_STATE_CACHE_ERROR)
 
     legacy_state = _LegacyBLESessionStateAdapter(iface)
-    instance_dict["_session_state"] = legacy_state
-    return cast(_BLESessionStatePort, legacy_state)
+    winner = instance_dict.setdefault("_session_state", legacy_state)
+    if isinstance(winner, (BLESessionState, _LegacyBLESessionStateAdapter)):
+        return cast(_BLESessionStatePort, winner)
+    # Preserve the existing compatibility behavior for an unrelated private
+    # slot value while ensuring the normal empty-slot race converges through
+    # ``setdefault`` on one adapter owner.
+    if instance_dict.get("_session_state") is winner:
+        instance_dict["_session_state"] = legacy_state
+        return cast(_BLESessionStatePort, legacy_state)
+    return _session_state_for(iface)

--- a/meshtastic/interfaces/ble/session_state.py
+++ b/meshtastic/interfaces/ble/session_state.py
@@ -1,0 +1,266 @@
+"""Owned mutable lifecycle state for a BLE interface session."""
+
+from dataclasses import dataclass
+import threading
+from threading import RLock
+from typing import TYPE_CHECKING, Any
+
+from meshtastic.interfaces.ble.coordination import ThreadLike
+
+if TYPE_CHECKING:
+    from meshtastic.interfaces.ble.client import BLEClient
+
+
+@dataclass(slots=True)
+class BLESessionState:  # pylint: disable=too-many-instance-attributes
+    """Own mutable BLE lifecycle flags and per-session bookkeeping.
+
+    Synchronization policy
+    ----------------------
+    ``lock`` is the same reentrant lock used by ``BLEStateManager``. Callers that
+    perform check-and-act sequences across these fields and connection-state
+    transitions must hold this lock. Simple fields intentionally remain plain
+    attributes so existing lifecycle code can migrate incrementally without
+    introducing nested-lock behavior.
+    """
+
+    lock: RLock
+    closed: bool = False
+    disconnect_notified: bool = False
+    client_publish_pending: bool = False
+    connected_publish_inflight_client: "BLEClient | None" = None
+    client_replacement_pending: bool = False
+    last_disconnect_source: str = ""
+    connection_alias_key: str | None = None
+    prior_publish_was_reconnect: bool = False
+    last_connect_pair_override: bool | None = None
+    last_connect_timeout_override: float | None = None
+    publishing_thread_override: object | None = None
+    ever_connected: bool = False
+    connection_session_epoch: int = 0
+    receive_recovery_attempts: int = 0
+    last_recovery_time: float = 0.0
+    read_retry_count: int = 0
+    last_empty_read_warning: float = 0.0
+    suppressed_empty_read_warnings: int = 0
+    want_receive: bool = True
+    receive_start_pending: bool = False
+    receive_start_pending_since: float | None = None
+    receive_thread: ThreadLike | None = None
+
+    def reset_receive_retry_state(self) -> None:
+        """Reset transient read retry and warning counters."""
+        self.read_retry_count = 0
+        self.last_empty_read_warning = 0.0
+        self.suppressed_empty_read_warnings = 0
+
+    def reset_recovery_state(self) -> None:
+        """Reset receive-recovery attempt bookkeeping."""
+        self.receive_recovery_attempts = 0
+        self.last_recovery_time = 0.0
+
+
+class _BLESessionStateCompatMixin:
+    """Preserve historical private lifecycle attributes over owned session state."""
+
+    _state_manager: Any
+    _session_state: BLESessionState
+
+    def _get_session_state(self) -> BLESessionState:
+        """Return owned lifecycle state, lazily supporting partial interfaces."""
+        state = self.__dict__.get("_session_state")
+        if isinstance(state, BLESessionState):
+            return state
+        state_manager = self.__dict__.get("_state_manager")
+        lock = getattr(state_manager, "lock", None)
+        if not hasattr(lock, "acquire") or not hasattr(lock, "release"):
+            lock = threading.RLock()
+        state = BLESessionState(lock=lock)
+        self.__dict__["_session_state"] = state
+        return state
+
+    @property
+    def _state_lock(self) -> threading.RLock:
+        """Compatibility view of the owned lifecycle lock."""
+        return self._get_session_state().lock
+
+    @_state_lock.setter
+    def _state_lock(self, value: threading.RLock) -> None:
+        self._get_session_state().lock = value
+
+    @property
+    def _closed(self) -> bool:
+        """Compatibility view of the owned session closed flag."""
+        return self._get_session_state().closed
+
+    @_closed.setter
+    def _closed(self, value: bool) -> None:
+        self._get_session_state().closed = value
+
+    @property
+    def _disconnect_notified(self) -> bool:
+        return self._get_session_state().disconnect_notified
+
+    @_disconnect_notified.setter
+    def _disconnect_notified(self, value: bool) -> None:
+        self._get_session_state().disconnect_notified = value
+
+    @property
+    def _client_publish_pending(self) -> bool:
+        return self._get_session_state().client_publish_pending
+
+    @_client_publish_pending.setter
+    def _client_publish_pending(self, value: bool) -> None:
+        self._get_session_state().client_publish_pending = value
+
+    @property
+    def _connected_publish_inflight_client(self) -> "BLEClient | None":
+        return self._get_session_state().connected_publish_inflight_client
+
+    @_connected_publish_inflight_client.setter
+    def _connected_publish_inflight_client(self, value: "BLEClient | None") -> None:
+        self._get_session_state().connected_publish_inflight_client = value
+
+    @property
+    def _client_replacement_pending(self) -> bool:
+        return self._get_session_state().client_replacement_pending
+
+    @_client_replacement_pending.setter
+    def _client_replacement_pending(self, value: bool) -> None:
+        self._get_session_state().client_replacement_pending = value
+
+    @property
+    def _last_disconnect_source(self) -> str:
+        return self._get_session_state().last_disconnect_source
+
+    @_last_disconnect_source.setter
+    def _last_disconnect_source(self, value: str) -> None:
+        self._get_session_state().last_disconnect_source = value
+
+    @property
+    def _connection_alias_key(self) -> str | None:
+        return self._get_session_state().connection_alias_key
+
+    @_connection_alias_key.setter
+    def _connection_alias_key(self, value: str | None) -> None:
+        self._get_session_state().connection_alias_key = value
+
+    @property
+    def _prior_publish_was_reconnect(self) -> bool:
+        return self._get_session_state().prior_publish_was_reconnect
+
+    @_prior_publish_was_reconnect.setter
+    def _prior_publish_was_reconnect(self, value: bool) -> None:
+        self._get_session_state().prior_publish_was_reconnect = value
+
+    @property
+    def _last_connect_pair_override(self) -> bool | None:
+        return self._get_session_state().last_connect_pair_override
+
+    @_last_connect_pair_override.setter
+    def _last_connect_pair_override(self, value: bool | None) -> None:
+        self._get_session_state().last_connect_pair_override = value
+
+    @property
+    def _last_connect_timeout_override(self) -> float | None:
+        return self._get_session_state().last_connect_timeout_override
+
+    @_last_connect_timeout_override.setter
+    def _last_connect_timeout_override(self, value: float | None) -> None:
+        self._get_session_state().last_connect_timeout_override = value
+
+    @property
+    def _publishing_thread_override(self) -> object | None:
+        return self._get_session_state().publishing_thread_override
+
+    @_publishing_thread_override.setter
+    def _publishing_thread_override(self, value: object | None) -> None:
+        self._get_session_state().publishing_thread_override = value
+
+    @property
+    def _ever_connected(self) -> bool:
+        return self._get_session_state().ever_connected
+
+    @_ever_connected.setter
+    def _ever_connected(self, value: bool) -> None:
+        self._get_session_state().ever_connected = value
+
+    @property
+    def _connection_session_epoch(self) -> int:
+        return self._get_session_state().connection_session_epoch
+
+    @_connection_session_epoch.setter
+    def _connection_session_epoch(self, value: int) -> None:
+        self._get_session_state().connection_session_epoch = value
+
+    @property
+    def _receive_recovery_attempts(self) -> int:
+        return self._get_session_state().receive_recovery_attempts
+
+    @_receive_recovery_attempts.setter
+    def _receive_recovery_attempts(self, value: int) -> None:
+        self._get_session_state().receive_recovery_attempts = value
+
+    @property
+    def _last_recovery_time(self) -> float:
+        return self._get_session_state().last_recovery_time
+
+    @_last_recovery_time.setter
+    def _last_recovery_time(self, value: float) -> None:
+        self._get_session_state().last_recovery_time = value
+
+    @property
+    def _read_retry_count(self) -> int:
+        return self._get_session_state().read_retry_count
+
+    @_read_retry_count.setter
+    def _read_retry_count(self, value: int) -> None:
+        self._get_session_state().read_retry_count = value
+
+    @property
+    def _last_empty_read_warning(self) -> float:
+        return self._get_session_state().last_empty_read_warning
+
+    @_last_empty_read_warning.setter
+    def _last_empty_read_warning(self, value: float) -> None:
+        self._get_session_state().last_empty_read_warning = value
+
+    @property
+    def _suppressed_empty_read_warnings(self) -> int:
+        return self._get_session_state().suppressed_empty_read_warnings
+
+    @_suppressed_empty_read_warnings.setter
+    def _suppressed_empty_read_warnings(self, value: int) -> None:
+        self._get_session_state().suppressed_empty_read_warnings = value
+
+    @property
+    def _want_receive(self) -> bool:
+        return self._get_session_state().want_receive
+
+    @_want_receive.setter
+    def _want_receive(self, value: bool) -> None:
+        self._get_session_state().want_receive = value
+
+    @property
+    def _receive_start_pending(self) -> bool:
+        return self._get_session_state().receive_start_pending
+
+    @_receive_start_pending.setter
+    def _receive_start_pending(self, value: bool) -> None:
+        self._get_session_state().receive_start_pending = value
+
+    @property
+    def _receive_start_pending_since(self) -> float | None:
+        return self._get_session_state().receive_start_pending_since
+
+    @_receive_start_pending_since.setter
+    def _receive_start_pending_since(self, value: float | None) -> None:
+        self._get_session_state().receive_start_pending_since = value
+
+    @property
+    def _receiveThread(self) -> ThreadLike | None:  # noqa: N802 - compatibility name
+        return self._get_session_state().receive_thread
+
+    @_receiveThread.setter
+    def _receiveThread(self, value: ThreadLike | None) -> None:  # noqa: N802
+        self._get_session_state().receive_thread = value

--- a/meshtastic/interfaces/ble/session_state.py
+++ b/meshtastic/interfaces/ble/session_state.py
@@ -4,6 +4,7 @@ import threading
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
+from meshtastic._core_constants import LAST_DISCONNECT_SOURCE_TYPE_ERROR
 from meshtastic.interfaces.ble.compat_adapter import (
     _get_declared_lock,
     _get_declared_member,
@@ -208,8 +209,9 @@ class _BLESessionStateCompatMixin:
     def _last_disconnect_source(self, value: str | None) -> None:
         if value is not None and not isinstance(value, str):
             raise TypeError(
-                "_last_disconnect_source must be a str or None, "
-                f"got {type(value).__name__}"
+                LAST_DISCONNECT_SOURCE_TYPE_ERROR.format(
+                    type_name=type(value).__name__
+                )
             )
         self._get_session_state().last_disconnect_source = value
 

--- a/meshtastic/interfaces/ble/session_state.py
+++ b/meshtastic/interfaces/ble/session_state.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from meshtastic._core_constants import LAST_DISCONNECT_SOURCE_TYPE_ERROR
 from meshtastic.interfaces.ble.compat_adapter import (
+    _get_declared_callable,
     _get_declared_lock,
     _get_declared_member,
 )
@@ -105,13 +106,40 @@ class _BLESessionStateCompatMixin:
             Canonical session owner installed for this interface.
         """
         instance_dict = self.__dict__
-        with state.lock:
+        state_manager_lock = _get_declared_lock(
+            instance_dict.get("_state_manager"), "lock"
+        )
+        raw_legacy_lock = instance_dict.get("_state_lock")
+        raw_legacy_lock_type = type(raw_legacy_lock)
+        raw_legacy_lock_is_valid = raw_legacy_lock is not None and (
+            _get_declared_callable(raw_legacy_lock_type, "__enter__") is not None
+            and _get_declared_callable(raw_legacy_lock_type, "__exit__") is not None
+        )
+        promotion_lock = state_manager_lock
+        if promotion_lock is None and raw_legacy_lock_is_valid:
+            promotion_lock = cast(_LockPort, raw_legacy_lock)
+        if promotion_lock is None:
+            promotion_lock = state._fallback_lock
+        with promotion_lock:
             current = instance_dict.get("_session_state")
             if isinstance(current, BLESessionState):
                 return current
             if current is state:
-                promoted = BLESessionState(lock=state.lock)
+                promoted = BLESessionState(lock=promotion_lock)
+                for field_name, legacy_name in state._FIELD_MAP.items():
+                    if field_name == "lock":
+                        continue
+                    setattr(
+                        promoted,
+                        field_name,
+                        instance_dict.get(
+                            legacy_name,
+                            state._FIELD_DEFAULTS[field_name],
+                        ),
+                    )
                 instance_dict["_session_state"] = promoted
+                for legacy_name in state._FIELD_MAP.values():
+                    instance_dict.pop(legacy_name, None)
                 return promoted
         return self._get_session_state()
 

--- a/meshtastic/interfaces/ble/session_state.py
+++ b/meshtastic/interfaces/ble/session_state.py
@@ -16,6 +16,10 @@ if TYPE_CHECKING:
 
 
 _MISSING_SESSION_FIELD = object()
+LEGACY_SESSION_STATE_CACHE_ERROR = (
+    "Legacy BLE lifecycle collaborators without an instance __dict__ must pass "
+    "session_state explicitly."
+)
 
 
 @dataclass(slots=True)
@@ -423,9 +427,10 @@ def _session_state_for(
 ) -> _BLESessionStatePort:
     """Return explicit/owned session state or a cached legacy interface adapter.
 
-    Caches the legacy adapter only on collaborators that expose a real
-    instance ``__dict__``. Slot-based or partial test doubles get a fresh
-    adapter per call rather than silently writing into a throwaway fallback.
+    Caches the legacy adapter on collaborators that expose a real instance
+    ``__dict__``. A legacy collaborator without cacheable instance storage must
+    provide ``explicit`` session state; otherwise separate coordinators could
+    silently create competing owners for the same lifecycle fields.
     """
     if explicit is not None:
         return explicit
@@ -439,7 +444,9 @@ def _session_state_for(
     if isinstance(iface, _BLESessionStateCompatMixin):
         return iface._get_session_state()
 
+    if not isinstance(instance_dict, dict):
+        raise TypeError(LEGACY_SESSION_STATE_CACHE_ERROR)
+
     legacy_state = _LegacyBLESessionStateAdapter(iface)
-    if isinstance(instance_dict, dict):
-        instance_dict["_session_state"] = legacy_state
+    instance_dict["_session_state"] = legacy_state
     return cast(_BLESessionStatePort, legacy_state)

--- a/meshtastic/interfaces/ble/state.py
+++ b/meshtastic/interfaces/ble/state.py
@@ -134,6 +134,20 @@ class BLEStateManager:
         with self._state_lock:
             return self._state
 
+    def _current_state_unlocked(self) -> ConnectionState:
+        """Return current state when the caller already owns ``lock``.
+
+        This internal primitive exists for lifecycle code that must update
+        connection state and session ownership atomically under the one shared
+        state-manager/session lock. Callers must already hold :attr:`lock`.
+
+        Returns
+        -------
+        ConnectionState
+            Current connection state without acquiring the lock again.
+        """
+        return self._state
+
     @property
     # COMPAT_STABLE_SHIM: public-first alias for `_current_state`.
     def current_state(self) -> ConnectionState:
@@ -402,9 +416,19 @@ class BLEStateManager:
             `True` if the transition succeeded or was a no-op (state is DISCONNECTED after the call), `False` otherwise.
         """
         with self._state_lock:
-            # Prefer validated transition semantics; this is a no-op when already
-            # disconnected and remains resilient to future transition-map edits.
-            return self._transition_to_unlocked(ConnectionState.DISCONNECTED)
+            return self._reset_to_disconnected_unlocked()
+
+    def _reset_to_disconnected_unlocked(self) -> bool:
+        """Reset to DISCONNECTED when the caller already owns ``lock``.
+
+        Returns
+        -------
+        bool
+            ``True`` when DISCONNECTED is reached, including a valid no-op.
+        """
+        # Prefer validated transition semantics; this is a no-op when already
+        # disconnected and remains resilient to future transition-map edits.
+        return self._transition_to_unlocked(ConnectionState.DISCONNECTED)
 
     # COMPAT_STABLE_SHIM: public-first alias for `_reset_to_disconnected`.
     def reset_to_disconnected(self) -> bool:

--- a/meshtastic/interfaces/ble/utils.py
+++ b/meshtastic/interfaces/ble/utils.py
@@ -7,7 +7,6 @@ import time
 from collections.abc import Awaitable, Callable
 from types import ModuleType
 from typing import Any, TypeVar, cast
-from unittest.mock import DEFAULT, Mock, NonCallableMock
 
 from meshtastic.interfaces.ble.constants import logger
 
@@ -18,45 +17,41 @@ _POSITIONAL_ONLY_KEYWORD_FRAGMENT = (
 )
 
 
-def _is_unconfigured_mock_member(candidate: object) -> bool:
-    """Return whether a candidate is an unconfigured auto-generated mock member.
+_MISSING = object()
 
-    Parameters
-    ----------
-    candidate : object
-        Candidate object to inspect.
 
-    Returns
-    -------
-    bool
-        True when the object is a mock member with default return behavior,
-        no side effect, and no recorded calls.
+def _get_declared_member(
+    target: object | None,
+    name: str,
+    default: T | None = None,
+) -> object | T | None:
+    """Return an explicitly declared member without invoking dynamic fallback.
+
+    ``MagicMock`` and other dynamic proxies synthesize arbitrary attributes via
+    ``__getattr__``. BLE compatibility dispatch should only consider members
+    that an object explicitly defines on the instance or its type. Using
+    ``inspect.getattr_static`` enforces that rule without making production code
+    aware of any test-double implementation.
     """
-    if not isinstance(candidate, (Mock, NonCallableMock)):
-        return False
-    return (
-        getattr(candidate, "_mock_return_value", DEFAULT) is DEFAULT
-        and getattr(candidate, "_mock_wraps", None) is None
-        and getattr(candidate, "side_effect", None) is None
-        and not getattr(candidate, "call_args_list", [])
-    )
+    if target is None:
+        return default
+    try:
+        inspect.getattr_static(target, name)
+    except AttributeError:
+        return default
+    try:
+        return getattr(target, name)
+    except AttributeError:
+        return default
 
 
-def _is_unconfigured_mock_callable(candidate: object) -> bool:
-    """Return whether a candidate is an unconfigured callable auto-generated mock.
-
-    Parameters
-    ----------
-    candidate : object
-        Candidate object to inspect.
-
-    Returns
-    -------
-    bool
-        True when candidate is callable and also matches
-        ``_is_unconfigured_mock_member``.
-    """
-    return callable(candidate) and _is_unconfigured_mock_member(candidate)
+def _get_declared_callable(
+    target: object | None,
+    name: str,
+) -> Callable[..., Any] | None:
+    """Return an explicitly declared callable member when available."""
+    candidate = _get_declared_member(target, name)
+    return cast(Callable[..., Any], candidate) if callable(candidate) else None
 
 
 def _is_unexpected_keyword_error(exc: TypeError, kwarg_name: str) -> bool:
@@ -163,15 +158,13 @@ def _resolve_safe_execute(iface: object) -> Callable[..., Any] | None:
         Resolved ``safe_execute`` callable when available and configured;
         otherwise ``None``.
     """
-    error_handler = getattr(iface, "error_handler", None)
-    safe_execute = getattr(error_handler, "safe_execute", None)
-    if callable(safe_execute) and not _is_unconfigured_mock_callable(safe_execute):
-        return cast(Callable[..., Any], safe_execute)
-    legacy_safe_execute = getattr(error_handler, "_safe_execute", None)
-    if callable(legacy_safe_execute) and not _is_unconfigured_mock_callable(
-        legacy_safe_execute
-    ):
-        return cast(Callable[..., Any], legacy_safe_execute)
+    error_handler = _get_declared_member(iface, "error_handler")
+    safe_execute = _get_declared_callable(error_handler, "safe_execute")
+    if safe_execute is not None:
+        return safe_execute
+    legacy_safe_execute = _get_declared_callable(error_handler, "_safe_execute")
+    if legacy_safe_execute is not None:
+        return legacy_safe_execute
     return None
 
 

--- a/meshtastic/interfaces/ble/utils.py
+++ b/meshtastic/interfaces/ble/utils.py
@@ -8,6 +8,10 @@ from collections.abc import Awaitable, Callable
 from types import ModuleType
 from typing import Any, TypeVar, cast
 
+from meshtastic.interfaces.ble.compat_adapter import (
+    _get_declared_callable,
+    _get_declared_member,
+)
 from meshtastic.interfaces.ble.constants import logger
 
 T = TypeVar("T")
@@ -15,43 +19,6 @@ _UNEXPECTED_KEYWORD_FRAGMENT = "unexpected keyword argument"
 _POSITIONAL_ONLY_KEYWORD_FRAGMENT = (
     "positional-only arguments passed as keyword arguments"
 )
-
-
-_MISSING = object()
-
-
-def _get_declared_member(
-    target: object | None,
-    name: str,
-    default: T | None = None,
-) -> object | T | None:
-    """Return an explicitly declared member without invoking dynamic fallback.
-
-    ``MagicMock`` and other dynamic proxies synthesize arbitrary attributes via
-    ``__getattr__``. BLE compatibility dispatch should only consider members
-    that an object explicitly defines on the instance or its type. Using
-    ``inspect.getattr_static`` enforces that rule without making production code
-    aware of any test-double implementation.
-    """
-    if target is None:
-        return default
-    try:
-        inspect.getattr_static(target, name)
-    except AttributeError:
-        return default
-    try:
-        return getattr(target, name)
-    except AttributeError:
-        return default
-
-
-def _get_declared_callable(
-    target: object | None,
-    name: str,
-) -> Callable[..., Any] | None:
-    """Return an explicitly declared callable member when available."""
-    candidate = _get_declared_member(target, name)
-    return cast(Callable[..., Any], candidate) if callable(candidate) else None
 
 
 def _is_unexpected_keyword_error(exc: TypeError, kwarg_name: str) -> bool:

--- a/meshtastic/interfaces/ble/utils.py
+++ b/meshtastic/interfaces/ble/utils.py
@@ -9,8 +9,8 @@ from types import ModuleType
 from typing import Any, TypeVar, cast
 
 from meshtastic.interfaces.ble.compat_adapter import (
-    _get_declared_callable,
     _get_declared_member,
+    _resolve_declared_callable,
 )
 from meshtastic.interfaces.ble.constants import logger
 
@@ -126,13 +126,7 @@ def _resolve_safe_execute(iface: object) -> Callable[..., Any] | None:
         otherwise ``None``.
     """
     error_handler = _get_declared_member(iface, "error_handler")
-    safe_execute = _get_declared_callable(error_handler, "safe_execute")
-    if safe_execute is not None:
-        return safe_execute
-    legacy_safe_execute = _get_declared_callable(error_handler, "_safe_execute")
-    if legacy_safe_execute is not None:
-        return legacy_safe_execute
-    return None
+    return _resolve_declared_callable(error_handler, "safe_execute", "_safe_execute")
 
 
 def _safe_execute_through_adapter(

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -22,7 +22,11 @@ from pubsub import pub
 
 import meshtastic.node
 from meshtastic._publishing import publishing_thread as publishingThread
-from meshtastic._core_constants import BROADCAST_ADDR, NODELESS_WANT_CONFIG_ID
+from meshtastic._core_constants import (
+    BROADCAST_ADDR,
+    LAST_DISCONNECT_SOURCE_TYPE_ERROR,
+    NODELESS_WANT_CONFIG_ID,
+)
 from meshtastic._response_types import ResponseHandler
 from meshtastic.mesh_interface_runtime.flows import (
     DEFAULT_TELEMETRY_TYPE,
@@ -266,8 +270,9 @@ class MeshInterface:  # pylint: disable=R0902
     def _last_disconnect_source(self, value: str | None) -> None:
         if value is not None and not isinstance(value, str):
             raise TypeError(
-                "_last_disconnect_source must be a str or None, "
-                f"got {type(value).__name__}"
+                LAST_DISCONNECT_SOURCE_TYPE_ERROR.format(
+                    type_name=type(value).__name__
+                )
             )
         self.__dict__["_last_disconnect_source"] = value
 
@@ -448,7 +453,7 @@ class MeshInterface:  # pylint: disable=R0902
             return f"interface failure: {self.failure}"
         if self._closing:
             return "interface is closing"
-        disconnect_source = getattr(self, "_last_disconnect_source", None)
+        disconnect_source = self._last_disconnect_source
         if disconnect_source and not self.isConnected.is_set():
             return f"interface disconnected ({disconnect_source})"
         return None
@@ -1571,7 +1576,7 @@ class MeshInterface:  # pylint: disable=R0902
                             abort_reason,
                             self.isConnected.is_set(),
                             self.failure,
-                            getattr(self, "_last_disconnect_source", None) or "unknown",
+                            self._last_disconnect_source or "unknown",
                         )
                         raise MeshInterface.MeshInterfaceError(abort_reason)
             if not connected:
@@ -1586,7 +1591,7 @@ class MeshInterface:  # pylint: disable=R0902
                             abort_reason_str,
                             self.isConnected.is_set(),
                             self.failure,
-                            getattr(self, "_last_disconnect_source", None) or "unknown",
+                            self._last_disconnect_source or "unknown",
                         )
                         raise MeshInterface.MeshInterfaceError(abort_reason_str)
                 logger.log(
@@ -1594,7 +1599,7 @@ class MeshInterface:  # pylint: disable=R0902
                     "Timed out waiting for connection completion (isConnected=%s, failure=%r, last_disconnect_source=%s)",
                     self.isConnected.is_set(),
                     self.failure,
-                    getattr(self, "_last_disconnect_source", None) or "unknown",
+                    self._last_disconnect_source or "unknown",
                 )
                 raise MeshInterface.MeshInterfaceError(
                     "Timed out waiting for connection completion"

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -264,6 +264,11 @@ class MeshInterface:  # pylint: disable=R0902
 
     @_last_disconnect_source.setter
     def _last_disconnect_source(self, value: str | None) -> None:
+        if value is not None and not isinstance(value, str):
+            raise TypeError(
+                "_last_disconnect_source must be a str or None, "
+                f"got {type(value).__name__}"
+            )
         self.__dict__["_last_disconnect_source"] = value
 
     # Optional instance-only overrides used by bounded reconnect probes.
@@ -1566,7 +1571,7 @@ class MeshInterface:  # pylint: disable=R0902
                             abort_reason,
                             self.isConnected.is_set(),
                             self.failure,
-                            getattr(self, "_last_disconnect_source", "unknown"),
+                            getattr(self, "_last_disconnect_source", None) or "unknown",
                         )
                         raise MeshInterface.MeshInterfaceError(abort_reason)
             if not connected:
@@ -1581,7 +1586,7 @@ class MeshInterface:  # pylint: disable=R0902
                             abort_reason_str,
                             self.isConnected.is_set(),
                             self.failure,
-                            getattr(self, "_last_disconnect_source", "unknown"),
+                            getattr(self, "_last_disconnect_source", None) or "unknown",
                         )
                         raise MeshInterface.MeshInterfaceError(abort_reason_str)
                 logger.log(
@@ -1589,7 +1594,7 @@ class MeshInterface:  # pylint: disable=R0902
                     "Timed out waiting for connection completion (isConnected=%s, failure=%r, last_disconnect_source=%s)",
                     self.isConnected.is_set(),
                     self.failure,
-                    getattr(self, "_last_disconnect_source", "unknown"),
+                    getattr(self, "_last_disconnect_source", None) or "unknown",
                 )
                 raise MeshInterface.MeshInterfaceError(
                     "Timed out waiting for connection completion"

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -255,7 +255,16 @@ class MeshInterface:  # pylint: disable=R0902
     """
 
     _queue_wait_timeout_seconds: ClassVar[float] = QUEUE_WAIT_TIMEOUT_SECONDS
-    _last_disconnect_source: str | None
+
+    @property
+    def _last_disconnect_source(self) -> str | None:
+        """Return the latest transport disconnect source, if known."""
+        value = self.__dict__.get("_last_disconnect_source")
+        return value if isinstance(value, str) else None
+
+    @_last_disconnect_source.setter
+    def _last_disconnect_source(self, value: str | None) -> None:
+        self.__dict__["_last_disconnect_source"] = value
 
     # Optional instance-only overrides used by bounded reconnect probes.
     _connect_wait_timeout_seconds: float

--- a/meshtastic/tests/_ble_runtime_fakes.py
+++ b/meshtastic/tests/_ble_runtime_fakes.py
@@ -1,0 +1,152 @@
+"""Typed BLE runtime fakes for lifecycle tests."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from meshtastic.interfaces.ble.state import ConnectionState
+
+
+class _FakeStateManager:
+    """Minimal state-manager fake implementing the current lifecycle contract."""
+
+    def __init__(
+        self,
+        *,
+        state: ConnectionState = ConnectionState.DISCONNECTED,
+        connected: bool = False,
+        closing: bool = False,
+    ) -> None:
+        self.state = state
+        self.connected = connected
+        self.closing = closing
+        self.transition_calls: list[ConnectionState] = []
+        self.reset_calls = 0
+
+    @property
+    def is_connected(self) -> bool:
+        """Return the configured connected state."""
+        return self.connected
+
+    @is_connected.setter
+    def is_connected(self, value: bool) -> None:
+        """Update the configured connected state."""
+        self.connected = value
+
+    @property
+    def current_state(self) -> ConnectionState:
+        """Return the configured connection state."""
+        return self.state
+
+    @current_state.setter
+    def current_state(self, value: ConnectionState) -> None:
+        """Update the configured connection state."""
+        self.state = value
+
+    def transition_to(self, new_state: ConnectionState) -> bool:
+        """Record and apply a state transition."""
+        self.transition_calls.append(new_state)
+        self.state = new_state
+        self.connected = new_state is ConnectionState.CONNECTED
+        return True
+
+    def reset_to_disconnected(self) -> bool:
+        """Record and apply a reset to disconnected state."""
+        self.reset_calls += 1
+        self.state = ConnectionState.DISCONNECTED
+        self.connected = False
+        return True
+
+    @property
+    def is_closing(self) -> bool:
+        """Return the configured closing state."""
+        return self.closing
+
+    @is_closing.setter
+    def is_closing(self, value: bool) -> None:
+        """Update the configured closing state."""
+        self.closing = value
+
+
+class _FakeConnectedClient:
+    """BLE client fake with an explicit public connectivity probe."""
+
+    def __init__(self, *, connected: bool) -> None:
+        self.connected = connected
+        self.probe_calls = 0
+
+    def isConnected(self) -> bool:  # noqa: N802 - public compatibility spelling
+        """Return the configured connectivity state."""
+        self.probe_calls += 1
+        return self.connected
+
+
+class _FakeThread:
+    """Small thread-like fake used by coordinator tests."""
+
+    def __init__(self) -> None:
+        self.started = False
+        self.join_timeouts: list[float | None] = []
+
+    def start(self) -> None:
+        """Record a start call."""
+        self.started = True
+
+    def join(self, timeout: float | None = None) -> None:
+        """Record a join call."""
+        self.join_timeouts.append(timeout)
+
+
+class _FakeThreadCoordinator:
+    """Thread-coordinator fake implementing current lifecycle hooks explicitly."""
+
+    def __init__(self) -> None:
+        self.created: list[tuple[str, bool, _FakeThread]] = []
+        self.started: list[object] = []
+        self.joined: list[tuple[object, float | None]] = []
+        self.events: list[str] = []
+        self.cleared_events: list[tuple[str, ...]] = []
+        self.wake_calls = 0
+        self.wake_events: list[tuple[str, ...]] = []
+
+    def create_thread(
+        self,
+        *,
+        target: Callable[..., object],
+        name: str,
+        daemon: bool = True,
+        args: tuple[object, ...] = (),
+        kwargs: dict[str, object] | None = None,
+    ) -> _FakeThread:
+        """Create and record a deterministic thread-like object."""
+        _ = (target, args, kwargs)
+        thread = _FakeThread()
+        self.created.append((name, daemon, thread))
+        return thread
+
+    def start_thread(self, thread: object) -> None:
+        """Record and start a thread-like object when possible."""
+        self.started.append(thread)
+        start = getattr(thread, "start", None)
+        if callable(start):
+            start()
+
+    def join_thread(self, thread: object, *, timeout: float | None = None) -> None:
+        """Record and join a thread-like object when possible."""
+        self.joined.append((thread, timeout))
+        join = getattr(thread, "join", None)
+        if callable(join):
+            join(timeout=timeout)
+
+    def set_event(self, event_name: str) -> None:
+        """Record an event set operation."""
+        self.events.append(event_name)
+
+    def clear_events(self, *event_names: str) -> None:
+        """Record an event clear operation."""
+        self.cleared_events.append(tuple(event_names))
+
+    def wake_waiting_threads(self, *event_names: str) -> None:
+        """Record a wake request and its requested event names."""
+        self.wake_calls += 1
+        self.wake_events.append(tuple(event_names))

--- a/meshtastic/tests/_ble_runtime_fakes.py
+++ b/meshtastic/tests/_ble_runtime_fakes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from collections.abc import Callable
 
 from meshtastic.interfaces.ble.state import ConnectionState
@@ -17,6 +18,7 @@ class _FakeStateManager:
         connected: bool = False,
         closing: bool = False,
     ) -> None:
+        self.lock = threading.RLock()
         self.state = state
         self.connected = connected
         self.closing = closing

--- a/meshtastic/tests/test_ble_compat_adapter.py
+++ b/meshtastic/tests/test_ble_compat_adapter.py
@@ -142,6 +142,8 @@ def test_declared_lock_rejects_instance_only_context_methods() -> None:
     owner = SimpleNamespace(lock=candidate)
 
     assert _get_declared_lock(owner, "lock") is None
-    with pytest.raises(TypeError):
+    # 3.10 raises the raw AttributeError from the type-level special-method
+    # lookup; 3.11+ wraps it into a TypeError.
+    with pytest.raises((TypeError, AttributeError)):
         with candidate:  # type: ignore[attr-defined]
             pass

--- a/meshtastic/tests/test_ble_compat_adapter.py
+++ b/meshtastic/tests/test_ble_compat_adapter.py
@@ -1,0 +1,115 @@
+"""Behavioral tests for structural BLE compatibility dispatch."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from meshtastic.interfaces.ble.compat_adapter import (
+    _get_declared_callable,
+    _get_declared_member,
+    _iter_declared_callables,
+    _iter_declared_members,
+    _resolve_declared_callable,
+    _resolve_declared_member,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _DynamicProxy:
+    """Collaborator that synthesizes undeclared attributes dynamically."""
+
+    def __getattr__(self, name: str) -> str:
+        return f"dynamic:{name}"
+
+
+class _DescriptorWithDynamicFallback:
+    """Declared descriptor whose failure would normally trigger ``__getattr__``."""
+
+    @property
+    def current(self) -> str:
+        raise AttributeError("descriptor unavailable")
+
+    def __getattr__(self, name: str) -> str:
+        return f"dynamic:{name}"
+
+
+class _DescriptorOwner:
+    """Collaborator exposing a real descriptor-backed compatibility member."""
+
+    @property
+    def current(self) -> str:
+        return "descriptor-value"
+
+
+class _CustomAttributeOwner:
+    """Collaborator with declared members mediated by ``__getattribute__``."""
+
+    current = "class-default"
+
+    def __getattribute__(self, name: str) -> object:
+        if name == "current":
+            return "custom-value"
+        return super().__getattribute__(name)
+
+
+def test_declared_member_ignores_dynamic_fallback() -> None:
+    """Compatibility lookup must not treat ``__getattr__`` output as a contract."""
+    assert _get_declared_member(_DynamicProxy(), "missing") is None
+
+
+def test_declared_member_does_not_fall_through_to_dynamic_proxy() -> None:
+    """Descriptor failure must not re-enable a synthesized ``__getattr__`` value."""
+    assert _get_declared_member(_DescriptorWithDynamicFallback(), "current") is None
+
+
+def test_declared_member_preserves_descriptor_semantics() -> None:
+    """Static declaration detection should still evaluate real descriptors."""
+    assert _get_declared_member(_DescriptorOwner(), "current") == "descriptor-value"
+
+
+def test_declared_member_preserves_custom_attribute_access() -> None:
+    """Lookup should honor an object's declared ``__getattribute__`` semantics."""
+    assert _get_declared_member(_CustomAttributeOwner(), "current") == "custom-value"
+
+
+def test_resolve_member_prefers_current_then_legacy_and_skips_none() -> None:
+    """Current names win, while explicit ``None`` permits legacy fallback."""
+    owner = SimpleNamespace(current="new", legacy="old")
+    assert _resolve_declared_member(owner, "current", "legacy") == "new"
+
+    owner.current = None
+    assert _resolve_declared_member(owner, "current", "legacy") == "old"
+
+
+def test_resolve_callable_ignores_noncallable_current_member() -> None:
+    """A legacy callable remains usable when the preferred member is data."""
+    legacy = lambda: "legacy"  # noqa: E731 - compact callable identity for assertion
+    owner = SimpleNamespace(current=False, legacy=legacy)
+
+    assert _resolve_declared_callable(owner, "current", "legacy") is legacy
+    assert _get_declared_callable(owner, "current") is None
+
+
+def test_iter_members_preserves_precedence_and_filters_missing_values() -> None:
+    """Iteration should expose only declared, non-``None`` compatibility members."""
+    owner = SimpleNamespace(first=1, second=None, third=3)
+
+    assert list(_iter_declared_members(owner, "first", "second", "third")) == [
+        ("first", 1),
+        ("third", 3),
+    ]
+
+
+def test_iter_callables_preserves_names_for_failure_reporting() -> None:
+    """Callable iteration should retain member names for policy-aware logging."""
+    first = lambda: 1  # noqa: E731 - compact callable identity for assertion
+    third = lambda: 3  # noqa: E731 - compact callable identity for assertion
+    owner = SimpleNamespace(first=first, second=2, third=third)
+
+    assert list(_iter_declared_callables(owner, "first", "second", "third")) == [
+        ("first", first),
+        ("third", third),
+    ]

--- a/meshtastic/tests/test_ble_compat_adapter.py
+++ b/meshtastic/tests/test_ble_compat_adapter.py
@@ -128,3 +128,20 @@ def test_declared_lock_accepts_real_context_manager_and_rejects_dynamic_only() -
             return _DynamicProxy()
 
     assert _get_declared_lock(_DynamicLockOwner(), "lock") is None
+
+
+def test_declared_lock_rejects_instance_only_context_methods() -> None:
+    """Lock validation should match Python's type-level special-method lookup."""
+
+    class _InstanceOnlyContextManager:
+        def __init__(self) -> None:
+            self.__enter__ = lambda: self
+            self.__exit__ = lambda *_args: None
+
+    candidate = _InstanceOnlyContextManager()
+    owner = SimpleNamespace(lock=candidate)
+
+    assert _get_declared_lock(owner, "lock") is None
+    with pytest.raises(TypeError):
+        with candidate:  # type: ignore[attr-defined]
+            pass

--- a/meshtastic/tests/test_ble_compat_adapter.py
+++ b/meshtastic/tests/test_ble_compat_adapter.py
@@ -8,6 +8,7 @@ import pytest
 
 from meshtastic.interfaces.ble.compat_adapter import (
     _get_declared_callable,
+    _get_declared_lock,
     _get_declared_member,
     _iter_declared_callables,
     _iter_declared_members,
@@ -113,3 +114,17 @@ def test_iter_callables_preserves_names_for_failure_reporting() -> None:
         ("first", first),
         ("third", third),
     ]
+
+
+def test_declared_lock_accepts_real_context_manager_and_rejects_dynamic_only() -> None:
+    """Lock resolution should require an explicitly declared context-manager contract."""
+    import threading
+
+    lock = threading.RLock()
+    assert _get_declared_lock(SimpleNamespace(lock=lock), "lock") is lock
+
+    class _DynamicLockOwner:
+        def __getattr__(self, _name: str) -> object:
+            return _DynamicProxy()
+
+    assert _get_declared_lock(_DynamicLockOwner(), "lock") is None

--- a/meshtastic/tests/test_ble_compat_services_coverage.py
+++ b/meshtastic/tests/test_ble_compat_services_coverage.py
@@ -201,7 +201,7 @@ class TestBLEManagementCommandsServiceHandlerResolution:
         result = BLEManagementCommandsService._handler_for_shim(iface)
         assert result is handler
 
-    def test_handler_for_shim_create_new_handler(self):
+    def test_handler_for_shim_create_new_handler(self) -> None:
         """Test creating new handler when no iface-owned handler exists."""
         iface = SimpleNamespace(_connected_elsewhere_late_bound=None)
 
@@ -529,7 +529,7 @@ class TestBLEReceiveRecoveryServiceControllerDetection:
         )
         assert result is True
 
-    def test_is_controller_like_dynamic_proxy(self):
+    def test_is_controller_like_dynamic_proxy(self) -> None:
         """Dynamic-only controller members should not satisfy the contract."""
         mock_controller = _DynamicAttributeProxy()
 
@@ -587,7 +587,7 @@ class TestBLEReceiveRecoveryServiceControllerDetection:
         result = BLEReceiveRecoveryService._resolve_controller_candidate(None)
         assert result is None
 
-    def test_resolve_controller_candidate_dynamic_proxy(self):
+    def test_resolve_controller_candidate_dynamic_proxy(self) -> None:
         """Dynamic-only controller candidates should resolve to None."""
         mock_controller = _DynamicAttributeProxy()
 

--- a/meshtastic/tests/test_ble_compat_services_coverage.py
+++ b/meshtastic/tests/test_ble_compat_services_coverage.py
@@ -12,9 +12,10 @@ from __future__ import annotations
 
 import logging
 import re
+from types import SimpleNamespace
 from collections.abc import Callable
 from typing import Any, cast
-from unittest.mock import MagicMock, Mock, NonCallableMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -29,10 +30,6 @@ from meshtastic.interfaces.ble.management_runtime import (
 )
 from meshtastic.interfaces.ble.receive_compat_service import BLEReceiveRecoveryService
 from meshtastic.interfaces.ble.receive_service import BLEReceiveRecoveryController
-from meshtastic.interfaces.ble.utils import (
-    _is_unconfigured_mock_callable,
-    _is_unconfigured_mock_member,
-)
 
 pytestmark = pytest.mark.unit
 
@@ -49,9 +46,14 @@ def configured_mock(return_value: Any = None, side_effect: Any = None) -> MagicM
     return mock
 
 
-def unconfigured_mock() -> Mock:
-    """Create an unconfigured mock for testing detection."""
-    return Mock()
+class _DynamicAttributeProxy:
+    """Test double that synthesizes undeclared attributes dynamically."""
+
+    def __getattr__(self, _name: str) -> _DynamicAttributeProxy:
+        return self
+
+    def __call__(self, *_args: Any, **_kwargs: Any) -> _DynamicAttributeProxy:
+        return self
 
 
 def create_configured_handler_mock():
@@ -136,15 +138,6 @@ class TestBLEManagementCommandsServiceHandlerDetection:
         )
         assert result is True
 
-    def test_has_required_handler_entrypoint_unconfigured_mock(self):
-        """Test that unconfigured mock handler returns False."""
-        mock_handler = unconfigured_mock()
-
-        result = BLEManagementCommandsService._has_required_handler_entrypoint(
-            mock_handler, expected_method="execute_management_command"
-        )
-        assert result is False
-
     def test_has_required_handler_entrypoint_any_method(self):
         """Test checking for any required entrypoint method."""
         handler = create_configured_handler_mock()
@@ -185,12 +178,6 @@ class TestBLEManagementCommandsServiceHandlerDetection:
         result = BLEManagementCommandsService._is_handler_like(handler)
         assert result is False
 
-    def test_is_handler_like_unconfigured_mock(self):
-        """Test unconfigured mock handler returns False."""
-        mock_handler = unconfigured_mock()
-
-        result = BLEManagementCommandsService._is_handler_like(mock_handler)
-        assert result is False
 
 
 class TestBLEManagementCommandsServiceHandlerResolution:
@@ -207,10 +194,8 @@ class TestBLEManagementCommandsServiceHandlerResolution:
 
     def test_handler_for_shim_direct_handler_field(self):
         """Test fallback to direct handler field."""
-        iface = MagicMock()
+        iface = SimpleNamespace()
         handler = create_configured_handler_mock()
-        # _get_management_command_handler is unconfigured mock (will be skipped)
-        iface._get_management_command_handler = unconfigured_mock()
         iface._management_command_handler = handler
 
         result = BLEManagementCommandsService._handler_for_shim(iface)
@@ -218,10 +203,7 @@ class TestBLEManagementCommandsServiceHandlerResolution:
 
     def test_handler_for_shim_create_new_handler(self):
         """Test creating new handler when no iface-owned handler exists."""
-        iface = MagicMock()
-        iface._get_management_command_handler = unconfigured_mock()
-        iface._management_command_handler = unconfigured_mock()
-        iface._connected_elsewhere_late_bound = None
+        iface = SimpleNamespace(_connected_elsewhere_late_bound=None)
 
         result = BLEManagementCommandsService._handler_for_shim(iface)
         assert isinstance(result, BLEManagementCommandHandler)
@@ -547,9 +529,9 @@ class TestBLEReceiveRecoveryServiceControllerDetection:
         )
         assert result is True
 
-    def test_is_controller_like_unconfigured_mock(self):
-        """Test unconfigured mock controller returns False."""
-        mock_controller = unconfigured_mock()
+    def test_is_controller_like_dynamic_proxy(self):
+        """Dynamic-only controller members should not satisfy the contract."""
+        mock_controller = _DynamicAttributeProxy()
 
         result = BLEReceiveRecoveryService._is_controller_like(mock_controller)
         assert result is False
@@ -605,9 +587,9 @@ class TestBLEReceiveRecoveryServiceControllerDetection:
         result = BLEReceiveRecoveryService._resolve_controller_candidate(None)
         assert result is None
 
-    def test_resolve_controller_candidate_unconfigured_mock(self):
-        """Test resolving unconfigured mock returns None."""
-        mock_controller = unconfigured_mock()
+    def test_resolve_controller_candidate_dynamic_proxy(self):
+        """Dynamic-only controller candidates should resolve to None."""
+        mock_controller = _DynamicAttributeProxy()
 
         result = BLEReceiveRecoveryService._resolve_controller_candidate(
             mock_controller
@@ -635,7 +617,7 @@ class TestBLEReceiveRecoveryServiceControllerForShim:
         iface = MagicMock()
         controller = create_configured_controller_mock()
 
-        iface._get_receive_recovery_controller = unconfigured_mock()
+        iface._get_receive_recovery_controller = _DynamicAttributeProxy()
         iface._receive_recovery_controller = controller
 
         result = BLEReceiveRecoveryService._controller_for_shim(iface)
@@ -644,8 +626,8 @@ class TestBLEReceiveRecoveryServiceControllerForShim:
     def test_controller_for_shim_create_new_controller(self):
         """Test creating new controller when no cached controller exists."""
         iface = MagicMock()
-        iface._get_receive_recovery_controller = unconfigured_mock()
-        iface._receive_recovery_controller = unconfigured_mock()
+        iface._get_receive_recovery_controller = _DynamicAttributeProxy()
+        iface._receive_recovery_controller = _DynamicAttributeProxy()
         iface._state_lock = None
 
         result = BLEReceiveRecoveryService._controller_for_shim(iface)
@@ -667,8 +649,8 @@ class TestBLEReceiveRecoveryServiceControllerForShim:
     def test_controller_for_shim_with_state_lock(self):
         """Test controller creation with state lock."""
         iface = MagicMock()
-        iface._get_receive_recovery_controller = unconfigured_mock()
-        iface._receive_recovery_controller = unconfigured_mock()
+        iface._get_receive_recovery_controller = _DynamicAttributeProxy()
+        iface._receive_recovery_controller = _DynamicAttributeProxy()
         mock_lock = MagicMock()
         mock_lock.__enter__ = MagicMock(return_value=None)
         mock_lock.__exit__ = MagicMock(return_value=None)
@@ -687,7 +669,7 @@ class TestBLEReceiveRecoveryServiceOperations:
         controller = create_configured_controller_mock()
         controller.handle_read_loop_disconnect = configured_mock(return_value=True)
         iface._receive_recovery_controller = controller
-        iface._get_receive_recovery_controller = unconfigured_mock()
+        iface._get_receive_recovery_controller = _DynamicAttributeProxy()
 
         mock_client = MagicMock(spec=BLEClient)
         result = BLEReceiveRecoveryService._handle_read_loop_disconnect(
@@ -725,7 +707,7 @@ class TestBLEReceiveRecoveryServiceOperations:
         controller = create_configured_controller_mock()
         controller._wait_for_read_trigger = configured_mock(return_value=(True, False))
         iface._receive_recovery_controller = controller
-        iface._get_receive_recovery_controller = unconfigured_mock()
+        iface._get_receive_recovery_controller = _DynamicAttributeProxy()
 
         coordinator = MagicMock()
         result = BLEReceiveRecoveryService._wait_for_read_trigger(
@@ -742,7 +724,7 @@ class TestBLEReceiveRecoveryServiceOperations:
             return_value=expected_result
         )
         iface._receive_recovery_controller = controller
-        iface._get_receive_recovery_controller = unconfigured_mock()
+        iface._get_receive_recovery_controller = _DynamicAttributeProxy()
 
         result = BLEReceiveRecoveryService._snapshot_client_state(iface)
         assert result == expected_result
@@ -753,7 +735,7 @@ class TestBLEReceiveRecoveryServiceOperations:
         controller = create_configured_controller_mock()
         controller._process_client_state = configured_mock(return_value=False)
         iface._receive_recovery_controller = controller
-        iface._get_receive_recovery_controller = unconfigured_mock()
+        iface._get_receive_recovery_controller = _DynamicAttributeProxy()
 
         coordinator = MagicMock()
         mock_client = MagicMock(spec=BLEClient)
@@ -774,7 +756,7 @@ class TestBLEReceiveRecoveryServiceOperations:
         controller = create_configured_controller_mock()
         controller._reset_recovery_after_stability = configured_mock()
         iface._receive_recovery_controller = controller
-        iface._get_receive_recovery_controller = unconfigured_mock()
+        iface._get_receive_recovery_controller = _DynamicAttributeProxy()
 
         # Should not raise
         BLEReceiveRecoveryService._reset_recovery_after_stability(iface)
@@ -786,7 +768,7 @@ class TestBLEReceiveRecoveryServiceOperations:
         controller = create_configured_controller_mock()
         controller._read_and_handle_payload = configured_mock(return_value=True)
         iface._receive_recovery_controller = controller
-        iface._get_receive_recovery_controller = unconfigured_mock()
+        iface._get_receive_recovery_controller = _DynamicAttributeProxy()
 
         mock_client = MagicMock(spec=BLEClient)
         result = BLEReceiveRecoveryService._read_and_handle_payload(
@@ -800,7 +782,7 @@ class TestBLEReceiveRecoveryServiceOperations:
         controller = create_configured_controller_mock()
         controller._handle_payload_read = configured_mock(return_value=(False, False))
         iface._receive_recovery_controller = controller
-        iface._get_receive_recovery_controller = unconfigured_mock()
+        iface._get_receive_recovery_controller = _DynamicAttributeProxy()
 
         mock_client = MagicMock(spec=BLEClient)
         result = BLEReceiveRecoveryService._handle_payload_read(
@@ -814,7 +796,7 @@ class TestBLEReceiveRecoveryServiceOperations:
         controller = create_configured_controller_mock()
         controller._run_receive_cycle = configured_mock(return_value=True)
         iface._receive_recovery_controller = controller
-        iface._get_receive_recovery_controller = unconfigured_mock()
+        iface._get_receive_recovery_controller = _DynamicAttributeProxy()
 
         coordinator = MagicMock()
         result = BLEReceiveRecoveryService._run_receive_cycle(
@@ -828,7 +810,7 @@ class TestBLEReceiveRecoveryServiceOperations:
         controller = create_configured_controller_mock()
         controller.receive_from_radio_impl = configured_mock()
         iface._receive_recovery_controller = controller
-        iface._get_receive_recovery_controller = unconfigured_mock()
+        iface._get_receive_recovery_controller = _DynamicAttributeProxy()
 
         # Should not raise
         BLEReceiveRecoveryService._receive_from_radio_impl(iface)
@@ -840,7 +822,7 @@ class TestBLEReceiveRecoveryServiceOperations:
         controller = create_configured_controller_mock()
         controller.recover_receive_thread = configured_mock()
         iface._receive_recovery_controller = controller
-        iface._get_receive_recovery_controller = unconfigured_mock()
+        iface._get_receive_recovery_controller = _DynamicAttributeProxy()
 
         # Should not raise
         BLEReceiveRecoveryService._recover_receive_thread(iface, "test disconnect")
@@ -855,7 +837,7 @@ class TestBLEReceiveRecoveryServiceOperations:
             return_value=expected_data
         )
         iface._receive_recovery_controller = controller
-        iface._get_receive_recovery_controller = unconfigured_mock()
+        iface._get_receive_recovery_controller = _DynamicAttributeProxy()
 
         mock_client = MagicMock(spec=BLEClient)
         result = BLEReceiveRecoveryService._read_from_radio_with_retries(
@@ -869,7 +851,7 @@ class TestBLEReceiveRecoveryServiceOperations:
         controller = create_configured_controller_mock()
         controller.handle_transient_read_error = configured_mock()
         iface._receive_recovery_controller = controller
-        iface._get_receive_recovery_controller = unconfigured_mock()
+        iface._get_receive_recovery_controller = _DynamicAttributeProxy()
 
         mock_error = MagicMock()
         # Should not raise
@@ -882,7 +864,7 @@ class TestBLEReceiveRecoveryServiceOperations:
         controller = create_configured_controller_mock()
         controller.log_empty_read_warning = configured_mock()
         iface._receive_recovery_controller = controller
-        iface._get_receive_recovery_controller = unconfigured_mock()
+        iface._get_receive_recovery_controller = _DynamicAttributeProxy()
 
         # Should not raise
         BLEReceiveRecoveryService._log_empty_read_warning(iface)
@@ -987,8 +969,8 @@ class TestBLEReceiveRecoveryServiceEdgeCases:
     def test_should_poll_without_notify_mock_value(self):
         """Test handling mock value for notify enabled flag."""
         iface = MagicMock()
-        # Set to unconfigured mock (should be treated as False)
-        iface._fromnum_notify_enabled = unconfigured_mock()
+        # A non-bool dynamic proxy must not be treated as notification-enabled.
+        iface._fromnum_notify_enabled = _DynamicAttributeProxy()
         mock_lock = MagicMock()
         mock_lock.__enter__ = MagicMock(return_value=None)
         mock_lock.__exit__ = MagicMock(return_value=None)
@@ -1032,62 +1014,6 @@ class TestBLEReceiveRecoveryServiceEdgeCases:
             controller, required_method="handle_read_loop_disconnect"
         )
         assert result is not None
-
-
-# =============================================================================
-# Mock Utility Function Tests
-# =============================================================================
-
-
-class TestMockUtilityFunctions:
-    """Test the mock utility functions used by compatibility services."""
-
-    def test_is_unconfigured_mock_member_with_mock(self):
-        """Test detecting unconfigured mock member."""
-        mock = Mock()
-        # Default mock without configuration should be detected
-        result = _is_unconfigured_mock_member(mock)
-        assert result is True
-
-    def test_is_unconfigured_mock_member_configured(self):
-        """Test configured mock is not detected as unconfigured."""
-        mock = MagicMock()
-        mock.return_value = "test"
-        result = _is_unconfigured_mock_member(mock)
-        assert result is False
-
-    def test_is_unconfigured_mock_member_non_callable(self):
-        """Test non-callable mock member detection."""
-        mock = NonCallableMock()
-        result = _is_unconfigured_mock_member(mock)
-        assert result is True
-
-    def test_is_unconfigured_mock_member_regular_object(self):
-        """Test regular object is not detected as unconfigured mock."""
-        regular_object = {"key": "value"}
-        result = _is_unconfigured_mock_member(regular_object)
-        assert result is False
-
-    def test_is_unconfigured_mock_callable_with_callable(self):
-        """Test detecting unconfigured callable mock."""
-        mock = Mock()
-        result = _is_unconfigured_mock_callable(mock)
-        assert result is True
-
-    def test_is_unconfigured_mock_callable_non_callable(self):
-        """Test non-callable mock returns False."""
-        mock = NonCallableMock()
-        result = _is_unconfigured_mock_callable(mock)
-        assert result is False
-
-    def test_is_unconfigured_mock_callable_regular_callable(self):
-        """Test regular callable is not detected as unconfigured mock."""
-
-        def regular_function():
-            pass
-
-        result = _is_unconfigured_mock_callable(regular_function)
-        assert result is False
 
 
 # =============================================================================
@@ -1283,7 +1209,7 @@ class TestBLECompatServicesIntegration:
 
         controller = RealisticController()
         iface._receive_recovery_controller = controller
-        iface._get_receive_recovery_controller = unconfigured_mock()
+        iface._get_receive_recovery_controller = _DynamicAttributeProxy()
 
         # Test various operations
         result = BLEReceiveRecoveryService._handle_read_loop_disconnect(

--- a/meshtastic/tests/test_ble_compat_services_coverage.py
+++ b/meshtastic/tests/test_ble_compat_services_coverage.py
@@ -305,7 +305,7 @@ class TestBLEManagementCommandsServiceOperations:
         iface._validate_management_preconditions = MagicMock()
         mock_client = MagicMock(spec=BLEClient)
         expected_result = (mock_client, None)
-        iface._get_management_client_for_target = configured_mock(
+        iface._get_management_client_for_target_locked = configured_mock(
             return_value=mock_client
         )
 

--- a/meshtastic/tests/test_ble_failure_policy.py
+++ b/meshtastic/tests/test_ble_failure_policy.py
@@ -11,6 +11,9 @@ from meshtastic.interfaces.ble.failure_policy import (
     _BLEFailureDisposition,
     _log_ble_failure,
 )
+from meshtastic.interfaces.ble.lifecycle_ownership_runtime import (
+    BLEConnectionOwnershipLifecycleCoordinator,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -44,3 +47,29 @@ def test_failure_dispositions_are_stable_diagnostic_values() -> None:
         "retryable",
         "terminal",
     }
+
+
+def test_ownership_probe_failure_logs_compatibility_fallback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A failed preferred ownership probe should log before legacy fallback."""
+
+    class _Owner:
+        def current_probe(self) -> bool:
+            raise RuntimeError("probe failed")
+
+        legacy_probe = True
+
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        result = BLEConnectionOwnershipLifecycleCoordinator._probe_bool_member(
+            _Owner(), "current_probe", "legacy_probe"
+        )
+
+    assert result is True
+    record = next(
+        record
+        for record in caplog.records
+        if record.getMessage() == "Error probing ownership member current_probe()"
+    )
+    assert record.ble_failure_disposition == "compatibility_fallback"  # type: ignore[attr-defined]
+    assert record.exc_info is not None

--- a/meshtastic/tests/test_ble_failure_policy.py
+++ b/meshtastic/tests/test_ble_failure_policy.py
@@ -101,8 +101,14 @@ def test_receive_closing_probe_failure_logs_compatibility_fallback(
     )
 
     with caplog.at_level(logging.DEBUG, logger=logger.name):
+        compatibility_is_closing = controller._probe_connection_closing_compat()  # noqa: SLF001
         with session.lock:
-            assert controller._is_connection_closing_locked() is False  # noqa: SLF001
+            assert (
+                controller._is_connection_closing_locked(  # noqa: SLF001
+                    compatibility_is_closing=compatibility_is_closing
+                )
+                is False
+            )
 
     record = next(
         record

--- a/meshtastic/tests/test_ble_failure_policy.py
+++ b/meshtastic/tests/test_ble_failure_policy.py
@@ -1,0 +1,46 @@
+"""Behavioral tests for explicit BLE failure dispositions."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from meshtastic.interfaces.ble.constants import logger
+from meshtastic.interfaces.ble.failure_policy import (
+    _BLEFailureDisposition,
+    _log_ble_failure,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_failure_policy_preserves_log_text_and_attaches_disposition(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Failure classification should add metadata without rewriting messages."""
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        try:
+            raise RuntimeError("boom")
+        except RuntimeError:
+            _log_ble_failure(
+                _BLEFailureDisposition.RETRYABLE,
+                "retry %s",
+                "operation",
+                level=logging.WARNING,
+            )
+
+    record = caplog.records[-1]
+    assert record.getMessage() == "retry operation"
+    assert record.ble_failure_disposition == "retryable"  # type: ignore[attr-defined]
+    assert record.exc_info is not None
+
+
+def test_failure_dispositions_are_stable_diagnostic_values() -> None:
+    """Each internal policy should expose a distinct machine-readable value."""
+    assert {item.value for item in _BLEFailureDisposition} == {
+        "compatibility_fallback",
+        "best_effort",
+        "retryable",
+        "terminal",
+    }

--- a/meshtastic/tests/test_ble_failure_policy.py
+++ b/meshtastic/tests/test_ble_failure_policy.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+import threading
+from types import SimpleNamespace
 
 import pytest
 
@@ -14,6 +16,8 @@ from meshtastic.interfaces.ble.failure_policy import (
 from meshtastic.interfaces.ble.lifecycle_ownership_runtime import (
     BLEConnectionOwnershipLifecycleCoordinator,
 )
+from meshtastic.interfaces.ble.receive_service import BLEReceiveRecoveryController
+from meshtastic.interfaces.ble.session_state import BLESessionState
 
 pytestmark = pytest.mark.unit
 
@@ -70,6 +74,40 @@ def test_ownership_probe_failure_logs_compatibility_fallback(
         record
         for record in caplog.records
         if record.getMessage() == "Error probing ownership member current_probe()"
+    )
+    assert record.ble_failure_disposition == "compatibility_fallback"  # type: ignore[attr-defined]
+    assert record.exc_info is not None
+
+
+def test_receive_closing_probe_failure_logs_compatibility_fallback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A failed current closing probe should log before the legacy fallback."""
+
+    class _StateManager:
+        def __init__(self) -> None:
+            self.lock = threading.RLock()
+            self._is_closing = False
+
+        def is_closing(self) -> bool:
+            raise RuntimeError("closing probe failed")
+
+    state_manager = _StateManager()
+    session = BLESessionState(lock=state_manager.lock)
+    iface = SimpleNamespace(_state_manager=state_manager)
+    controller = BLEReceiveRecoveryController(
+        iface,  # type: ignore[arg-type]
+        session_state=session,
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        with session.lock:
+            assert controller._is_connection_closing_locked() is False  # noqa: SLF001
+
+    record = next(
+        record
+        for record in caplog.records
+        if record.getMessage() == "State manager is_closing() probe failed"
     )
     assert record.ble_failure_disposition == "compatibility_fallback"  # type: ignore[attr-defined]
     assert record.exc_info is not None

--- a/meshtastic/tests/test_ble_lifecycle.py
+++ b/meshtastic/tests/test_ble_lifecycle.py
@@ -180,6 +180,18 @@ class TestClientIsConnectedCompat:
         client._is_connected = True
         assert _client_is_connected_compat(client) is True
 
+    def test_client_is_connected_property_failure_falls_back(self) -> None:
+        """A failing declared descriptor should not abort later connectivity probes."""
+
+        class _Client:
+            @property
+            def isConnected(self) -> bool:  # noqa: N802 - compatibility spelling
+                raise RuntimeError("descriptor failed")
+
+            _is_connected = True
+
+        assert _client_is_connected_compat(_Client()) is True
+
 
 @pytest.mark.unit
 class TestLifecycleStateAccess:
@@ -194,6 +206,12 @@ class TestLifecycleStateAccess:
     def state_access(self, mock_iface: SimpleNamespace) -> _LifecycleStateAccess:
         """Create _LifecycleStateAccess instance."""
         return _LifecycleStateAccess(mock_iface)
+
+    def test_fake_state_manager_exposes_shared_lock(
+        self, mock_iface: SimpleNamespace
+    ) -> None:
+        """Lifecycle fakes should model the production shared-lock contract."""
+        assert mock_iface._state_manager.lock is not None
 
     def test_is_connected_via_public_callable(
         self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace

--- a/meshtastic/tests/test_ble_lifecycle.py
+++ b/meshtastic/tests/test_ble_lifecycle.py
@@ -588,7 +588,7 @@ class TestLifecycleThreadAccess:
     ) -> None:
         """Test join_thread fallback to thread.join."""
         mock_thread = MagicMock()
-        # Configure join so it's not detected as unconfigured mock
+        # Configure join explicitly for this thread-coordinator double
         mock_thread.join = MagicMock(return_value=None)
         mock_iface.thread_coordinator = None
         thread_access.join_thread(mock_thread, timeout=1.0)
@@ -781,7 +781,7 @@ class TestLifecycleErrorAccess:
         # Configure error_handler so it's not detected as unconfigured
         error_handler = MagicMock()
         error_handler.return_value = True
-        # Pre-configure common methods to avoid auto-generated unconfigured mocks
+        # Declare the collaborator methods exercised by this lifecycle path
         error_handler.safe_cleanup = MagicMock(return_value=True)
         error_handler._safe_cleanup = MagicMock(return_value=True)
         error_handler.safe_execute = MagicMock(return_value=True)

--- a/meshtastic/tests/test_ble_lifecycle.py
+++ b/meshtastic/tests/test_ble_lifecycle.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import threading
 import time
 from collections.abc import Callable, Generator
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -42,7 +43,6 @@ from ._ble_runtime_fakes import (
 )
 
 # pylint: disable=too-many-lines
-
 
 
 class _ImmediateThread:
@@ -186,31 +186,31 @@ class TestLifecycleStateAccess:
     """Test _LifecycleStateAccess class."""
 
     @pytest.fixture
-    def mock_iface(self) -> Any:
+    def mock_iface(self) -> SimpleNamespace:
         """Create an interface double with an explicit state-manager fake."""
-        return type("Iface", (), {"_state_manager": _FakeStateManager()})()
+        return SimpleNamespace(_state_manager=_FakeStateManager())
 
     @pytest.fixture
-    def state_access(self, mock_iface: Any) -> _LifecycleStateAccess:
+    def state_access(self, mock_iface: SimpleNamespace) -> _LifecycleStateAccess:
         """Create _LifecycleStateAccess instance."""
         return _LifecycleStateAccess(mock_iface)
 
     def test_is_connected_via_public_callable(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test is_connected via public callable."""
         mock_iface._state_manager.connected = True
         assert state_access.is_connected() is True
 
     def test_is_connected_via_public_bool(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test is_connected via public boolean attribute."""
         mock_iface._state_manager.is_connected = True
         assert state_access.is_connected() is True
 
     def test_is_connected_via_legacy_callable(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test is_connected via legacy callable."""
         mock_iface._state_manager.is_connected = None
@@ -218,7 +218,7 @@ class TestLifecycleStateAccess:
         assert state_access.is_connected() is True
 
     def test_is_connected_via_legacy_bool(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test is_connected via legacy boolean attribute."""
         mock_iface._state_manager.is_connected = None
@@ -226,7 +226,7 @@ class TestLifecycleStateAccess:
         assert state_access.is_connected() is True
 
     def test_is_connected_raises_when_missing(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test that AttributeError is raised when is_connected not found."""
         mock_iface._state_manager.is_connected = None
@@ -235,7 +235,7 @@ class TestLifecycleStateAccess:
             state_access.is_connected()
 
     def test_is_connected_exception_in_public_callable(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test exception handling in public is_connected callable."""
         mock_iface._state_manager.is_connected = MagicMock(
@@ -245,7 +245,7 @@ class TestLifecycleStateAccess:
         assert state_access.is_connected() is True
 
     def test_is_connected_exception_in_legacy_callable(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test exception handling in legacy is_connected callable."""
         mock_iface._state_manager.is_connected = None
@@ -256,21 +256,21 @@ class TestLifecycleStateAccess:
             state_access.is_connected()
 
     def test_current_state_via_public_callable(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test current_state via public callable."""
         mock_iface._state_manager.state = ConnectionState.CONNECTED
         assert state_access.current_state() == ConnectionState.CONNECTED
 
     def test_current_state_via_public_attribute(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test current_state via public attribute."""
         mock_iface._state_manager.current_state = ConnectionState.CONNECTING
         assert state_access.current_state() == ConnectionState.CONNECTING
 
     def test_current_state_via_legacy_callable(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test current_state via legacy callable."""
         mock_iface._state_manager.current_state = None
@@ -280,7 +280,7 @@ class TestLifecycleStateAccess:
         assert state_access.current_state() == ConnectionState.DISCONNECTED
 
     def test_current_state_via_legacy_attribute(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test current_state via legacy attribute."""
         mock_iface._state_manager.current_state = None
@@ -288,7 +288,7 @@ class TestLifecycleStateAccess:
         assert state_access.current_state() == ConnectionState.ERROR
 
     def test_current_state_raises_when_missing(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test that AttributeError is raised when current_state not found."""
         mock_iface._state_manager.current_state = None
@@ -299,7 +299,7 @@ class TestLifecycleStateAccess:
             state_access.current_state()
 
     def test_current_state_exception_in_callable(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test exception handling in current_state callable."""
         mock_iface._state_manager.current_state = MagicMock(
@@ -309,14 +309,14 @@ class TestLifecycleStateAccess:
         assert state_access.current_state() == ConnectionState.CONNECTED
 
     def test_transition_to_via_public_callable(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test transition_to via public callable."""
         assert state_access.transition_to(ConnectionState.CONNECTED) is True
         assert mock_iface._state_manager.transition_calls == [ConnectionState.CONNECTED]
 
     def test_transition_to_via_legacy_callable(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test transition_to via legacy callable."""
         mock_iface._state_manager.transition_to = None
@@ -324,7 +324,7 @@ class TestLifecycleStateAccess:
         assert state_access.transition_to(ConnectionState.DISCONNECTING) is True
 
     def test_transition_to_raises_when_missing(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test that AttributeError is raised when transition_to not found."""
         mock_iface._state_manager.transition_to = None
@@ -333,7 +333,7 @@ class TestLifecycleStateAccess:
             state_access.transition_to(ConnectionState.DISCONNECTED)
 
     def test_transition_to_exception_in_callable(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test exception handling in transition_to callable."""
         mock_iface._state_manager.transition_to = MagicMock(
@@ -343,7 +343,7 @@ class TestLifecycleStateAccess:
         assert state_access.transition_to(ConnectionState.CONNECTED) is True
 
     def test_reset_to_disconnected_via_public_callable(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test reset_to_disconnected via public callable."""
         mock_iface._state_manager.state = ConnectionState.CONNECTED
@@ -351,7 +351,7 @@ class TestLifecycleStateAccess:
         assert mock_iface._state_manager.reset_calls == 1
 
     def test_reset_to_disconnected_via_legacy_callable(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test reset_to_disconnected via legacy callable."""
         mock_iface._state_manager.reset_to_disconnected = None
@@ -359,7 +359,7 @@ class TestLifecycleStateAccess:
         assert state_access.reset_to_disconnected() is True
 
     def test_reset_to_disconnected_raises_when_missing(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test that AttributeError is raised when reset_to_disconnected not found."""
         mock_iface._state_manager.reset_to_disconnected = None
@@ -368,7 +368,7 @@ class TestLifecycleStateAccess:
             state_access.reset_to_disconnected()
 
     def test_reset_to_disconnected_exception_in_callable(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test exception handling in reset_to_disconnected callable."""
         mock_iface._state_manager.reset_to_disconnected = MagicMock(
@@ -378,21 +378,21 @@ class TestLifecycleStateAccess:
         assert state_access.reset_to_disconnected() is True
 
     def test_is_closing_via_public_callable(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test is_closing via public callable."""
         mock_iface._state_manager.closing = True
         assert state_access.is_closing() is True
 
     def test_is_closing_via_public_bool(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test is_closing via public boolean."""
         mock_iface._state_manager.is_closing = True
         assert state_access.is_closing() is True
 
     def test_is_closing_via_legacy_callable(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test is_closing via legacy callable."""
         mock_iface._state_manager.is_closing = None
@@ -400,7 +400,7 @@ class TestLifecycleStateAccess:
         assert state_access.is_closing() is True
 
     def test_is_closing_via_legacy_bool(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test is_closing via legacy boolean."""
         mock_iface._state_manager.is_closing = None
@@ -408,7 +408,7 @@ class TestLifecycleStateAccess:
         assert state_access.is_closing() is True
 
     def test_is_closing_graceful_degradation(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test that is_closing returns False gracefully when not found."""
         mock_iface._state_manager.is_closing = None
@@ -417,7 +417,7 @@ class TestLifecycleStateAccess:
         assert state_access.is_closing() is False
 
     def test_is_closing_exception_in_callable(
-        self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
+        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test exception handling in is_closing callable."""
         mock_iface._state_manager.is_closing = MagicMock(
@@ -440,17 +440,17 @@ class TestLifecycleThreadAccess:
     """Test _LifecycleThreadAccess class."""
 
     @pytest.fixture
-    def mock_iface(self) -> Any:
+    def mock_iface(self) -> SimpleNamespace:
         """Create an interface double with an explicit thread coordinator fake."""
-        return type("Iface", (), {"thread_coordinator": _FakeThreadCoordinator()})()
+        return SimpleNamespace(thread_coordinator=_FakeThreadCoordinator())
 
     @pytest.fixture
-    def thread_access(self, mock_iface: Any) -> _LifecycleThreadAccess:
+    def thread_access(self, mock_iface: SimpleNamespace) -> _LifecycleThreadAccess:
         """Create _LifecycleThreadAccess instance."""
         return _LifecycleThreadAccess(mock_iface)
 
     def test_create_thread_via_public_callable(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test create_thread via public callable."""
         mock_thread = MagicMock()
@@ -467,7 +467,7 @@ class TestLifecycleThreadAccess:
         assert result is mock_thread
 
     def test_create_thread_via_legacy_callable(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test create_thread via legacy callable."""
         mock_thread = MagicMock()
@@ -485,7 +485,7 @@ class TestLifecycleThreadAccess:
         assert result is mock_thread
 
     def test_create_thread_raises_when_coordinator_missing(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test that AttributeError is raised when thread_coordinator is missing."""
         mock_iface.thread_coordinator = None
@@ -500,7 +500,7 @@ class TestLifecycleThreadAccess:
             thread_access.create_thread(target=dummy_target, name="test", daemon=True)
 
     def test_create_thread_raises_when_method_missing(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test that AttributeError is raised when create_thread method is missing."""
         mock_iface.thread_coordinator.create_thread = None
@@ -516,7 +516,7 @@ class TestLifecycleThreadAccess:
             thread_access.create_thread(target=dummy_target, name="test", daemon=True)
 
     def test_start_thread_via_public_callable(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test start_thread via public callable."""
         mock_thread = MagicMock()
@@ -526,7 +526,7 @@ class TestLifecycleThreadAccess:
         mock_iface.thread_coordinator.start_thread.assert_called_once_with(mock_thread)
 
     def test_start_thread_via_legacy_callable(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test start_thread via legacy callable."""
         mock_thread = MagicMock()
@@ -536,7 +536,7 @@ class TestLifecycleThreadAccess:
         mock_iface.thread_coordinator._start_thread.assert_called_once_with(mock_thread)
 
     def test_start_thread_raises_when_coordinator_missing(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test that AttributeError is raised when thread_coordinator is missing."""
         mock_iface.thread_coordinator = None
@@ -548,7 +548,7 @@ class TestLifecycleThreadAccess:
             thread_access.start_thread(mock_thread)
 
     def test_start_thread_raises_when_method_missing(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test that AttributeError is raised when start_thread method is missing."""
         mock_iface.thread_coordinator.start_thread = None
@@ -561,7 +561,7 @@ class TestLifecycleThreadAccess:
             thread_access.start_thread(mock_thread)
 
     def test_join_thread_via_public_callable(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test join_thread via public callable."""
         mock_thread = MagicMock()
@@ -572,7 +572,7 @@ class TestLifecycleThreadAccess:
         )
 
     def test_join_thread_via_legacy_callable(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test join_thread via legacy callable."""
         mock_thread = MagicMock()
@@ -584,7 +584,7 @@ class TestLifecycleThreadAccess:
         )
 
     def test_join_thread_fallback_to_thread_join(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test join_thread fallback to thread.join."""
         mock_thread = MagicMock()
@@ -596,7 +596,7 @@ class TestLifecycleThreadAccess:
         assert mock_thread.join.call_count >= 1
 
     def test_join_thread_exception_handling_public(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test exception handling in public join_thread."""
         mock_thread = MagicMock()
@@ -609,7 +609,7 @@ class TestLifecycleThreadAccess:
         mock_iface.thread_coordinator._join_thread.assert_called_once()
 
     def test_join_thread_exception_handling_both(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test exception handling when both coordinator methods fail."""
         mock_thread = MagicMock()
@@ -623,7 +623,7 @@ class TestLifecycleThreadAccess:
         thread_access.join_thread(mock_thread, timeout=1.0)
 
     def test_join_thread_exception_in_thread_join(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test exception handling in thread.join fallback."""
         mock_thread = MagicMock()
@@ -633,7 +633,7 @@ class TestLifecycleThreadAccess:
         thread_access.join_thread(mock_thread, timeout=1.0)
 
     def test_set_event_via_public_callable(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test set_event via public callable."""
         mock_iface.thread_coordinator.set_event = MagicMock(return_value=None)
@@ -641,7 +641,7 @@ class TestLifecycleThreadAccess:
         mock_iface.thread_coordinator.set_event.assert_called_once_with("test_event")
 
     def test_set_event_via_legacy_callable(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test set_event via legacy callable."""
         mock_iface.thread_coordinator.set_event = None
@@ -650,7 +650,7 @@ class TestLifecycleThreadAccess:
         mock_iface.thread_coordinator._set_event.assert_called_once_with("test_event")
 
     def test_set_event_missing_coordinator(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test set_event when coordinator is missing (best effort, no raise)."""
         mock_iface.thread_coordinator = None
@@ -658,7 +658,7 @@ class TestLifecycleThreadAccess:
         thread_access.set_event("test_event")
 
     def test_set_event_exception_handling(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test exception handling in set_event."""
         mock_iface.thread_coordinator.set_event = MagicMock(
@@ -670,7 +670,7 @@ class TestLifecycleThreadAccess:
         mock_iface.thread_coordinator._set_event.assert_called_once()
 
     def test_clear_events_via_public_callable(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test clear_events via public callable."""
         mock_iface.thread_coordinator.clear_events = MagicMock(return_value=None)
@@ -680,7 +680,7 @@ class TestLifecycleThreadAccess:
         )
 
     def test_clear_events_via_legacy_callable(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test clear_events via legacy callable."""
         mock_iface.thread_coordinator.clear_events = None
@@ -691,7 +691,7 @@ class TestLifecycleThreadAccess:
         )
 
     def test_clear_events_missing_coordinator(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test clear_events when coordinator is missing (best effort, no raise)."""
         mock_iface.thread_coordinator = None
@@ -699,7 +699,7 @@ class TestLifecycleThreadAccess:
         thread_access.clear_events("event1")
 
     def test_clear_events_exception_handling(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test exception handling in clear_events."""
         mock_iface.thread_coordinator.clear_events = MagicMock(
@@ -711,7 +711,7 @@ class TestLifecycleThreadAccess:
         mock_iface.thread_coordinator._clear_events.assert_called_once()
 
     def test_wake_waiting_threads_via_public(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test wake_waiting_threads via public callable."""
         mock_iface.thread_coordinator.wake_waiting_threads = MagicMock(
@@ -723,7 +723,7 @@ class TestLifecycleThreadAccess:
         )
 
     def test_wake_waiting_threads_via_legacy(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test wake_waiting_threads via legacy callable."""
         mock_iface.thread_coordinator.wake_waiting_threads = None
@@ -736,7 +736,7 @@ class TestLifecycleThreadAccess:
         )
 
     def test_wake_waiting_threads_fallback_to_set_event(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test wake_waiting_threads fallback to set_event."""
         mock_iface.thread_coordinator.wake_waiting_threads = None
@@ -747,7 +747,7 @@ class TestLifecycleThreadAccess:
         assert mock_iface.thread_coordinator.set_event.call_count == 2
 
     def test_wake_waiting_threads_missing_coordinator(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test wake_waiting_threads when coordinator is missing (best effort, no raise)."""
         mock_iface.thread_coordinator = None
@@ -755,7 +755,7 @@ class TestLifecycleThreadAccess:
         thread_access.wake_waiting_threads("event1")
 
     def test_wake_waiting_threads_exception_handling(
-        self, thread_access: _LifecycleThreadAccess, mock_iface: MagicMock
+        self, thread_access: _LifecycleThreadAccess, mock_iface: SimpleNamespace
     ) -> None:
         """Test exception handling in wake_waiting_threads with partial failures."""
         mock_iface.thread_coordinator.wake_waiting_threads = MagicMock(

--- a/meshtastic/tests/test_ble_lifecycle.py
+++ b/meshtastic/tests/test_ble_lifecycle.py
@@ -35,22 +35,14 @@ from meshtastic.interfaces.ble.lifecycle_receive_runtime import (
 from meshtastic.interfaces.ble.state import ConnectionState
 from meshtastic.interfaces.ble.utils import _thread_start_probe
 
+from ._ble_runtime_fakes import (
+    _FakeConnectedClient,
+    _FakeStateManager,
+    _FakeThreadCoordinator,
+)
+
 # pylint: disable=too-many-lines
 
-
-def configured_mock(return_value: Any = None, side_effect: Any = None) -> MagicMock:
-    """Create a configured MagicMock that won't be detected as unconfigured.
-
-    The _is_unconfigured_mock_callable function checks if a mock has default
-    return value and no side_effect. This helper ensures mocks are properly
-    configured to avoid being skipped.
-    """
-    mock = MagicMock()
-    if side_effect is not None:
-        mock.side_effect = side_effect
-    else:
-        mock.return_value = return_value
-    return mock
 
 
 class _ImmediateThread:
@@ -132,9 +124,9 @@ class TestClientIsConnectedCompat:
 
     def test_client_is_connected_via_callable(self) -> None:
         """Test getting connected state via callable isConnected."""
-        client = MagicMock()
-        client.isConnected = MagicMock(return_value=True)
+        client = _FakeConnectedClient(connected=True)
         assert _client_is_connected_compat(client) is True
+        assert client.probe_calls == 1
 
     def test_client_is_connected_via_is_connected_callable(self) -> None:
         """Test getting connected state via callable is_connected."""
@@ -154,8 +146,7 @@ class TestClientIsConnectedCompat:
 
     def test_client_is_connected_via_bool_attribute(self) -> None:
         """Test getting connected state via boolean attribute."""
-        client = MagicMock()
-        client.isConnected = False
+        client = type("Client", (), {"isConnected": False})()
         assert _client_is_connected_compat(client) is False
 
     def test_client_is_connected_via_is_connected_bool(self) -> None:
@@ -195,14 +186,12 @@ class TestLifecycleStateAccess:
     """Test _LifecycleStateAccess class."""
 
     @pytest.fixture
-    def mock_iface(self) -> MagicMock:
-        """Create a mock BLEInterface with state manager."""
-        iface = MagicMock()
-        iface._state_manager = MagicMock()
-        return iface
+    def mock_iface(self) -> Any:
+        """Create an interface double with an explicit state-manager fake."""
+        return type("Iface", (), {"_state_manager": _FakeStateManager()})()
 
     @pytest.fixture
-    def state_access(self, mock_iface: MagicMock) -> _LifecycleStateAccess:
+    def state_access(self, mock_iface: Any) -> _LifecycleStateAccess:
         """Create _LifecycleStateAccess instance."""
         return _LifecycleStateAccess(mock_iface)
 
@@ -210,7 +199,7 @@ class TestLifecycleStateAccess:
         self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
     ) -> None:
         """Test is_connected via public callable."""
-        mock_iface._state_manager.is_connected = MagicMock(return_value=True)
+        mock_iface._state_manager.connected = True
         assert state_access.is_connected() is True
 
     def test_is_connected_via_public_bool(
@@ -270,9 +259,7 @@ class TestLifecycleStateAccess:
         self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
     ) -> None:
         """Test current_state via public callable."""
-        mock_iface._state_manager.current_state = MagicMock(
-            return_value=ConnectionState.CONNECTED
-        )
+        mock_iface._state_manager.state = ConnectionState.CONNECTED
         assert state_access.current_state() == ConnectionState.CONNECTED
 
     def test_current_state_via_public_attribute(
@@ -325,8 +312,8 @@ class TestLifecycleStateAccess:
         self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
     ) -> None:
         """Test transition_to via public callable."""
-        mock_iface._state_manager.transition_to = MagicMock(return_value=True)
         assert state_access.transition_to(ConnectionState.CONNECTED) is True
+        assert mock_iface._state_manager.transition_calls == [ConnectionState.CONNECTED]
 
     def test_transition_to_via_legacy_callable(
         self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
@@ -359,8 +346,9 @@ class TestLifecycleStateAccess:
         self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
     ) -> None:
         """Test reset_to_disconnected via public callable."""
-        mock_iface._state_manager.reset_to_disconnected = MagicMock(return_value=True)
+        mock_iface._state_manager.state = ConnectionState.CONNECTED
         assert state_access.reset_to_disconnected() is True
+        assert mock_iface._state_manager.reset_calls == 1
 
     def test_reset_to_disconnected_via_legacy_callable(
         self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
@@ -393,7 +381,7 @@ class TestLifecycleStateAccess:
         self, state_access: _LifecycleStateAccess, mock_iface: MagicMock
     ) -> None:
         """Test is_closing via public callable."""
-        mock_iface._state_manager.is_closing = MagicMock(return_value=True)
+        mock_iface._state_manager.closing = True
         assert state_access.is_closing() is True
 
     def test_is_closing_via_public_bool(
@@ -452,19 +440,12 @@ class TestLifecycleThreadAccess:
     """Test _LifecycleThreadAccess class."""
 
     @pytest.fixture
-    def mock_iface(self) -> MagicMock:
-        """Create a mock BLEInterface with properly configured thread coordinator."""
-        iface = MagicMock()
-        # Configure thread_coordinator mock so it's not detected as unconfigured
-        # The _is_unconfigured_mock_member checks for DEFAULT return_value, no side_effect, and no calls
-        coordinator = MagicMock()
-        # Set a simple return value to mark it as "configured"
-        coordinator.return_value = True
-        iface.thread_coordinator = coordinator
-        return iface
+    def mock_iface(self) -> Any:
+        """Create an interface double with an explicit thread coordinator fake."""
+        return type("Iface", (), {"thread_coordinator": _FakeThreadCoordinator()})()
 
     @pytest.fixture
-    def thread_access(self, mock_iface: MagicMock) -> _LifecycleThreadAccess:
+    def thread_access(self, mock_iface: Any) -> _LifecycleThreadAccess:
         """Create _LifecycleThreadAccess instance."""
         return _LifecycleThreadAccess(mock_iface)
 

--- a/meshtastic/tests/test_ble_lifecycle.py
+++ b/meshtastic/tests/test_ble_lifecycle.py
@@ -213,12 +213,13 @@ class TestLifecycleStateAccess:
         """Lifecycle fakes should model the production shared-lock contract."""
         assert mock_iface._state_manager.lock is not None
 
-    def test_is_connected_via_public_callable(
-        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
-    ) -> None:
+    def test_is_connected_via_public_callable(self) -> None:
         """Test is_connected via public callable."""
-        mock_iface._state_manager.connected = True
+        probe = MagicMock(return_value=True)
+        state_access = _LifecycleStateAccess(SimpleNamespace(is_connected=probe))
+
         assert state_access.is_connected() is True
+        probe.assert_called_once_with()
 
     def test_is_connected_via_public_bool(
         self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
@@ -273,12 +274,13 @@ class TestLifecycleStateAccess:
         with pytest.raises(AttributeError, match=STATE_MANAGER_MISSING_CONNECTED_MSG):
             state_access.is_connected()
 
-    def test_current_state_via_public_callable(
-        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
-    ) -> None:
+    def test_current_state_via_public_callable(self) -> None:
         """Test current_state via public callable."""
-        mock_iface._state_manager.state = ConnectionState.CONNECTED
+        probe = MagicMock(return_value=ConnectionState.CONNECTED)
+        state_access = _LifecycleStateAccess(SimpleNamespace(current_state=probe))
+
         assert state_access.current_state() == ConnectionState.CONNECTED
+        probe.assert_called_once_with()
 
     def test_current_state_via_public_attribute(
         self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
@@ -395,12 +397,43 @@ class TestLifecycleStateAccess:
         mock_iface._state_manager._reset_to_disconnected = MagicMock(return_value=True)
         assert state_access.reset_to_disconnected() is True
 
-    def test_is_closing_via_public_callable(
-        self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace
-    ) -> None:
+    def test_transition_non_bool_public_result_does_not_repeat_mutation(self) -> None:
+        """A successful public transition must not invoke the legacy mutator too."""
+        public_transition = MagicMock(return_value=None)
+        legacy_transition = MagicMock(return_value=True)
+        state_access = _LifecycleStateAccess(
+            SimpleNamespace(
+                transition_to=public_transition,
+                _transition_to=legacy_transition,
+            )
+        )
+
+        assert state_access.transition_to(ConnectionState.CONNECTING) is True
+        public_transition.assert_called_once_with(ConnectionState.CONNECTING)
+        legacy_transition.assert_not_called()
+
+    def test_reset_non_bool_public_result_does_not_repeat_mutation(self) -> None:
+        """A successful public reset must not invoke the legacy mutator too."""
+        public_reset = MagicMock(return_value=None)
+        legacy_reset = MagicMock(return_value=True)
+        state_access = _LifecycleStateAccess(
+            SimpleNamespace(
+                reset_to_disconnected=public_reset,
+                _reset_to_disconnected=legacy_reset,
+            )
+        )
+
+        assert state_access.reset_to_disconnected() is True
+        public_reset.assert_called_once_with()
+        legacy_reset.assert_not_called()
+
+    def test_is_closing_via_public_callable(self) -> None:
         """Test is_closing via public callable."""
-        mock_iface._state_manager.closing = True
+        probe = MagicMock(return_value=True)
+        state_access = _LifecycleStateAccess(SimpleNamespace(is_closing=probe))
+
         assert state_access.is_closing() is True
+        probe.assert_called_once_with()
 
     def test_is_closing_via_public_bool(
         self, state_access: _LifecycleStateAccess, mock_iface: SimpleNamespace

--- a/meshtastic/tests/test_ble_reconnection_coverage.py
+++ b/meshtastic/tests/test_ble_reconnection_coverage.py
@@ -194,6 +194,39 @@ class TestReconnectSchedulerHookResolution:
         assert hook is legacy_hook
 
     @pytest.mark.unit
+    def test_resolve_hook_ignores_synthesized_public_member(self) -> None:
+        """A dynamic public hook must not outrank a declared legacy hook."""
+
+        class _Coordinator:
+            def __init__(self) -> None:
+                self.legacy_calls = 0
+
+            def _create_thread(self, **_kwargs: object) -> str:
+                self.legacy_calls += 1
+                return "legacy"
+
+            def __getattr__(self, _name: str) -> object:
+                return lambda **_kwargs: "dynamic"
+
+        coordinator = _Coordinator()
+        scheduler = ReconnectScheduler(
+            state_manager=BLEStateManager(),
+            state_lock=RLock(),
+            thread_coordinator=coordinator,  # type: ignore[arg-type]
+            interface=SimpleNamespace(
+                _is_connection_closing=False,
+                _can_initiate_connection=True,
+            ),  # type: ignore[arg-type]
+        )
+
+        hook = scheduler._resolve_thread_coordinator_hook(
+            "create_thread", "_create_thread"
+        )
+
+        assert hook() == "legacy"
+        assert coordinator.legacy_calls == 1
+
+    @pytest.mark.unit
     def test_resolve_hook_missing_raises(self) -> None:
         """Missing both hooks raises ThreadCoordinatorMissingMethodError."""
         coordinator = SimpleNamespace()
@@ -409,6 +442,30 @@ class TestReconnectWorkerCallPolicy:
         )
         result = worker._call_policy("next_attempt")
         assert result == (1.0, True)
+
+    @pytest.mark.unit
+    def test_call_policy_ignores_synthesized_public_member(self) -> None:
+        """Policy lookup should use a declared legacy hook over dynamic synthesis."""
+
+        class _Policy:
+            def __init__(self) -> None:
+                self.legacy_calls = 0
+
+            def _next_attempt(self) -> tuple[float, bool]:
+                self.legacy_calls += 1
+                return (2.0, True)
+
+            def __getattr__(self, _name: str) -> object:
+                return lambda *_args: (99.0, False)
+
+        policy = _Policy()
+        worker = ReconnectWorker(
+            interface=SimpleNamespace(),  # type: ignore[arg-type]
+            reconnect_policy=policy,  # type: ignore[arg-type]
+        )
+
+        assert worker._call_policy("next_attempt") == (2.0, True)
+        assert policy.legacy_calls == 1
 
     @pytest.mark.unit  # type: ignore[arg-type]
     def test_call_policy_missing_raises(self) -> None:

--- a/meshtastic/tests/test_ble_reconnection_coverage.py
+++ b/meshtastic/tests/test_ble_reconnection_coverage.py
@@ -26,8 +26,6 @@ from meshtastic.interfaces.ble.reconnection import (
     ReconnectScheduler,
     ReconnectWorker,
     ThreadCoordinatorMissingMethodError,
-    _camel_to_snake,
-    _snake_to_camel,
 )
 from meshtastic.interfaces.ble.state import BLEStateManager
 
@@ -38,52 +36,6 @@ def clear_gating_registry() -> Generator[None, None, None]:
     _clear_all_registries()
     yield
     _clear_all_registries()
-
-
-class TestNamingHelpers:
-    """Tests for camelCase/snake_case conversion helpers."""
-
-    @pytest.mark.unit
-    def test_camel_to_snake_basic(self) -> None:
-        """Basic camelCase to snake_case conversion."""
-        assert _camel_to_snake("camelCase") == "camel_case"
-        assert _camel_to_snake("getAttemptCount") == "get_attempt_count"
-        assert _camel_to_snake("nextAttempt") == "next_attempt"
-
-    @pytest.mark.unit
-    def test_camel_to_snake_upper_camel(self) -> None:
-        """UpperCamelCase conversion."""
-        assert _camel_to_snake("UpperCamel") == "upper_camel"
-        assert _camel_to_snake("ReconnectPolicy") == "reconnect_policy"
-
-    @pytest.mark.unit
-    def test_camel_to_snake_single_word(self) -> None:
-        """Single word stays unchanged."""
-        assert _camel_to_snake("word") == "word"
-        assert _camel_to_snake("Word") == "word"
-
-    @pytest.mark.unit
-    def test_camel_to_snake_consecutive_upper(self) -> None:
-        """Consecutive uppercase letters."""
-        assert _camel_to_snake("XMLHttpRequest") == "x_m_l_http_request"
-        assert _camel_to_snake("IOError") == "i_o_error"
-
-    @pytest.mark.unit
-    def test_snake_to_camel_basic(self) -> None:
-        """Basic snake_case to camelCase conversion."""
-        assert _snake_to_camel("snake_case") == "snakeCase"
-        assert _snake_to_camel("get_attempt_count") == "getAttemptCount"
-        assert _snake_to_camel("next_attempt") == "nextAttempt"
-
-    @pytest.mark.unit
-    def test_snake_to_camel_single_word(self) -> None:
-        """Single word stays unchanged."""
-        assert _snake_to_camel("word") == "word"
-
-    @pytest.mark.unit
-    def test_snake_to_camel_multiple_words(self) -> None:
-        """Multiple word conversion."""
-        assert _snake_to_camel("a_b_c_d") == "aBCD"
 
 
 class TestReconnectPolicyMissingMethodError:
@@ -414,49 +366,47 @@ class TestReconnectSchedulerClearReference:
 
 
 class TestReconnectWorkerCallPolicy:
-    """Tests for policy method calling with naming compatibility."""
+    """Tests for canonical reconnect-policy method dispatch."""
 
     @pytest.mark.unit
-    def test_call_policy_camel_case(self) -> None:  # type: ignore[arg-type]
-        """Policy method called via camelCase name."""
-        policy = MagicMock()
-        policy.next_attempt = MagicMock(return_value=(1.0, True))
+    def test_call_policy_uses_declared_canonical_method(self) -> None:
+        """Policy dispatch should invoke the declared canonical snake_case method."""
+        next_attempt = MagicMock(return_value=(1.0, True))
+        policy = SimpleNamespace(next_attempt=next_attempt)
         worker = ReconnectWorker(
             interface=SimpleNamespace(),  # type: ignore[arg-type]
-            reconnect_policy=policy,
+            reconnect_policy=policy,  # type: ignore[arg-type]
         )
         result = worker._call_policy("next_attempt")
         assert result == (1.0, True)
-        policy.next_attempt.assert_called_once()
+        next_attempt.assert_called_once_with()
 
     @pytest.mark.unit
-    def test_call_policy_snake_case_fallback(self) -> None:
-        """Policy method called via snake_case fallback."""
-        policy = MagicMock()  # type: ignore[arg-type]
-        policy.next_attempt = None
-        policy.nextAttempt = None
-        policy.next_attempt = MagicMock(return_value=(1.0, True))
+    @pytest.mark.parametrize("legacy_name", ["nextAttempt", "_next_attempt"])
+    def test_call_policy_rejects_noncanonical_aliases(self, legacy_name: str) -> None:
+        """Internal reconnect policy dispatch must not preserve naming aliases."""
+        policy = SimpleNamespace(**{legacy_name: lambda: (1.0, True)})
         worker = ReconnectWorker(
             interface=SimpleNamespace(),  # type: ignore[arg-type]
-            reconnect_policy=policy,
+            reconnect_policy=policy,  # type: ignore[arg-type]
         )
-        result = worker._call_policy("next_attempt")
-        assert result == (1.0, True)
+        with pytest.raises(ReconnectPolicyMissingMethodError, match="next_attempt"):
+            worker._call_policy("next_attempt")
 
     @pytest.mark.unit
     def test_call_policy_ignores_synthesized_public_member(self) -> None:
-        """Policy lookup should use a declared legacy hook over dynamic synthesis."""
+        """Policy lookup should reject dynamically synthesized canonical members."""
 
         class _Policy:
             def __init__(self) -> None:
-                self.legacy_calls = 0
-
-            def _next_attempt(self) -> tuple[float, bool]:
-                self.legacy_calls += 1
-                return (2.0, True)
+                self.synthesized_calls = 0
 
             def __getattr__(self, _name: str) -> object:
-                return lambda *_args: (99.0, False)
+                def _synthesized(*_args: object) -> tuple[float, bool]:
+                    self.synthesized_calls += 1
+                    return (99.0, False)
+
+                return _synthesized
 
         policy = _Policy()
         worker = ReconnectWorker(
@@ -464,8 +414,9 @@ class TestReconnectWorkerCallPolicy:
             reconnect_policy=policy,  # type: ignore[arg-type]
         )
 
-        assert worker._call_policy("next_attempt") == (2.0, True)
-        assert policy.legacy_calls == 1
+        with pytest.raises(ReconnectPolicyMissingMethodError, match="next_attempt"):
+            worker._call_policy("next_attempt")
+        assert policy.synthesized_calls == 0
 
     @pytest.mark.unit  # type: ignore[arg-type]
     def test_call_policy_missing_raises(self) -> None:
@@ -477,19 +428,6 @@ class TestReconnectWorkerCallPolicy:
         )
         with pytest.raises(ReconnectPolicyMissingMethodError):
             worker._call_policy("nonexistent_method")
-
-    @pytest.mark.unit
-    def test_call_policy_underscore_fallback(self) -> None:  # type: ignore[arg-type]
-        """Policy method called via underscore-prefixed fallback."""
-        policy = SimpleNamespace()
-        policy._next_attempt = MagicMock(return_value=(1.0, True))
-        worker = ReconnectWorker(
-            interface=SimpleNamespace(),  # type: ignore[arg-type]
-            reconnect_policy=policy,  # type: ignore[arg-type]
-        )
-        result = worker._call_policy("next_attempt")
-        assert result == (1.0, True)
-
 
 class TestReconnectWorkerShouldAbortReconnect:
     """Tests for abort reconnect decision logic."""

--- a/meshtastic/tests/test_ble_shutdown_runtime.py
+++ b/meshtastic/tests/test_ble_shutdown_runtime.py
@@ -20,6 +20,28 @@ from meshtastic.interfaces.ble.lifecycle_shutdown_runtime import (
 pytestmark = pytest.mark.unit
 
 
+class _TrackingRLock:
+    """Reentrant lock test double exposing aggregate ownership state."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._depth = 0
+
+    @property
+    def held(self) -> bool:
+        """Return whether at least one reentrant acquisition is active."""
+        return self._depth > 0
+
+    def __enter__(self) -> "_TrackingRLock":
+        self._lock.acquire()
+        self._depth += 1
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self._depth -= 1
+        self._lock.release()
+
+
 class _ImmediateThread:
     """Run thread targets inline for deterministic unit tests."""
 
@@ -280,23 +302,9 @@ class TestReceiveThreadSessionLocking:
     def test_receive_thread_reference_is_read_under_session_lock(self) -> None:
         """Shutdown should snapshot the current receive thread while holding its owner lock."""
 
-        class _TrackingLock:
-            def __init__(self) -> None:
-                self._lock = threading.RLock()
-                self.held = False
-
-            def __enter__(self) -> "_TrackingLock":
-                self._lock.acquire()
-                self.held = True
-                return self
-
-            def __exit__(self, *_args: object) -> None:
-                self.held = False
-                self._lock.release()
-
         class _ObservedSession:
             def __init__(self) -> None:
-                self.lock = _TrackingLock()
+                self.lock = _TrackingRLock()
                 self._receive_thread: object | None = None
                 self.receive_start_pending = False
                 self.receive_start_pending_since = None
@@ -320,3 +328,50 @@ class TestReceiveThreadSessionLocking:
             wake_waiting_threads=lambda *_events: None,
             join_thread=lambda *_args, **_kwargs: None,
         )
+
+    def test_receive_thread_liveness_probes_run_outside_session_lock(self) -> None:
+        """Thread-like liveness callbacks must not execute under shared state lock."""
+
+        class _ObservedSession:
+            def __init__(self) -> None:
+                self.lock = _TrackingRLock()
+                self._receive_thread: object | None = None
+                self.receive_start_pending = True
+                self.receive_start_pending_since = 1.0
+
+            @property
+            def receive_thread(self) -> object | None:
+                assert self.lock.held is True
+                return self._receive_thread
+
+            @receive_thread.setter
+            def receive_thread(self, value: object | None) -> None:
+                assert self.lock.held is True
+                self._receive_thread = value
+
+        session = _ObservedSession()
+        probe_lock_states: list[bool] = []
+        probe_results = iter((True, True, False))
+
+        class _ThreadLike:
+            ident = 42
+            name = "ObservedReceive"
+
+            def is_alive(self) -> bool:
+                probe_lock_states.append(session.lock.held)
+                return next(probe_results)
+
+        with session.lock:
+            session.receive_thread = _ThreadLike()
+        coordinator = BLEShutdownLifecycleCoordinator(
+            MagicMock(), session_state=session  # type: ignore[arg-type]
+        )
+
+        coordinator._shutdown_receive_thread(
+            wake_waiting_threads=lambda *_events: None,
+            join_thread=lambda *_args, **_kwargs: None,
+        )
+
+        assert probe_lock_states == [False, False, False]
+        with session.lock:
+            assert session.receive_thread is None

--- a/meshtastic/tests/test_ble_shutdown_runtime.py
+++ b/meshtastic/tests/test_ble_shutdown_runtime.py
@@ -162,7 +162,7 @@ class TestBoundedThreadTOCTOU:
 
         blocker = threading.Event()
 
-        # Use a real function so _is_unconfigured_mock_callable does not skip it.
+        # Use an explicitly declared function so structural hook lookup resolves it.
         def slow_cleanup() -> None:
             blocker.wait()
 

--- a/meshtastic/tests/test_ble_shutdown_runtime.py
+++ b/meshtastic/tests/test_ble_shutdown_runtime.py
@@ -296,6 +296,42 @@ class TestBoundedThreadTOCTOU:
         previous.join.assert_not_called()
 
 
+class TestShutdownStateProbeLocking:
+    """Test shutdown state-manager probes respect the shared lock boundary."""
+
+    def test_current_state_probe_runs_outside_session_lock(self) -> None:
+        """Shutdown must not call state-manager current-state hooks under session lock."""
+        from meshtastic.interfaces.ble.session_state import BLESessionState
+        from meshtastic.interfaces.ble.state import ConnectionState
+
+        lock = _TrackingRLock()
+        session = BLESessionState(lock=lock)
+        iface = MagicMock()
+        iface._management_lock = threading.RLock()
+        iface._management_inflight = 0
+        probe_lock_states: list[bool] = []
+
+        def _current_state() -> ConnectionState:
+            probe_lock_states.append(lock.held)
+            return ConnectionState.DISCONNECTED
+
+        coordinator = BLEShutdownLifecycleCoordinator(
+            iface, session_state=session  # type: ignore[arg-type]
+        )
+
+        result = coordinator._await_management_shutdown(  # noqa: SLF001
+            management_shutdown_wait_timeout=0.1,
+            management_wait_poll_seconds=0.01,
+            current_state_getter=_current_state,
+            is_closing_getter=lambda: False,
+            transition_to_state=lambda _state: True,
+            reset_to_disconnected=lambda: True,
+        )
+
+        assert result is False
+        assert probe_lock_states == [False]
+
+
 class TestReceiveThreadSessionLocking:
     """Test shutdown receive-thread state capture synchronization."""
 
@@ -308,10 +344,12 @@ class TestReceiveThreadSessionLocking:
                 self._receive_thread: object | None = None
                 self.receive_start_pending = False
                 self.receive_start_pending_since = None
+                self.receive_thread_reads = 0
 
             @property
             def receive_thread(self) -> object | None:
                 assert self.lock.held is True
+                self.receive_thread_reads += 1
                 return self._receive_thread
 
             @receive_thread.setter
@@ -328,6 +366,8 @@ class TestReceiveThreadSessionLocking:
             wake_waiting_threads=lambda *_events: None,
             join_thread=lambda *_args, **_kwargs: None,
         )
+
+        assert session.receive_thread_reads == 1
 
     def test_receive_thread_liveness_probes_run_outside_session_lock(self) -> None:
         """Thread-like liveness callbacks must not execute under shared state lock."""

--- a/meshtastic/tests/test_ble_shutdown_runtime.py
+++ b/meshtastic/tests/test_ble_shutdown_runtime.py
@@ -272,3 +272,51 @@ class TestBoundedThreadTOCTOU:
         coordinator._close_mesh_interface(timeout=1.0)
 
         previous.join.assert_not_called()
+
+
+class TestReceiveThreadSessionLocking:
+    """Test shutdown receive-thread state capture synchronization."""
+
+    def test_receive_thread_reference_is_read_under_session_lock(self) -> None:
+        """Shutdown should snapshot the current receive thread while holding its owner lock."""
+
+        class _TrackingLock:
+            def __init__(self) -> None:
+                self._lock = threading.RLock()
+                self.held = False
+
+            def __enter__(self) -> "_TrackingLock":
+                self._lock.acquire()
+                self.held = True
+                return self
+
+            def __exit__(self, *_args: object) -> None:
+                self.held = False
+                self._lock.release()
+
+        class _ObservedSession:
+            def __init__(self) -> None:
+                self.lock = _TrackingLock()
+                self._receive_thread: object | None = None
+                self.receive_start_pending = False
+                self.receive_start_pending_since = None
+
+            @property
+            def receive_thread(self) -> object | None:
+                assert self.lock.held is True
+                return self._receive_thread
+
+            @receive_thread.setter
+            def receive_thread(self, value: object | None) -> None:
+                assert self.lock.held is True
+                self._receive_thread = value
+
+        session = _ObservedSession()
+        coordinator = BLEShutdownLifecycleCoordinator(
+            MagicMock(), session_state=session  # type: ignore[arg-type]
+        )
+
+        coordinator._shutdown_receive_thread(
+            wake_waiting_threads=lambda *_events: None,
+            join_thread=lambda *_args, **_kwargs: None,
+        )

--- a/meshtastic/tests/test_ble_shutdown_runtime.py
+++ b/meshtastic/tests/test_ble_shutdown_runtime.py
@@ -7,6 +7,7 @@ and shutdown client teardown paths.
 from __future__ import annotations
 
 import threading
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -188,7 +189,7 @@ class TestBoundedThreadTOCTOU:
         def slow_cleanup() -> None:
             blocker.wait()
 
-        iface.thread_coordinator.cleanup = slow_cleanup
+        iface.thread_coordinator = SimpleNamespace(cleanup=slow_cleanup)
 
         coordinator = BLEShutdownLifecycleCoordinator(iface)
         started_threads: list[threading.Thread] = []
@@ -211,6 +212,12 @@ class TestBoundedThreadTOCTOU:
         assert started_count == 1
         blocker.set()
 
+    def test_cleanup_missing_thread_coordinator_is_best_effort(self) -> None:
+        """Missing optional coordinator state must not escape shutdown cleanup."""
+        coordinator = BLEShutdownLifecycleCoordinator(SimpleNamespace())  # type: ignore[arg-type]
+
+        coordinator._cleanup_thread_coordinator()
+
     def test_start_failure_clears_stored_ref(self):
         """If thread.start() fails, the stored ref must be cleared under lock."""
         iface = MagicMock()
@@ -221,7 +228,7 @@ class TestBoundedThreadTOCTOU:
         def real_cleanup() -> None:
             pass
 
-        iface.thread_coordinator.cleanup = real_cleanup
+        iface.thread_coordinator = SimpleNamespace(cleanup=real_cleanup)
 
         coordinator = BLEShutdownLifecycleCoordinator(iface)
 
@@ -245,7 +252,7 @@ class TestBoundedThreadTOCTOU:
         def real_cleanup() -> None:
             pass
 
-        iface.thread_coordinator.cleanup = real_cleanup
+        iface.thread_coordinator = SimpleNamespace(cleanup=real_cleanup)
 
         coordinator = BLEShutdownLifecycleCoordinator(iface)
 

--- a/meshtastic/tests/test_core_runtime_primitives.py
+++ b/meshtastic/tests/test_core_runtime_primitives.py
@@ -67,6 +67,12 @@ def test_public_core_constants_are_leaf_module_identities() -> None:
         assert getattr(meshtastic, name) is getattr(_core_constants, name), name
 
 
+def test_internal_core_validation_messages_are_not_public_exports() -> None:
+    """Internal validation literals must not accidentally expand package-root API."""
+    assert "LAST_DISCONNECT_SOURCE_TYPE_ERROR" not in _core_constants.__all__
+    assert not hasattr(meshtastic, "LAST_DISCONNECT_SOURCE_TYPE_ERROR")
+
+
 def test_public_response_types_are_leaf_module_identities() -> None:
     """Historical response types should retain identity through the package facade."""
     for name in _response_types.__all__:

--- a/meshtastic/tests/test_mesh_interface_wait_receive.py
+++ b/meshtastic/tests/test_mesh_interface_wait_receive.py
@@ -1946,6 +1946,7 @@ def test_queue_wait_abort_reason_reports_failure_and_closing() -> None:
         assert iface._queue_wait_abort_reason() == "interface is closing"
 
 
+@pytest.mark.unit
 def test_disconnect_source_property_rejects_non_string_values() -> None:
     """Disconnect diagnostics should reject values the getter would discard."""
     iface = MeshInterface.__new__(MeshInterface)

--- a/meshtastic/tests/test_mesh_interface_wait_receive.py
+++ b/meshtastic/tests/test_mesh_interface_wait_receive.py
@@ -1946,6 +1946,20 @@ def test_queue_wait_abort_reason_reports_failure_and_closing() -> None:
         assert iface._queue_wait_abort_reason() == "interface is closing"
 
 
+def test_disconnect_source_property_rejects_non_string_values() -> None:
+    """Disconnect diagnostics should reject values the getter would discard."""
+    iface = MeshInterface.__new__(MeshInterface)
+
+    with pytest.raises(
+        TypeError,
+        match="_last_disconnect_source must be a str or None, got int",
+    ):
+        iface._last_disconnect_source = 7  # type: ignore[assignment]
+
+    iface._last_disconnect_source = None
+    assert iface._last_disconnect_source is None
+
+
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_queue_wait_timeout_can_be_overridden_by_transport_subclass() -> None:

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import builtins
 import contextlib
 from collections.abc import Iterator
 from threading import Event, RLock
@@ -33,7 +32,6 @@ from tests.test_ble_interface_fixtures import DummyClient, _build_interface
 
 pytestmark = pytest.mark.unit
 
-MOCK_IMPORT_UNAVAILABLE_MSG = "mock import unavailable"
 TEST_BLE_ADDRESS = "AA:BB:CC:DD:EE:FF"
 TEST_CONNECT_TIMEOUT_SECONDS = 5.0
 
@@ -88,21 +86,6 @@ def test_connection_helpers_cover_mock_import_and_inline_safe_cleanup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Connection helper utilities should handle import fallback and inline cleanup execution."""
-    real_import = builtins.__import__
-
-    def _import_with_mock_failure(
-        name: str,
-        globals_arg: dict[str, object] | None = None,
-        locals_arg: dict[str, object] | None = None,
-        fromlist: tuple[str, ...] = (),
-        level: int = 0,
-    ) -> object:
-        if name == "unittest.mock":
-            raise ImportError(MOCK_IMPORT_UNAVAILABLE_MSG)
-        return real_import(name, globals_arg, locals_arg, fromlist, level)
-
-    monkeypatch.setattr(builtins, "__import__", _import_with_mock_failure)
-    assert connection_mod._is_mock_instance(object()) is False
 
     cleanup_calls: list[str] = []
 
@@ -522,7 +505,7 @@ def test_client_error_handler_and_connection_state_branches(
         func()
 
     client.error_handler = SimpleNamespace(
-        safe_cleanup=MagicMock(),
+        safe_cleanup=None,
         _safe_cleanup=_legacy_cleanup,
     )
     client._error_handler_safe_cleanup(lambda: None, "cleanup")
@@ -627,7 +610,7 @@ def test_orchestrator_dispatch_and_event_remaining_branches(
     with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
         assert (
             orchestrator._dispatch_public_or_underscore(
-                target=SimpleNamespace(_legacy=MagicMock()),
+                target=SimpleNamespace(),
                 public_name="public",
                 underscore_name="_legacy",
                 call_member=False,

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -87,7 +87,11 @@ def test_connectivity_probes_share_declared_fallback_semantics() -> None:
     """Connection and management paths should use the same declared fallback."""
 
     class FallbackConnectivityClient:
+        def __init__(self) -> None:
+            self.preferred_probe_calls = 0
+
         def isConnected(self) -> bool:  # noqa: N802 - compatibility spelling
+            self.preferred_probe_calls += 1
             raise RuntimeError("preferred probe failed")
 
         def _is_connected(self) -> bool:
@@ -99,7 +103,9 @@ def test_connectivity_probes_share_declared_fallback_semantics() -> None:
     client = FallbackConnectivityClient()
 
     assert ConnectionValidator._client_is_connected(client) is True  # type: ignore[arg-type]
+    assert client.preferred_probe_calls == 1
     assert BLEManagementCommandHandler._is_client_connected(client) is True  # type: ignore[arg-type]
+    assert client.preferred_probe_calls == 2
 
 
 def test_connection_helpers_cover_mock_import_and_inline_safe_cleanup(

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -369,6 +369,27 @@ def test_connection_orchestrator_direct_and_retry_exception_paths(
             orchestrator._compat_find_device(TEST_BLE_ADDRESS)
 
 
+def test_compat_find_device_ignores_synthesized_preferred_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Declared legacy find-device hooks should beat synthesized preferred names."""
+
+    class _LegacyFindDeviceInterface:
+        def __getattr__(self, _name: str) -> object:
+            return lambda _target: (_ for _ in ()).throw(
+                AssertionError("dynamic find-device hook must be ignored")
+            )
+
+        def find_device(self, target: str | None) -> object:
+            return SimpleNamespace(address=target)
+
+    with _make_orchestrator(monkeypatch) as (_iface, orchestrator):
+        orchestrator.interface = _LegacyFindDeviceInterface()
+        result = orchestrator._compat_find_device(TEST_BLE_ADDRESS)
+
+    assert result.address == TEST_BLE_ADDRESS
+
+
 def test_attempt_direct_connect_allows_discovery_for_derived_address(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -1724,3 +1724,35 @@ def test_bleclient_remaining_hook_and_connection_branches() -> None:
     client._require_bleak_client = lambda _message: _BrokenServices()
     with pytest.raises(BLEClient.BLEError):
         client._get_services()
+
+
+def test_discovery_cached_client_ignores_synthesized_connectivity_probe() -> None:
+    """A dynamic public probe must not override a declared connected-state member."""
+
+    class _CachedDiscoveryClient:
+        bleak_client = object()
+        is_connected = True
+
+        def __init__(self) -> None:
+            self.discover_calls = 0
+
+        def discover(self, **_kwargs: object) -> dict[str, object]:
+            self.discover_calls += 1
+            return {}
+
+        def __getattr__(self, name: str) -> object:
+            if name == "isConnected":
+                return lambda: False
+            raise AttributeError(name)
+
+    cached = _CachedDiscoveryClient()
+    manager = DiscoveryManager(
+        client_factory=lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("connected cached client should be reused")
+        )
+    )
+    manager._client = cached  # type: ignore[assignment]
+
+    assert manager._discover_devices(None) == []
+    assert manager._client is cached
+    assert cached.discover_calls == 1

--- a/tests/test_ble_connection_discovery_client_targets.py
+++ b/tests/test_ble_connection_discovery_client_targets.py
@@ -27,6 +27,7 @@ from meshtastic.interfaces.ble.errors import (
     BLEDeviceNotFoundError,
     BLEErrorHandler,
 )
+from meshtastic.interfaces.ble.management_runtime import BLEManagementCommandHandler
 from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
 from tests.test_ble_interface_fixtures import DummyClient, _build_interface
 
@@ -80,6 +81,25 @@ def test_connection_validator_client_is_connected_member_paths() -> None:
 
     client_unknown = SimpleNamespace(isConnected=lambda: "yes")
     assert ConnectionValidator._client_is_connected(client_unknown) is False
+
+
+def test_connectivity_probes_share_declared_fallback_semantics() -> None:
+    """Connection and management paths should use the same declared fallback."""
+
+    class FallbackConnectivityClient:
+        def isConnected(self) -> bool:  # noqa: N802 - compatibility spelling
+            raise RuntimeError("preferred probe failed")
+
+        def _is_connected(self) -> bool:
+            return True
+
+        def __getattr__(self, _name: str) -> object:
+            return lambda: False
+
+    client = FallbackConnectivityClient()
+
+    assert ConnectionValidator._client_is_connected(client) is True  # type: ignore[arg-type]
+    assert BLEManagementCommandHandler._is_client_connected(client) is True  # type: ignore[arg-type]
 
 
 def test_connection_helpers_cover_mock_import_and_inline_safe_cleanup(

--- a/tests/test_ble_connection_edge_cases.py
+++ b/tests/test_ble_connection_edge_cases.py
@@ -59,8 +59,11 @@ def _make_orchestrator_client_manager() -> MagicMock:
             "update_client_reference",
         ]
     )
+    client_manager.connect_client = MagicMock()
     client_manager.connect_client.return_value = None
+    client_manager.safe_close_client = MagicMock()
     client_manager.safe_close_client.return_value = None
+    client_manager.update_client_reference = MagicMock()
     client_manager.update_client_reference.return_value = None
     return client_manager
 
@@ -181,6 +184,7 @@ def test_connection_validator_check_existing_client_none_request() -> None:
 
     # Create mock client
     mock_client = MagicMock()
+    mock_client.isConnected = MagicMock()
     mock_client.isConnected.return_value = True
 
     # Should return True for None request
@@ -196,6 +200,7 @@ def test_connection_validator_check_existing_client_disconnected() -> None:
     validator = ConnectionValidator(state_manager, lock, MockBLEError)
 
     mock_client = MagicMock()
+    mock_client.isConnected = MagicMock()
     mock_client.isConnected.return_value = False
 
     assert not validator._check_existing_client(mock_client, "address", None)
@@ -374,6 +379,7 @@ def test_connection_validator_check_existing_client_matching_address() -> None:
     validator = ConnectionValidator(state_manager, lock, MockBLEError)
 
     mock_client = MagicMock()
+    mock_client.isConnected = MagicMock()
     mock_client.isConnected.return_value = True
     mock_bleak_client = MagicMock()
     mock_bleak_client.address = "AA:BB:CC:DD:EE:FF"
@@ -398,6 +404,7 @@ def test_connection_validator_check_existing_client_uses_cached_client_address()
     validator = ConnectionValidator(state_manager, lock, MockBLEError)
 
     mock_client = MagicMock()
+    mock_client.isConnected = MagicMock()
     mock_client.isConnected.return_value = True
     mock_client.address = "AA:BB:CC:DD:EE:FF"
     mock_client.bleak_client = SimpleNamespace(address=None)
@@ -458,6 +465,7 @@ def test_client_manager_safe_close_client_prefers_public_safe_cleanup() -> None:
     mock_client = MagicMock()
     mock_client._closed = False
     mock_client.bleak_client = object()
+    mock_client.is_connected = MagicMock()
     mock_client.is_connected.return_value = True
 
     manager._safe_close_client(mock_client)
@@ -498,7 +506,9 @@ def test_client_manager_update_client_reference_schedules_close() -> None:
     old_client = MagicMock()
     new_client = MagicMock()
     thread_like = MagicMock()
+    thread_coordinator._create_thread = MagicMock()
     thread_coordinator._create_thread.return_value = thread_like
+    thread_coordinator._start_thread = MagicMock()
     thread_coordinator._start_thread.return_value = None
 
     manager._update_client_reference(new_client, old_client)
@@ -567,7 +577,9 @@ def test_connection_orchestrator_interrupt_resets_state_and_closes_client() -> N
 
     client_manager = _make_orchestrator_client_manager()
     mock_client = MagicMock()
+    client_manager.create_client = MagicMock()
     client_manager.create_client.return_value = mock_client
+    client_manager.connect_client = MagicMock()
     client_manager.connect_client.side_effect = KeyboardInterrupt()
 
     interface = MagicMock()
@@ -607,12 +619,14 @@ def test_connection_orchestrator_aborts_fallback_when_interface_closing() -> Non
 
     client_manager = _make_orchestrator_client_manager()
     direct_client = MagicMock()
+    client_manager.create_client = MagicMock()
     client_manager.create_client.return_value = direct_client
 
     interface = MagicMock()
     interface.BLEError = MockBLEError
     interface._closed = False
     discovered_device = BLEDevice("AA:BB:CC:DD:EE:FF", "Mesh", details=None)
+    interface.findDevice = MagicMock()
     interface.findDevice.return_value = discovered_device
     interface.find_device = MagicMock(return_value=discovered_device)
     interface._find_device = MagicMock(return_value=discovered_device)
@@ -627,6 +641,7 @@ def test_connection_orchestrator_aborts_fallback_when_interface_closing() -> Non
             raise TimeoutError("direct connect timed out")
         raise AssertionError("fallback connect should not run while closing")
 
+    client_manager.connect_client = MagicMock()
     client_manager.connect_client.side_effect = _connect_side_effect
 
     orchestrator = ConnectionOrchestrator(
@@ -665,7 +680,9 @@ def test_transition_failure_to_disconnected_forces_reset_when_transitions_reject
     """_transition_failure_to_disconnected should force reset if transition calls fail."""
     state_manager = MagicMock()
     state_manager._current_state = ConnectionState.CONNECTING
+    state_manager._transition_to = MagicMock()
     state_manager._transition_to.return_value = False
+    state_manager._reset_to_disconnected = MagicMock()
     state_manager._reset_to_disconnected.return_value = True
     state_lock = RLock()
     validator = ConnectionValidator(BLEStateManager(), state_lock, MockBLEError)
@@ -697,6 +714,7 @@ def test_finalize_connection_sets_reconnected_event_and_logs_normalized_address(
     interface.BLEError = MockBLEError
     interface._ever_connected = True
     thread_coordinator = MagicMock()
+    thread_coordinator._set_event = MagicMock()
     thread_coordinator._set_event.return_value = None
     orchestrator = ConnectionOrchestrator(
         interface=interface,
@@ -708,6 +726,7 @@ def test_finalize_connection_sets_reconnected_event_and_logs_normalized_address(
         thread_coordinator=thread_coordinator,
     )
     client = MagicMock()
+    client.isConnected = MagicMock()
     client.isConnected.return_value = True
     on_connected = MagicMock()
 
@@ -738,6 +757,7 @@ def test_finalize_connection_can_defer_connected_side_effects() -> None:
     interface.BLEError = MockBLEError
     interface._ever_connected = True
     thread_coordinator = MagicMock()
+    thread_coordinator._set_event = MagicMock()
     thread_coordinator._set_event.return_value = None
     orchestrator = ConnectionOrchestrator(
         interface=interface,
@@ -749,6 +769,7 @@ def test_finalize_connection_can_defer_connected_side_effects() -> None:
         thread_coordinator=thread_coordinator,
     )
     client = MagicMock()
+    client.isConnected = MagicMock()
     client.isConnected.return_value = True
     on_connected = MagicMock()
 
@@ -841,6 +862,7 @@ def test_connection_orchestrator_raises_when_connect_state_transition_fails() ->
     assert state_manager._transition_to(ConnectionState.CONNECTING)
     assert state_manager._transition_to(ConnectionState.CONNECTED)
     validator = MagicMock(spec_set=ConnectionValidator)
+    validator.validate_connection_request = MagicMock()
     validator.validate_connection_request.return_value = None
     client_manager = _make_orchestrator_client_manager()
     interface = MagicMock()
@@ -885,7 +907,9 @@ def test_connection_orchestrator_reraises_retry_ble_dbus_error(
     client_manager = _make_orchestrator_client_manager()
     direct_client = MagicMock()
     retry_client = MagicMock()
+    client_manager.create_client = MagicMock()
     client_manager.create_client.side_effect = [direct_client, retry_client]
+    client_manager.connect_client = MagicMock()
     client_manager.connect_client.side_effect = [
         OSError("direct connect failed"),
         BleakDBusError("org.bluez.Error.Failed", ["retry dbus failure"]),
@@ -894,6 +918,7 @@ def test_connection_orchestrator_reraises_retry_ble_dbus_error(
     interface = MagicMock()
     interface.BLEError = MockBLEError
     interface._closed = False
+    interface.findDevice = MagicMock()
     interface.findDevice.return_value = BLEDevice(
         "AA:BB:CC:DD:EE:FF", "Meshtastic", details=None
     )
@@ -936,6 +961,7 @@ def test_connection_orchestrator_returns_after_successful_direct_connect() -> No
     validator = ConnectionValidator(state_manager, state_lock, MockBLEError)
     client_manager = _make_orchestrator_client_manager()
     direct_client = MagicMock()
+    client_manager.create_client = MagicMock()
     client_manager.create_client.return_value = direct_client
 
     interface = MagicMock()
@@ -976,6 +1002,7 @@ def test_connection_orchestrator_forwards_pair_on_connect_to_client_creation() -
     validator = ConnectionValidator(state_manager, state_lock, MockBLEError)
     client_manager = _make_orchestrator_client_manager()
     direct_client = MagicMock()
+    client_manager.create_client = MagicMock()
     client_manager.create_client.return_value = direct_client
 
     interface = MagicMock()
@@ -1025,6 +1052,7 @@ def test_connection_orchestrator_uses_explicit_connect_timeout_override() -> Non
     validator = ConnectionValidator(state_manager, state_lock, MockBLEError)
     client_manager = _make_orchestrator_client_manager()
     direct_client = MagicMock()
+    client_manager.create_client = MagicMock()
     client_manager.create_client.return_value = direct_client
 
     interface = MagicMock()
@@ -1066,6 +1094,7 @@ def test_connection_orchestrator_allows_none_connect_timeout() -> None:
     validator = ConnectionValidator(state_manager, state_lock, MockBLEError)
     client_manager = _make_orchestrator_client_manager()
     direct_client = MagicMock()
+    client_manager.create_client = MagicMock()
     client_manager.create_client.return_value = direct_client
 
     interface = MagicMock()
@@ -1160,7 +1189,9 @@ def test_connection_orchestrator_preserves_pair_on_connect_across_direct_retry()
     client_manager = _make_orchestrator_client_manager()
     direct_client = MagicMock()
     retry_client = MagicMock()
+    client_manager.create_client = MagicMock()
     client_manager.create_client.side_effect = [direct_client, retry_client]
+    client_manager.connect_client = MagicMock()
     client_manager.connect_client.side_effect = [
         BleakDeviceNotFoundError("AA:BB:CC:DD:EE:FF", "not found"),
         None,
@@ -1216,10 +1247,12 @@ def test_connection_orchestrator_preserves_pair_on_connect_across_identifier_fal
     client_manager = _make_orchestrator_client_manager()
     direct_client = MagicMock()
     discovered_client = MagicMock()
+    client_manager.create_client = MagicMock()
     client_manager.create_client.side_effect = [
         direct_client,
         discovered_client,
     ]
+    client_manager.connect_client = MagicMock()
     client_manager.connect_client.side_effect = [
         BleakDeviceNotFoundError("mesh-node", "not found"),
         None,
@@ -1229,6 +1262,7 @@ def test_connection_orchestrator_preserves_pair_on_connect_across_identifier_fal
     interface.BLEError = MockBLEError
     interface._closed = False
     discovered_device = BLEDevice("AA:BB:CC:DD:EE:FF", "mesh-node", details=None)
+    interface.findDevice = MagicMock()
     interface.findDevice.return_value = discovered_device
 
     orchestrator = ConnectionOrchestrator(
@@ -1281,12 +1315,14 @@ def test_connection_orchestrator_uses_full_timeout_for_non_pairing_fallback() ->
     validator = ConnectionValidator(state_manager, state_lock, MockBLEError)
     client_manager = _make_orchestrator_client_manager()
     fallback_client = MagicMock()
+    client_manager.create_client = MagicMock()
     client_manager.create_client.return_value = fallback_client
 
     interface = MagicMock()
     interface.BLEError = MockBLEError
     interface._closed = False
     discovered_device = BLEDevice("AA:BB:CC:DD:EE:FF", "Mesh", details=None)
+    interface.findDevice = MagicMock()
     interface.findDevice.return_value = discovered_device
 
     orchestrator = ConnectionOrchestrator(
@@ -1332,7 +1368,9 @@ def test_connection_orchestrator_skips_scan_after_direct_device_not_found_for_ex
     client_manager = _make_orchestrator_client_manager()
     direct_client = MagicMock()
     retry_client = MagicMock()
+    client_manager.create_client = MagicMock()
     client_manager.create_client.side_effect = [direct_client, retry_client]
+    client_manager.connect_client = MagicMock()
     client_manager.connect_client.side_effect = [
         BleakDeviceNotFoundError("AA:BB:CC:DD:EE:FF", "not found"),
         None,
@@ -1399,7 +1437,9 @@ def test_connection_orchestrator_skips_scan_after_direct_timeout_for_explicit_ad
     client_manager = _make_orchestrator_client_manager()
     direct_client = MagicMock()
     retry_client = MagicMock()
+    client_manager.create_client = MagicMock()
     client_manager.create_client.side_effect = [direct_client, retry_client]
+    client_manager.connect_client = MagicMock()
     client_manager.connect_client.side_effect = [
         TimeoutError("direct connect timed out"),
         None,
@@ -1466,7 +1506,9 @@ def test_connection_orchestrator_uses_discovery_for_non_address_identifier_after
     client_manager = _make_orchestrator_client_manager()
     direct_client = MagicMock()
     discovered_client = MagicMock()
+    client_manager.create_client = MagicMock()
     client_manager.create_client.side_effect = [direct_client, discovered_client]
+    client_manager.connect_client = MagicMock()
     client_manager.connect_client.side_effect = [
         BleakDeviceNotFoundError("mesh-node", "not found"),
         None,
@@ -1476,6 +1518,7 @@ def test_connection_orchestrator_uses_discovery_for_non_address_identifier_after
     interface.BLEError = MockBLEError
     interface._closed = False
     discovered_device = BLEDevice("11:22:33:44:55:66", "Mesh", details=None)
+    interface.findDevice = MagicMock()
     interface.findDevice.return_value = discovered_device
 
     orchestrator = ConnectionOrchestrator(
@@ -1535,7 +1578,9 @@ def test_connection_orchestrator_derived_current_address_uses_discovery_after_di
     client_manager = _make_orchestrator_client_manager()
     direct_client = MagicMock()
     discovered_client = MagicMock()
+    client_manager.create_client = MagicMock()
     client_manager.create_client.side_effect = [direct_client, discovered_client]
+    client_manager.connect_client = MagicMock()
     client_manager.connect_client.side_effect = [
         TimeoutError("direct connect timed out"),
         None,
@@ -1546,6 +1591,7 @@ def test_connection_orchestrator_derived_current_address_uses_discovery_after_di
     interface._closed = False
     derived_current_address = "AA:BB:CC:DD:EE:FF"
     discovered_device = BLEDevice("11:22:33:44:55:66", "Mesh", details=None)
+    interface.findDevice = MagicMock()
     interface.findDevice.return_value = discovered_device
 
     orchestrator = ConnectionOrchestrator(
@@ -1605,10 +1651,12 @@ def test_connection_orchestrator_falls_back_to_find_device_when_findDevice_missi
     client_manager = _make_orchestrator_client_manager()
     direct_client = MagicMock()
     discovered_client = MagicMock()
+    client_manager.create_client = MagicMock()
     client_manager.create_client.side_effect = [
         direct_client,
         discovered_client,
     ]
+    client_manager.connect_client = MagicMock()
     client_manager.connect_client.side_effect = [
         BleakDeviceNotFoundError("mesh-node", "not found"),
         None,
@@ -1653,10 +1701,12 @@ def test_connection_orchestrator_falls_back_to_underscore_find_device() -> None:
     client_manager = _make_orchestrator_client_manager()
     direct_client = MagicMock()
     discovered_client = MagicMock()
+    client_manager.create_client = MagicMock()
     client_manager.create_client.side_effect = [
         direct_client,
         discovered_client,
     ]
+    client_manager.connect_client = MagicMock()
     client_manager.connect_client.side_effect = [
         BleakDeviceNotFoundError("mesh-node", "not found"),
         None,
@@ -1703,10 +1753,12 @@ def test_connection_orchestrator_raises_after_explicit_address_direct_retry_not_
     client_manager = _make_orchestrator_client_manager()
     direct_client = MagicMock()
     retry_client = MagicMock()
+    client_manager.create_client = MagicMock()
     client_manager.create_client.side_effect = [
         direct_client,
         retry_client,
     ]
+    client_manager.connect_client = MagicMock()
     client_manager.connect_client.side_effect = [
         BleakDeviceNotFoundError("AA:BB:CC:DD:EE:FF", "not found"),
         BleakDeviceNotFoundError("AA:BB:CC:DD:EE:FF", "not found"),
@@ -1765,7 +1817,9 @@ def test_connection_orchestrator_handles_bleak_dbus_error_during_connect() -> No
     validator = ConnectionValidator(state_manager, state_lock, MockBLEError)
     client_manager = _make_orchestrator_client_manager()
     direct_client = MagicMock()
+    client_manager.create_client = MagicMock()
     client_manager.create_client.return_value = direct_client
+    client_manager.connect_client = MagicMock()
     client_manager.connect_client.side_effect = BleakDBusError(
         "org.bluez.Error.Failed", []
     )
@@ -1918,6 +1972,7 @@ def test_client_manager_safe_close_client_fallback_on_unsupported_await_timeout(
     mock_client = MagicMock()
     mock_client._closed = False
     mock_client.bleak_client = object()
+    mock_client.is_connected = MagicMock()
     mock_client.is_connected.return_value = True
 
     def _reject_await_timeout(*, await_timeout: float | None = None) -> None:
@@ -1926,6 +1981,7 @@ def test_client_manager_safe_close_client_fallback_on_unsupported_await_timeout(
                 "disconnect() got an unexpected keyword argument 'await_timeout'"
             )
 
+    mock_client.disconnect = MagicMock()
     mock_client.disconnect.side_effect = _reject_await_timeout
 
     manager._safe_close_client(mock_client)
@@ -1949,12 +2005,14 @@ def test_client_manager_safe_close_client_does_not_fallback_on_unrelated_typeerr
     mock_client = MagicMock()
     mock_client._closed = False
     mock_client.bleak_client = object()
+    mock_client.is_connected = MagicMock()
     mock_client.is_connected.return_value = True
 
     def _raise_unrelated(*, await_timeout: float | None = None) -> None:
         del await_timeout
         raise TypeError("takes 1 positional argument but 2 were given")
 
+    mock_client.disconnect = MagicMock()
     mock_client.disconnect.side_effect = _raise_unrelated
 
     # _safe_close_client should swallow the error and still run close()
@@ -1972,7 +2030,9 @@ def test_retry_direct_connect_cleans_up_retry_client_on_interrupt() -> None:
     validator = ConnectionValidator(state_manager, state_lock, MockBLEError)
     client_manager = _make_orchestrator_client_manager()
     retry_client = MagicMock()
+    client_manager.create_client = MagicMock()
     client_manager.create_client.return_value = retry_client
+    client_manager.connect_client = MagicMock()
     client_manager.connect_client.side_effect = KeyboardInterrupt("stop")
 
     interface = MagicMock()
@@ -2013,6 +2073,7 @@ def test_retry_direct_connect_skips_cleanup_on_successful_return() -> None:
     validator = ConnectionValidator(state_manager, state_lock, MockBLEError)
     client_manager = _make_orchestrator_client_manager()
     retry_client = MagicMock()
+    client_manager.create_client = MagicMock()
     client_manager.create_client.return_value = retry_client
 
     interface = MagicMock()
@@ -2061,7 +2122,9 @@ def test_stale_cleanup_retry_propagates_address_mismatch(
     client_manager = _make_orchestrator_client_manager()
     direct_client = MagicMock()
     retry_client = MagicMock()
+    client_manager.create_client = MagicMock()
     client_manager.create_client.side_effect = [direct_client, retry_client]
+    client_manager.connect_client = MagicMock()
     client_manager.connect_client.side_effect = [
         OSError("stale bluez"),
         None,
@@ -2140,10 +2203,12 @@ def test_stale_cleanup_retry_fallback_on_generic_retry_failure(
     client_manager = _make_orchestrator_client_manager()
     direct_client = MagicMock()
     retry_client = MagicMock()
+    client_manager.create_client = MagicMock()
     client_manager.create_client.side_effect = [
         direct_client,
         retry_client,
     ]
+    client_manager.connect_client = MagicMock()
     client_manager.connect_client.side_effect = [
         OSError("stale bluez"),
         BleakError("retry failed"),

--- a/tests/test_ble_connection_edge_cases.py
+++ b/tests/test_ble_connection_edge_cases.py
@@ -28,7 +28,10 @@ from meshtastic.interfaces.ble.constants import (
     DIRECT_CONNECT_TIMEOUT_SECONDS,
     BLEConfig,
 )
-from meshtastic.interfaces.ble.reconnection import ReconnectWorker
+from meshtastic.interfaces.ble.reconnection import (
+    ReconnectPolicyMissingMethodError,
+    ReconnectWorker,
+)
 from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
 
 
@@ -547,8 +550,8 @@ def test_client_manager_connect_client_refreshes_services_on_non_callable_probe(
 
 
 @pytest.mark.unit
-def test_reconnect_worker_call_policy_resolves_snake_to_legacy_camelcase() -> None:
-    """_call_policy should resolve snake_case requests to legacy camelCase methods."""
+def test_reconnect_worker_call_policy_rejects_legacy_camelcase() -> None:
+    """ReconnectPolicy orchestration must not preserve legacy camelCase aliases."""
 
     class LegacyCamelPolicy:
         """Policy stub exposing only legacy camelCase methods."""
@@ -564,8 +567,10 @@ def test_reconnect_worker_call_policy_resolves_snake_to_legacy_camelcase() -> No
     policy = LegacyCamelPolicy()
     worker = ReconnectWorker(MagicMock(), policy)  # type: ignore[arg-type]
 
-    assert worker._call_policy("next_attempt") == (0.25, False)
-    assert worker._call_policy("get_attempt_count") == 7
+    with pytest.raises(ReconnectPolicyMissingMethodError, match="next_attempt"):
+        worker._call_policy("next_attempt")
+    with pytest.raises(ReconnectPolicyMissingMethodError, match="get_attempt_count"):
+        worker._call_policy("get_attempt_count")
 
 
 @pytest.mark.unit
@@ -1859,11 +1864,11 @@ def test_reconnect_worker_returns_when_should_abort_is_true() -> None:
 
     class _Policy:
         @staticmethod
-        def _reset() -> None:
+        def reset() -> None:
             pass
 
         @staticmethod
-        def _get_attempt_count() -> int:
+        def get_attempt_count() -> int:
             return 0
 
     interface = MagicMock()
@@ -1884,11 +1889,11 @@ def test_reconnect_worker_returns_when_attempt_count_is_none() -> None:
 
     class _Policy:
         @staticmethod
-        def _reset() -> None:
+        def reset() -> None:
             pass
 
         @staticmethod
-        def _get_attempt_count() -> None:
+        def get_attempt_count() -> None:
             return None
 
     interface = MagicMock()
@@ -1911,11 +1916,11 @@ def test_reconnect_worker_logs_and_returns_when_attempt_count_is_non_int(
 
     class _Policy:
         @staticmethod
-        def _reset() -> None:
+        def reset() -> None:
             pass
 
         @staticmethod
-        def _get_attempt_count() -> float:
+        def get_attempt_count() -> float:
             return 1.5
 
     interface = MagicMock()
@@ -1938,11 +1943,11 @@ def test_reconnect_worker_returns_when_interface_already_connected() -> None:
 
     class _Policy:
         @staticmethod
-        def _reset() -> None:
+        def reset() -> None:
             pass
 
         @staticmethod
-        def _get_attempt_count() -> int:
+        def get_attempt_count() -> int:
             return 0
 
     interface = MagicMock()

--- a/tests/test_ble_gating.py
+++ b/tests/test_ble_gating.py
@@ -612,14 +612,34 @@ def test_clear_all_registries_delegates_to_registry_owner() -> None:
     addr_locks = registry.addr_locks
     connected = registry.connected_addrs
     connecting = registry.connecting_addrs
+    connected_owners = registry.connected_owners
+    connected_owner_ids = registry.connected_owner_ids
+    connected_marked_at = registry.connected_marked_at
+    connecting_owners = registry.connecting_owners
+    connecting_owner_ids = registry.connecting_owner_ids
+    connecting_marked_at = registry.connecting_marked_at
 
-    gating._mark_connecting("AA:BB:CC:DD:EE:FF")
-    gating._mark_connected("11:22:33:44:55:66")
+    connecting_owner = object()
+    connected_owner = object()
+    gating._mark_connecting("AA:BB:CC:DD:EE:FF", owner=connecting_owner)
+    gating._mark_connected("11:22:33:44:55:66", owner=connected_owner)
     gating._clear_all_registries()
 
     assert registry.addr_locks is addr_locks
     assert registry.connected_addrs is connected
     assert registry.connecting_addrs is connecting
+    assert registry.connected_owners is connected_owners
+    assert registry.connected_owner_ids is connected_owner_ids
+    assert registry.connected_marked_at is connected_marked_at
+    assert registry.connecting_owners is connecting_owners
+    assert registry.connecting_owner_ids is connecting_owner_ids
+    assert registry.connecting_marked_at is connecting_marked_at
     assert not registry.addr_locks
     assert not registry.connected_addrs
     assert not registry.connecting_addrs
+    assert not registry.connected_owners
+    assert not registry.connected_owner_ids
+    assert not registry.connected_marked_at
+    assert not registry.connecting_owners
+    assert not registry.connecting_owner_ids
+    assert not registry.connecting_marked_at

--- a/tests/test_ble_gating.py
+++ b/tests/test_ble_gating.py
@@ -622,28 +622,31 @@ def test_clear_all_registries_delegates_to_registry_owner() -> None:
 
     connecting_owner = object()
     connected_owner = object()
-    gating._mark_connecting("AA:BB:CC:DD:EE:FF", owner=connecting_owner)
-    gating._mark_connected("11:22:33:44:55:66", owner=connected_owner)
-    lock_holders["test-holder"] = 1
-    gating._clear_all_registries()
+    try:
+        gating._mark_connecting("AA:BB:CC:DD:EE:FF", owner=connecting_owner)
+        gating._mark_connected("11:22:33:44:55:66", owner=connected_owner)
+        lock_holders["test-holder"] = 1
+        gating._clear_all_registries()
 
-    assert registry.addr_locks is addr_locks
-    assert registry.connected_addrs is connected
-    assert registry.connecting_addrs is connecting
-    assert registry.connected_owners is connected_owners
-    assert registry.connected_owner_ids is connected_owner_ids
-    assert registry.connected_marked_at is connected_marked_at
-    assert registry.connecting_owners is connecting_owners
-    assert registry.connecting_owner_ids is connecting_owner_ids
-    assert registry.connecting_marked_at is connecting_marked_at
-    assert registry.lock_holders is lock_holders
-    assert not registry.addr_locks
-    assert not registry.connected_addrs
-    assert not registry.connecting_addrs
-    assert not registry.connected_owners
-    assert not registry.connected_owner_ids
-    assert not registry.connected_marked_at
-    assert not registry.connecting_owners
-    assert not registry.connecting_owner_ids
-    assert not registry.connecting_marked_at
-    assert not registry.lock_holders
+        assert registry.addr_locks is addr_locks
+        assert registry.connected_addrs is connected
+        assert registry.connecting_addrs is connecting
+        assert registry.connected_owners is connected_owners
+        assert registry.connected_owner_ids is connected_owner_ids
+        assert registry.connected_marked_at is connected_marked_at
+        assert registry.connecting_owners is connecting_owners
+        assert registry.connecting_owner_ids is connecting_owner_ids
+        assert registry.connecting_marked_at is connecting_marked_at
+        assert registry.lock_holders is lock_holders
+        assert not registry.addr_locks
+        assert not registry.connected_addrs
+        assert not registry.connecting_addrs
+        assert not registry.connected_owners
+        assert not registry.connected_owner_ids
+        assert not registry.connected_marked_at
+        assert not registry.connecting_owners
+        assert not registry.connecting_owner_ids
+        assert not registry.connecting_marked_at
+        assert not registry.lock_holders
+    finally:
+        gating._clear_all_registries()

--- a/tests/test_ble_gating.py
+++ b/tests/test_ble_gating.py
@@ -584,3 +584,42 @@ class TestIsCurrentlyConnectedElsewhere:
 
         assert not _is_currently_connected_elsewhere("aabbccddeeff")
         assert key not in _CONNECTED_ADDRS
+
+
+def test_default_registry_owns_compatibility_collection_aliases() -> None:
+    """Legacy module collections should be identities owned by one registry."""
+    from meshtastic.interfaces.ble import gating
+
+    registry = gating._DEFAULT_REGISTRY
+    assert gating._REGISTRY_LOCK is registry.lock
+    assert gating._ADDR_LOCKS is registry.addr_locks
+    assert gating._CONNECTED_ADDRS is registry.connected_addrs
+    assert gating._CONNECTING_ADDRS is registry.connecting_addrs
+    assert gating._CONNECTED_OWNERS is registry.connected_owners
+    assert gating._CONNECTED_OWNER_IDS is registry.connected_owner_ids
+    assert gating._CONNECTED_MARKED_AT is registry.connected_marked_at
+    assert gating._CONNECTING_OWNERS is registry.connecting_owners
+    assert gating._CONNECTING_OWNER_IDS is registry.connecting_owner_ids
+    assert gating._CONNECTING_MARKED_AT is registry.connecting_marked_at
+    assert gating._LOCK_HOLDERS is registry.lock_holders
+
+
+def test_clear_all_registries_delegates_to_registry_owner() -> None:
+    """Reset helper should clear object-owned collections without rebinding them."""
+    from meshtastic.interfaces.ble import gating
+
+    registry = gating._DEFAULT_REGISTRY
+    addr_locks = registry.addr_locks
+    connected = registry.connected_addrs
+    connecting = registry.connecting_addrs
+
+    gating._mark_connecting("AA:BB:CC:DD:EE:FF")
+    gating._mark_connected("11:22:33:44:55:66")
+    gating._clear_all_registries()
+
+    assert registry.addr_locks is addr_locks
+    assert registry.connected_addrs is connected
+    assert registry.connecting_addrs is connecting
+    assert not registry.addr_locks
+    assert not registry.connected_addrs
+    assert not registry.connecting_addrs

--- a/tests/test_ble_gating.py
+++ b/tests/test_ble_gating.py
@@ -618,11 +618,13 @@ def test_clear_all_registries_delegates_to_registry_owner() -> None:
     connecting_owners = registry.connecting_owners
     connecting_owner_ids = registry.connecting_owner_ids
     connecting_marked_at = registry.connecting_marked_at
+    lock_holders = registry.lock_holders
 
     connecting_owner = object()
     connected_owner = object()
     gating._mark_connecting("AA:BB:CC:DD:EE:FF", owner=connecting_owner)
     gating._mark_connected("11:22:33:44:55:66", owner=connected_owner)
+    lock_holders["test-holder"] = 1
     gating._clear_all_registries()
 
     assert registry.addr_locks is addr_locks
@@ -634,6 +636,7 @@ def test_clear_all_registries_delegates_to_registry_owner() -> None:
     assert registry.connecting_owners is connecting_owners
     assert registry.connecting_owner_ids is connecting_owner_ids
     assert registry.connecting_marked_at is connecting_marked_at
+    assert registry.lock_holders is lock_holders
     assert not registry.addr_locks
     assert not registry.connected_addrs
     assert not registry.connecting_addrs
@@ -643,3 +646,4 @@ def test_clear_all_registries_delegates_to_registry_owner() -> None:
     assert not registry.connecting_owners
     assert not registry.connecting_owner_ids
     assert not registry.connecting_marked_at
+    assert not registry.lock_holders

--- a/tests/test_ble_integration_scenarios.py
+++ b/tests/test_ble_integration_scenarios.py
@@ -130,10 +130,10 @@ def test_client_manager_handles_concurrent_updates() -> None:
         thread.ident = 1
         thread.is_alive.return_value = True
 
-    thread_coordinator._create_thread.side_effect = (
-        lambda *_args, **_kwargs: _new_thread()
+    thread_coordinator._create_thread = MagicMock(
+        side_effect=lambda *_args, **_kwargs: _new_thread()
     )
-    thread_coordinator._start_thread.side_effect = _mark_started
+    thread_coordinator._start_thread = MagicMock(side_effect=_mark_started)
     error_handler = MagicMock()
 
     manager = ClientManager(state_manager, lock, thread_coordinator, error_handler)
@@ -226,7 +226,7 @@ def test_connection_validator_with_normalized_addresses() -> None:
 
     # Create mock client with various address formats
     mock_client = MagicMock()
-    mock_client.isConnected.return_value = True
+    mock_client.isConnected = MagicMock(return_value=True)
     mock_bleak = MagicMock()
     mock_bleak.address = "AA:BB:CC:DD:EE:FF"
     mock_client.bleak_client = mock_bleak

--- a/tests/test_ble_interface_coverage.py
+++ b/tests/test_ble_interface_coverage.py
@@ -1503,6 +1503,34 @@ def test_compat_dispatch_callable_ignores_synthesized_preferred_name() -> None:
     assert result == "legacy-result"
 
 
+def test_lifecycle_wrapper_ignores_synthesized_private_hook() -> None:
+    """Lifecycle wrappers should fall through to a declared public hook."""
+    calls: list[str] = []
+
+    class _DynamicLifecycleController:
+        def __getattr__(self, _name: str) -> object:
+            return lambda *_args, **_kwargs: False
+
+        def handle_disconnect(
+            self,
+            source: str,
+            *,
+            client: object | None = None,
+            bleak_client: object | None = None,
+        ) -> bool:
+            del client, bleak_client
+            calls.append(source)
+            return True
+
+    iface = _build_minimal_interface()
+    iface._get_lifecycle_controller = (  # type: ignore[method-assign]
+        lambda: _DynamicLifecycleController()
+    )
+
+    assert iface._handle_disconnect("declared-fallback") is True
+    assert calls == ["declared-fallback"]
+
+
 def test_compat_dispatch_callable_falls_back_to_legacy() -> None:
     """_compat_dispatch_callable should fall back to legacy name."""
     target = MagicMock()

--- a/tests/test_ble_interface_coverage.py
+++ b/tests/test_ble_interface_coverage.py
@@ -1200,6 +1200,60 @@ def test_get_or_create_collaborator_lockless_fallback_converges_racing_callers()
     assert iface._test_collaborator is results[0]
 
 
+def test_notification_registration_compat_state_probe_revalidates_outside_lock() -> None:
+    """Fallback registration probes must release and then revalidate state ownership."""
+
+    class _TrackingLock:
+        def __init__(self) -> None:
+            self._lock = threading.RLock()
+            self._depth = 0
+
+        @property
+        def held(self) -> bool:
+            return self._depth > 0
+
+        def __enter__(self) -> "_TrackingLock":
+            self._lock.acquire()
+            self._depth += 1
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            self._depth -= 1
+            self._lock.release()
+
+    class _Client:
+        def isConnected(self) -> bool:  # noqa: N802 - compatibility spelling
+            return True
+
+    lock = _TrackingLock()
+    client = _Client()
+    iface = SimpleNamespace(
+        _state_lock=lock,
+        _state_manager=SimpleNamespace(lock=lock),
+        _closed=False,
+        _connection_session_epoch=7,
+        client=None,
+        _client_publish_pending=True,
+    )
+    probe_lock_states: list[bool] = []
+
+    def _current_state() -> ConnectionState:
+        probe_lock_states.append(lock.held)
+        with lock:
+            iface._connection_session_epoch += 1
+        return ConnectionState.CONNECTING
+
+    iface._state_manager_current_state = _current_state
+
+    assert (
+        BLEInterface._is_notification_registration_current(  # noqa: SLF001
+            iface, client, 7  # type: ignore[arg-type]
+        )
+        is False
+    )
+    assert probe_lock_states == [False]
+
+
 # ============================================================================
 # Retry Policy Tests
 # ============================================================================

--- a/tests/test_ble_interface_coverage.py
+++ b/tests/test_ble_interface_coverage.py
@@ -980,15 +980,16 @@ def test_notification_dispatcher_reports_handler_error(
 def test_set_receive_wanted_delegates_to_explicit_controller_hook() -> None:
     """_set_receive_wanted should delegate to an explicitly declared lifecycle hook."""
     iface = _build_minimal_interface()
+    calls: list[bool] = []
 
-    mock_controller = MagicMock()
-    mock_controller._set_receive_wanted = MagicMock()
-    mock_controller._set_receive_wanted.side_effect = lambda **kwargs: None
+    class _DeclaredController:
+        def _set_receive_wanted(self, *, want_receive: bool) -> None:
+            calls.append(want_receive)
 
-    iface._lifecycle_controller = mock_controller
+    iface._lifecycle_controller = _DeclaredController()  # type: ignore[assignment]
 
     iface._set_receive_wanted(True)
-    mock_controller._set_receive_wanted.assert_called_once_with(want_receive=True)
+    assert calls == [True]
 
 
 def test_should_run_receive_loop_uses_explicit_controller_hook() -> None:
@@ -2024,10 +2025,8 @@ class _DynamicOnlyStateLock:
         raise AttributeError(name)
 
 
-def test_get_management_client_if_available_ignores_undeclared_lock_ownership(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """_get_management_client_if_available should ignore an undeclared lock ownership probe."""
+def test_get_management_client_if_available_ignores_undeclared_lock_ownership() -> None:
+    """Unlocked management lookup must not inspect private lock-ownership probes."""
     iface = _build_minimal_interface()
 
     dynamic_lock = _DynamicOnlyStateLock()
@@ -2042,25 +2041,11 @@ def test_get_management_client_if_available_ignores_undeclared_lock_ownership(
     assert dynamic_lock.dynamic_probe_lookups == 0
 
 
-def test_get_management_client_if_available_uses_locked_version(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """_get_management_client_if_available should use locked version when lock owned."""
+def test_get_management_client_if_available_uses_locked_version() -> None:
+    """Locked management lookup should explicitly dispatch to the locked handler."""
     iface = _build_minimal_interface()
 
     expected_client = DummyClient()
-
-    class OwnedStateLock:
-        def __enter__(self) -> "OwnedStateLock":
-            return self
-
-        def __exit__(self, *_args: object) -> None:
-            return None
-
-        def _is_owned(self) -> bool:
-            return True
-
-    iface._state_lock = OwnedStateLock()
 
     get_management_client_if_available_locked = MagicMock(return_value=expected_client)
     handler = SimpleNamespace(
@@ -2069,15 +2054,13 @@ def test_get_management_client_if_available_uses_locked_version(
     )
     iface._management_command_handler = handler
 
-    result = iface._get_management_client_if_available("test-address")
+    result = iface._get_management_client_if_available_locked("test-address")
     assert result is expected_client
     get_management_client_if_available_locked.assert_called_once_with("test-address")
 
 
-def test_get_management_client_for_target_ignores_undeclared_lock_ownership(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """_get_management_client_for_target should ignore an undeclared lock ownership probe."""
+def test_get_management_client_for_target_ignores_undeclared_lock_ownership() -> None:
+    """Unlocked target lookup must not inspect private lock-ownership probes."""
     iface = _build_minimal_interface()
 
     dynamic_lock = _DynamicOnlyStateLock()
@@ -2095,25 +2078,11 @@ def test_get_management_client_for_target_ignores_undeclared_lock_ownership(
     assert dynamic_lock.dynamic_probe_lookups == 0
 
 
-def test_get_management_client_for_target_uses_locked_version(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """_get_management_client_for_target should use locked version when lock owned."""
+def test_get_management_client_for_target_uses_locked_version() -> None:
+    """Locked target lookup should explicitly dispatch to the locked handler."""
     iface = _build_minimal_interface()
 
     expected_client = DummyClient()
-
-    class OwnedStateLock:
-        def __enter__(self) -> "OwnedStateLock":
-            return self
-
-        def __exit__(self, *_args: object) -> None:
-            return None
-
-        def _is_owned(self) -> bool:
-            return True
-
-    iface._state_lock = OwnedStateLock()
 
     get_management_client_for_target_locked = MagicMock(return_value=expected_client)
     handler = SimpleNamespace(
@@ -2122,7 +2091,7 @@ def test_get_management_client_for_target_uses_locked_version(
     )
     iface._management_command_handler = handler
 
-    result = iface._get_management_client_for_target(
+    result = iface._get_management_client_for_target_locked(
         "test-address",
         prefer_current_client=True,
     )

--- a/tests/test_ble_interface_coverage.py
+++ b/tests/test_ble_interface_coverage.py
@@ -970,31 +970,25 @@ def test_notification_dispatcher_reports_handler_error(
 
 
 # ============================================================================
-# Compatibility and Mock Handling Tests
+# Compatibility Dispatch Tests
 # ============================================================================
 
 
-def test_set_receive_wanted_handles_unconfigured_mock(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """_set_receive_wanted should handle unconfigured mock lifecycle controller."""
+def test_set_receive_wanted_delegates_to_explicit_controller_hook() -> None:
+    """_set_receive_wanted should delegate to an explicitly declared lifecycle hook."""
     iface = _build_minimal_interface()
 
-    # Create a mock that returns unconfigured mock callables
     mock_controller = MagicMock()
     mock_controller._set_receive_wanted = MagicMock()
     mock_controller._set_receive_wanted.side_effect = lambda **kwargs: None
 
     iface._lifecycle_controller = mock_controller
 
-    # Should not raise when dealing with unconfigured mocks
     iface._set_receive_wanted(True)
 
 
-def test_should_run_receive_loop_handles_unconfigured_mock(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """_should_run_receive_loop should handle unconfigured mock lifecycle controller."""
+def test_should_run_receive_loop_uses_explicit_controller_hook() -> None:
+    """_should_run_receive_loop should use an explicitly declared lifecycle hook."""
     iface = _build_minimal_interface()
 
     iface._lifecycle_controller = SimpleNamespace(should_run_receive_loop=lambda: False)
@@ -1002,10 +996,8 @@ def test_should_run_receive_loop_handles_unconfigured_mock(
     assert result is False
 
 
-def test_start_receive_thread_handles_unconfigured_mock(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """_start_receive_thread should handle unconfigured mock lifecycle controller."""
+def test_start_receive_thread_uses_explicit_controller_hook() -> None:
+    """_start_receive_thread should use an explicitly declared lifecycle hook."""
     iface = _build_minimal_interface()
 
     start_receive_thread = MagicMock(side_effect=lambda **kwargs: None)
@@ -1294,19 +1286,19 @@ def test_close_clears_connecting_state_with_exception(
     assert "Failed to clear connecting gates" in caplog.text
 
 
-def test_close_handles_lifecycle_close_exception(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Close should handle exceptions from lifecycle controller close."""
+def test_close_propagates_lifecycle_close_exception() -> None:
+    """Close should preserve failures raised by an explicit lifecycle collaborator."""
+
+    class _FailingLifecycleController:
+        @staticmethod
+        def _close(**_kwargs: object) -> None:
+            raise RuntimeError("Close failed")
+
     iface = _build_minimal_interface()
+    iface._lifecycle_controller = _FailingLifecycleController()  # type: ignore[assignment]
 
-    mock_controller = MagicMock()
-    mock_controller._close = MagicMock(side_effect=Exception("Close failed"))
-
-    iface._lifecycle_controller = mock_controller
-
-    # Should not raise despite exception in lifecycle close
-    iface.close()
+    with pytest.raises(RuntimeError, match="Close failed"):
+        iface.close()
 
 
 # ============================================================================
@@ -1921,13 +1913,12 @@ def test_client_manager_update_client_reference_dispatches() -> None:
 # ============================================================================
 
 
-def test_get_management_client_if_available_handles_unconfigured_mock_lock(
+def test_get_management_client_if_available_ignores_undeclared_lock_ownership(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """_get_management_client_if_available should handle unconfigured mock lock."""
+    """_get_management_client_if_available should ignore an undeclared lock ownership probe."""
     iface = _build_minimal_interface()
 
-    # Make state_lock an unconfigured mock
     iface._state_lock = MagicMock()
     iface._state_lock._is_owned = MagicMock()
 
@@ -1965,13 +1956,12 @@ def test_get_management_client_if_available_uses_locked_version(
     get_management_client_if_available_locked.assert_called_once_with("test-address")
 
 
-def test_get_management_client_for_target_handles_unconfigured_mock_lock(
+def test_get_management_client_for_target_ignores_undeclared_lock_ownership(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """_get_management_client_for_target should handle unconfigured mock lock."""
+    """_get_management_client_for_target should ignore an undeclared lock ownership probe."""
     iface = _build_minimal_interface()
 
-    # Make state_lock an unconfigured mock
     iface._state_lock = MagicMock()
     iface._state_lock._is_owned = MagicMock()
 

--- a/tests/test_ble_interface_coverage.py
+++ b/tests/test_ble_interface_coverage.py
@@ -985,6 +985,7 @@ def test_set_receive_wanted_delegates_to_explicit_controller_hook() -> None:
     iface._lifecycle_controller = mock_controller
 
     iface._set_receive_wanted(True)
+    mock_controller._set_receive_wanted.assert_called_once_with(want_receive=True)
 
 
 def test_should_run_receive_loop_uses_explicit_controller_hook() -> None:
@@ -1481,6 +1482,27 @@ def test_compat_dispatch_callable_prefers_public_name() -> None:
     target.public_method.assert_called_once()
 
 
+def test_compat_dispatch_callable_ignores_synthesized_preferred_name() -> None:
+    """Compatibility dispatch should prefer declared legacy hooks over dynamic proxies."""
+
+    class _DynamicCompatibilityTarget:
+        def __getattr__(self, _name: str) -> object:
+            return lambda: "dynamic-result"
+
+        def legacy_method(self) -> str:
+            return "legacy-result"
+
+    result = BLEInterface._compat_dispatch_callable(
+        _DynamicCompatibilityTarget(),
+        public_name="public_method",
+        legacy_name="legacy_method",
+        fallback_attr_name=None,
+        error_message="Method not found",
+    )
+
+    assert result == "legacy-result"
+
+
 def test_compat_dispatch_callable_falls_back_to_legacy() -> None:
     """_compat_dispatch_callable should fall back to legacy name."""
     target = MagicMock()
@@ -1913,14 +1935,33 @@ def test_client_manager_update_client_reference_dispatches() -> None:
 # ============================================================================
 
 
+class _DynamicOnlyStateLock:
+    """Lock double whose ownership probe exists only through ``__getattr__``."""
+
+    def __init__(self) -> None:
+        self.dynamic_probe_lookups = 0
+
+    def __enter__(self) -> "_DynamicOnlyStateLock":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def __getattr__(self, name: str) -> object:
+        if name == "_is_owned":
+            self.dynamic_probe_lookups += 1
+            return lambda: True
+        raise AttributeError(name)
+
+
 def test_get_management_client_if_available_ignores_undeclared_lock_ownership(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """_get_management_client_if_available should ignore an undeclared lock ownership probe."""
     iface = _build_minimal_interface()
 
-    iface._state_lock = MagicMock()
-    iface._state_lock._is_owned = MagicMock()
+    dynamic_lock = _DynamicOnlyStateLock()
+    iface._state_lock = dynamic_lock
 
     handler = MagicMock()
     handler.get_management_client_if_available = MagicMock(return_value=None)
@@ -1928,6 +1969,7 @@ def test_get_management_client_if_available_ignores_undeclared_lock_ownership(
 
     result = iface._get_management_client_if_available("test-address")
     assert result is None
+    assert dynamic_lock.dynamic_probe_lookups == 0
 
 
 def test_get_management_client_if_available_uses_locked_version(
@@ -1939,6 +1981,12 @@ def test_get_management_client_if_available_uses_locked_version(
     expected_client = DummyClient()
 
     class OwnedStateLock:
+        def __enter__(self) -> "OwnedStateLock":
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
         def _is_owned(self) -> bool:
             return True
 
@@ -1962,8 +2010,8 @@ def test_get_management_client_for_target_ignores_undeclared_lock_ownership(
     """_get_management_client_for_target should ignore an undeclared lock ownership probe."""
     iface = _build_minimal_interface()
 
-    iface._state_lock = MagicMock()
-    iface._state_lock._is_owned = MagicMock()
+    dynamic_lock = _DynamicOnlyStateLock()
+    iface._state_lock = dynamic_lock
 
     handler = MagicMock()
     handler.get_management_client_for_target = MagicMock(return_value=None)
@@ -1974,6 +2022,7 @@ def test_get_management_client_for_target_ignores_undeclared_lock_ownership(
         prefer_current_client=True,
     )
     assert result is None
+    assert dynamic_lock.dynamic_probe_lookups == 0
 
 
 def test_get_management_client_for_target_uses_locked_version(
@@ -1985,6 +2034,12 @@ def test_get_management_client_for_target_uses_locked_version(
     expected_client = DummyClient()
 
     class OwnedStateLock:
+        def __enter__(self) -> "OwnedStateLock":
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
         def _is_owned(self) -> bool:
             return True
 

--- a/tests/test_ble_interface_coverage.py
+++ b/tests/test_ble_interface_coverage.py
@@ -1160,6 +1160,45 @@ def test_get_or_create_collaborator_uses_double_checked_locking() -> None:
     assert result1 is result2
 
 
+def test_get_or_create_collaborator_lockless_fallback_converges_racing_callers() -> None:
+    """Partial lockless interfaces must still return one collaborator owner."""
+
+    class _PartialInterface:
+        pass
+
+    iface = _PartialInterface()
+    rendezvous = threading.Barrier(3)
+    created: list[object] = []
+    results: list[object] = []
+
+    def _factory() -> object:
+        candidate = object()
+        created.append(candidate)
+        time.sleep(0.02)
+        return candidate
+
+    def _resolve() -> None:
+        rendezvous.wait(timeout=2.0)
+        results.append(
+            BLEInterface._get_or_create_collaborator(  # noqa: SLF001
+                iface, "_test_collaborator", _factory  # type: ignore[arg-type]
+            )
+        )
+
+    workers = [threading.Thread(target=_resolve) for _ in range(2)]
+    for worker in workers:
+        worker.start()
+    rendezvous.wait(timeout=2.0)
+    for worker in workers:
+        worker.join(timeout=2.0)
+
+    assert all(not worker.is_alive() for worker in workers)
+    assert len(created) == 1
+    assert len(results) == 2
+    assert results[0] is results[1]
+    assert iface._test_collaborator is results[0]
+
+
 # ============================================================================
 # Retry Policy Tests
 # ============================================================================

--- a/tests/test_ble_interface_coverage.py
+++ b/tests/test_ble_interface_coverage.py
@@ -178,6 +178,7 @@ def _build_minimal_interface() -> BLEInterface:
         notification_manager=iface._notification_manager,
         error_handler_provider=lambda: MagicMock(),
         trigger_read_event=lambda: None,
+        registration_current_provider=lambda _client, _epoch: True,
     )
     # Set up required attributes for lifecycle controllers
     iface._lifecycle_controller = MagicMock()
@@ -941,6 +942,7 @@ def test_notification_dispatcher_handles_handler_error(
         notification_manager=NotificationManager(),
         error_handler_provider=lambda: MagicMock(),
         trigger_read_event=lambda: None,
+        registration_current_provider=lambda _client, _epoch: True,
     )
 
     dispatcher.handle_malformed_fromnum("Test reason", exc_info=False)
@@ -963,6 +965,7 @@ def test_notification_dispatcher_reports_handler_error(
             handle_unhandled_exception=_report_exception
         ),
         trigger_read_event=lambda: None,
+        registration_current_provider=lambda _client, _epoch: True,
     )
 
     dispatcher.report_notification_handler_error("Test handler error")

--- a/tests/test_ble_interface_discovery_compat.py
+++ b/tests/test_ble_interface_discovery_compat.py
@@ -233,6 +233,7 @@ def test_invoke_safe_execute_compat_reports_handler_failure_after_execution() ->
         notification_manager=NotificationManager(),
         error_handler_provider=lambda: SimpleNamespace(),
         trigger_read_event=lambda: None,
+        registration_current_provider=lambda _client, _epoch: True,
     )
     reported_errors: list[BaseException] = []
     fallback_runs: list[str] = []

--- a/tests/test_ble_interface_discovery_compat.py
+++ b/tests/test_ble_interface_discovery_compat.py
@@ -738,6 +738,13 @@ def test_discovery_manager_accepts_discover_underscore_only_factory() -> None:
     }
 
     class UnderscoreDiscoveryClient:
+        def __getattr__(self, name: str) -> object:
+            if name == "discover":
+                return lambda **_kwargs: (_ for _ in ()).throw(
+                    AssertionError("dynamic discover hook must be ignored")
+                )
+            raise AttributeError(name)
+
         @staticmethod
         def _discover(**_kwargs: object) -> dict[str, Any]:
             return discover_result
@@ -780,6 +787,42 @@ def test_discovery_manager_prefers_configured_underscore_discover_when_public_mi
     devices = manager.discover_devices(address=None)
     assert devices == [filtered_device]
     client._discover.assert_called_once()
+
+
+def test_discovery_manager_ignores_synthesized_await_bridge() -> None:
+    """Declared legacy await bridges should beat synthesized preferred members."""
+    filtered_device = _create_ble_device("AA:BB:CC:DD:EE:FF", "Filtered")
+    discover_result = {
+        "filtered": (
+            filtered_device,
+            SimpleNamespace(service_uuids=[SERVICE_UUID]),
+        ),
+    }
+
+    async def _discover() -> dict[str, Any]:
+        return discover_result
+
+    class _LegacyAwaitBridgeClient:
+        def __getattr__(self, name: str) -> object:
+            if name == "async_await":
+                return lambda _awaitable: (_ for _ in ()).throw(
+                    AssertionError("dynamic await bridge must be ignored")
+                )
+            raise AttributeError(name)
+
+        @staticmethod
+        def discover(**_kwargs: object) -> Any:
+            return _discover()
+
+        @staticmethod
+        def _async_await(awaitable: Any) -> dict[str, Any]:
+            return asyncio.run(awaitable)
+
+    manager = DiscoveryManager(
+        client_factory=lambda **_kwargs: _LegacyAwaitBridgeClient()
+    )
+
+    assert manager._discover_devices(address=None) == [filtered_device]
 
 
 def test_discovery_manager_discards_cached_client_on_non_kwarg_typeerror(

--- a/tests/test_ble_interface_discovery_compat.py
+++ b/tests/test_ble_interface_discovery_compat.py
@@ -750,10 +750,10 @@ def test_discovery_manager_accepts_discover_underscore_only_factory() -> None:
     assert devices == [filtered_device]
 
 
-def test_discovery_manager_prefers_configured_underscore_discover_over_unconfigured_mock_public_discover() -> (
+def test_discovery_manager_prefers_configured_underscore_discover_when_public_missing() -> (
     None
 ):
-    """Verify discovery prefers configured ``_discover`` over unconfigured ``discover``.
+    """Verify discovery prefers configured ``_discover`` when ``discover`` is absent.
 
     Returns
     -------
@@ -767,20 +767,19 @@ def test_discovery_manager_prefers_configured_underscore_discover_over_unconfigu
         ),
     }
     client = MagicMock()
-    client._discover.return_value = discover_result
+    client.discover = None
+    client._discover = MagicMock(return_value=discover_result)
     manager = DiscoveryManager(client_factory=lambda **_kwargs: client)
 
     devices = manager._discover_devices(address=None)
 
     assert devices == [filtered_device]
     client._discover.assert_called_once()
-    client.discover.assert_not_called()
 
     client._discover.reset_mock()
     devices = manager.discover_devices(address=None)
     assert devices == [filtered_device]
     client._discover.assert_called_once()
-    client.discover.assert_not_called()
 
 
 def test_discovery_manager_discards_cached_client_on_non_kwarg_typeerror(

--- a/tests/test_ble_interface_management_core.py
+++ b/tests/test_ble_interface_management_core.py
@@ -912,7 +912,7 @@ def test_ble_client_management_ignores_synthesized_optional_method() -> None:
     client = BLEClient.__new__(BLEClient)
     client.bleak_client = _DynamicBleakClient()  # type: ignore[assignment]
 
-    with pytest.raises(BLEClient.BLEError, match="pair"):
+    with pytest.raises(BLEClient.BLEError, match=re.escape("pair unsupported")):
         client._run_optional_management_method(  # noqa: SLF001
             method_name="pair",
             await_timeout=1.0,

--- a/tests/test_ble_interface_management_core.py
+++ b/tests/test_ble_interface_management_core.py
@@ -804,7 +804,7 @@ def test_execute_management_command_falls_back_when_existing_client_disappears(
 
     monkeypatch.setattr(
         iface,
-        "_get_management_client_if_available",
+        "_get_management_client_if_available_locked",
         _get_management_client,
     )
     monkeypatch.setattr(
@@ -825,7 +825,7 @@ def test_execute_management_command_requires_resolved_target_address(
     """Management command path should fail when no target address can be resolved."""
     iface = _build_interface(monkeypatch, DummyClient(), start_receive_thread=False)
     monkeypatch.setattr(
-        iface, "_get_management_client_if_available", lambda _address: None
+        iface, "_get_management_client_if_available_locked", lambda _address: None
     )
     monkeypatch.setattr(
         iface, "_resolve_target_address_for_management", lambda _address: None

--- a/tests/test_ble_interface_management_core.py
+++ b/tests/test_ble_interface_management_core.py
@@ -912,10 +912,11 @@ def test_ble_client_management_ignores_synthesized_optional_method() -> None:
     client = BLEClient.__new__(BLEClient)
     client.bleak_client = _DynamicBleakClient()  # type: ignore[assignment]
 
-    with pytest.raises(BLEClient.BLEError, match=re.escape("pair unsupported")):
+    with pytest.raises(BLEClient.BLEError) as exc_info:
         client._run_optional_management_method(  # noqa: SLF001
             method_name="pair",
             await_timeout=1.0,
             not_initialized_error=BLECLIENT_ERROR_CANNOT_PAIR_NOT_INITIALIZED,
             unsupported_error="pair unsupported",
         )
+    assert str(exc_info.value) == "pair unsupported"

--- a/tests/test_ble_interface_management_core.py
+++ b/tests/test_ble_interface_management_core.py
@@ -897,3 +897,25 @@ def test_dummy_client_management_rejects_cleared_backend(
     else:
         with pytest.raises(BLEClient.BLEError, match=re.escape(expected_error)):
             client.unpair()
+
+
+def test_ble_client_management_ignores_synthesized_optional_method() -> None:
+    """Optional management operations should require a declared backend method."""
+
+    class _DynamicBleakClient:
+        def __getattr__(self, _name: str) -> object:
+            async def _dynamic(**_kwargs: object) -> None:
+                return None
+
+            return _dynamic
+
+    client = BLEClient.__new__(BLEClient)
+    client.bleak_client = _DynamicBleakClient()  # type: ignore[assignment]
+
+    with pytest.raises(BLEClient.BLEError, match="pair"):
+        client._run_optional_management_method(  # noqa: SLF001
+            method_name="pair",
+            await_timeout=1.0,
+            not_initialized_error=BLECLIENT_ERROR_CANNOT_PAIR_NOT_INITIALIZED,
+            unsupported_error="pair unsupported",
+        )

--- a/tests/test_ble_interface_shutdown_notifications.py
+++ b/tests/test_ble_interface_shutdown_notifications.py
@@ -503,7 +503,7 @@ class _ClientWithCallbacks(DummyClient):
             self.callbacks[uuid] = cast(Callable[[Any, bytes], None], args[1])
 
 
-def test_register_notifications_safe_call_inline_fallback_when_safe_execute_unconfigured(
+def test_register_notifications_safe_call_inline_fallback_when_safe_execute_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Notification wrappers should use inline fallback when safe_execute hooks are unconfigured."""
@@ -535,8 +535,6 @@ def test_register_notifications_safe_call_inline_fallback_when_safe_execute_unco
         client.callbacks[LOGRADIO_UUID]("sender", b"log")
 
         assert errors == ["Error in log notification handler"]
-        safe_execute.assert_not_called()
-        legacy_safe_execute.assert_not_called()
     finally:
         iface.close()
 

--- a/tests/test_ble_interface_shutdown_notifications.py
+++ b/tests/test_ble_interface_shutdown_notifications.py
@@ -840,6 +840,46 @@ def test_register_notifications_rolls_back_if_session_changes_during_start(
         iface.close()
 
 
+@pytest.mark.parametrize("characteristic", [LEGACY_LOGRADIO_UUID, LOGRADIO_UUID])
+def test_register_notifications_stale_optional_subscription_stops_once(
+    monkeypatch: pytest.MonkeyPatch,
+    characteristic: str,
+) -> None:
+    """A stale optional subscription should be stopped exactly once."""
+    iface_holder: dict[str, ble_mod.BLEInterface] = {}
+
+    class _OptionalStaleClient(DummyClient):
+        def __init__(self) -> None:
+            super().__init__()
+            self.start_notify_calls: list[str] = []
+
+        def has_characteristic(self, uuid: str) -> bool:
+            return uuid == characteristic
+
+        def start_notify(self, *args: object, **_kwargs: object) -> None:
+            if not args:
+                return
+            started = cast(str, args[0])
+            self.start_notify_calls.append(started)
+            if started == characteristic:
+                iface = iface_holder["iface"]
+                with iface._state_lock:
+                    iface._connection_session_epoch += 1
+
+    client = _OptionalStaleClient()
+    iface = _build_interface(monkeypatch, client, start_receive_thread=False)
+    iface_holder["iface"] = iface
+    try:
+        iface._register_notifications(cast(BLEClient, client))
+
+        assert client.start_notify_calls == [characteristic]
+        assert client.stop_notify_calls == [characteristic]
+        assert not iface._notification_dispatcher._started_notify_characteristics
+        assert iface._fromnum_notify_enabled is False
+    finally:
+        iface.close()
+
+
 def test_register_notifications_rolls_back_if_client_disconnects_during_start(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_ble_interface_shutdown_notifications.py
+++ b/tests/test_ble_interface_shutdown_notifications.py
@@ -568,6 +568,7 @@ def test_register_notifications_ignores_synthesized_public_error_reporter() -> N
         notification_manager=NotificationManager(),
         error_handler_provider=lambda: None,
         trigger_read_event=lambda: None,
+        registration_current_provider=lambda _client, _epoch: True,
     )
     dispatcher.register_notifications(
         iface,  # type: ignore[arg-type]
@@ -709,6 +710,160 @@ def test_register_notifications_reuses_cached_wrapper_with_latest_handlers(
     finally:
         iface.close()
 
+
+
+class _FromNumRegistrationClient(DummyClient):
+    """Notification-capable client for connection-finalization ownership tests."""
+
+    def __init__(
+        self,
+        address: str = "dummy",
+        *,
+        on_fromnum_start: Callable[["_FromNumRegistrationClient"], None] | None = None,
+    ) -> None:
+        super().__init__()
+        self.address = address
+        assert self.bleak_client is not None
+        self.bleak_client.address = address
+        self.on_fromnum_start = on_fromnum_start
+        self.start_notify_calls: list[str] = []
+
+    def has_characteristic(self, uuid: str) -> bool:
+        """Expose only the critical FROMNUM notification characteristic."""
+        return uuid == FROMNUM_UUID
+
+    def start_notify(self, *args: object, **_kwargs: object) -> None:
+        """Record FROMNUM subscription and optionally mutate lifecycle state."""
+        if not args:
+            return
+        characteristic = cast(str, args[0])
+        self.start_notify_calls.append(characteristic)
+        if characteristic == FROMNUM_UUID and self.on_fromnum_start is not None:
+            self.on_fromnum_start(self)
+
+
+def _prepare_provisional_notification_registration(
+    iface: ble_mod.BLEInterface,
+    *,
+    published_client: DummyClient | None,
+    replacement_pending: bool = False,
+) -> int:
+    """Place an interface in the pre-publication CONNECTING phase."""
+    with iface._state_lock:
+        iface.client = published_client
+        iface._disconnect_notified = False
+        iface._client_publish_pending = True
+        iface._client_replacement_pending = replacement_pending
+        iface._connection_session_epoch += 1
+        iface._state_manager._reset_to_disconnected()
+        assert iface._state_manager._transition_to(ConnectionState.CONNECTING)
+        return iface._connection_session_epoch
+
+
+def test_register_notifications_keeps_fromnum_during_provisional_connect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FROMNUM registration must survive normal pre-publication finalization."""
+    client = _FromNumRegistrationClient()
+    iface = _build_interface(monkeypatch, client, start_receive_thread=False)
+    try:
+        _prepare_provisional_notification_registration(iface, published_client=None)
+
+        iface._register_notifications(cast(BLEClient, client))
+
+        assert client.start_notify_calls == [FROMNUM_UUID]
+        assert client.stop_notify_calls == []
+        assert iface._fromnum_notify_enabled is True
+        assert iface._receive_recovery_controller._should_poll_without_notify() is False
+        assert FROMNUM_UUID in iface._notification_dispatcher._started_notify_characteristics
+    finally:
+        with iface._state_lock:
+            iface.client = client
+            iface._client_publish_pending = False
+        iface.close()
+
+
+def test_register_notifications_keeps_fromnum_during_client_replacement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A replacement client may register before replacing the published client."""
+    old_client = _FromNumRegistrationClient("old")
+    new_client = _FromNumRegistrationClient("new")
+    iface = _build_interface(monkeypatch, old_client, start_receive_thread=False)
+    try:
+        _prepare_provisional_notification_registration(
+            iface,
+            published_client=old_client,
+            replacement_pending=True,
+        )
+
+        iface._register_notifications(cast(BLEClient, new_client))
+
+        assert new_client.start_notify_calls == [FROMNUM_UUID]
+        assert new_client.stop_notify_calls == []
+        assert iface._fromnum_notify_enabled is True
+    finally:
+        with iface._state_lock:
+            iface.client = new_client
+            iface._client_publish_pending = False
+            iface._client_replacement_pending = False
+        iface.close()
+
+
+def test_register_notifications_rolls_back_if_session_changes_during_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Session rollover during notification I/O must invalidate registration."""
+    iface_holder: dict[str, ble_mod.BLEInterface] = {}
+
+    def _roll_session(_client: _FromNumRegistrationClient) -> None:
+        iface = iface_holder["iface"]
+        with iface._state_lock:
+            iface._client_publish_pending = False
+            iface._connection_session_epoch += 1
+
+    client = _FromNumRegistrationClient(on_fromnum_start=_roll_session)
+    iface = _build_interface(monkeypatch, client, start_receive_thread=False)
+    iface_holder["iface"] = iface
+    try:
+        _prepare_provisional_notification_registration(iface, published_client=None)
+
+        iface._register_notifications(cast(BLEClient, client))
+
+        assert client.start_notify_calls == [FROMNUM_UUID]
+        assert client.stop_notify_calls == [FROMNUM_UUID]
+        assert iface._fromnum_notify_enabled is False
+        assert not iface._notification_dispatcher._started_notify_characteristics
+    finally:
+        with iface._state_lock:
+            iface.client = client
+        iface.close()
+
+
+def test_register_notifications_rolls_back_if_client_disconnects_during_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A disconnected provisional client must not retain its subscription."""
+
+    def _disconnect_candidate(candidate: _FromNumRegistrationClient) -> None:
+        candidate._initialized = False
+        candidate.bleak_client = None
+
+    client = _FromNumRegistrationClient(on_fromnum_start=_disconnect_candidate)
+    iface = _build_interface(monkeypatch, client, start_receive_thread=False)
+    try:
+        _prepare_provisional_notification_registration(iface, published_client=None)
+
+        iface._register_notifications(cast(BLEClient, client))
+
+        assert client.start_notify_calls == [FROMNUM_UUID]
+        assert client.stop_notify_calls == [FROMNUM_UUID]
+        assert iface._fromnum_notify_enabled is False
+        assert not iface._notification_dispatcher._started_notify_characteristics
+    finally:
+        with iface._state_lock:
+            iface.client = client
+        iface.close()
 
 def test_register_notifications_retries_fromnum_notify_acquired_once(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_ble_interface_shutdown_notifications.py
+++ b/tests/test_ble_interface_shutdown_notifications.py
@@ -783,6 +783,71 @@ def test_register_notifications_keeps_fromnum_during_provisional_connect(
         iface.close()
 
 
+def test_register_notifications_serializes_overlapping_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One dispatcher must not overlap backend registration transactions."""
+    client = _FromNumRegistrationClient()
+    iface = _build_interface(monkeypatch, client, start_receive_thread=False)
+    _prepare_provisional_notification_registration(iface, published_client=None)
+
+    first_backend_started = threading.Event()
+    second_backend_started = threading.Event()
+    release_first_backend = threading.Event()
+    start_barrier = threading.Barrier(3)
+    start_count_lock = threading.Lock()
+    start_count = 0
+    failures: list[BaseException] = []
+    original_start_notify = client.start_notify
+
+    def _blocking_start_notify(*args: object, **kwargs: object) -> None:
+        nonlocal start_count
+        original_start_notify(*args, **kwargs)
+        if not args or args[0] != FROMNUM_UUID:
+            return
+        with start_count_lock:
+            start_count += 1
+            current_start = start_count
+        if current_start == 1:
+            first_backend_started.set()
+            assert release_first_backend.wait(timeout=2.0)
+        else:
+            second_backend_started.set()
+
+    client.start_notify = _blocking_start_notify  # type: ignore[method-assign]
+
+    def _register() -> None:
+        try:
+            start_barrier.wait(timeout=2.0)
+            iface._register_notifications(cast(BLEClient, client))
+        except BaseException as exc:  # noqa: BLE001 - surfaced below
+            failures.append(exc)
+
+    workers = [threading.Thread(target=_register) for _ in range(2)]
+    try:
+        for worker in workers:
+            worker.start()
+        start_barrier.wait(timeout=2.0)
+        assert first_backend_started.wait(timeout=2.0)
+        assert not second_backend_started.wait(timeout=0.1)
+        release_first_backend.set()
+        for worker in workers:
+            worker.join(timeout=2.0)
+
+        assert all(not worker.is_alive() for worker in workers)
+        assert not failures, failures
+        assert client.start_notify_calls == [FROMNUM_UUID]
+        assert iface._fromnum_notify_enabled is True
+    finally:
+        release_first_backend.set()
+        for worker in workers:
+            worker.join(timeout=2.0)
+        with iface._state_lock:
+            iface.client = client
+            iface._client_publish_pending = False
+        iface.close()
+
+
 def test_register_notifications_keeps_fromnum_during_client_replacement(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1186,7 +1251,7 @@ def test_reconnect_worker_successful_attempt() -> None:
             self.reset_called = False
             self._attempt_count = 0
 
-        def _reset(self) -> None:
+        def reset(self) -> None:
             """Reset the retry policy to its initial state.
 
             Sets the internal attempt counter to 0 and records that a reset occurred by setting `reset_called` to True.
@@ -1194,11 +1259,11 @@ def test_reconnect_worker_successful_attempt() -> None:
             self.reset_called = True
             self._attempt_count = 0
 
-        def _get_attempt_count(self) -> int:
+        def get_attempt_count(self) -> int:
             """Return the internal attempt count for ReconnectWorker tests."""
             return self._attempt_count
 
-        def _next_attempt(self) -> tuple[float, bool]:
+        def next_attempt(self) -> tuple[float, bool]:
             """Determine the delay before the next retry and whether another attempt should be made.
 
             Increments the internal attempt counter as a side effect.
@@ -1342,7 +1407,7 @@ def test_reconnect_worker_respects_retry_limits(
             self.reset_called = False
             self.attempts = 0
 
-        def _reset(self) -> None:
+        def reset(self) -> None:
             """Mark the retry policy as reset and clear its attempt counter.
 
             Sets the internal `reset_called` flag to True and resets `attempts` to 0.
@@ -1350,11 +1415,11 @@ def test_reconnect_worker_respects_retry_limits(
             self.reset_called = True
             self.attempts = 0
 
-        def _get_attempt_count(self) -> int:
+        def get_attempt_count(self) -> int:
             """Return the internal attempt count for ReconnectWorker tests."""
             return self.attempts
 
-        def _next_attempt(self) -> tuple[float, bool]:
+        def next_attempt(self) -> tuple[float, bool]:
             """Return the delay before the next retry and whether another retry should be attempted.
 
             Returns

--- a/tests/test_ble_interface_shutdown_notifications.py
+++ b/tests/test_ble_interface_shutdown_notifications.py
@@ -1454,7 +1454,7 @@ def test_register_notifications_rolls_back_backend_if_local_tracking_fails(
 ) -> None:
     """A local FROMNUM tracking failure must unwind the active backend notify."""
     client = _FromNumRegistrationClient()
-    iface = _build_interface(monkeypatch, client)
+    iface = _build_interface(monkeypatch, client, start_receive_thread=False)
     try:
         _prepare_provisional_notification_registration(iface, published_client=None)
 

--- a/tests/test_ble_interface_shutdown_notifications.py
+++ b/tests/test_ble_interface_shutdown_notifications.py
@@ -537,6 +537,54 @@ def test_register_notifications_safe_call_inline_fallback_when_safe_execute_miss
         iface.close()
 
 
+def test_register_notifications_ignores_synthesized_public_error_reporter() -> None:
+    """A synthesized public reporter must not mask the declared legacy fallback."""
+    from meshtastic.interfaces.ble.notifications import (
+        BLENotificationDispatcher,
+        NotificationManager,
+    )
+
+    client = _ClientWithCallbacks()
+    legacy_errors: list[str] = []
+    dynamic_errors: list[str] = []
+
+    class _Iface:
+        _connection_session_epoch = 1
+        BLEError = BLEClient.BLEError
+
+        def __init__(self) -> None:
+            self.client = client
+
+        def _report_notification_handler_error(self, message: str) -> None:
+            legacy_errors.append(message)
+
+        def __getattr__(self, name: str) -> object:
+            if name == "report_notification_handler_error":
+                return lambda message: dynamic_errors.append(message)
+            raise AttributeError(name)
+
+    iface = _Iface()
+    dispatcher = BLENotificationDispatcher(
+        notification_manager=NotificationManager(),
+        error_handler_provider=lambda: None,
+        trigger_read_event=lambda: None,
+    )
+    dispatcher.register_notifications(
+        iface,  # type: ignore[arg-type]
+        cast(BLEClient, client),
+        legacy_log_handler=lambda _sender, _data: None,
+        log_handler=lambda _sender, _data: (_ for _ in ()).throw(
+            RuntimeError("handler boom")
+        ),
+        from_num_handler=lambda _sender, _data: None,
+    )
+
+    client.callbacks[LOGRADIO_UUID]("sender", b"log")
+
+    assert legacy_errors == ["Error in log notification handler"]
+    assert dynamic_errors == []
+
+
 def test_register_notifications_safe_execute_fallback_still_invokes_handler(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_ble_interface_shutdown_notifications.py
+++ b/tests/test_ble_interface_shutdown_notifications.py
@@ -1445,3 +1445,41 @@ def test_reconnect_worker_respects_retry_limits(
     assert sleep_calls == [0.25]
     assert iface._reconnect_policy.reset_called is True
     assert iface._reconnect_scheduler.cleared is True
+
+
+@pytest.mark.parametrize("failure_hook", ["get_callback", "subscribe"])
+def test_register_notifications_rolls_back_backend_if_local_tracking_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    failure_hook: str,
+) -> None:
+    """A local FROMNUM tracking failure must unwind the active backend notify."""
+    client = _FromNumRegistrationClient()
+    iface = _build_interface(monkeypatch, client)
+    try:
+        _prepare_provisional_notification_registration(iface, published_client=None)
+
+        if failure_hook == "get_callback":
+            monkeypatch.setattr(
+                iface._notification_manager,
+                "_get_callback",
+                lambda _uuid: (_ for _ in ()).throw(
+                    RuntimeError("local callback lookup failed")
+                ),
+            )
+        else:
+            monkeypatch.setattr(
+                iface._notification_manager,
+                "_subscribe",
+                lambda _uuid, _callback: (_ for _ in ()).throw(
+                    RuntimeError("local subscription tracking failed")
+                ),
+            )
+
+        iface._register_notifications(cast(BLEClient, client))
+
+        assert client.start_notify_calls == [FROMNUM_UUID]
+        assert client.stop_notify_calls == [FROMNUM_UUID]
+        assert iface._fromnum_notify_enabled is False
+        assert not iface._notification_dispatcher._started_notify_characteristics
+    finally:
+        iface.close()

--- a/tests/test_ble_interface_shutdown_notifications.py
+++ b/tests/test_ble_interface_shutdown_notifications.py
@@ -511,12 +511,10 @@ def test_register_notifications_safe_call_inline_fallback_when_safe_execute_miss
     client = _ClientWithCallbacks()
     iface = _build_interface(monkeypatch, client, start_receive_thread=False)
     errors: list[str] = []
-    safe_execute = MagicMock()
-    legacy_safe_execute = MagicMock()
     try:
         iface.error_handler = SimpleNamespace(
-            safe_execute=safe_execute,
-            _safe_execute=legacy_safe_execute,
+            safe_execute=None,
+            _safe_execute=None,
         )
         monkeypatch.setattr(
             iface,

--- a/tests/test_ble_interface_shutdown_notifications.py
+++ b/tests/test_ble_interface_shutdown_notifications.py
@@ -711,7 +711,6 @@ def test_register_notifications_reuses_cached_wrapper_with_latest_handlers(
         iface.close()
 
 
-
 class _FromNumRegistrationClient(DummyClient):
     """Notification-capable client for connection-finalization ownership tests."""
 
@@ -798,6 +797,11 @@ def test_register_notifications_serializes_overlapping_calls(
     start_count_lock = threading.Lock()
     start_count = 0
     failures: list[BaseException] = []
+    registration_entries = 0
+    registration_entry_lock = threading.Lock()
+    second_worker_entered = threading.Event()
+    dispatcher = iface._get_notification_dispatcher()
+    original_register_notifications = dispatcher.register_notifications
     original_start_notify = client.start_notify
 
     def _blocking_start_notify(*args: object, **kwargs: object) -> None:
@@ -816,6 +820,16 @@ def test_register_notifications_serializes_overlapping_calls(
 
     client.start_notify = _blocking_start_notify  # type: ignore[method-assign]
 
+    def _observed_register_notifications(*args: object, **kwargs: object) -> None:
+        nonlocal registration_entries
+        with registration_entry_lock:
+            registration_entries += 1
+            if registration_entries == 2:
+                second_worker_entered.set()
+        original_register_notifications(*args, **kwargs)  # type: ignore[arg-type]
+
+    dispatcher.register_notifications = _observed_register_notifications  # type: ignore[method-assign]
+
     def _register() -> None:
         try:
             start_barrier.wait(timeout=2.0)
@@ -829,6 +843,7 @@ def test_register_notifications_serializes_overlapping_calls(
             worker.start()
         start_barrier.wait(timeout=2.0)
         assert first_backend_started.wait(timeout=2.0)
+        assert second_worker_entered.wait(timeout=2.0)
         assert not second_backend_started.wait(timeout=0.1)
         release_first_backend.set()
         for worker in workers:

--- a/tests/test_ble_lifecycle_controller.py
+++ b/tests/test_ble_lifecycle_controller.py
@@ -292,43 +292,6 @@ class TestBLELifecycleControllerHookResolution:
         configured_hook.assert_called_once_with()
         assert resolved_is_closing == [True]
 
-    def test_resolve_hook_with_unconfigured_mock_returns_fallback(self) -> None:
-        """_resolve_hook should return fallback when hook is an unconfigured mock."""
-        # An unconfigured MagicMock (default behavior)
-        unconfigured_hook = MagicMock()
-        resolved_is_closing: list[bool] = []
-
-        def _discard_invalidated_connected_client(
-            *_args: object,
-            **kwargs: object,
-        ) -> None:
-            is_closing_getter = kwargs.get("is_closing_getter")
-            if callable(is_closing_getter):
-                resolved_is_closing.append(is_closing_getter())
-
-        mock_iface = SimpleNamespace(_state_manager_is_closing=unconfigured_hook)
-        mock_ownership = SimpleNamespace(
-            _discard_invalidated_connected_client=_discard_invalidated_connected_client
-        )
-
-        controller = BLELifecycleController(mock_iface)
-        controller._connection_ownership = mock_ownership  # type: ignore[assignment]
-
-        mock_client = SimpleNamespace(address="test-addr")
-        with patch(
-            "meshtastic.interfaces.ble.lifecycle_service.BLELifecycleService._state_manager_is_closing",
-            return_value=True,
-        ) as state_manager_is_closing:
-            # This should use fallback instead of the unconfigured mock.
-            controller._discard_invalidated_connected_client(
-                mock_client,
-                restore_address=None,
-                restore_last_connection_request=None,
-            )
-
-        state_manager_is_closing.assert_called_once_with(mock_iface)
-        assert resolved_is_closing == [True]
-
     def test_resolve_hook_with_missing_hook_returns_fallback(self) -> None:
         """_resolve_hook should return fallback when hook attribute is missing."""
         mock_iface = SimpleNamespace()  # No _state_manager_is_closing attribute

--- a/tests/test_ble_lifecycle_receive_targets.py
+++ b/tests/test_ble_lifecycle_receive_targets.py
@@ -103,7 +103,7 @@ def test_lifecycle_error_handler_cleanup_and_execute_branches(
             raise RuntimeError("hook post-processing failure")
 
         iface.error_handler = SimpleNamespace(
-            safe_cleanup=MagicMock(),
+            safe_cleanup=None,
             _safe_cleanup=_legacy_cleanup,
         )
 
@@ -1087,16 +1087,16 @@ def test_receive_controller_hook_resolution_helpers(
             raising=True,
         )
         assert controller._as_usable_callable(None) is None
-        assert controller._is_unusable_mock_value(None) is True
-        assert controller._is_unusable_mock_value("ready") is False
+        assert controller._is_unusable_probe_value(None) is True
+        assert controller._is_unusable_probe_value("ready") is False
     finally:
         original_close()
 
 
-def test_receive_controller_filters_unconfigured_lifecycle_controllers(
+def test_receive_controller_filters_missing_lifecycle_controllers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Receive controller should treat unconfigured lifecycle controllers as absent."""
+    """Receive controller should treat missing lifecycle controllers as absent."""
     iface = _make_iface(monkeypatch)
     original_close = iface.close
     original_get_lifecycle_controller = iface._get_lifecycle_controller
@@ -1108,9 +1108,7 @@ def test_receive_controller_filters_unconfigured_lifecycle_controllers(
             lambda _name: None,
             raising=True,
         )
-        iface._get_lifecycle_controller = MagicMock()
-        assert controller._get_lifecycle_controller() is None
-        iface._get_lifecycle_controller = lambda: MagicMock()
+        iface._get_lifecycle_controller = lambda: None
         assert controller._get_lifecycle_controller() is None
     finally:
         iface._get_lifecycle_controller = original_get_lifecycle_controller
@@ -1331,7 +1329,7 @@ def test_receive_controller_propagates_lifecycle_should_run_failures(
 def test_receive_controller_has_ever_connected_session_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Receive controller should expose mock-safe `_ever_connected` fallback behavior."""
+    """Receive controller should expose compatibility `_ever_connected` fallback behavior."""
     iface = _make_iface(monkeypatch)
     original_get_lifecycle_controller = iface._get_lifecycle_controller
     try:
@@ -1527,10 +1525,10 @@ def test_receive_compat_controller_for_shim_accepts_injected_controller_double(
         iface.close()
 
 
-def test_receive_compat_controller_for_shim_rejects_unconfigured_mock(
+def test_receive_compat_controller_for_shim_rejects_dynamic_placeholder(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Receive shim should ignore unconfigured mock placeholders."""
+    """Receive shim should ignore dynamically synthesized controller placeholders."""
     iface = _make_iface(monkeypatch)
     try:
         iface._get_receive_recovery_controller = lambda: MagicMock()
@@ -1634,7 +1632,7 @@ def test_receive_service_branch_targets_disconnect_and_wait_paths(
         assert cleared
 
         iface._state_manager = SimpleNamespace(
-            is_connecting=MagicMock(),
+            is_connecting=None,
             _is_connecting=True,
         )
         client, is_connecting, publish_pending, is_closing = (

--- a/tests/test_ble_lifecycle_receive_targets.py
+++ b/tests/test_ble_lifecycle_receive_targets.py
@@ -1072,23 +1072,28 @@ def test_lifecycle_shutdown_receive_thread_skips_self_join_by_ident(
         iface.close()
 
 
-def test_receive_controller_hook_resolution_helpers(
+def test_receive_controller_hook_resolution_uses_declared_members(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Receive controller helper resolution should treat null hooks as unusable."""
+    """Receive hook resolution should ignore synthesized members and use declared ones."""
     iface = _make_iface(monkeypatch)
     original_close = iface.close
+
+    class _DynamicHookOwner:
+        public_hook = staticmethod(lambda: "declared")
+
+        def __getattr__(self, _name: str) -> object:
+            return lambda: "dynamic"
+
     try:
         controller = iface._get_receive_recovery_controller()
-        monkeypatch.setattr(
-            controller,
-            "_resolve_iface_receive_hook_override",
-            lambda _name: None,
-            raising=True,
+        hook = controller._resolve_private_public_callable(
+            _DynamicHookOwner(),
+            private_name="private_hook",
+            public_name="public_hook",
         )
-        assert controller._as_usable_callable(None) is None
-        assert controller._is_unusable_probe_value(None) is True
-        assert controller._is_unusable_probe_value("ready") is False
+        assert hook is not None
+        assert hook() == "declared"
     finally:
         original_close()
 

--- a/tests/test_ble_notifications_coverage.py
+++ b/tests/test_ble_notifications_coverage.py
@@ -578,24 +578,6 @@ def test_resolve_error_handler_provider_failure() -> None:
 
 
 @pytest.mark.unit
-def test_resolve_error_handler_unconfigured_mock() -> None:
-    """Test error handler resolution with unconfigured mock."""
-
-    unconfigured_mock = Mock()
-
-    dispatcher = BLENotificationDispatcher(
-        notification_manager=NotificationManager(),
-        error_handler_provider=lambda: unconfigured_mock,
-        trigger_read_event=lambda: None,
-    )
-
-    result = dispatcher._resolve_error_handler()
-
-    # Should return None for unconfigured mock
-    assert result is None
-
-
-@pytest.mark.unit
 def test_report_notification_handler_error_no_handler(
     notification_dispatcher: BLENotificationDispatcher,
 ) -> None:
@@ -621,21 +603,9 @@ def test_report_notification_handler_error_with_safe_execute(
     dispatcher = notification_dispatcher
     dispatcher._error_handler_provider = lambda: mock_handler
 
-    # Patch both checks so our mock is considered configured
-    with (
-        patch(
-            "meshtastic.interfaces.ble.notifications._is_unconfigured_mock_member",
-            return_value=False,
-        ),
-        patch(
-            "meshtastic.interfaces.ble.notifications._is_unconfigured_mock_callable",
-            return_value=False,
-        ),
-    ):
-        dispatcher.report_notification_handler_error("Test error")
+    dispatcher.report_notification_handler_error("Test error")
 
-        # safe_execute should have been called
-        assert mock_handler.safe_execute.called
+    assert mock_handler.safe_execute.called
 
 
 @pytest.mark.unit
@@ -939,14 +909,8 @@ def test_dispatcher_error_handler_resolution_chain() -> None:
         trigger_read_event=lambda: None,
     )
 
-    # Patch _is_unconfigured_mock_member to return False so our handler is considered configured
-    with patch(
-        "meshtastic.interfaces.ble.notifications._is_unconfigured_mock_member",
-        return_value=False,
-    ):
-        result = dispatcher._resolve_error_handler()
-        # _resolve_error_handler returns the handler object, not the safe_execute callable
-        assert result is mock_handler
+    result = dispatcher._resolve_error_handler()
+    assert result is mock_handler
 
 
 @pytest.mark.unit

--- a/tests/test_ble_notifications_coverage.py
+++ b/tests/test_ble_notifications_coverage.py
@@ -977,6 +977,28 @@ def test_fromnum_notify_enabled_property(
 
 
 @pytest.mark.unit
+def test_fromnum_notify_enabled_reads_do_not_enter_registration_lock(
+    notification_dispatcher: BLENotificationDispatcher,
+) -> None:
+    """Hot receive-path flag reads must not wait on registration serialization."""
+
+    class _RejectingLock:
+        def __enter__(self) -> None:
+            raise AssertionError("flag reads must not acquire the registration lock")
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+    dispatcher = notification_dispatcher
+    dispatcher._registration_lock = _RejectingLock()  # type: ignore[assignment]  # noqa: SLF001
+
+    assert dispatcher.fromnum_notify_enabled is False
+
+    with pytest.raises(AssertionError, match="registration lock"):
+        dispatcher.fromnum_notify_enabled = True
+
+
+@pytest.mark.unit
 def test_notification_manager_len(notification_manager: NotificationManager) -> None:
     """Test NotificationManager __len__ method."""
     manager = notification_manager

--- a/tests/test_ble_notifications_coverage.py
+++ b/tests/test_ble_notifications_coverage.py
@@ -40,6 +40,7 @@ def notification_dispatcher() -> BLENotificationDispatcher:
         notification_manager=manager,
         error_handler_provider=lambda: Mock(),
         trigger_read_event=lambda: None,
+        registration_current_provider=lambda _client, _epoch: True,
     )
 
 
@@ -561,6 +562,7 @@ def test_resolve_error_handler_provider_failure() -> None:
         notification_manager=NotificationManager(),
         error_handler_provider=failing_provider,
         trigger_read_event=lambda: None,
+        registration_current_provider=lambda _client, _epoch: True,
     )
 
     with patch("meshtastic.interfaces.ble.notifications.logger") as mock_logger:
@@ -932,6 +934,7 @@ def test_dispatcher_resolves_error_handler_from_provider() -> None:
         notification_manager=NotificationManager(),
         error_handler_provider=lambda: error_handler,
         trigger_read_event=lambda: None,
+        registration_current_provider=lambda _client, _epoch: True,
     )
 
     result = dispatcher._resolve_error_handler()

--- a/tests/test_ble_notifications_coverage.py
+++ b/tests/test_ble_notifications_coverage.py
@@ -609,6 +609,35 @@ def test_report_notification_handler_error_with_safe_execute(
 
 
 @pytest.mark.unit
+def test_report_notification_handler_error_uses_declared_legacy_safe_execute(
+    notification_dispatcher: BLENotificationDispatcher,
+) -> None:
+    """A synthesized public hook must not mask the declared legacy hook."""
+
+    class LegacyErrorHandler:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def _safe_execute(self, func: Callable[[], None], **_kwargs: object) -> None:
+            self.calls += 1
+            try:
+                func()
+            except RuntimeError:
+                pass
+
+        def __getattr__(self, _name: str) -> object:
+            return lambda *_args, **_kwargs: None
+
+    handler = LegacyErrorHandler()
+    dispatcher = notification_dispatcher
+    dispatcher._error_handler_provider = lambda: handler
+
+    dispatcher.report_notification_handler_error("Test error")
+
+    assert handler.calls == 1
+
+
+@pytest.mark.unit
 def test_report_notification_handler_error_with_handle_unhandled_exception(
     notification_dispatcher: BLENotificationDispatcher,
 ) -> None:
@@ -895,22 +924,18 @@ def test_notification_manager_thread_safety(
 
 
 @pytest.mark.unit
-def test_dispatcher_error_handler_resolution_chain() -> None:
-    """Test error handler resolution tries multiple hooks in order."""
-
-    # Test with handler that has _safe_execute but not safe_execute
-    mock_handler = Mock()
-    # Don't set safe_execute at all
-    mock_handler._safe_execute = Mock(return_value=None)
+def test_dispatcher_resolves_error_handler_from_provider() -> None:
+    """The dispatcher should return the error handler supplied by its provider."""
+    error_handler = object()
 
     dispatcher = BLENotificationDispatcher(
         notification_manager=NotificationManager(),
-        error_handler_provider=lambda: mock_handler,
+        error_handler_provider=lambda: error_handler,
         trigger_read_event=lambda: None,
     )
 
     result = dispatcher._resolve_error_handler()
-    assert result is mock_handler
+    assert result is error_handler
 
 
 @pytest.mark.unit

--- a/tests/test_ble_session_state.py
+++ b/tests/test_ble_session_state.py
@@ -69,3 +69,27 @@ def test_lifecycle_controller_shares_owned_session_state() -> None:
     assert controller._disconnect._session is iface._session_state
     assert controller._connection_ownership._session is iface._session_state
     assert controller._shutdown._session is iface._session_state
+
+
+def test_lazy_session_state_ignores_dynamically_synthesized_lock() -> None:
+    """Lazy state creation should only reuse an explicitly declared state lock."""
+
+    class DynamicStateManager:
+        def __getattr__(self, _name: str) -> object:
+            return self
+
+        def acquire(self) -> None:
+            raise AssertionError("dynamic lock should not be used")
+
+        def release(self) -> None:
+            raise AssertionError("dynamic lock should not be used")
+
+    iface = BLEInterface.__new__(BLEInterface)
+    dynamic_manager = DynamicStateManager()
+    iface._state_manager = dynamic_manager
+
+    state = iface._get_session_state()
+
+    assert state.lock is not dynamic_manager
+    assert state.lock.acquire(blocking=False)
+    state.lock.release()

--- a/tests/test_ble_session_state.py
+++ b/tests/test_ble_session_state.py
@@ -1,8 +1,11 @@
 """Tests for owned BLE session-state compatibility views."""
 
+import threading
+from types import SimpleNamespace
+
 from meshtastic.interfaces.ble.interface import BLEInterface
 from meshtastic.interfaces.ble.lifecycle_controller_runtime import BLELifecycleController
-from meshtastic.interfaces.ble.session_state import BLESessionState
+from meshtastic.interfaces.ble.session_state import BLESessionState, _session_state_for
 from meshtastic.interfaces.ble.state import BLEStateManager
 
 
@@ -93,3 +96,80 @@ def test_lazy_session_state_ignores_dynamically_synthesized_lock() -> None:
     assert state.lock is not dynamic_manager
     assert state.lock.acquire(blocking=False)
     state.lock.release()
+
+
+def test_legacy_session_state_adapter_implements_reset_contract() -> None:
+    """Legacy interfaces should satisfy the complete session-state reset port."""
+    legacy = SimpleNamespace(
+        _state_lock=threading.RLock(),
+        _read_retry_count=5,
+        _last_empty_read_warning=7.5,
+        _suppressed_empty_read_warnings=3,
+        _receive_recovery_attempts=4,
+        _last_recovery_time=12.0,
+    )
+
+    state = _session_state_for(legacy)
+    assert _session_state_for(legacy) is state
+    assert state.lock is state.lock
+
+    state.reset_read_retry_count()
+    assert legacy._read_retry_count == 0
+
+    legacy._read_retry_count = 2
+    state.reset_receive_retry_state()
+    assert legacy._read_retry_count == 0
+    assert legacy._last_empty_read_warning == 0.0
+    assert legacy._suppressed_empty_read_warnings == 0
+
+    state.reset_recovery_state()
+    assert legacy._receive_recovery_attempts == 0
+    assert legacy._last_recovery_time == 0.0
+
+
+def test_receive_lifecycle_uses_explicit_session_pending_markers() -> None:
+    """Explicit session state must govern stale/pending receive-start decisions."""
+    from meshtastic.interfaces.ble.lifecycle_receive_runtime import (
+        BLEReceiveLifecycleCoordinator,
+    )
+
+    state_manager = BLEStateManager()
+    state = BLESessionState(lock=state_manager.lock)
+    pending_thread = SimpleNamespace(name="PendingReceive", ident=None, is_alive=lambda: False)
+    state.receive_thread = pending_thread
+    state.receive_start_pending = True
+    state.receive_start_pending_since = 10**12  # safely in the future for this probe
+
+    # Deliberately contradictory legacy fields prove the coordinator reads the
+    # explicit session owner rather than compatibility fields on the interface.
+    iface = SimpleNamespace(
+        _receive_start_pending=False,
+        _receive_start_pending_since=None,
+    )
+    coordinator = BLEReceiveLifecycleCoordinator(iface, session_state=state)  # type: ignore[arg-type]
+
+    def _unexpected_create(**_kwargs: object) -> object:
+        raise AssertionError("pending session state should suppress thread creation")
+
+    created, recovery_attempts = coordinator._check_receive_start_conditions(  # noqa: SLF001
+        name="PendingReceive",
+        reset_recovery=False,
+        create_runtime_thread=_unexpected_create,  # type: ignore[arg-type]
+    )
+
+    assert created is None
+    assert recovery_attempts is None
+    assert state.receive_start_pending is True
+
+
+def test_receive_controller_reads_ever_connected_from_explicit_session() -> None:
+    """Receive reconnect detection should use the shared session owner."""
+    from meshtastic.interfaces.ble.receive_service import BLEReceiveRecoveryController
+
+    state_manager = BLEStateManager()
+    state = BLESessionState(lock=state_manager.lock, ever_connected=True)
+    iface = SimpleNamespace(_ever_connected=False)
+
+    controller = BLEReceiveRecoveryController(iface, session_state=state)  # type: ignore[arg-type]
+
+    assert controller._has_ever_connected_session() is True  # noqa: SLF001

--- a/tests/test_ble_session_state.py
+++ b/tests/test_ble_session_state.py
@@ -1,6 +1,7 @@
 """Tests for owned BLE session-state compatibility views."""
 
 from meshtastic.interfaces.ble.interface import BLEInterface
+from meshtastic.interfaces.ble.lifecycle_controller_runtime import BLELifecycleController
 from meshtastic.interfaces.ble.session_state import BLESessionState
 from meshtastic.interfaces.ble.state import BLEStateManager
 
@@ -56,3 +57,15 @@ def test_session_state_retry_reset_helpers() -> None:
     assert state.suppressed_empty_read_warnings == 0
     assert state.receive_recovery_attempts == 0
     assert state.last_recovery_time == 0.0
+
+
+def test_lifecycle_controller_shares_owned_session_state() -> None:
+    """Lifecycle coordinators should share the interface's single state owner."""
+    iface = _bare_interface()
+
+    controller = BLELifecycleController(iface)
+
+    assert controller._receive._session is iface._session_state
+    assert controller._disconnect._session is iface._session_state
+    assert controller._connection_ownership._session is iface._session_state
+    assert controller._shutdown._session is iface._session_state

--- a/tests/test_ble_session_state.py
+++ b/tests/test_ble_session_state.py
@@ -309,11 +309,15 @@ def test_receive_lifecycle_schedules_inconclusive_restart_outside_session_lock()
     class _TrackingLock:
         def __init__(self) -> None:
             self._lock = threading.RLock()
-            self.held = False
+            self._depth = 0
+
+        @property
+        def held(self) -> bool:
+            return self._depth > 0
 
         def __enter__(self) -> "_TrackingLock":
             self._lock.acquire()
-            self.held = True
+            self._depth += 1
             return self
 
         def __exit__(
@@ -322,7 +326,7 @@ def test_receive_lifecycle_schedules_inconclusive_restart_outside_session_lock()
             _exc_value: BaseException | None,
             _traceback: TracebackType | None,
         ) -> None:
-            self.held = False
+            self._depth -= 1
             self._lock.release()
 
     lock = _TrackingLock()

--- a/tests/test_ble_session_state.py
+++ b/tests/test_ble_session_state.py
@@ -4,11 +4,13 @@ import threading
 from types import SimpleNamespace, TracebackType
 
 import pytest
+from bleak.exc import BleakError
 
 from meshtastic.interfaces.ble.interface import BLEInterface
 from meshtastic.interfaces.ble.lifecycle_controller_runtime import (
     BLELifecycleController,
 )
+from meshtastic.interfaces.ble.ports import _BLESessionStatePort
 from meshtastic.interfaces.ble.session_state import (
     BLESessionState,
     LEGACY_SESSION_STATE_CACHE_ERROR,
@@ -18,6 +20,33 @@ from meshtastic.interfaces.ble.session_state import (
 from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
 
 pytestmark = pytest.mark.unit
+
+
+class _TrackingRLock:
+    """Reentrant lock test double exposing aggregate ownership state."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._depth = 0
+
+    @property
+    def held(self) -> bool:
+        """Return whether at least one reentrant acquisition is active."""
+        return self._depth > 0
+
+    def __enter__(self) -> "_TrackingRLock":
+        self._lock.acquire()
+        self._depth += 1
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc_value: BaseException | None,
+        _traceback: TracebackType | None,
+    ) -> None:
+        self._depth -= 1
+        self._lock.release()
 
 
 def _bare_interface() -> BLEInterface:
@@ -52,6 +81,12 @@ def test_interface_lifecycle_fields_delegate_to_session_state() -> None:
     assert iface._session_state.receive_start_pending is True
     assert iface._session_state.receive_start_pending_since == 12.5
 
+    with pytest.raises(
+        TypeError,
+        match="_last_disconnect_source must be a str or None, got int",
+    ):
+        iface._last_disconnect_source = 7  # type: ignore[assignment]
+
 
 def test_session_state_retry_reset_helpers() -> None:
     """Retry/recovery bookkeeping resets should be explicit and complete."""
@@ -71,6 +106,101 @@ def test_session_state_retry_reset_helpers() -> None:
     assert state.suppressed_empty_read_warnings == 0
     assert state.receive_recovery_attempts == 0
     assert state.last_recovery_time == 0.0
+
+
+def test_lazy_session_state_creation_converges_across_racing_callers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent lazy access must return one canonical session-state owner."""
+    import meshtastic.interfaces.ble.session_state as session_state_module
+
+    iface = BLEInterface.__new__(BLEInterface)
+    rendezvous = threading.Barrier(2)
+    original_get_declared_lock = session_state_module._get_declared_lock
+
+    def _racing_get_declared_lock(target: object, name: str) -> object | None:
+        if target is None and name == "lock":
+            rendezvous.wait(timeout=2.0)
+            return None
+        return original_get_declared_lock(target, name)
+
+    monkeypatch.setattr(
+        session_state_module,
+        "_get_declared_lock",
+        _racing_get_declared_lock,
+    )
+    states: list[BLESessionState] = []
+
+    def _resolve_state() -> None:
+        states.append(iface._get_session_state())  # noqa: SLF001
+
+    workers = [threading.Thread(target=_resolve_state) for _ in range(2)]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=2.0)
+
+    assert all(not worker.is_alive() for worker in workers)
+    assert len(states) == 2
+    assert states[0] is states[1]
+    assert iface.__dict__["_session_state"] is states[0]
+
+
+def test_legacy_session_state_resolution_is_atomic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Racing legacy coordinators must converge on one cached adapter owner."""
+    import meshtastic.interfaces.ble.session_state as session_state_module
+
+    iface = SimpleNamespace()
+    rendezvous = threading.Barrier(2)
+    original_adapter = session_state_module._LegacyBLESessionStateAdapter
+
+    class _RacingAdapter(original_adapter):
+        def __init__(self, target: object) -> None:
+            super().__init__(target)
+            rendezvous.wait(timeout=2.0)
+
+    monkeypatch.setattr(
+        session_state_module,
+        "_LegacyBLESessionStateAdapter",
+        _RacingAdapter,
+    )
+    states: list[object] = []
+
+    def _resolve_state() -> None:
+        states.append(session_state_module._session_state_for(iface))
+
+    workers = [threading.Thread(target=_resolve_state) for _ in range(2)]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=2.0)
+
+    assert all(not worker.is_alive() for worker in workers)
+    assert len(states) == 2
+    assert states[0] is states[1]
+    assert iface.__dict__["_session_state"] is states[0]
+
+
+def test_legacy_adapter_field_map_matches_session_state_protocol() -> None:
+    """The cast-backed legacy adapter must cover every protocol data field."""
+    protocol_fields = set(_BLESessionStatePort.__annotations__)
+
+    assert set(_LegacyBLESessionStateAdapter._FIELD_MAP) == protocol_fields  # noqa: SLF001
+    assert set(_LegacyBLESessionStateAdapter._FIELD_DEFAULTS) == (  # noqa: SLF001
+        protocol_fields - {"lock"}
+    )
+
+
+def test_legacy_adapter_rejects_unknown_fields_with_context() -> None:
+    """Unsupported adapter fields should fail with an actionable message."""
+    state = _session_state_for(SimpleNamespace())
+
+    with pytest.raises(AttributeError, match="does not proxy session field 'unknown'"):
+        _ = state.unknown  # type: ignore[attr-defined]
+    with pytest.raises(AttributeError, match="does not proxy session field 'unknown'"):
+        state.unknown = True  # type: ignore[attr-defined]
 
 
 def test_lifecycle_controller_shares_owned_session_state() -> None:
@@ -300,36 +430,47 @@ def test_receive_controller_invalid_lifecycle_results_fall_back_to_session() -> 
     assert controller._is_connection_closing() is True  # noqa: SLF001
 
 
+def test_transient_retry_does_not_resurrect_concurrent_counter_reset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Retry bookkeeping must advance from the current counter after policy work."""
+    import meshtastic.interfaces.ble.receive_service as receive_service_module
+    from meshtastic.interfaces.ble.receive_service import BLEReceiveRecoveryController
+
+    state_manager = BLEStateManager()
+    state = BLESessionState(lock=state_manager.lock, read_retry_count=3)
+    delay_attempts: list[int] = []
+
+    def _should_retry(_policy: object, attempt: int) -> bool:
+        assert attempt == 3
+        state._reset_read_retry_count()
+        return True
+
+    iface = SimpleNamespace(
+        _transient_read_policy=object(),
+        _retry_policy_should_retry=_should_retry,
+        _retry_policy_get_delay=lambda _policy, attempt: delay_attempts.append(attempt)
+        or 0.0,
+        BLEError=RuntimeError,
+    )
+    controller = BLEReceiveRecoveryController(
+        iface, session_state=state  # type: ignore[arg-type]
+    )
+    monkeypatch.setattr(receive_service_module, "_sleep", lambda _delay: None)
+
+    controller.handle_transient_read_error(BleakError("transient"))
+
+    assert state.read_retry_count == 1
+    assert delay_attempts == [0]
+
+
 def test_receive_lifecycle_schedules_inconclusive_restart_outside_session_lock() -> None:
     """Deferred restart scheduling must not begin while the session lock is held."""
     from meshtastic.interfaces.ble.lifecycle_receive_runtime import (
         BLEReceiveLifecycleCoordinator,
     )
 
-    class _TrackingLock:
-        def __init__(self) -> None:
-            self._lock = threading.RLock()
-            self._depth = 0
-
-        @property
-        def held(self) -> bool:
-            return self._depth > 0
-
-        def __enter__(self) -> "_TrackingLock":
-            self._lock.acquire()
-            self._depth += 1
-            return self
-
-        def __exit__(
-            self,
-            _exc_type: type[BaseException] | None,
-            _exc_value: BaseException | None,
-            _traceback: TracebackType | None,
-        ) -> None:
-            self._depth -= 1
-            self._lock.release()
-
-    lock = _TrackingLock()
+    lock = _TrackingRLock()
     state = BLESessionState(lock=lock)
     existing = SimpleNamespace(
         name="InconclusiveReceive", ident=None, is_alive=lambda: False
@@ -363,6 +504,78 @@ def test_receive_lifecycle_schedules_inconclusive_restart_outside_session_lock()
     assert recovery_attempts is None
     assert scheduled == [(existing, True)]
     assert state.receive_start_pending is True
+
+
+def test_receive_lifecycle_thread_probes_run_outside_session_lock() -> None:
+    """Receive-start thread probes should not execute arbitrary code under state lock."""
+    from meshtastic.interfaces.ble.lifecycle_receive_runtime import (
+        BLEReceiveLifecycleCoordinator,
+    )
+
+    lock = _TrackingRLock()
+    state = BLESessionState(lock=lock)
+    probe_lock_states: list[bool] = []
+
+    class _ExistingThread:
+        name = "PendingReceive"
+        ident = None
+
+        def is_alive(self) -> bool:
+            probe_lock_states.append(lock.held)
+            return False
+
+    existing = _ExistingThread()
+    state.receive_thread = existing  # type: ignore[assignment]
+    state.receive_start_pending = True
+    state.receive_start_pending_since = 0.0
+    iface = SimpleNamespace(_receive_from_radio_impl=lambda: None)
+    coordinator = BLEReceiveLifecycleCoordinator(  # type: ignore[arg-type]
+        iface, session_state=state
+    )
+    staged = SimpleNamespace(name="ReplacementReceive", ident=None, is_alive=lambda: False)
+
+    created, recovery_attempts = coordinator._check_receive_start_conditions(  # noqa: SLF001
+        name="ReplacementReceive",
+        reset_recovery=False,
+        create_runtime_thread=lambda **_kwargs: staged,  # type: ignore[return-value]
+    )
+
+    assert created is staged
+    assert recovery_attempts is None
+    assert probe_lock_states == [False, False]
+
+
+def test_receive_recovery_reset_probes_thread_outside_session_lock() -> None:
+    """Recovery-reset liveness checks must not run while session state is locked."""
+    from meshtastic.interfaces.ble.lifecycle_receive_runtime import (
+        BLEReceiveLifecycleCoordinator,
+    )
+
+    lock = _TrackingRLock()
+    state = BLESessionState(lock=lock, receive_recovery_attempts=2)
+    probe_lock_states: list[bool] = []
+
+    class _Thread:
+        ident = 42
+        name = "Receive"
+
+        def is_alive(self) -> bool:
+            probe_lock_states.append(lock.held)
+            return True
+
+    thread = _Thread()
+    state.receive_thread = thread  # type: ignore[assignment]
+    coordinator = BLEReceiveLifecycleCoordinator(  # type: ignore[arg-type]
+        SimpleNamespace(), session_state=state
+    )
+
+    coordinator._maybe_reset_receive_recovery(  # noqa: SLF001
+        thread=thread,  # type: ignore[arg-type]
+        recovery_attempts_before_start=2,
+    )
+
+    assert probe_lock_states == [False]
+    assert state.receive_recovery_attempts == 0
 
 
 def test_disconnect_plan_reads_epoch_from_explicit_session_state() -> None:
@@ -402,6 +615,51 @@ def test_disconnect_plan_reads_epoch_from_explicit_session_state() -> None:
 
     assert plan.session_epoch == 9
     assert iface._connection_session_epoch == 1
+
+
+def test_disconnect_source_write_uses_session_lock() -> None:
+    """Disconnect diagnostics should obey the shared session ownership boundary."""
+    from meshtastic.interfaces.ble.lifecycle_disconnect_runtime import (
+        BLEDisconnectLifecycleCoordinator,
+    )
+    from meshtastic.interfaces.ble.lifecycle_primitives import _DisconnectPlan
+
+    class _Session:
+        def __init__(self) -> None:
+            self.lock = _TrackingRLock()
+            self.connection_session_epoch = 5
+            self._last_disconnect_source: str | None = None
+
+        @property
+        def last_disconnect_source(self) -> str | None:
+            return self._last_disconnect_source
+
+        @last_disconnect_source.setter
+        def last_disconnect_source(self, value: str | None) -> None:
+            assert self.lock.held is True
+            self._last_disconnect_source = value
+
+    session = _Session()
+    iface = SimpleNamespace(client=None)
+    coordinator = BLEDisconnectLifecycleCoordinator(
+        iface, session_state=session  # type: ignore[arg-type]
+    )
+    plan = _DisconnectPlan(
+        early_return=False,
+        session_epoch=5,
+        address="AA:BB:CC:DD:EE:FF",
+        was_publish_pending=True,
+    )
+
+    should_reconnect = coordinator._execute_disconnect_side_effects(  # noqa: SLF001
+        plan=plan,
+        source="test",
+        close_previous_client_async=lambda _client: None,
+        clear_events=lambda *_events: None,
+    )
+
+    assert should_reconnect is False
+    assert session.last_disconnect_source == "ble.test"
 
 
 def test_ownership_cleanup_reads_explicit_session_state() -> None:

--- a/tests/test_ble_session_state.py
+++ b/tests/test_ble_session_state.py
@@ -130,9 +130,13 @@ def test_lazy_session_state_creation_converges_across_racing_callers(
         _racing_get_declared_lock,
     )
     states: list[BLESessionState] = []
+    failures: list[BaseException] = []
 
     def _resolve_state() -> None:
-        states.append(iface._get_session_state())  # noqa: SLF001
+        try:
+            states.append(iface._get_session_state())  # noqa: SLF001
+        except BaseException as exc:  # noqa: BLE001 - surfaced below
+            failures.append(exc)
 
     workers = [threading.Thread(target=_resolve_state) for _ in range(2)]
     for worker in workers:
@@ -141,6 +145,7 @@ def test_lazy_session_state_creation_converges_across_racing_callers(
         worker.join(timeout=2.0)
 
     assert all(not worker.is_alive() for worker in workers)
+    assert not failures, failures
     assert len(states) == 2
     assert states[0] is states[1]
     assert iface.__dict__["_session_state"] is states[0]
@@ -167,9 +172,13 @@ def test_legacy_session_state_resolution_is_atomic(
         _RacingAdapter,
     )
     states: list[object] = []
+    failures: list[BaseException] = []
 
     def _resolve_state() -> None:
-        states.append(session_state_module._session_state_for(iface))
+        try:
+            states.append(session_state_module._session_state_for(iface))
+        except BaseException as exc:  # noqa: BLE001 - surfaced below
+            failures.append(exc)
 
     workers = [threading.Thread(target=_resolve_state) for _ in range(2)]
     for worker in workers:
@@ -178,6 +187,7 @@ def test_legacy_session_state_resolution_is_atomic(
         worker.join(timeout=2.0)
 
     assert all(not worker.is_alive() for worker in workers)
+    assert not failures, failures
     assert len(states) == 2
     assert states[0] is states[1]
     assert iface.__dict__["_session_state"] is states[0]

--- a/tests/test_ble_session_state.py
+++ b/tests/test_ble_session_state.py
@@ -307,23 +307,54 @@ def test_partial_interface_resolves_mixin_session_owner_directly() -> None:
     assert state.lock is iface._state_lock
 
 
-def test_mixin_promotion_preserves_cached_adapter_lock() -> None:
-    """Fallback adapter promotion must retain one shared, replaceable state lock."""
+def test_mixin_promotion_preserves_legacy_values_and_state_manager_lock() -> None:
+    """Adapter promotion must preserve legacy values and canonical lock ownership."""
     iface = BLEInterface.__new__(BLEInterface)
+    state_manager = BLEStateManager()
+    iface.__dict__["_state_manager"] = state_manager
+    iface.__dict__["_closed"] = True
+    iface.__dict__["_connection_session_epoch"] = 17
+    iface.__dict__["_want_receive"] = False
+    iface.__dict__["_last_disconnect_source"] = "legacy-callback"
     adapter = _LegacyBLESessionStateAdapter(iface)
     iface.__dict__["_session_state"] = adapter
 
     state = iface._get_session_state()
 
     assert isinstance(state, BLESessionState)
-    assert state.lock is adapter.lock
-    assert iface._state_lock is adapter.lock
+    assert state.lock is state_manager.lock
+    assert iface._state_lock is state_manager.lock
+    assert state.closed is True
+    assert state.connection_session_epoch == 17
+    assert state.want_receive is False
+    assert state.last_disconnect_source == "legacy-callback"
+    assert "_closed" not in iface.__dict__
+    assert "_connection_session_epoch" not in iface.__dict__
+    assert "_want_receive" not in iface.__dict__
+    assert "_last_disconnect_source" not in iface.__dict__
 
     replacement_lock = threading.RLock()
     iface._state_lock = replacement_lock
 
     assert state.lock is replacement_lock
     assert adapter.lock is replacement_lock
+
+
+def test_mixin_promotion_preserves_raw_legacy_lock_without_state_manager() -> None:
+    """A pre-migration raw state lock must survive adapter promotion."""
+    iface = BLEInterface.__new__(BLEInterface)
+    legacy_lock = threading.RLock()
+    iface.__dict__["_state_lock"] = legacy_lock
+    iface.__dict__["_closed"] = True
+    adapter = _LegacyBLESessionStateAdapter(iface)
+    iface.__dict__["_session_state"] = adapter
+
+    state = iface._get_session_state()
+
+    assert state.lock is legacy_lock
+    assert state.closed is True
+    assert "_state_lock" not in iface.__dict__
+    assert "_closed" not in iface.__dict__
 
 
 def test_uncacheable_legacy_collaborator_requires_explicit_session() -> None:

--- a/tests/test_ble_session_state.py
+++ b/tests/test_ble_session_state.py
@@ -434,23 +434,29 @@ def test_receive_controller_invalid_lifecycle_results_fall_back_to_session() -> 
     assert controller._is_connection_closing() is True  # noqa: SLF001
 
 
-def test_transient_retry_does_not_resurrect_concurrent_counter_reset(
+@pytest.mark.parametrize(
+    "first_decision",
+    [True, False],
+    ids=["stale-retry", "stale-terminal"],
+)
+def test_transient_retry_revalidates_concurrent_counter_reset(
     monkeypatch: pytest.MonkeyPatch,
+    first_decision: bool,
 ) -> None:
-    """Retry bookkeeping must advance from the current counter after policy work."""
+    """Concurrent retry resets must invalidate either stale policy decision."""
     import meshtastic.interfaces.ble.receive_service as receive_service_module
     from meshtastic.interfaces.ble.receive_service import BLEReceiveRecoveryController
 
     state_manager = BLEStateManager()
     state = BLESessionState(lock=state_manager.lock, read_retry_count=3)
-    delay_attempts: list[int] = []
-
     policy_attempts: list[int] = []
+    delay_attempts: list[int] = []
 
     def _should_retry(_policy: object, attempt: int) -> bool:
         policy_attempts.append(attempt)
         if attempt == 3:
             state._reset_read_retry_count()
+            return first_decision
         return True
 
     iface = SimpleNamespace(
@@ -470,45 +476,6 @@ def test_transient_retry_does_not_resurrect_concurrent_counter_reset(
     assert policy_attempts == [3, 0]
     assert state.read_retry_count == 1
     assert delay_attempts == [0]
-
-
-def test_transient_retry_revalidates_stale_terminal_policy_decision(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A concurrent retry reset must invalidate a stale terminal decision."""
-    import meshtastic.interfaces.ble.receive_service as receive_service_module
-    from meshtastic.interfaces.ble.receive_service import BLEReceiveRecoveryController
-
-    state_manager = BLEStateManager()
-    state = BLESessionState(lock=state_manager.lock, read_retry_count=3)
-    policy_attempts: list[int] = []
-    delay_attempts: list[int] = []
-
-    def _should_retry(_policy: object, attempt: int) -> bool:
-        policy_attempts.append(attempt)
-        if attempt == 3:
-            state._reset_read_retry_count()
-            return False
-        return True
-
-    iface = SimpleNamespace(
-        _transient_read_policy=object(),
-        _retry_policy_should_retry=_should_retry,
-        _retry_policy_get_delay=lambda _policy, attempt: delay_attempts.append(attempt)
-        or 0.0,
-        BLEError=RuntimeError,
-    )
-    controller = BLEReceiveRecoveryController(
-        iface, session_state=state  # type: ignore[arg-type]
-    )
-    monkeypatch.setattr(receive_service_module, "_sleep", lambda _delay: None)
-
-    controller.handle_transient_read_error(BleakError("transient"))
-
-    assert policy_attempts == [3, 0]
-    assert state.read_retry_count == 1
-    assert delay_attempts == [0]
-
 
 def test_receive_lifecycle_schedules_inconclusive_restart_outside_session_lock() -> None:
     """Deferred restart scheduling must not begin while the session lock is held."""
@@ -589,6 +556,51 @@ def test_receive_lifecycle_thread_probes_run_outside_session_lock() -> None:
     assert created is staged
     assert recovery_attempts is None
     assert probe_lock_states == [False, False]
+
+
+def test_receive_lifecycle_thread_diagnostics_run_outside_session_lock() -> None:
+    """Thread-like name and repr access must not execute while state is locked."""
+    from meshtastic.interfaces.ble.lifecycle_receive_runtime import (
+        BLEReceiveLifecycleCoordinator,
+    )
+
+    lock = _TrackingRLock()
+    state = BLESessionState(lock=lock)
+    diagnostic_lock_states: list[tuple[str, bool]] = []
+
+    class _NamelessThread:
+        ident = 42
+
+        def is_alive(self) -> bool:
+            return True
+
+        def __getattribute__(self, name: str) -> object:
+            if name == "name":
+                diagnostic_lock_states.append(("name", lock.held))
+                raise AttributeError(name)
+            return object.__getattribute__(self, name)
+
+        def __repr__(self) -> str:
+            diagnostic_lock_states.append(("repr", lock.held))
+            return "<NamelessReceive>"
+
+    existing = _NamelessThread()
+    state.receive_thread = existing  # type: ignore[assignment]
+    coordinator = BLEReceiveLifecycleCoordinator(  # type: ignore[arg-type]
+        SimpleNamespace(_receive_from_radio_impl=lambda: None),
+        session_state=state,
+    )
+
+    result = coordinator._check_receive_start_conditions(  # noqa: SLF001
+        name="Receive",
+        reset_recovery=False,
+        create_runtime_thread=lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("live existing thread must prevent replacement")
+        ),
+    )
+
+    assert result == (None, None)
+    assert diagnostic_lock_states == [("name", False), ("repr", False)]
 
 
 def test_receive_recovery_reset_probes_thread_outside_session_lock() -> None:
@@ -813,6 +825,78 @@ def test_shutdown_closing_probe_runs_outside_session_lock() -> None:
 
     assert coordinator.is_connection_closing() is False
     assert probe_lock_states == [False]
+
+
+def test_ownership_invalidation_closing_probe_runs_outside_session_lock() -> None:
+    """Invalidation compatibility probes must not execute under session state lock."""
+    from meshtastic.interfaces.ble.lifecycle_ownership_runtime import (
+        BLEConnectionOwnershipLifecycleCoordinator,
+    )
+
+    lock = _TrackingRLock()
+    client = object()
+    state = BLESessionState(
+        lock=lock,
+        client_publish_pending=True,
+        connected_publish_inflight_client=client,  # type: ignore[arg-type]
+    )
+    iface = SimpleNamespace(
+        client=None,
+        address="legacy-address",
+        _last_connection_request="legacy-request",
+    )
+    coordinator = BLEConnectionOwnershipLifecycleCoordinator(
+        iface, session_state=state  # type: ignore[arg-type]
+    )
+    probe_lock_states: list[bool] = []
+
+    def _is_closing() -> bool:
+        probe_lock_states.append(lock.held)
+        return False
+
+    coordinator._discard_invalidated_connected_client(  # noqa: SLF001
+        client,  # type: ignore[arg-type]
+        restore_address="AA:BB:CC:DD:EE:FF",
+        restore_last_connection_request="restored",
+        is_closing_getter=_is_closing,
+        reset_to_disconnected=lambda: True,
+        current_state_getter=lambda: ConnectionState.DISCONNECTED,
+        transition_to_disconnected=lambda: True,
+        safe_cleanup=lambda _cleanup, _name: None,
+    )
+
+    assert probe_lock_states == [False]
+
+
+def test_receive_snapshot_compatibility_probes_run_outside_session_lock() -> None:
+    """Receive snapshot compatibility callbacks must run before session locking."""
+    from meshtastic.interfaces.ble.receive_service import BLEReceiveRecoveryController
+
+    lock = _TrackingRLock()
+    state = BLESessionState(lock=lock)
+    probe_lock_states: list[tuple[str, bool]] = []
+
+    def _is_connecting() -> bool:
+        probe_lock_states.append(("connecting", lock.held))
+        return True
+
+    def _is_closing() -> bool:
+        probe_lock_states.append(("closing", lock.held))
+        return False
+
+    iface = SimpleNamespace(
+        client=None,
+        _state_manager=SimpleNamespace(
+            is_connecting=_is_connecting,
+            is_closing=_is_closing,
+        ),
+    )
+    controller = BLEReceiveRecoveryController(
+        iface, session_state=state  # type: ignore[arg-type]
+    )
+
+    assert controller._snapshot_client_state() == (None, True, False, False)  # noqa: SLF001
+    assert probe_lock_states == [("connecting", False), ("closing", False)]
 
 
 def test_disconnect_planning_runs_address_helpers_outside_session_lock() -> None:

--- a/tests/test_ble_session_state.py
+++ b/tests/test_ble_session_state.py
@@ -518,6 +518,7 @@ def test_transient_retry_revalidates_concurrent_counter_reset(
     assert state.read_retry_count == 1
     assert delay_attempts == [0]
 
+
 def test_receive_lifecycle_schedules_inconclusive_restart_outside_session_lock() -> None:
     """Deferred restart scheduling must not begin while the session lock is held."""
     from meshtastic.interfaces.ble.lifecycle_receive_runtime import (
@@ -586,7 +587,9 @@ def test_receive_lifecycle_thread_probes_run_outside_session_lock() -> None:
     coordinator = BLEReceiveLifecycleCoordinator(  # type: ignore[arg-type]
         iface, session_state=state
     )
-    staged = SimpleNamespace(name="ReplacementReceive", ident=None, is_alive=lambda: False)
+    staged = SimpleNamespace(
+        name="ReplacementReceive", ident=None, is_alive=lambda: False
+    )
 
     created, recovery_attempts = coordinator._check_receive_start_conditions(  # noqa: SLF001
         name="ReplacementReceive",
@@ -1119,6 +1122,7 @@ def test_transient_retry_revalidation_is_bounded_under_continuous_churn(
 
     assert len(policy_attempts) == TRANSIENT_RETRY_POLICY_REVALIDATION_MAX_ATTEMPTS
     assert delay_attempts == []
+    assert "decision superseded by concurrent retry-state changes" in caplog.text
 
 
 def test_disconnect_reconnect_closing_probe_runs_outside_session_lock() -> None:

--- a/tests/test_ble_session_state.py
+++ b/tests/test_ble_session_state.py
@@ -3,16 +3,21 @@
 import threading
 from types import SimpleNamespace, TracebackType
 
+import pytest
+
 from meshtastic.interfaces.ble.interface import BLEInterface
 from meshtastic.interfaces.ble.lifecycle_controller_runtime import (
     BLELifecycleController,
 )
 from meshtastic.interfaces.ble.session_state import (
     BLESessionState,
+    LEGACY_SESSION_STATE_CACHE_ERROR,
     _LegacyBLESessionStateAdapter,
     _session_state_for,
 )
 from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
+
+pytestmark = pytest.mark.unit
 
 
 def _bare_interface() -> BLEInterface:
@@ -175,6 +180,49 @@ def test_mixin_promotion_preserves_cached_adapter_lock() -> None:
 
     assert state.lock is replacement_lock
     assert adapter.lock is replacement_lock
+
+
+def test_uncacheable_legacy_collaborator_requires_explicit_session() -> None:
+    """Slot-only legacy collaborators must not create competing implicit owners."""
+
+    class _SlotLegacy:
+        __slots__ = ("_closed", "_receiveThread")
+
+        def __init__(self) -> None:
+            self._closed = False
+            self._receiveThread = None
+
+    legacy = _SlotLegacy()
+    explicit = BLESessionState(lock=threading.RLock())
+
+    with pytest.raises(TypeError) as exc_info:
+        _session_state_for(legacy)
+
+    assert str(exc_info.value) == LEGACY_SESSION_STATE_CACHE_ERROR
+    assert _session_state_for(legacy, explicit) is explicit
+
+
+def test_disconnect_reconnect_scheduler_missing_on_partial_interface() -> None:
+    """Partial interfaces should fail with the stable missing-scheduler contract."""
+    from threading import Event, RLock
+
+    from meshtastic.interfaces.ble.lifecycle_disconnect_runtime import (
+        BLEDisconnectLifecycleCoordinator,
+    )
+    from meshtastic.interfaces.ble.lifecycle_primitives import (
+        RECONNECT_SCHEDULER_MISSING_MSG,
+    )
+
+    state = BLESessionState(lock=RLock())
+    iface = SimpleNamespace(auto_reconnect=True, _shutdown_event=Event())
+    coordinator = BLEDisconnectLifecycleCoordinator(  # type: ignore[arg-type]
+        iface, session_state=state
+    )
+
+    with pytest.raises(AttributeError) as exc_info:
+        coordinator.schedule_auto_reconnect(is_closing_getter=lambda: False)
+
+    assert str(exc_info.value) == RECONNECT_SCHEDULER_MISSING_MSG
 
 
 def test_receive_lifecycle_uses_explicit_session_pending_markers() -> None:

--- a/tests/test_ble_session_state.py
+++ b/tests/test_ble_session_state.py
@@ -985,8 +985,105 @@ def test_disconnect_planning_runs_address_helpers_outside_session_lock() -> None
     assert all(held is False for _operation, held in helper_lock_states)
 
 
+def test_disconnect_compatibility_state_callbacks_run_outside_session_lock() -> None:
+    """Legacy state probes and mutations must not execute under session ownership."""
+    from meshtastic.interfaces.ble.lifecycle_disconnect_runtime import (
+        BLEDisconnectLifecycleCoordinator,
+    )
+
+    lock = _TrackingRLock()
+    state = BLESessionState(lock=lock)
+    previous_client = SimpleNamespace(address="AA:BB:CC:DD:EE:FF")
+    state.connection_alias_key = "AA:BB:CC:DD:EE:FF"
+    callback_lock_states: list[tuple[str, bool]] = []
+    current_states = iter((ConnectionState.CONNECTED, ConnectionState.ERROR))
+
+    def _current_state() -> ConnectionState:
+        callback_lock_states.append(("current", lock.held))
+        return next(current_states)
+
+    def _transition() -> bool:
+        callback_lock_states.append(("transition", lock.held))
+        return False
+
+    def _reset() -> bool:
+        callback_lock_states.append(("reset", lock.held))
+        return False
+
+    iface = SimpleNamespace(
+        auto_reconnect=False,
+        client=previous_client,
+        address="AA:BB:CC:DD:EE:FF",
+        _extract_client_address=lambda _client: "AA:BB:CC:DD:EE:FF",
+        _sorted_address_keys=lambda *keys: [key for key in keys if key],
+    )
+    coordinator = BLEDisconnectLifecycleCoordinator(  # type: ignore[arg-type]
+        iface, session_state=state
+    )
+
+    plan = coordinator._resolve_disconnect_target(  # noqa: SLF001
+        "test",
+        client=previous_client,  # type: ignore[arg-type]
+        bleak_client=None,
+        current_state_getter=_current_state,
+        is_closing_getter=lambda: False,
+        transition_to_disconnected=_transition,
+        reset_to_disconnected=_reset,
+    )
+
+    assert plan.early_return is None
+    assert callback_lock_states == [
+        ("current", False),
+        ("transition", False),
+        ("reset", False),
+        ("current", False),
+    ]
+
+
+def test_disconnect_canonical_state_manager_keeps_state_and_session_atomic() -> None:
+    """Owned state-manager transitions should use lock-safe canonical primitives."""
+    from meshtastic.interfaces.ble.lifecycle_disconnect_runtime import (
+        BLEDisconnectLifecycleCoordinator,
+    )
+
+    state_manager = BLEStateManager()
+    assert state_manager.transition_to(ConnectionState.CONNECTING)
+    assert state_manager.transition_to(ConnectionState.CONNECTED)
+    state = BLESessionState(lock=state_manager.lock)
+    previous_client = SimpleNamespace(address="AA:BB:CC:DD:EE:FF")
+    iface = SimpleNamespace(
+        auto_reconnect=False,
+        client=previous_client,
+        address="AA:BB:CC:DD:EE:FF",
+        _state_manager=state_manager,
+        _extract_client_address=lambda _client: "AA:BB:CC:DD:EE:FF",
+        _sorted_address_keys=lambda *keys: [key for key in keys if key],
+    )
+    coordinator = BLEDisconnectLifecycleCoordinator(  # type: ignore[arg-type]
+        iface, session_state=state
+    )
+    coordinator._state_access.current_state = lambda: (_ for _ in ()).throw(  # type: ignore[method-assign]  # noqa: SLF001
+        AssertionError("canonical state read must not use compatibility dispatch")
+    )
+    coordinator._state_access.transition_to = lambda _state: (_ for _ in ()).throw(  # type: ignore[method-assign]  # noqa: SLF001
+        AssertionError("canonical transition must not use compatibility dispatch")
+    )
+
+    plan = coordinator._resolve_disconnect_target(  # noqa: SLF001
+        "test",
+        client=previous_client,  # type: ignore[arg-type]
+        bleak_client=None,
+    )
+
+    assert plan.early_return is None
+    assert iface.client is None
+    assert state.disconnect_notified is True
+    assert state_manager.current_state == ConnectionState.DISCONNECTED
+
+
 def test_transient_retry_revalidation_is_bounded_under_continuous_churn(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A pathological policy/state race must not spin the receive thread forever."""
     import meshtastic.interfaces.ble.receive_service as receive_service_module

--- a/tests/test_ble_session_state.py
+++ b/tests/test_ble_session_state.py
@@ -1,5 +1,6 @@
 """Tests for owned BLE session-state compatibility views."""
 
+import logging
 import threading
 from types import SimpleNamespace, TracebackType
 
@@ -319,6 +320,7 @@ def test_mixin_promotion_preserves_legacy_values_and_state_manager_lock() -> Non
     adapter = _LegacyBLESessionStateAdapter(iface)
     iface.__dict__["_session_state"] = adapter
 
+    assert adapter.lock is state_manager.lock
     state = iface._get_session_state()
 
     assert isinstance(state, BLESessionState)
@@ -349,12 +351,27 @@ def test_mixin_promotion_preserves_raw_legacy_lock_without_state_manager() -> No
     adapter = _LegacyBLESessionStateAdapter(iface)
     iface.__dict__["_session_state"] = adapter
 
+    assert adapter.lock is legacy_lock
     state = iface._get_session_state()
 
     assert state.lock is legacy_lock
     assert state.closed is True
     assert "_state_lock" not in iface.__dict__
     assert "_closed" not in iface.__dict__
+
+
+def test_mixin_promotion_without_declared_lock_reuses_adapter_fallback() -> None:
+    """Promotion without a declared owner lock must keep the adapter's one lock."""
+    iface = BLEInterface.__new__(BLEInterface)
+    adapter = _LegacyBLESessionStateAdapter(iface)
+    iface.__dict__["_session_state"] = adapter
+
+    fallback_lock = adapter.lock
+    state = iface._get_session_state()
+
+    assert isinstance(state, BLESessionState)
+    assert state.lock is fallback_lock
+    assert adapter.lock is fallback_lock
 
 
 def test_uncacheable_legacy_collaborator_requires_explicit_session() -> None:
@@ -428,12 +445,10 @@ def test_receive_lifecycle_uses_explicit_session_pending_markers() -> None:
     def _unexpected_create(**_kwargs: object) -> object:
         raise AssertionError("pending session state should suppress thread creation")
 
-    created, recovery_attempts = (
-        coordinator._check_receive_start_conditions(  # noqa: SLF001
-            name="PendingReceive",
-            reset_recovery=False,
-            create_runtime_thread=_unexpected_create,  # type: ignore[arg-type]
-        )
+    created, recovery_attempts = coordinator._check_receive_start_conditions(  # noqa: SLF001
+        name="PendingReceive",
+        reset_recovery=False,
+        create_runtime_thread=_unexpected_create,  # type: ignore[arg-type]
     )
 
     assert created is None
@@ -503,12 +518,14 @@ def test_transient_retry_revalidates_concurrent_counter_reset(
     iface = SimpleNamespace(
         _transient_read_policy=object(),
         _retry_policy_should_retry=_should_retry,
-        _retry_policy_get_delay=lambda _policy, attempt: delay_attempts.append(attempt)
-        or 0.0,
+        _retry_policy_get_delay=lambda _policy, attempt: (
+            delay_attempts.append(attempt) or 0.0
+        ),
         BLEError=RuntimeError,
     )
     controller = BLEReceiveRecoveryController(
-        iface, session_state=state  # type: ignore[arg-type]
+        iface,
+        session_state=state,  # type: ignore[arg-type]
     )
     monkeypatch.setattr(receive_service_module, "_sleep", lambda _delay: None)
 
@@ -519,7 +536,9 @@ def test_transient_retry_revalidates_concurrent_counter_reset(
     assert delay_attempts == [0]
 
 
-def test_receive_lifecycle_schedules_inconclusive_restart_outside_session_lock() -> None:
+def test_receive_lifecycle_schedules_inconclusive_restart_outside_session_lock() -> (
+    None
+):
     """Deferred restart scheduling must not begin while the session lock is held."""
     from meshtastic.interfaces.ble.lifecycle_receive_runtime import (
         BLEReceiveLifecycleCoordinator,
@@ -702,7 +721,8 @@ def test_disconnect_plan_reads_epoch_from_explicit_session_state() -> None:
         _sorted_address_keys=lambda *keys: [key for key in keys if key],
     )
     coordinator = BLEDisconnectLifecycleCoordinator(
-        iface, session_state=state  # type: ignore[arg-type]
+        iface,
+        session_state=state,  # type: ignore[arg-type]
     )
 
     plan = coordinator._resolve_disconnect_target(  # noqa: SLF001
@@ -744,7 +764,8 @@ def test_disconnect_source_write_uses_session_lock() -> None:
     session = _Session()
     iface = SimpleNamespace(client=None)
     coordinator = BLEDisconnectLifecycleCoordinator(
-        iface, session_state=session  # type: ignore[arg-type]
+        iface,
+        session_state=session,  # type: ignore[arg-type]
     )
     plan = _DisconnectPlan(
         early_return=False,
@@ -787,7 +808,8 @@ def test_ownership_cleanup_reads_explicit_session_state() -> None:
         _connection_session_epoch=1,
     )
     coordinator = BLEConnectionOwnershipLifecycleCoordinator(
-        iface, session_state=state  # type: ignore[arg-type]
+        iface,
+        session_state=state,  # type: ignore[arg-type]
     )
 
     coordinator._discard_invalidated_connected_client(  # noqa: SLF001
@@ -890,7 +912,8 @@ def test_ownership_invalidation_closing_probe_runs_outside_session_lock() -> Non
         _last_connection_request="legacy-request",
     )
     coordinator = BLEConnectionOwnershipLifecycleCoordinator(
-        iface, session_state=state  # type: ignore[arg-type]
+        iface,
+        session_state=state,  # type: ignore[arg-type]
     )
     probe_lock_states: list[bool] = []
 
@@ -910,6 +933,75 @@ def test_ownership_invalidation_closing_probe_runs_outside_session_lock() -> Non
     )
 
     assert probe_lock_states == [False]
+
+
+def test_ownership_status_probes_run_outside_session_lock() -> None:
+    """Ownership compatibility/client probes must not run under shared state lock."""
+    from meshtastic.interfaces.ble.lifecycle_ownership_runtime import (
+        BLEConnectionOwnershipLifecycleCoordinator,
+    )
+
+    lock = _TrackingRLock()
+    client = object()
+    state = BLESessionState(lock=lock)
+    iface = SimpleNamespace(client=client, _state_manager=SimpleNamespace())
+    coordinator = BLEConnectionOwnershipLifecycleCoordinator(
+        iface,
+        session_state=state,  # type: ignore[arg-type]
+    )
+    probe_lock_states: list[tuple[str, bool]] = []
+
+    def _probe(name: str) -> bool:
+        probe_lock_states.append((name, lock.held))
+        return True
+
+    assert coordinator._get_connected_client_status(  # noqa: SLF001
+        client,  # type: ignore[arg-type]
+        is_closing_getter=lambda: not _probe("closing"),
+        state_connected_getter=lambda: _probe("state"),
+        client_connected_getter=lambda _client: _probe("client"),
+    ) == (True, False)
+    assert probe_lock_states == [
+        ("closing", False),
+        ("state", False),
+        ("client", False),
+    ]
+
+
+def test_ownership_status_provider_revalidates_session_epoch() -> None:
+    """A status result cannot authorize publication after session generation changes."""
+    from meshtastic.interfaces.ble.lifecycle_ownership_runtime import (
+        BLEConnectionOwnershipLifecycleCoordinator,
+    )
+
+    lock = _TrackingRLock()
+    client = object()
+    state = BLESessionState(lock=lock, connection_session_epoch=4)
+    iface = SimpleNamespace(
+        client=client,
+        _state_manager=SimpleNamespace(),
+        _has_lost_gate_ownership=lambda *_keys: False,
+    )
+    coordinator = BLEConnectionOwnershipLifecycleCoordinator(
+        iface,
+        session_state=state,  # type: ignore[arg-type]
+    )
+
+    def _racing_status(_client: object) -> tuple[bool, bool]:
+        assert lock.held is False
+        with lock:
+            state.connection_session_epoch += 1
+        return True, False
+
+    snapshot = coordinator._verify_ownership_snapshot(  # noqa: SLF001
+        client,  # type: ignore[arg-type]
+        "device-key",
+        "alias-key",
+        get_connected_client_status_locked=_racing_status,  # type: ignore[arg-type]
+    )
+
+    assert snapshot.still_owned is False
+    assert snapshot.is_closing is False
 
 
 def test_receive_snapshot_compatibility_probes_run_outside_session_lock() -> None:
@@ -936,7 +1028,8 @@ def test_receive_snapshot_compatibility_probes_run_outside_session_lock() -> Non
         ),
     )
     controller = BLEReceiveRecoveryController(
-        iface, session_state=state  # type: ignore[arg-type]
+        iface,
+        session_state=state,  # type: ignore[arg-type]
     )
 
     assert controller._snapshot_client_state() == (None, True, False, False)  # noqa: SLF001
@@ -1109,14 +1202,19 @@ def test_transient_retry_revalidation_is_bounded_under_continuous_churn(
     iface = SimpleNamespace(
         _transient_read_policy=object(),
         _retry_policy_should_retry=_should_retry,
-        _retry_policy_get_delay=lambda _policy, attempt: delay_attempts.append(attempt)
-        or 0.0,
+        _retry_policy_get_delay=lambda _policy, attempt: (
+            delay_attempts.append(attempt) or 0.0
+        ),
         BLEError=RuntimeError,
     )
     controller = BLEReceiveRecoveryController(
-        iface, session_state=state  # type: ignore[arg-type]
+        iface,
+        session_state=state,  # type: ignore[arg-type]
     )
     monkeypatch.setattr(receive_service_module, "_sleep", lambda _delay: None)
+    caplog.set_level(
+        logging.WARNING, logger="meshtastic.interfaces.ble.receive_service"
+    )
 
     controller.handle_transient_read_error(BleakError("transient"))
 

--- a/tests/test_ble_session_state.py
+++ b/tests/test_ble_session_state.py
@@ -1,7 +1,7 @@
 """Tests for owned BLE session-state compatibility views."""
 
 import threading
-from types import SimpleNamespace
+from types import SimpleNamespace, TracebackType
 
 from meshtastic.interfaces.ble.interface import BLEInterface
 from meshtastic.interfaces.ble.lifecycle_controller_runtime import (
@@ -133,6 +133,20 @@ def test_legacy_session_state_adapter_implements_reset_contract() -> None:
     assert legacy._last_recovery_time == 0.0
 
 
+def test_legacy_session_state_adapter_tracks_replaced_declared_lock() -> None:
+    """Legacy adapters should follow the interface's current declared state lock."""
+    first_lock = threading.RLock()
+    replacement_lock = threading.RLock()
+    legacy = SimpleNamespace(_state_lock=first_lock)
+
+    state = _session_state_for(legacy)
+    assert state.lock is first_lock
+
+    legacy._state_lock = replacement_lock
+
+    assert state.lock is replacement_lock
+
+
 def test_partial_interface_resolves_mixin_session_owner_directly() -> None:
     """Partial BLE interfaces should not create a competing legacy adapter."""
     iface = BLEInterface.__new__(BLEInterface)
@@ -145,7 +159,7 @@ def test_partial_interface_resolves_mixin_session_owner_directly() -> None:
 
 
 def test_mixin_promotion_preserves_cached_adapter_lock() -> None:
-    """Fallback adapter promotion must retain the coordinator's shared lock."""
+    """Fallback adapter promotion must retain one shared, replaceable state lock."""
     iface = BLEInterface.__new__(BLEInterface)
     adapter = _LegacyBLESessionStateAdapter(iface)
     iface.__dict__["_session_state"] = adapter
@@ -155,6 +169,12 @@ def test_mixin_promotion_preserves_cached_adapter_lock() -> None:
     assert isinstance(state, BLESessionState)
     assert state.lock is adapter.lock
     assert iface._state_lock is adapter.lock
+
+    replacement_lock = threading.RLock()
+    iface._state_lock = replacement_lock
+
+    assert state.lock is replacement_lock
+    assert adapter.lock is replacement_lock
 
 
 def test_receive_lifecycle_uses_explicit_session_pending_markers() -> None:
@@ -178,7 +198,9 @@ def test_receive_lifecycle_uses_explicit_session_pending_markers() -> None:
         _receive_start_pending=False,
         _receive_start_pending_since=None,
     )
-    coordinator = BLEReceiveLifecycleCoordinator(iface, session_state=state)  # type: ignore[arg-type]
+    coordinator = BLEReceiveLifecycleCoordinator(  # type: ignore[arg-type]
+        iface, session_state=state
+    )
 
     def _unexpected_create(**_kwargs: object) -> object:
         raise AssertionError("pending session state should suppress thread creation")
@@ -207,6 +229,127 @@ def test_receive_controller_reads_ever_connected_from_explicit_session() -> None
     controller = BLEReceiveRecoveryController(iface, session_state=state)  # type: ignore[arg-type]
 
     assert controller._has_ever_connected_session() is True  # noqa: SLF001
+
+
+def test_receive_controller_invalid_lifecycle_results_fall_back_to_session() -> None:
+    """Non-bool lifecycle probes must not override authoritative session state."""
+    from meshtastic.interfaces.ble.receive_service import BLEReceiveRecoveryController
+
+    state_manager = BLEStateManager()
+    state = BLESessionState(lock=state_manager.lock, ever_connected=True, closed=True)
+    lifecycle = SimpleNamespace(
+        _has_ever_connected_session=lambda: None,
+        _is_connection_closing=lambda: object(),
+    )
+    iface = SimpleNamespace(
+        _get_lifecycle_controller=lambda: lifecycle,
+        _state_manager=None,
+        _is_connection_closing=False,
+    )
+    controller = BLEReceiveRecoveryController(iface, session_state=state)  # type: ignore[arg-type]
+
+    assert controller._has_ever_connected_session() is True  # noqa: SLF001
+    assert controller._is_connection_closing() is True  # noqa: SLF001
+
+
+def test_receive_lifecycle_schedules_inconclusive_restart_outside_session_lock() -> None:
+    """Deferred restart scheduling must not begin while the session lock is held."""
+    from meshtastic.interfaces.ble.lifecycle_receive_runtime import (
+        BLEReceiveLifecycleCoordinator,
+    )
+
+    class _TrackingLock:
+        def __init__(self) -> None:
+            self._lock = threading.RLock()
+            self.held = False
+
+        def __enter__(self) -> "_TrackingLock":
+            self._lock.acquire()
+            self.held = True
+            return self
+
+        def __exit__(
+            self,
+            _exc_type: type[BaseException] | None,
+            _exc_value: BaseException | None,
+            _traceback: TracebackType | None,
+        ) -> None:
+            self.held = False
+            self._lock.release()
+
+    lock = _TrackingLock()
+    state = BLESessionState(lock=lock)
+    existing = SimpleNamespace(
+        name="InconclusiveReceive", ident=None, is_alive=lambda: False
+    )
+    state.receive_thread = existing  # type: ignore[assignment]
+    iface = SimpleNamespace(_receive_from_radio_impl=lambda: None)
+    coordinator = BLEReceiveLifecycleCoordinator(  # type: ignore[arg-type]
+        iface, session_state=state
+    )
+    scheduled: list[tuple[object, bool]] = []
+
+    def _capture_schedule(**kwargs: object) -> None:
+        assert lock.held is False
+        scheduled.append(
+            (kwargs["existing_thread"], bool(kwargs["enforce_pending_timeout"]))
+        )
+
+    coordinator._schedule_deferred_receive_restart = (  # type: ignore[method-assign]
+        _capture_schedule
+    )
+
+    created, recovery_attempts = coordinator._check_receive_start_conditions(  # noqa: SLF001
+        name="InconclusiveReceive",
+        reset_recovery=False,
+        create_runtime_thread=lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("inconclusive liveness must defer thread creation")
+        ),
+    )
+
+    assert created is None
+    assert recovery_attempts is None
+    assert scheduled == [(existing, True)]
+    assert state.receive_start_pending is True
+
+
+def test_disconnect_plan_reads_epoch_from_explicit_session_state() -> None:
+    """Disconnect staleness must use the coordinator's owned session epoch."""
+    from meshtastic.interfaces.ble.lifecycle_disconnect_runtime import (
+        BLEDisconnectLifecycleCoordinator,
+    )
+
+    state_manager = BLEStateManager()
+    state = BLESessionState(
+        lock=state_manager.lock,
+        client_publish_pending=True,
+        connection_session_epoch=9,
+    )
+    iface = SimpleNamespace(
+        auto_reconnect=False,
+        client=None,
+        address="AA:BB:CC:DD:EE:FF",
+        _connection_session_epoch=1,
+        _shutdown_event=threading.Event(),
+        _extract_client_address=lambda _client: None,
+        _sorted_address_keys=lambda *keys: [key for key in keys if key],
+    )
+    coordinator = BLEDisconnectLifecycleCoordinator(
+        iface, session_state=state  # type: ignore[arg-type]
+    )
+
+    plan = coordinator._resolve_disconnect_target(  # noqa: SLF001
+        "explicit-session",
+        client=None,
+        bleak_client=None,
+        current_state_getter=lambda: ConnectionState.CONNECTED,
+        is_closing_getter=lambda: False,
+        transition_to_disconnected=lambda: True,
+        reset_to_disconnected=lambda: True,
+    )
+
+    assert plan.session_epoch == 9
+    assert iface._connection_session_epoch == 1
 
 
 def test_ownership_cleanup_reads_explicit_session_state() -> None:

--- a/tests/test_ble_session_state.py
+++ b/tests/test_ble_session_state.py
@@ -185,7 +185,11 @@ def test_legacy_session_state_resolution_is_atomic(
 
 def test_legacy_adapter_field_map_matches_session_state_protocol() -> None:
     """The cast-backed legacy adapter must cover every protocol data field."""
-    protocol_fields = set(_BLESessionStatePort.__annotations__)
+    protocol_fields = {
+        field_name
+        for protocol_base in _BLESessionStatePort.__mro__
+        for field_name in getattr(protocol_base, "__annotations__", {})
+    }
 
     assert set(_LegacyBLESessionStateAdapter._FIELD_MAP) == protocol_fields  # noqa: SLF001
     assert set(_LegacyBLESessionStateAdapter._FIELD_DEFAULTS) == (  # noqa: SLF001
@@ -441,9 +445,12 @@ def test_transient_retry_does_not_resurrect_concurrent_counter_reset(
     state = BLESessionState(lock=state_manager.lock, read_retry_count=3)
     delay_attempts: list[int] = []
 
+    policy_attempts: list[int] = []
+
     def _should_retry(_policy: object, attempt: int) -> bool:
-        assert attempt == 3
-        state._reset_read_retry_count()
+        policy_attempts.append(attempt)
+        if attempt == 3:
+            state._reset_read_retry_count()
         return True
 
     iface = SimpleNamespace(
@@ -460,6 +467,45 @@ def test_transient_retry_does_not_resurrect_concurrent_counter_reset(
 
     controller.handle_transient_read_error(BleakError("transient"))
 
+    assert policy_attempts == [3, 0]
+    assert state.read_retry_count == 1
+    assert delay_attempts == [0]
+
+
+def test_transient_retry_revalidates_stale_terminal_policy_decision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A concurrent retry reset must invalidate a stale terminal decision."""
+    import meshtastic.interfaces.ble.receive_service as receive_service_module
+    from meshtastic.interfaces.ble.receive_service import BLEReceiveRecoveryController
+
+    state_manager = BLEStateManager()
+    state = BLESessionState(lock=state_manager.lock, read_retry_count=3)
+    policy_attempts: list[int] = []
+    delay_attempts: list[int] = []
+
+    def _should_retry(_policy: object, attempt: int) -> bool:
+        policy_attempts.append(attempt)
+        if attempt == 3:
+            state._reset_read_retry_count()
+            return False
+        return True
+
+    iface = SimpleNamespace(
+        _transient_read_policy=object(),
+        _retry_policy_should_retry=_should_retry,
+        _retry_policy_get_delay=lambda _policy, attempt: delay_attempts.append(attempt)
+        or 0.0,
+        BLEError=RuntimeError,
+    )
+    controller = BLEReceiveRecoveryController(
+        iface, session_state=state  # type: ignore[arg-type]
+    )
+    monkeypatch.setattr(receive_service_module, "_sleep", lambda _delay: None)
+
+    controller.handle_transient_read_error(BleakError("transient"))
+
+    assert policy_attempts == [3, 0]
     assert state.read_retry_count == 1
     assert delay_attempts == [0]
 
@@ -705,3 +751,209 @@ def test_ownership_cleanup_reads_explicit_session_state() -> None:
     assert iface._client_publish_pending is False
     assert iface._connected_publish_inflight_client is None
     assert iface._connection_session_epoch == 1
+
+
+def test_receive_start_resnapshot_loop_is_bounded_under_continuous_churn() -> None:
+    """Repeated snapshot invalidation must bail out instead of spinning forever."""
+    from meshtastic.interfaces.ble.lifecycle_receive_runtime import (
+        RECEIVE_START_SNAPSHOT_MAX_ATTEMPTS,
+        BLEReceiveLifecycleCoordinator,
+    )
+
+    state_manager = BLEStateManager()
+    state = BLESessionState(lock=state_manager.lock, want_receive=True)
+    probe_count = 0
+
+    class _ChurningThread:
+        name = "ChurningReceive"
+        ident = None
+
+        def is_alive(self) -> bool:
+            nonlocal probe_count
+            probe_count += 1
+            with state.lock:
+                state.receive_thread = _ChurningThread()  # type: ignore[assignment]
+            return False
+
+    state.receive_thread = _ChurningThread()  # type: ignore[assignment]
+    coordinator = BLEReceiveLifecycleCoordinator(  # type: ignore[arg-type]
+        SimpleNamespace(), session_state=state
+    )
+    created_threads: list[object] = []
+
+    result = coordinator._check_receive_start_conditions(  # noqa: SLF001
+        name="Receive",
+        reset_recovery=False,
+        create_runtime_thread=lambda **_kwargs: created_threads.append(object()),  # type: ignore[return-value]
+    )
+
+    assert result == (None, None)
+    assert probe_count == RECEIVE_START_SNAPSHOT_MAX_ATTEMPTS
+    assert created_threads == []
+
+
+def test_shutdown_closing_probe_runs_outside_session_lock() -> None:
+    """Closing compatibility probes must not execute under shared lifecycle state."""
+    from meshtastic.interfaces.ble.lifecycle_shutdown_runtime import (
+        BLEShutdownLifecycleCoordinator,
+    )
+
+    lock = _TrackingRLock()
+    state = BLESessionState(lock=lock)
+    probe_lock_states: list[bool] = []
+
+    def _is_closing() -> bool:
+        probe_lock_states.append(lock.held)
+        return False
+
+    iface = SimpleNamespace(_state_manager=SimpleNamespace(is_closing=_is_closing))
+    coordinator = BLEShutdownLifecycleCoordinator(  # type: ignore[arg-type]
+        iface, session_state=state
+    )
+
+    assert coordinator.is_connection_closing() is False
+    assert probe_lock_states == [False]
+
+
+def test_disconnect_planning_runs_address_helpers_outside_session_lock() -> None:
+    """Address/registry planning must not extend the disconnect state critical section."""
+    from meshtastic.interfaces.ble.lifecycle_disconnect_runtime import (
+        BLEDisconnectLifecycleCoordinator,
+    )
+
+    lock = _TrackingRLock()
+    state = BLESessionState(lock=lock)
+    previous_client = SimpleNamespace(address="AA:BB:CC:DD:EE:FF")
+    helper_lock_states: list[tuple[str, bool]] = []
+
+    def _extract_client_address(_client: object) -> str:
+        helper_lock_states.append(("extract", lock.held))
+        return "AA:BB:CC:DD:EE:FF"
+
+    def _sorted_address_keys(*keys: str | None) -> list[str]:
+        helper_lock_states.append(("sort", lock.held))
+        return [key for key in keys if key]
+
+    iface = SimpleNamespace(
+        auto_reconnect=False,
+        client=previous_client,
+        address="AA:BB:CC:DD:EE:FF",
+        _extract_client_address=_extract_client_address,
+        _sorted_address_keys=_sorted_address_keys,
+    )
+    coordinator = BLEDisconnectLifecycleCoordinator(  # type: ignore[arg-type]
+        iface, session_state=state
+    )
+
+    plan = coordinator._resolve_disconnect_target(  # noqa: SLF001
+        "test",
+        client=previous_client,  # type: ignore[arg-type]
+        bleak_client=None,
+        current_state_getter=lambda: ConnectionState.CONNECTED,
+        is_closing_getter=lambda: False,
+        transition_to_disconnected=lambda: True,
+        reset_to_disconnected=lambda: True,
+    )
+
+    assert plan.early_return is None
+    assert helper_lock_states
+    assert all(held is False for _operation, held in helper_lock_states)
+
+
+def test_transient_retry_revalidation_is_bounded_under_continuous_churn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pathological policy/state race must not spin the receive thread forever."""
+    import meshtastic.interfaces.ble.receive_service as receive_service_module
+    from meshtastic.interfaces.ble.receive_service import (
+        TRANSIENT_RETRY_POLICY_REVALIDATION_MAX_ATTEMPTS,
+        BLEReceiveRecoveryController,
+    )
+
+    state_manager = BLEStateManager()
+    state = BLESessionState(lock=state_manager.lock)
+    policy_attempts: list[int] = []
+    delay_attempts: list[int] = []
+
+    def _should_retry(_policy: object, attempt: int) -> bool:
+        policy_attempts.append(attempt)
+        with state.lock:
+            state.read_retry_count += 1
+        return True
+
+    iface = SimpleNamespace(
+        _transient_read_policy=object(),
+        _retry_policy_should_retry=_should_retry,
+        _retry_policy_get_delay=lambda _policy, attempt: delay_attempts.append(attempt)
+        or 0.0,
+        BLEError=RuntimeError,
+    )
+    controller = BLEReceiveRecoveryController(
+        iface, session_state=state  # type: ignore[arg-type]
+    )
+    monkeypatch.setattr(receive_service_module, "_sleep", lambda _delay: None)
+
+    controller.handle_transient_read_error(BleakError("transient"))
+
+    assert len(policy_attempts) == TRANSIENT_RETRY_POLICY_REVALIDATION_MAX_ATTEMPTS
+    assert delay_attempts == []
+
+
+def test_disconnect_reconnect_closing_probe_runs_outside_session_lock() -> None:
+    """Reconnect closing probes must not execute under shared lifecycle state."""
+    from meshtastic.interfaces.ble.lifecycle_disconnect_runtime import (
+        BLEDisconnectLifecycleCoordinator,
+    )
+
+    lock = _TrackingRLock()
+    state = BLESessionState(lock=lock)
+    probe_lock_states: list[bool] = []
+
+    def _is_closing() -> bool:
+        probe_lock_states.append(lock.held)
+        return True
+
+    iface = SimpleNamespace(
+        auto_reconnect=True,
+        _shutdown_event=threading.Event(),
+        _reconnect_scheduler=SimpleNamespace(schedule_reconnect=lambda *_args: None),
+    )
+    coordinator = BLEDisconnectLifecycleCoordinator(  # type: ignore[arg-type]
+        iface, session_state=state
+    )
+
+    coordinator.schedule_auto_reconnect(is_closing_getter=_is_closing)
+
+    assert probe_lock_states == [False]
+
+
+def test_shutdown_start_does_not_probe_closing_after_terminal_close() -> None:
+    """Repeated shutdown must short-circuit before compatibility probe execution."""
+    from meshtastic.interfaces.ble.lifecycle_shutdown_runtime import (
+        BLEShutdownLifecycleCoordinator,
+    )
+
+    state_manager = BLEStateManager()
+    state = BLESessionState(lock=state_manager.lock, closed=True)
+    management_lock = threading.RLock()
+    iface = SimpleNamespace(
+        _management_lock=management_lock,
+        _management_idle_condition=threading.Condition(management_lock),
+        _management_inflight=0,
+    )
+    coordinator = BLEShutdownLifecycleCoordinator(  # type: ignore[arg-type]
+        iface, session_state=state
+    )
+
+    result = coordinator._await_management_shutdown(  # noqa: SLF001
+        management_shutdown_wait_timeout=0.01,
+        management_wait_poll_seconds=0.001,
+        current_state_getter=lambda: ConnectionState.DISCONNECTED,
+        is_closing_getter=lambda: (_ for _ in ()).throw(
+            AssertionError("closing probe must not run after terminal close")
+        ),
+        transition_to_state=lambda _state: True,
+        reset_to_disconnected=lambda: True,
+    )
+
+    assert result is None

--- a/tests/test_ble_session_state.py
+++ b/tests/test_ble_session_state.py
@@ -4,9 +4,15 @@ import threading
 from types import SimpleNamespace
 
 from meshtastic.interfaces.ble.interface import BLEInterface
-from meshtastic.interfaces.ble.lifecycle_controller_runtime import BLELifecycleController
-from meshtastic.interfaces.ble.session_state import BLESessionState, _session_state_for
-from meshtastic.interfaces.ble.state import BLEStateManager
+from meshtastic.interfaces.ble.lifecycle_controller_runtime import (
+    BLELifecycleController,
+)
+from meshtastic.interfaces.ble.session_state import (
+    BLESessionState,
+    _LegacyBLESessionStateAdapter,
+    _session_state_for,
+)
+from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
 
 
 def _bare_interface() -> BLEInterface:
@@ -52,8 +58,8 @@ def test_session_state_retry_reset_helpers() -> None:
     state.receive_recovery_attempts = 2
     state.last_recovery_time = 11.0
 
-    state.reset_receive_retry_state()
-    state.reset_recovery_state()
+    state._reset_receive_retry_state()
+    state._reset_recovery_state()
 
     assert state.read_retry_count == 0
     assert state.last_empty_read_warning == 0.0
@@ -111,20 +117,44 @@ def test_legacy_session_state_adapter_implements_reset_contract() -> None:
 
     state = _session_state_for(legacy)
     assert _session_state_for(legacy) is state
-    assert state.lock is state.lock
+    assert state.lock is legacy._state_lock
 
-    state.reset_read_retry_count()
+    state._reset_read_retry_count()
     assert legacy._read_retry_count == 0
 
     legacy._read_retry_count = 2
-    state.reset_receive_retry_state()
+    state._reset_receive_retry_state()
     assert legacy._read_retry_count == 0
     assert legacy._last_empty_read_warning == 0.0
     assert legacy._suppressed_empty_read_warnings == 0
 
-    state.reset_recovery_state()
+    state._reset_recovery_state()
     assert legacy._receive_recovery_attempts == 0
     assert legacy._last_recovery_time == 0.0
+
+
+def test_partial_interface_resolves_mixin_session_owner_directly() -> None:
+    """Partial BLE interfaces should not create a competing legacy adapter."""
+    iface = BLEInterface.__new__(BLEInterface)
+
+    state = _session_state_for(iface)
+
+    assert isinstance(state, BLESessionState)
+    assert state is iface._get_session_state()
+    assert state.lock is iface._state_lock
+
+
+def test_mixin_promotion_preserves_cached_adapter_lock() -> None:
+    """Fallback adapter promotion must retain the coordinator's shared lock."""
+    iface = BLEInterface.__new__(BLEInterface)
+    adapter = _LegacyBLESessionStateAdapter(iface)
+    iface.__dict__["_session_state"] = adapter
+
+    state = iface._get_session_state()
+
+    assert isinstance(state, BLESessionState)
+    assert state.lock is adapter.lock
+    assert iface._state_lock is adapter.lock
 
 
 def test_receive_lifecycle_uses_explicit_session_pending_markers() -> None:
@@ -135,7 +165,9 @@ def test_receive_lifecycle_uses_explicit_session_pending_markers() -> None:
 
     state_manager = BLEStateManager()
     state = BLESessionState(lock=state_manager.lock)
-    pending_thread = SimpleNamespace(name="PendingReceive", ident=None, is_alive=lambda: False)
+    pending_thread = SimpleNamespace(
+        name="PendingReceive", ident=None, is_alive=lambda: False
+    )
     state.receive_thread = pending_thread
     state.receive_start_pending = True
     state.receive_start_pending_since = 10**12  # safely in the future for this probe
@@ -151,10 +183,12 @@ def test_receive_lifecycle_uses_explicit_session_pending_markers() -> None:
     def _unexpected_create(**_kwargs: object) -> object:
         raise AssertionError("pending session state should suppress thread creation")
 
-    created, recovery_attempts = coordinator._check_receive_start_conditions(  # noqa: SLF001
-        name="PendingReceive",
-        reset_recovery=False,
-        create_runtime_thread=_unexpected_create,  # type: ignore[arg-type]
+    created, recovery_attempts = (
+        coordinator._check_receive_start_conditions(  # noqa: SLF001
+            name="PendingReceive",
+            reset_recovery=False,
+            create_runtime_thread=_unexpected_create,  # type: ignore[arg-type]
+        )
     )
 
     assert created is None
@@ -173,3 +207,48 @@ def test_receive_controller_reads_ever_connected_from_explicit_session() -> None
     controller = BLEReceiveRecoveryController(iface, session_state=state)  # type: ignore[arg-type]
 
     assert controller._has_ever_connected_session() is True  # noqa: SLF001
+
+
+def test_ownership_cleanup_reads_explicit_session_state() -> None:
+    """Publish cleanup must not consult contradictory interface compatibility fields."""
+    from meshtastic.interfaces.ble.lifecycle_ownership_runtime import (
+        BLEConnectionOwnershipLifecycleCoordinator,
+    )
+
+    client = object()
+    state_manager = BLEStateManager()
+    state = BLESessionState(
+        lock=state_manager.lock,
+        client_publish_pending=True,
+        connected_publish_inflight_client=client,  # type: ignore[arg-type]
+        connection_session_epoch=9,
+    )
+    iface = SimpleNamespace(
+        client=None,
+        address="legacy-address",
+        _last_connection_request="legacy-request",
+        _client_publish_pending=False,
+        _connected_publish_inflight_client=None,
+        _connection_session_epoch=1,
+    )
+    coordinator = BLEConnectionOwnershipLifecycleCoordinator(
+        iface, session_state=state  # type: ignore[arg-type]
+    )
+
+    coordinator._discard_invalidated_connected_client(  # noqa: SLF001
+        client,  # type: ignore[arg-type]
+        restore_address="AA:BB:CC:DD:EE:FF",
+        restore_last_connection_request="restored",
+        is_closing_getter=lambda: False,
+        reset_to_disconnected=lambda: True,
+        current_state_getter=lambda: ConnectionState.DISCONNECTED,
+        transition_to_disconnected=lambda: True,
+        safe_cleanup=lambda _cleanup, _name: None,
+    )
+
+    assert state.client_publish_pending is False
+    assert state.connected_publish_inflight_client is None
+    assert state.connection_session_epoch == 9
+    assert iface._client_publish_pending is False
+    assert iface._connected_publish_inflight_client is None
+    assert iface._connection_session_epoch == 1

--- a/tests/test_ble_session_state.py
+++ b/tests/test_ble_session_state.py
@@ -1,0 +1,58 @@
+"""Tests for owned BLE session-state compatibility views."""
+
+from meshtastic.interfaces.ble.interface import BLEInterface
+from meshtastic.interfaces.ble.session_state import BLESessionState
+from meshtastic.interfaces.ble.state import BLEStateManager
+
+
+def _bare_interface() -> BLEInterface:
+    """Create an uninitialized interface with only owned state collaborators."""
+    iface = BLEInterface.__new__(BLEInterface)
+    state_manager = BLEStateManager()
+    iface._state_manager = state_manager
+    iface._session_state = BLESessionState(lock=state_manager.lock)
+    return iface
+
+
+def test_interface_lifecycle_fields_delegate_to_session_state() -> None:
+    """Historical private fields should remain writable views of owned state."""
+    iface = _bare_interface()
+
+    iface._closed = True
+    iface._disconnect_notified = True
+    iface._client_publish_pending = True
+    iface._last_disconnect_source = "test"
+    iface._connection_session_epoch = 7
+    iface._want_receive = False
+    iface._receive_start_pending = True
+    iface._receive_start_pending_since = 12.5
+
+    assert iface._state_lock is iface._state_manager.lock
+    assert iface._session_state.closed is True
+    assert iface._session_state.disconnect_notified is True
+    assert iface._session_state.client_publish_pending is True
+    assert iface._session_state.last_disconnect_source == "test"
+    assert iface._session_state.connection_session_epoch == 7
+    assert iface._session_state.want_receive is False
+    assert iface._session_state.receive_start_pending is True
+    assert iface._session_state.receive_start_pending_since == 12.5
+
+
+def test_session_state_retry_reset_helpers() -> None:
+    """Retry/recovery bookkeeping resets should be explicit and complete."""
+    state_manager = BLEStateManager()
+    state = BLESessionState(lock=state_manager.lock)
+    state.read_retry_count = 3
+    state.last_empty_read_warning = 9.5
+    state.suppressed_empty_read_warnings = 4
+    state.receive_recovery_attempts = 2
+    state.last_recovery_time = 11.0
+
+    state.reset_receive_retry_state()
+    state.reset_recovery_state()
+
+    assert state.read_retry_count == 0
+    assert state.last_empty_read_warning == 0.0
+    assert state.suppressed_empty_read_warnings == 0
+    assert state.receive_recovery_attempts == 0
+    assert state.last_recovery_time == 0.0

--- a/tests/test_ble_utils_service_targets.py
+++ b/tests/test_ble_utils_service_targets.py
@@ -597,7 +597,7 @@ def test_management_helpers_cover_factory_and_target_edge_paths(
     try:
         iface._finish_management_operation = MagicMock()
         iface._validate_management_preconditions = MagicMock(return_value=None)
-        iface._get_management_client_if_available = MagicMock(
+        iface._get_management_client_if_available_locked = MagicMock(
             side_effect=RuntimeError("target resolution failure")
         )
 
@@ -617,7 +617,7 @@ def test_management_helpers_cover_factory_and_target_edge_paths(
             use_existing_client_without_resolved_address=True,
             expected_implicit_binding="AA:BB:CC:DD:EE:FF",
         )
-        fresh_iface._get_management_client_if_available = lambda _address: DummyClient()
+        fresh_iface._get_management_client_if_available_locked = lambda _address: DummyClient()
         fresh_iface._resolve_target_address_for_management = lambda _address: None
         fresh_iface._validate_management_preconditions = lambda: None
         fresh_iface._get_current_implicit_management_binding_locked = (
@@ -811,7 +811,7 @@ def test_resolve_management_target_existing_client_explicit_address_paths(
             expected_implicit_binding=None,
         )
         iface._validate_management_preconditions = lambda: None
-        iface._get_management_client_if_available = lambda _address: None
+        iface._get_management_client_if_available_locked = lambda _address: None
         resolved_addresses: list[str | None] = []
 
         def _resolve_target_address(address: str | None) -> str:
@@ -834,7 +834,7 @@ def test_resolve_management_target_existing_client_explicit_address_paths(
         refreshed_client.bleak_client = SimpleNamespace(address=None)
         resolved_addresses.clear()
 
-        iface._get_management_client_if_available = lambda _address: refreshed_client
+        iface._get_management_client_if_available_locked = lambda _address: refreshed_client
         iface._extract_client_address = lambda _client: None
 
         target, active_client = BLEManagementCommandsService._resolve_management_target(

--- a/tests/test_ble_utils_service_targets.py
+++ b/tests/test_ble_utils_service_targets.py
@@ -466,11 +466,16 @@ def test_legacy_status_publish_ignores_synthesized_thread_provider(
     )
 
     class _Iface:
+        def __init__(self) -> None:
+            self.synthesized_provider_calls = 0
+
         def __getattr__(self, name: str) -> object:
             if name == "_get_publishing_thread":
-                return lambda: (_ for _ in ()).throw(
-                    AssertionError("synthesized provider must be ignored")
-                )
+                def _synthesized_provider() -> object:
+                    self.synthesized_provider_calls += 1
+                    raise AssertionError("synthesized provider must be ignored")
+
+                return _synthesized_provider
             raise AttributeError(name)
 
     iface = _Iface()
@@ -494,6 +499,7 @@ def test_legacy_status_publish_ignores_synthesized_thread_provider(
     )
 
     assert sent == [("meshtastic.connection.status", iface, True)]
+    assert iface.synthesized_provider_calls == 0
 
 
 def test_coordination_inert_thread_start_is_noop() -> None:

--- a/tests/test_ble_utils_service_targets.py
+++ b/tests/test_ble_utils_service_targets.py
@@ -403,6 +403,99 @@ def test_publish_connection_status_legacy_resolves_default_publishing_thread(
     assert sent == [("meshtastic.connection.status", iface, True)]
 
 
+def test_status_publish_ignores_synthesized_closing_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A synthesized closing hook must not suppress an otherwise valid publish."""
+    import meshtastic.mesh_interface as mesh_iface_module
+    from meshtastic.interfaces.ble import (
+        compatibility_service as compatibility_service_mod,
+    )
+
+    sent: list[tuple[str, object, bool]] = []
+
+    class _StateManager:
+        _is_closing = False
+
+        def __getattr__(self, name: str) -> object:
+            if name == "is_closing":
+                return lambda: True
+            raise AttributeError(name)
+
+    class _ImmediateThread:
+        def __init__(self, *, target: Any, **_kwargs: object) -> None:
+            self._target = target
+
+        def start(self) -> None:
+            self._target()
+
+    iface = SimpleNamespace(_closed=False, _state_manager=_StateManager())
+    monkeypatch.setattr(
+        mesh_iface_module,
+        "pub",
+        SimpleNamespace(
+            sendMessage=lambda topic, *, interface, connected: sent.append(
+                (topic, interface, connected)
+            )
+        ),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        compatibility_service_mod, "Thread", _ImmediateThread, raising=True
+    )
+
+    BLECompatibilityEventService.publish_connection_status(
+        iface,  # type: ignore[arg-type]
+        connected=True,
+        publishing_thread=None,
+    )
+
+    assert sent == [("meshtastic.connection.status", iface, True)]
+
+
+def test_legacy_status_publish_ignores_synthesized_thread_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy status publishing should only call a declared provider hook."""
+    import meshtastic.mesh_interface as mesh_iface_module
+
+    sent: list[tuple[str, object, bool]] = []
+    fallback_thread = SimpleNamespace(
+        queue=SimpleNamespace(put_nowait=lambda callback: callback()),
+        thread=None,
+    )
+
+    class _Iface:
+        def __getattr__(self, name: str) -> object:
+            if name == "_get_publishing_thread":
+                return lambda: (_ for _ in ()).throw(
+                    AssertionError("synthesized provider must be ignored")
+                )
+            raise AttributeError(name)
+
+    iface = _Iface()
+    monkeypatch.setattr(
+        mesh_iface_module, "publishingThread", fallback_thread, raising=True
+    )
+    monkeypatch.setattr(
+        mesh_iface_module,
+        "pub",
+        SimpleNamespace(
+            sendMessage=lambda topic, *, interface, connected: sent.append(
+                (topic, interface, connected)
+            )
+        ),
+        raising=True,
+    )
+
+    BLECompatibilityEventService.publish_connection_status_legacy(
+        iface,  # type: ignore[arg-type]
+        connected=True,
+    )
+
+    assert sent == [("meshtastic.connection.status", iface, True)]
+
+
 def test_coordination_inert_thread_start_is_noop() -> None:
     """Starting an inert coordinator thread should only warn and return."""
     coordinator = ThreadCoordinator()

--- a/tests/test_ble_utils_service_targets.py
+++ b/tests/test_ble_utils_service_targets.py
@@ -902,7 +902,7 @@ def test_utils_remaining_optional_kwarg_and_safe_execute_branches() -> None:
 
     iface_no_hooks = SimpleNamespace(
         error_handler=SimpleNamespace(
-            safe_execute=MagicMock(), _safe_execute=MagicMock()
+            safe_execute=None, _safe_execute=None
         )
     )
     assert ble_utils._resolve_safe_execute(iface_no_hooks) is None
@@ -927,10 +927,10 @@ def test_utils_remaining_optional_kwarg_and_safe_execute_branches() -> None:
 
 
 def test_utils_resolve_safe_execute_legacy_hook_branch() -> None:
-    """Legacy underscore safe_execute hook should be returned when public hook is unconfigured."""
+    """Legacy underscore safe_execute hook should be returned when public hook is absent."""
     iface = SimpleNamespace(
         error_handler=SimpleNamespace(
-            safe_execute=MagicMock(),
+            safe_execute=None,
             _safe_execute=lambda func, **_kwargs: func(),
         )
     )

--- a/tests/test_ble_utils_service_targets.py
+++ b/tests/test_ble_utils_service_targets.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import importlib
+import logging
 from queue import Empty, Full
 from threading import Event, RLock
 from types import SimpleNamespace
@@ -451,6 +452,58 @@ def test_status_publish_ignores_synthesized_closing_probe(
     )
 
     assert sent == [("meshtastic.connection.status", iface, True)]
+def test_status_publish_closing_probe_failure_is_best_effort(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Closing-state probe failures must not escape best-effort publication."""
+    import meshtastic.mesh_interface as mesh_iface_module
+    from meshtastic.interfaces.ble import (
+        compatibility_service as compatibility_service_mod,
+    )
+
+    sent: list[tuple[str, object, bool]] = []
+
+    class _RaisingStateManager:
+        @property
+        def is_closing(self) -> bool:
+            raise RuntimeError("closing probe failed")
+
+    class _ImmediateThread:
+        def __init__(self, *, target: Any, **_kwargs: object) -> None:
+            self._target = target
+
+        def start(self) -> None:
+            self._target()
+
+    iface = SimpleNamespace(_closed=False, _state_manager=_RaisingStateManager())
+    monkeypatch.setattr(
+        mesh_iface_module,
+        "pub",
+        SimpleNamespace(
+            sendMessage=lambda topic, *, interface, connected: sent.append(
+                (topic, interface, connected)
+            )
+        ),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        compatibility_service_mod, "Thread", _ImmediateThread, raising=True
+    )
+    caplog.set_level(logging.DEBUG, logger="meshtastic.ble")
+
+    BLECompatibilityEventService.publish_connection_status(
+        iface,  # type: ignore[arg-type]
+        connected=True,
+        publishing_thread=None,
+    )
+
+    assert sent == [("meshtastic.connection.status", iface, True)]
+    assert any(
+        getattr(record, "ble_failure_disposition", None) == "compatibility_fallback"
+        and "Error probing interface closing state" in record.getMessage()
+        for record in caplog.records
+    )
 
 
 def test_legacy_status_publish_ignores_synthesized_thread_provider(
@@ -617,7 +670,9 @@ def test_management_helpers_cover_factory_and_target_edge_paths(
             use_existing_client_without_resolved_address=True,
             expected_implicit_binding="AA:BB:CC:DD:EE:FF",
         )
-        fresh_iface._get_management_client_if_available_locked = lambda _address: DummyClient()
+        fresh_iface._get_management_client_if_available_locked = lambda _address: (
+            DummyClient()
+        )
         fresh_iface._resolve_target_address_for_management = lambda _address: None
         fresh_iface._validate_management_preconditions = lambda: None
         fresh_iface._get_current_implicit_management_binding_locked = (
@@ -688,8 +743,38 @@ def test_management_handler_call_iface_override_respects_instance_and_subclass_o
         )
         assert fallback_calls == ["fallback"]
 
-        iface._resolve_target_address_for_management = (
-            lambda address: f"override:{address}"
+        class _SynthesizingInterface:
+            def __init__(self) -> None:
+                self.synthesized_override_calls = 0
+
+            def __getattr__(self, name: str) -> object:
+                if name == "_resolve_target_address_for_management":
+
+                    def _synthesized(address: str | None) -> str:
+                        self.synthesized_override_calls += 1
+                        return f"synthesized:{address}"
+
+                    return _synthesized
+                raise AttributeError(name)
+
+        synthesizing_iface = _SynthesizingInterface()
+        synthesizing_handler = BLEManagementCommandHandler(
+            synthesizing_iface,  # type: ignore[arg-type]
+            ble_client_factory=DummyClient,
+            connected_elsewhere=lambda *_args, **_kwargs: False,
+        )
+        assert (
+            synthesizing_handler._call_iface_override(
+                "_resolve_target_address_for_management",
+                _fallback,
+                "dynamic-node",
+            )
+            == "fallback:dynamic-node"
+        )
+        assert synthesizing_iface.synthesized_override_calls == 0
+
+        iface._resolve_target_address_for_management = lambda address: (
+            f"override:{address}"
         )
         assert (
             handler._call_iface_override(
@@ -699,7 +784,7 @@ def test_management_handler_call_iface_override_respects_instance_and_subclass_o
             )
             == "override:mesh-node"
         )
-        assert fallback_calls == ["fallback"]
+        assert fallback_calls == ["fallback", "fallback"]
 
         class _OverrideInterface(type(iface)):
             def _resolve_target_address_for_management(
@@ -721,7 +806,7 @@ def test_management_handler_call_iface_override_respects_instance_and_subclass_o
             )
             == "subclass:mesh-node"
         )
-        assert fallback_calls == ["fallback"]
+        assert fallback_calls == ["fallback", "fallback"]
     finally:
         iface.close()
 
@@ -834,7 +919,9 @@ def test_resolve_management_target_existing_client_explicit_address_paths(
         refreshed_client.bleak_client = SimpleNamespace(address=None)
         resolved_addresses.clear()
 
-        iface._get_management_client_if_available_locked = lambda _address: refreshed_client
+        iface._get_management_client_if_available_locked = lambda _address: (
+            refreshed_client
+        )
         iface._extract_client_address = lambda _client: None
 
         target, active_client = BLEManagementCommandsService._resolve_management_target(


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR completes the BLE boundary refactor by consolidating mutable lifecycle state, compatibility dispatch, failure classification, connection ownership, notification registration, and test collaborators behind explicit runtime owners.

The result removes production mock-awareness and dynamic-hook ambiguity while preserving the existing Meshtastic-compatible public API and the historical private compatibility shims that this fork intentionally supports.

Later review rounds also harden concurrency semantics around session-state promotion, connected-publication ownership, disconnect transitions, receive-thread lifecycle, transient retry decisions, notification registration, and shutdown so arbitrary compatibility collaborators do not execute while shared lifecycle locks are held.

## Key changes

### Session and connection-state ownership

* Added `BLESessionState` as the canonical owner of mutable BLE lifecycle and per-session state.
* Kept historical private `BLEInterface` lifecycle fields as compatibility views over the owned state.
* Ensured partial and legacy interfaces converge on one cached session owner rather than creating competing locks.
* Preserve legacy lifecycle values when promoting `_LegacyBLESessionStateAdapter` to `BLESessionState`.
* Session promotion uses the adapter's canonical lock-selection policy, preserves the state-manager or valid raw legacy lock, and removes migrated private shadow fields after ownership transfer.
* Added lock-owned `BLEStateManager` primitives for operations where connection state and session ownership must remain atomic.
* Connected-publication ownership probes now run outside the shared session lock and are revalidated against epoch, client identity, terminal state, and canonical connection state before mutation.

### Compatibility boundary

* Centralized declared-member and current-vs-legacy compatibility dispatch in `compat_adapter.py`.
* Removed all production `unittest.mock` awareness and mock-specific control flow.
* Dynamically synthesized `__getattr__` members are no longer treated as valid BLE compatibility hooks.
* Preserved explicit public-first and legacy fallbacks for supported discovery, lifecycle, management, thread/event, error-handler, and connectivity seams.
* Tightened reconnect-policy internals to canonical exact method names instead of implicit snake/camel/underscored alias inference.
* Internal management override dispatch now accepts only declared instance or real subclass overrides, ignoring synthesized attributes.

### Lifecycle and concurrency

* Lifecycle coordinators now share explicit session state rather than reaching through `BLEInterface` private fields for owned lifecycle data.
* Disconnect handling keeps canonical `BLEStateManager` transition and session-ownership clearing atomic under the shared lock.
* Legacy/custom state probes, transitions, reset callbacks, publication providers, and client-connectivity probes execute outside the shared lifecycle lock and are revalidated before state mutation.
* Notification-registration ownership checks use lock-owned canonical state reads or lock-free compatibility probes followed by full epoch/client/publish-state revalidation.
* Receive-thread liveness/start probes and deferred restart scheduling run outside the shared session lock, with snapshot revalidation before mutation.
* Caller-supplied transient retry policy runs outside the shared lock; concurrent retry-state changes trigger bounded decision revalidation.
* Exhausted retry-decision contention is surfaced as a warning while stale error decisions remain safely discarded.
* Shutdown cleanup remains best effort for partial collaborators and avoids masking an original shutdown failure.
* Best-effort connection-status publication contains closing-state probe failures and records structured compatibility-fallback diagnostics.

### Notification registration

* Serialized each dispatcher registration transaction so overlapping calls cannot diverge backend subscriptions from local registration state.
* Track started characteristics before post-start validation so rollback stops each backend subscription exactly once.
* Keep FROMNUM registration session-aware across provisional connection publication and client replacement.
* Decoupled the hot `fromnum_notify_enabled` read from long-running registration I/O while retaining serialized writes and rollback.
* Kept callback delivery independent of registration serialization.
* Strengthened concurrency tests so they prove the second registration reaches the dispatcher before asserting backend serialization.

### Gating and failure policy

* Added `_BLEAddressRegistry` as the owner of process-wide BLE address claims, locks, owner metadata, timestamps, and holder counts while retaining historical module-level aliases.
* Added explicit BLE failure dispositions for compatibility fallback, best-effort cleanup, retryable failures, and terminal operation failures.
* Preserved required exception behavior and logging semantics while attaching structured metadata to intentionally suppressed or recovered BLE failures.

### Tests and validation

* Added typed BLE state/lifecycle/thread fakes so production behavior is no longer shaped by permissive `MagicMock` attribute synthesis.
* Added deterministic concurrency and regression coverage for address-registry clearing, session-state promotion, receive-thread ownership, notification-registration serialization, stale registration rollback, lifecycle lock boundaries, retry-state revalidation, ownership epoch races, and compatibility precedence.
* Added explicit coverage proving compatibility state/client callbacks are not invoked while shared lifecycle state is locked.
* Added coverage that session promotion preserves values and canonical lock ownership and removes stale shadow state.
* Internal validation-message constants remain private rather than expanding the package-root API.
* Public API and import compatibility remain unchanged.

## Compatibility notes

* No public API surface changes; existing documented compatibility shims are preserved.
* `BLENotificationDispatcher` is an internal runtime collaborator and requires a `registration_current_provider` when constructed directly.
* Lifecycle coordinator constructors accept optional explicit `session_state`; historical construction still resolves the interface-owned or legacy state automatically.
* Explicitly declared lifecycle `_close` hooks continue to propagate their exceptions.
* BLE compatibility hooks must be explicitly declared; arbitrary dynamically synthesized attributes are intentionally not valid hooks.

The refactor preserves the public compatibility surface while making BLE runtime ownership, synchronization, publication, and fallback behavior substantially more explicit and deterministic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->