### PR TITLE
Modularize Connected CLI Actions and Harden Resource Lifecycles

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -29,6 +29,7 @@ from pubsub import pub
 
 import meshtastic.cli.config_io as cli_config_io
 import meshtastic.cli.runtime as cli_runtime
+from meshtastic.cli.context import ActionOutcome, CliContext
 import meshtastic.ota
 import meshtastic.serial_interface
 import meshtastic.tcp_interface
@@ -2559,11 +2560,6 @@ def onConnected(interface: MeshInterface) -> None:
     RuntimeError
         If `mt_config.args` is not set up before calling this function.
     """
-    closeNow = False  # Should we drop the connection after we finish?
-    waitForAckNak = (
-        False  # Should we wait for an acknowledgment if we send to a remote node?
-    )
-    skip_ack_wait = False  # OTA reboots the node before an ACK can be observed.
     try:
         args = mt_config.args
         if args is None:
@@ -2574,6 +2570,13 @@ def onConnected(interface: MeshInterface) -> None:
             "requestChannelAttempts": args.channel_fetch_attempts,
             "timeout": args.timeout,
         }
+        context = CliContext(
+            interface=interface,
+            args=args,
+            get_node_kwargs=getNode_kwargs,
+            outcome=ActionOutcome(wait_for_ack_nak=False),
+        )
+        outcome = context.outcome
 
         # do not print this line if we are exporting the config
         if not args.export_config:
@@ -2594,14 +2597,14 @@ def onConnected(interface: MeshInterface) -> None:
             interface.getNode(args.dest, False, **getNode_kwargs).setTime(args.set_time)
 
         if args.remove_position:
-            closeNow = True
-            waitForAckNak = True
+            outcome.close_now = True
+            outcome.wait_for_ack_nak = True
 
             _cli_print("Removing fixed position and disabling fixed position setting")
             interface.getNode(args.dest, False, **getNode_kwargs).removeFixedPosition()
         elif args.setlat or args.setlon or args.setalt:
-            closeNow = True
-            waitForAckNak = True
+            outcome.close_now = True
+            outcome.wait_for_ack_nak = True
 
             alt = 0
             lat = 0.0
@@ -2629,8 +2632,8 @@ def onConnected(interface: MeshInterface) -> None:
             )
 
         if args.set_owner or args.set_owner_short or args.set_is_unmessageable:
-            closeNow = True
-            waitForAckNak = True
+            outcome.close_now = True
+            outcome.wait_for_ack_nak = True
 
             long_name = args.set_owner.strip() if args.set_owner else None
             short_name = args.set_owner_short.strip() if args.set_owner_short else None
@@ -2668,8 +2671,8 @@ def onConnected(interface: MeshInterface) -> None:
             )
 
         if args.set_canned_message:
-            closeNow = True
-            waitForAckNak = True
+            outcome.close_now = True
+            outcome.wait_for_ack_nak = True
             node = interface.getNode(args.dest, False, **getNode_kwargs)
             if node.module_available(mesh_pb2.CANNEDMSG_CONFIG):
                 _cli_print(
@@ -2682,8 +2685,8 @@ def onConnected(interface: MeshInterface) -> None:
                 )
 
         if args.set_ringtone:
-            closeNow = True
-            waitForAckNak = True
+            outcome.close_now = True
+            outcome.wait_for_ack_nak = True
             node = interface.getNode(args.dest, False, **getNode_kwargs)
             if node.module_available(mesh_pb2.EXTNOTIF_CONFIG):
                 _cli_print(f"Setting ringtone to {args.set_ringtone}")
@@ -2695,7 +2698,7 @@ def onConnected(interface: MeshInterface) -> None:
 
         if args.pos_fields:
             # If --pos-fields invoked with args, set position fields
-            closeNow = True
+            outcome.close_now = True
             positionConfig = interface.getNode(
                 args.dest, **getNode_kwargs
             ).localConfig.position
@@ -2721,7 +2724,7 @@ def onConnected(interface: MeshInterface) -> None:
 
         elif args.pos_fields is not None:
             # If --pos-fields invoked without args, read and display current value
-            closeNow = True
+            outcome.close_now = True
             positionConfig = interface.getNode(
                 args.dest, **getNode_kwargs
             ).localConfig.position
@@ -2738,7 +2741,7 @@ def onConnected(interface: MeshInterface) -> None:
                 _cli_exit(
                     "ERROR: Ham radio callsign cannot be empty or contain only whitespace characters"
                 )
-            closeNow = True
+            outcome.close_now = True
             _cli_print(f"Setting Ham ID to {ham_id} and turning off encryption")
             interface.getNode(args.dest, **getNode_kwargs).setOwner(
                 ham_id, is_licensed=True
@@ -2749,55 +2752,55 @@ def onConnected(interface: MeshInterface) -> None:
             ).turnOffEncryptionOnPrimaryChannel()
 
         if args.reboot:
-            closeNow = True
-            waitForAckNak = True
-            skip_ack_wait = True
+            outcome.close_now = True
+            outcome.wait_for_ack_nak = True
+            outcome.skip_ack_wait = True
             interface.getNode(args.dest, False, **getNode_kwargs).reboot()
 
         if args.reboot_ota:
-            closeNow = True
-            waitForAckNak = True
-            skip_ack_wait = True
+            outcome.close_now = True
+            outcome.wait_for_ack_nak = True
+            outcome.skip_ack_wait = True
             interface.getNode(args.dest, False, **getNode_kwargs).rebootOTA()
 
         if args.ota_update:
-            closeNow = True
-            skip_ack_wait = True
+            outcome.close_now = True
+            outcome.skip_ack_wait = True
             _handle_ota_update(interface, args, getNode_kwargs)
             return
 
         if args.enter_dfu:
-            closeNow = True
-            waitForAckNak = True
-            skip_ack_wait = True
+            outcome.close_now = True
+            outcome.wait_for_ack_nak = True
+            outcome.skip_ack_wait = True
             interface.getNode(args.dest, False, **getNode_kwargs).enterDFUMode()
 
         if args.shutdown:
-            closeNow = True
-            waitForAckNak = True
-            skip_ack_wait = True
+            outcome.close_now = True
+            outcome.wait_for_ack_nak = True
+            outcome.skip_ack_wait = True
             interface.getNode(args.dest, False, **getNode_kwargs).shutdown()
 
         if args.device_metadata:
-            closeNow = True
+            outcome.close_now = True
             interface.getNode(args.dest, False, **getNode_kwargs).getMetadata()
 
         if args.begin_edit:
-            closeNow = True
+            outcome.close_now = True
             interface.getNode(
                 args.dest, False, **getNode_kwargs
             ).beginSettingsTransaction()
 
         if args.commit_edit:
-            closeNow = True
+            outcome.close_now = True
             interface.getNode(
                 args.dest, False, **getNode_kwargs
             ).commitSettingsTransaction()
 
         if args.factory_reset or args.factory_reset_device:
-            closeNow = True
-            waitForAckNak = True
-            skip_ack_wait = True
+            outcome.close_now = True
+            outcome.wait_for_ack_nak = True
+            outcome.skip_ack_wait = True
 
             full = bool(args.factory_reset_device)
             reset_node = interface.getNode(args.dest, False, **getNode_kwargs)
@@ -2823,55 +2826,55 @@ def onConnected(interface: MeshInterface) -> None:
                 _post_factory_reset_ready_probe(interface)
 
         if args.remove_node:
-            closeNow = True
-            waitForAckNak = True
+            outcome.close_now = True
+            outcome.wait_for_ack_nak = True
             interface.getNode(args.dest, False, **getNode_kwargs).removeNode(
                 args.remove_node
             )
 
         if args.set_favorite_node:
-            closeNow = True
-            waitForAckNak = True
+            outcome.close_now = True
+            outcome.wait_for_ack_nak = True
             interface.getNode(args.dest, False, **getNode_kwargs).setFavorite(
                 args.set_favorite_node
             )
 
         if args.remove_favorite_node:
-            closeNow = True
-            waitForAckNak = True
+            outcome.close_now = True
+            outcome.wait_for_ack_nak = True
             interface.getNode(args.dest, False, **getNode_kwargs).removeFavorite(
                 args.remove_favorite_node
             )
 
         if args.set_ignored_node:
-            closeNow = True
-            waitForAckNak = True
+            outcome.close_now = True
+            outcome.wait_for_ack_nak = True
             interface.getNode(args.dest, False, **getNode_kwargs).setIgnored(
                 args.set_ignored_node
             )
 
         if args.remove_ignored_node:
-            closeNow = True
-            waitForAckNak = True
+            outcome.close_now = True
+            outcome.wait_for_ack_nak = True
             interface.getNode(args.dest, False, **getNode_kwargs).removeIgnored(
                 args.remove_ignored_node
             )
 
         if args.reset_nodedb:
-            closeNow = True
-            waitForAckNak = True
+            outcome.close_now = True
+            outcome.wait_for_ack_nak = True
             interface.getNode(args.dest, False, **getNode_kwargs).resetNodeDb()
 
         if args.add_contact:
-            closeNow = True
-            waitForAckNak = True
-            skip_ack_wait = True  # addContactURL() owns the remote ACK wait
+            outcome.close_now = True
+            outcome.wait_for_ack_nak = True
+            outcome.skip_ack_wait = True  # addContactURL() owns the remote ACK wait
             interface.getNode(args.dest, False, **getNode_kwargs).addContactURL(
                 args.add_contact
             )
 
         if args.sendtext:
-            closeNow = True
+            outcome.close_now = True
             channelIndex = mt_config.channel_index or 0
             if checkChannel(interface, channelIndex):
                 _cli_print(
@@ -2965,7 +2968,7 @@ def onConnected(interface: MeshInterface) -> None:
                         f"Writing GPIO mask 0x{bitmask:x} with value 0x{bitval:x} to {args.dest}"
                     )
                     rhc.writeGPIOs(args.dest, bitmask, bitval)
-                    closeNow = True
+                    outcome.close_now = True
 
                 if args.gpio_rd:
                     bitmask = int(args.gpio_rd, 16)
@@ -2990,26 +2993,26 @@ def onConnected(interface: MeshInterface) -> None:
 
         # handle settings
         if args.set:
-            closeNow = True
-            waitForAckNak = True
+            outcome.close_now = True
+            outcome.wait_for_ack_nak = True
             _handle_set_command(interface, args, getNode_kwargs)
 
         if args.configure:
-            closeNow = True
-            waitForAckNak = True
+            outcome.close_now = True
+            outcome.wait_for_ack_nak = True
             _settings_transaction_started, _phase1_channel_url_applied = (
                 _handle_configure_command(interface, args, getNode_kwargs)
             )
             if _settings_transaction_started or _phase1_channel_url_applied:
-                waitForAckNak = False
-                skip_ack_wait = True
+                outcome.wait_for_ack_nak = False
+                outcome.skip_ack_wait = True
 
         if args.export_config:
             if args.dest != BROADCAST_ADDR:
                 print("Exporting configuration of remote nodes is not supported.")
                 return
 
-            closeNow = True
+            outcome.close_now = True
             config_txt = exportConfig(interface)
 
             if args.export_config == "-":
@@ -3024,7 +3027,7 @@ def onConnected(interface: MeshInterface) -> None:
                     _cli_exit(f"ERROR: Failed to write config file: {e}")
 
         if args.ch_set_url:
-            closeNow = True
+            outcome.close_now = True
             interface.getNode(args.dest, **getNode_kwargs).setURL(
                 args.ch_set_url, addOnly=False
             )
@@ -3032,7 +3035,7 @@ def onConnected(interface: MeshInterface) -> None:
         # handle changing channels
 
         if args.ch_add_url:
-            closeNow = True
+            outcome.close_now = True
             interface.getNode(args.dest, **getNode_kwargs).setURL(
                 args.ch_add_url, addOnly=True
             )
@@ -3046,7 +3049,7 @@ def onConnected(interface: MeshInterface) -> None:
                     "remove --ch-index and retry. Use --ch-set, --ch-del, --ch-enable, "
                     "or --ch-disable when targeting a specific index."
                 )
-            closeNow = True
+            outcome.close_now = True
             if len(args.ch_add) > 10:
                 _cli_exit("Warning: Channel name must be shorter. Channel not added.")
             n = interface.getNode(args.dest, **getNode_kwargs)
@@ -3073,7 +3076,7 @@ def onConnected(interface: MeshInterface) -> None:
                 mt_config.channel_index = ch.index
 
         if args.ch_del:
-            closeNow = True
+            outcome.close_now = True
 
             ch_del_idx = mt_config.channel_index
             if ch_del_idx is None:
@@ -3145,7 +3148,7 @@ def onConnected(interface: MeshInterface) -> None:
             _set_simple_config(preset_val)
 
         if args.ch_set or args.ch_enable or args.ch_disable:
-            closeNow = True
+            outcome.close_now = True
 
             _idx: int | None = mt_config.channel_index
             if _idx is None:
@@ -3234,7 +3237,7 @@ def onConnected(interface: MeshInterface) -> None:
                 )
 
         if args.get_canned_message:
-            closeNow = True
+            outcome.close_now = True
             print("")
             messages = interface.getNode(
                 args.dest, **getNode_kwargs
@@ -3242,13 +3245,13 @@ def onConnected(interface: MeshInterface) -> None:
             print(f"canned_plugin_message:{messages}")
 
         if args.get_ringtone:
-            closeNow = True
+            outcome.close_now = True
             print("")
             ringtone = interface.getNode(args.dest, **getNode_kwargs).get_ringtone()
             print(f"ringtone:{ringtone}")
 
         if args.show_region_presets:
-            closeNow = True
+            outcome.close_now = True
             if not _is_local_destination(interface, args.dest):
                 print(
                     "Region/preset capabilities are available only from the local node."
@@ -3302,7 +3305,7 @@ def onConnected(interface: MeshInterface) -> None:
             None,
         )
         if lockdown_action is not None:
-            closeNow = True
+            outcome.close_now = True
             if not _is_local_destination(interface, args.dest):
                 _cli_exit(
                     "Lockdown commands apply only to the directly connected local node."
@@ -3385,7 +3388,7 @@ def onConnected(interface: MeshInterface) -> None:
                 interface.showInfo()
                 print("")
                 interface.getNode(args.dest, **getNode_kwargs).showInfo()
-                closeNow = True
+                outcome.close_now = True
                 print("")
                 pypi_version = meshtastic.util.check_if_newer_version()
                 if pypi_version:
@@ -3400,7 +3403,7 @@ def onConnected(interface: MeshInterface) -> None:
                 )
 
         if args.get:
-            closeNow = True
+            outcome.close_now = True
             node = interface.getNode(args.dest, False, **getNode_kwargs)
             found = False
             for pref in args.get:
@@ -3410,7 +3413,7 @@ def onConnected(interface: MeshInterface) -> None:
                 _cli_print("Completed getting preferences")
 
         if args.nodes:
-            closeNow = True
+            outcome.close_now = True
             if args.dest != BROADCAST_ADDR:
                 print("Showing node list of a remote node is not supported.")
                 return
@@ -3423,7 +3426,7 @@ def onConnected(interface: MeshInterface) -> None:
             return
 
         if args.qr or args.qr_all:
-            closeNow = True
+            outcome.close_now = True
             url = interface.getNode(args.dest, True, **getNode_kwargs).getURL(
                 includeAll=args.qr_all
             )
@@ -3439,7 +3442,7 @@ def onConnected(interface: MeshInterface) -> None:
                 print("Install pyqrcode to view a QR code printed to terminal.")
 
         if args.contact_qr:
-            closeNow = True
+            outcome.close_now = True
             url = interface.localNode.getContactURL(
                 args.contact_qr,
                 should_ignore=args.contact_ignore,
@@ -3476,7 +3479,7 @@ def onConnected(interface: MeshInterface) -> None:
                         )
                     stress = PowerStress(interface)
                     stress.run()
-                    closeNow = True  # exit immediately after stress test
+                    outcome.close_now = True  # exit immediately after stress test
             else:
                 _cli_exit(
                     "The powermon module could not be loaded. "
@@ -3485,14 +3488,14 @@ def onConnected(interface: MeshInterface) -> None:
                 )
 
         if args.listen:
-            closeNow = False
+            outcome.close_now = False
 
         have_tunnel = platform.system() == "Linux"
         if have_tunnel and args.tunnel:
             if args.dest != BROADCAST_ADDR:
                 _cli_exit("A tunnel can only be created using the local node.", 1)
             # Even if others said we could close, stay open if the user asked for a tunnel
-            closeNow = False
+            outcome.close_now = False
             if interface.noProto:
                 logger.warning("Not starting Tunnel - disabled by noProto")
             else:
@@ -3503,13 +3506,13 @@ def onConnected(interface: MeshInterface) -> None:
                 else:
                     tunnel.Tunnel(interface)
 
-        if not skip_ack_wait and (
-            args.ack or (args.dest != BROADCAST_ADDR and waitForAckNak)
+        if not outcome.skip_ack_wait and (
+            args.ack or (args.dest != BROADCAST_ADDR and outcome.wait_for_ack_nak)
         ):
             _cli_print(
                 "Waiting for an acknowledgment from remote node (this could take a while)"
             )
-            interface.getNode(args.dest, False, **getNode_kwargs).iface.waitForAckNak()
+            interface.getNode(args.dest, False, **getNode_kwargs).iface.outcome.wait_for_ack_nak()
 
         if args.wait_to_disconnect:
             _cli_print(
@@ -3518,7 +3521,7 @@ def onConnected(interface: MeshInterface) -> None:
             time.sleep(int(args.wait_to_disconnect))
 
         # if the user didn't ask for serial debugging output, we might want to exit after we've done our operation
-        if (not args.seriallog) and closeNow:
+        if (not args.seriallog) and outcome.close_now:
             try:
                 interface.close()
             except Exception:

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -8,7 +8,6 @@ import argparse
 import binascii
 import contextlib
 import contextvars
-import enum
 import getpass
 import importlib
 import logging
@@ -21,12 +20,12 @@ from collections.abc import Callable, Iterator, Sequence
 from types import ModuleType
 from typing import Any, NoReturn, Protocol, cast
 
-import yaml
 from google.protobuf.descriptor import FieldDescriptor
 from google.protobuf.json_format import MessageToDict
 from pubsub import pub
 
 import meshtastic.cli.config_io as cli_config_io
+import meshtastic.cli.configure_actions as cli_configure_actions
 import meshtastic.cli.device_actions as cli_device_actions
 import meshtastic.cli.runtime as cli_runtime
 from meshtastic.cli.context import ActionOutcome, CliContext
@@ -64,8 +63,7 @@ from meshtastic.cli.values import (  # noqa: F401,W0611 - legacy __main__ compat
     parse_modem_preset_name as _parse_modem_preset_name,
 )
 from meshtastic.configure_verify import (
-    _verify_channel_url_against_state,
-    _verify_requested_fields,
+    _verify_channel_url_against_state,  # noqa: F401 - legacy __main__ compatibility export
 )
 from meshtastic.host_port import parseHostAndPort
 from meshtastic.interfaces.ble import BLEInterface
@@ -214,53 +212,45 @@ BITFIELD_ENUMS = {
 # ==============================================================================
 
 # Delay after applying configuration changes (owner, channel, etc.)
-CONFIG_APPLY_DELAY_SECONDS = 0.5
-CONFIG_WRITE_PACE_SECONDS = 0.1
+CONFIG_APPLY_DELAY_SECONDS = cli_configure_actions.CONFIG_APPLY_DELAY_SECONDS
+CONFIG_WRITE_PACE_SECONDS = cli_configure_actions.CONFIG_WRITE_PACE_SECONDS
 """Short inter-write cadence that drains transport queues without stretching transactions."""
 
 # Delay after setURL operations, which write up to 8 channel snapshots
 # plus LoRa config; the device needs extra time to commit all changes
 # before accepting further admin messages.
-CONFIG_SETURL_DELAY_SECONDS = 2.0
+CONFIG_SETURL_DELAY_SECONDS = cli_configure_actions.CONFIG_SETURL_DELAY_SECONDS
 
-CONFIG_COMMIT_SETTLE_SECONDS = 1.0
+CONFIG_COMMIT_SETTLE_SECONDS = cli_configure_actions.CONFIG_COMMIT_SETTLE_SECONDS
 """Settle delay after commitSettingsTransaction before assuming the session may end."""
 
-CONFIG_RECONNECT_WAIT_SECONDS = 15.0
+CONFIG_RECONNECT_WAIT_SECONDS = cli_configure_actions.CONFIG_RECONNECT_WAIT_SECONDS
 """Maximum time to wait for device reconnect after a reboot-capable configure commit."""
 
-SETURL_STABILITY_TIMEOUT_SECONDS = 30.0
+SETURL_STABILITY_TIMEOUT_SECONDS = (
+    cli_configure_actions.SETURL_STABILITY_TIMEOUT_SECONDS
+)
 """Timeout for post-setURL transport stability before opening Phase 2 writes."""
 
-FACTORY_RESET_READY_PROBE_TIMEOUT_SECONDS = cli_device_actions.FACTORY_RESET_READY_PROBE_TIMEOUT_SECONDS
+FACTORY_RESET_READY_PROBE_TIMEOUT_SECONDS = (
+    cli_device_actions.FACTORY_RESET_READY_PROBE_TIMEOUT_SECONDS
+)
 """Timeout for post-reset reconnect probe inside factory-reset command."""
 
-FACTORY_RESET_ACCEPTANCE_TIMEOUT_SECONDS = cli_device_actions.FACTORY_RESET_ACCEPTANCE_TIMEOUT_SECONDS
+FACTORY_RESET_ACCEPTANCE_TIMEOUT_SECONDS = (
+    cli_device_actions.FACTORY_RESET_ACCEPTANCE_TIMEOUT_SECONDS
+)
 """Maximum time to observe a local reset ACK/NAK or reboot disconnect."""
 
-FACTORY_RESET_ACCEPTANCE_POLL_SECONDS = cli_device_actions.FACTORY_RESET_ACCEPTANCE_POLL_SECONDS
+FACTORY_RESET_ACCEPTANCE_POLL_SECONDS = (
+    cli_device_actions.FACTORY_RESET_ACCEPTANCE_POLL_SECONDS
+)
 """Polling interval while waiting for local reset command acceptance."""
 
-CONFIGURE_PHASE1_HEADER = (
-    "Phase 1: Applying direct configuration "
-    "(channel URL updates may trigger reconnect/reboot)..."
-)
+CONFIGURE_PHASE1_HEADER = cli_configure_actions.CONFIGURE_PHASE1_HEADER
 """Printed once when --configure starts applying Phase 1 settings."""
 
-_ALLOWED_CONFIGURE_KEYS = frozenset(
-    {
-        "owner",
-        "owner_short",
-        "ownerShort",
-        "channel_url",
-        "channelUrl",
-        "canned_messages",
-        "ringtone",
-        "location",
-        "config",
-        "module_config",
-    }
-)
+_ALLOWED_CONFIGURE_KEYS = cli_configure_actions.ALLOWED_CONFIGURE_KEYS
 
 # Delay between GPIO watch iterations
 GPIO_WATCH_INTERVAL_SECONDS = 1.0
@@ -391,11 +381,22 @@ def supportInfo() -> None:
     print("Please add the output from the command: meshtastic --info")
 
 
-class _ConfigureReconnectResult(enum.Enum):
-    RECONNECT_FAILED = "reconnect_failed"
-    CONFIG_RELOAD_FAILED = "config_reload_failed"
-    VERIFICATION_INCOMPLETE = "verification_incomplete"
-    VERIFIED = "verified"
+_ConfigureReconnectResult = cli_configure_actions.ConfigureReconnectResult
+
+
+def _configure_hooks() -> cli_configure_actions.ConfigureHooks:
+    """Build configure dependencies from current entrypoint compatibility seams."""
+    return cli_configure_actions.ConfigureHooks(
+        cli_exit=_cli_exit,
+        cli_print=_cli_print,
+        traverse_config=traverseConfig,
+        preflight_mode=_CONFIGURE_PREFLIGHT_MODE,
+        is_local_destination=_is_local_destination,
+        post_seturl_stability_check=_post_seturl_stability_check,
+        post_configure_reconnect_and_verify=_post_configure_reconnect_and_verify,
+        channel_url_matches_current_device_state=_channel_url_matches_current_device_state,
+        pace_configure_write=_pace_configure_write,
+    )
 
 
 def _post_configure_reconnect_and_verify(
@@ -407,211 +408,25 @@ def _post_configure_reconnect_and_verify(
     verify_config_fields: dict[str, dict[str, Any]] | None = None,
     verify_module_config_fields: dict[str, dict[str, Any]] | None = None,
 ) -> _ConfigureReconnectResult:
-    """Reconnect after a configure commit, reload config, and verify values.
-
-    After ``commitSettingsTransaction()``, the firmware may reboot the device.
-    This helper:
-
-    1. Waits for the interface to disconnect and reconnect within *timeout*.
-    2. Calls ``waitForConfig()`` to reload the device configuration.
-    3. If any verification targets were provided (channel URL, config fields,
-       or module config fields), performs value-aware comparison of the
-       explicitly requested settings against what the device reports.
-
-    Returns a _ConfigureReconnectResult indicating the outcome.
-    """
-    deadline = time.monotonic() + timeout
-
-    disconnect_window = 2.0
-    logger.debug(
-        "Waiting up to %.1fs for device disconnect (reboot indication)...",
-        disconnect_window,
+    """Compatibility wrapper for configure reconnect verification."""
+    return cli_configure_actions._post_configure_reconnect_and_verify(
+        interface,
+        timeout=timeout,
+        node_dest=node_dest,
+        verify_channel_url=verify_channel_url,
+        verify_config_fields=verify_config_fields,
+        verify_module_config_fields=verify_module_config_fields,
+        verify_channel_url_against_state=_verify_channel_url_against_state,
     )
-    disconnect_deadline = time.monotonic() + disconnect_window
-    disconnected = False
-    while time.monotonic() < disconnect_deadline:
-        if not interface.isConnected.is_set():
-            disconnected = True
-            logger.info("Device disconnected (reboot indication received).")
-            break
-        time.sleep(0.2)
-
-    if not disconnected:
-        logger.debug(
-            "No disconnect detected within %.1fs; device may not require reboot.",
-            disconnect_window,
-        )
-
-    reconnect_deadline = deadline
-    if disconnected:
-        logger.debug(
-            "Waiting up to %.1fs for device reconnect...",
-            reconnect_deadline - time.monotonic(),
-        )
-    while time.monotonic() < reconnect_deadline:
-        if interface.isConnected.is_set():
-            logger.info("Device reconnected.")
-            break
-        time.sleep(0.2)
-
-    if not interface.isConnected.is_set():
-        logger.warning(
-            "Device did not reconnect within %.1fs after configure commit. "
-            "Configuration may still be applying.",
-            timeout,
-        )
-        return _ConfigureReconnectResult.RECONNECT_FAILED
-
-    try:
-        interface.waitForConfig()
-        logger.info("Device config reloaded after reboot.")
-    except Exception:
-        logger.warning(
-            "Device reconnected but config reload failed; "
-            "configuration may still be applying.",
-            exc_info=True,
-        )
-        return _ConfigureReconnectResult.CONFIG_RELOAD_FAILED
-
-    has_verification = (
-        verify_channel_url or verify_config_fields or verify_module_config_fields
-    )
-    if not has_verification:
-        return _ConfigureReconnectResult.VERIFIED
-
-    if not disconnected:
-        try:
-            _refresh_no_disconnect_verify_state(
-                interface.getNode(node_dest),
-                verify_channel_url=verify_channel_url,
-                verify_config_fields=verify_config_fields,
-                verify_module_config_fields=verify_module_config_fields,
-            )
-            interface.waitForConfig()
-            logger.debug(
-                "No disconnect observed; touched config/channel state refreshed before verification."
-            )
-        except Exception:
-            logger.warning(
-                "No-disconnect verify refresh failed while reloading config.",
-                exc_info=True,
-            )
-            return _ConfigureReconnectResult.CONFIG_RELOAD_FAILED
-
-    try:
-        result = _verify_post_reconnect_config(
-            interface,
-            node_dest,
-            verify_channel_url=verify_channel_url,
-            verify_config_fields=verify_config_fields,
-            verify_module_config_fields=verify_module_config_fields,
-        )
-    except Exception:
-        logger.warning(
-            "Post-reconnect verification failed unexpectedly.",
-            exc_info=True,
-        )
-        return _ConfigureReconnectResult.VERIFICATION_INCOMPLETE
-
-    return result
 
 
 def _post_seturl_stability_check(
-    interface: MeshInterface,
-    *,
-    timeout: float = 15.0,
+    interface: MeshInterface, *, timeout: float = 15.0
 ) -> bool:
-    _MAX_STABILITY_ATTEMPTS = 3
-    _STABILITY_WINDOW_SECONDS = 1.5
-    _RECONNECT_WAIT_SECONDS = 10.0
-
-    deadline = time.monotonic() + timeout
-
-    is_connected_event = getattr(interface, "isConnected", None)
-
-    def _event_is_set() -> bool:
-        return bool(
-            is_connected_event is not None
-            and hasattr(is_connected_event, "is_set")
-            and is_connected_event.is_set()
-        )
-
-    def _event_wait(timeout_seconds: float) -> bool:
-        return bool(
-            is_connected_event is not None
-            and hasattr(is_connected_event, "wait")
-            and is_connected_event.wait(timeout_seconds)
-        )
-
-    def _trigger_reconnect() -> bool:
-        reconnect = getattr(interface, "_attempt_reconnect", None)
-        if callable(reconnect):
-            try:
-                if reconnect():
-                    return _event_is_set()
-            except Exception:
-                logger.debug(
-                    "post-setURL reconnect hook failed.",
-                    exc_info=True,
-                )
-        connect = getattr(interface, "connect", None)
-        if callable(connect):
-            try:
-                connect()
-            except Exception:
-                logger.debug(
-                    "post-setURL connect() trigger failed.",
-                    exc_info=True,
-                )
-        return _event_is_set()
-
-    for _attempt in range(_MAX_STABILITY_ATTEMPTS):
-        if time.monotonic() >= deadline:
-            return False
-
-        if not _event_is_set():
-            _trigger_reconnect()
-            remaining = deadline - time.monotonic()
-            if remaining > 0:
-                _event_wait(min(_RECONNECT_WAIT_SECONDS, remaining))
-
-        if not _event_is_set():
-            logger.warning(
-                "Transport not connected after setURL (attempt %d/%d)",
-                _attempt + 1,
-                _MAX_STABILITY_ATTEMPTS,
-            )
-            continue
-
-        stability_end = time.monotonic() + _STABILITY_WINDOW_SECONDS
-        stable = True
-        while time.monotonic() < stability_end:
-            if not _event_is_set():
-                stable = False
-                break
-            time.sleep(0.1)
-
-        if not stable:
-            logger.warning(
-                "Transport dropped during stability window (attempt %d/%d)",
-                _attempt + 1,
-                _MAX_STABILITY_ATTEMPTS,
-            )
-            continue
-
-        try:
-            interface.waitForConfig()
-            return True
-        except Exception:
-            logger.warning(
-                "Config reload failed after setURL (attempt %d/%d)",
-                _attempt + 1,
-                _MAX_STABILITY_ATTEMPTS,
-                exc_info=True,
-            )
-            continue
-
-    return False
+    """Compatibility wrapper for post-SetURL transport stabilization."""
+    return cli_configure_actions._post_seturl_stability_check(
+        interface, timeout=timeout
+    )
 
 
 def _send_local_factory_reset_and_wait(
@@ -626,7 +441,6 @@ def _send_local_factory_reset_and_wait(
     )
 
 
-
 @contextlib.contextmanager
 def _temporary_instance_attributes(
     instance: Any, overrides: dict[str, Any]
@@ -636,32 +450,20 @@ def _temporary_instance_attributes(
         yield
 
 
-
 def _post_factory_reset_ready_probe(interface: MeshInterface) -> None:
     """Compatibility wrapper for the canonical factory-reset readiness probe."""
     cli_device_actions.post_factory_reset_ready_probe(interface)
 
 
-
 def _validate_non_empty_mapping_sections(
-    *,
-    top_level_key: str,
-    section_mapping: dict[str, Any],
+    *, top_level_key: str, section_mapping: dict[str, Any]
 ) -> dict[str, dict[str, Any]]:
-    """Validate that each section payload is a mapping.
-
-    Empty mappings (e.g., ``audio: {}``) are allowed — they represent
-    protobuf default values and are emitted by ``--export-config``.
-    """
-    validated_sections: dict[str, dict[str, Any]] = {}
-    for section_name, section_value in section_mapping.items():
-        if not isinstance(section_value, dict):
-            _cli_exit(
-                f"ERROR: '{top_level_key}.{section_name}' must be a non-empty mapping, got "
-                f"{type(section_value).__name__}"
-            )
-        validated_sections[section_name] = section_value
-    return validated_sections
+    """Compatibility wrapper for configure section validation."""
+    return cli_configure_actions._validate_non_empty_mapping_sections(
+        _configure_hooks(),
+        top_level_key=top_level_key,
+        section_mapping=section_mapping,
+    )
 
 
 def _preflight_configure_sections(
@@ -670,37 +472,13 @@ def _preflight_configure_sections(
     config_sections: dict[str, dict[str, Any]],
     module_config_sections: dict[str, dict[str, Any]],
 ) -> None:
-    """Validate configuration values on protobuf copies before device mutation."""
-    roots = (
-        ("config", target_node.localConfig, config_sections),
-        ("module_config", target_node.moduleConfig, module_config_sections),
+    """Compatibility wrapper for configure preflight validation."""
+    cli_configure_actions._preflight_configure_sections(
+        _configure_hooks(),
+        target_node,
+        config_sections=config_sections,
+        module_config_sections=module_config_sections,
     )
-    token = _CONFIGURE_PREFLIGHT_MODE.set(True)
-    try:
-        for top_level_key, source_message, sections in roots:
-            if not sections:
-                continue
-            candidate = type(source_message)()
-            candidate.CopyFrom(source_message)
-            for section, section_values in sections.items():
-                failed_fields: list[str] = []
-                applied = traverseConfig(
-                    section,
-                    section_values,
-                    candidate,
-                    failed_fields=failed_fields,
-                )
-                if applied:
-                    continue
-                field_suffix = (
-                    f" Invalid field: {failed_fields[0]}." if failed_fields else ""
-                )
-                _cli_exit(
-                    f"Failed to apply {top_level_key} section {section!r} "
-                    f"due to structural errors.{field_suffix}"
-                )
-    finally:
-        _CONFIGURE_PREFLIGHT_MODE.reset(token)
 
 
 def _refresh_no_disconnect_verify_state(
@@ -710,74 +488,29 @@ def _refresh_no_disconnect_verify_state(
     verify_config_fields: dict[str, dict[str, Any]] | None,
     verify_module_config_fields: dict[str, dict[str, Any]] | None,
 ) -> None:
-    """Invalidate touched cached state and request fresh values for Phase 3 verification."""
-    request_config = getattr(target_node, "requestConfig", None)
-
-    for section_name in verify_config_fields or {}:
-        section_snake = meshtastic.util.camel_to_snake(section_name)
-        field_desc = target_node.localConfig.DESCRIPTOR.fields_by_name.get(
-            section_snake
-        )
-        if field_desc is None:
-            logger.warning(
-                "Skipping config refresh for unknown section %r.",
-                section_name,
-            )
-            continue
-        target_node.localConfig.ClearField(section_snake)
-        if callable(request_config):
-            request_config(field_desc)
-
-    for section_name in verify_module_config_fields or {}:
-        section_snake = meshtastic.util.camel_to_snake(section_name)
-        field_desc = target_node.moduleConfig.DESCRIPTOR.fields_by_name.get(
-            section_snake
-        )
-        if field_desc is None:
-            logger.warning(
-                "Skipping module_config refresh for unknown section %r.",
-                section_name,
-            )
-            continue
-        target_node.moduleConfig.ClearField(section_snake)
-        if callable(request_config):
-            request_config(field_desc)
-
-    if verify_channel_url:
-        target_node.channels = None
-        target_node.partialChannels = []
-        request_channels = getattr(target_node, "requestChannels", None)
-        if callable(request_channels):
-            request_channels(0)
+    """Compatibility wrapper for touched-state refresh before verification."""
+    cli_configure_actions._refresh_no_disconnect_verify_state(
+        target_node,
+        verify_channel_url=verify_channel_url,
+        verify_config_fields=verify_config_fields,
+        verify_module_config_fields=verify_module_config_fields,
+    )
 
 
 def _channel_url_matches_current_device_state(
-    target_node: Any,
-    requested_channel_url: str,
+    target_node: Any, requested_channel_url: str
 ) -> bool:
-    """Return True when requested channel URL already matches loaded device state."""
-    local_config = getattr(target_node, "localConfig", None)
-    has_field = getattr(local_config, "HasField", None)
-    if local_config is None or not callable(has_field) or not has_field("lora"):
-        return False
-    return _verify_channel_url_against_state(
+    """Compatibility wrapper for channel URL equality checks."""
+    return cli_configure_actions._channel_url_matches_current_device_state(
+        target_node,
         requested_channel_url,
-        device_channels=getattr(target_node, "channels", None),
-        device_lora_config=local_config.lora,
-        emit_warnings=False,
+        verify_channel_url_against_state=_verify_channel_url_against_state,
     )
 
 
 def _flatten_leaf_paths(prefix: str, mapping: dict[str, Any]) -> list[str]:
-    """Recursively flatten a nested mapping into dotted leaf paths."""
-    paths: list[str] = []
-    for key, value in mapping.items():
-        dotted = f"{prefix}.{key}"
-        if isinstance(value, dict) and value:
-            paths.extend(_flatten_leaf_paths(dotted, value))
-        else:
-            paths.append(dotted)
-    return paths
+    """Compatibility wrapper for configure verification path flattening."""
+    return cli_configure_actions._flatten_leaf_paths(prefix, mapping)
 
 
 def _verify_config_sections(
@@ -786,33 +519,10 @@ def _verify_config_sections(
     label: str,
     verified_fields: list[str] | None = None,
 ) -> bool:
-    for section_name, yaml_values in config_fields.items():
-        section_snake = meshtastic.util.camel_to_snake(section_name)
-        if not proto_config.HasField(section_snake):
-            logger.warning(
-                "%s section %r not present after reload.",
-                label,
-                section_name,
-            )
-            return False
-        proto_section = getattr(proto_config, section_snake)
-        mismatches = _verify_requested_fields(yaml_values, proto_section, section_name)
-        if mismatches:
-            logger.warning(
-                "%s section %r field mismatches: %s",
-                label,
-                section_name,
-                ", ".join(mismatches),
-            )
-            return False
-        if verified_fields is not None:
-            verified_fields.extend(_flatten_leaf_paths(section_snake, yaml_values))
-        logger.debug(
-            "%s section %r verified (all requested field values match).",
-            label,
-            section_name,
-        )
-    return True
+    """Compatibility wrapper for protobuf section verification."""
+    return cli_configure_actions._verify_config_sections(
+        config_fields, proto_config, label, verified_fields=verified_fields
+    )
 
 
 def _verify_post_reconnect_config(
@@ -823,58 +533,15 @@ def _verify_post_reconnect_config(
     verify_config_fields: dict[str, dict[str, Any]] | None = None,
     verify_module_config_fields: dict[str, dict[str, Any]] | None = None,
 ) -> _ConfigureReconnectResult:
-    if not interface.isConnected.is_set():
-        logger.warning("Post-reconnect verification skipped: transport disconnected.")
-        return _ConfigureReconnectResult.VERIFICATION_INCOMPLETE
-
-    target_node = interface.getNode(node_dest)
-    verified_fields: list[str] = []
-
-    if verify_channel_url:
-        local_config = getattr(target_node, "localConfig", None)
-        has_field = getattr(local_config, "HasField", None)
-        device_lora_config = (
-            local_config.lora
-            if local_config is not None and callable(has_field) and has_field("lora")
-            else None
-        )
-        if not _verify_channel_url_against_state(
-            verify_channel_url,
-            device_channels=getattr(target_node, "channels", None),
-            device_lora_config=device_lora_config,
-        ):
-            logger.warning(
-                "Channel URL verification: device state does not match requested URL."
-            )
-            return _ConfigureReconnectResult.VERIFICATION_INCOMPLETE
-        verified_fields.append("channel_url")
-
-    if verify_config_fields and not _verify_config_sections(
-        verify_config_fields,
-        target_node.localConfig,
-        "Config",
-        verified_fields=verified_fields,
-    ):
-        return _ConfigureReconnectResult.VERIFICATION_INCOMPLETE
-
-    if verify_module_config_fields and not _verify_config_sections(
-        verify_module_config_fields,
-        target_node.moduleConfig,
-        "Module config",
-        verified_fields=verified_fields,
-    ):
-        return _ConfigureReconnectResult.VERIFICATION_INCOMPLETE
-
-    if not interface.isConnected.is_set():
-        logger.warning(
-            "Post-reconnect verification did not complete: transport disconnected."
-        )
-        return _ConfigureReconnectResult.VERIFICATION_INCOMPLETE
-
-    if verified_fields:
-        logger.info("Verified: %s", ", ".join(verified_fields))
-
-    return _ConfigureReconnectResult.VERIFIED
+    """Compatibility wrapper for post-reconnect value verification."""
+    return cli_configure_actions._verify_post_reconnect_config(
+        interface,
+        node_dest,
+        verify_channel_url=verify_channel_url,
+        verify_config_fields=verify_config_fields,
+        verify_module_config_fields=verify_module_config_fields,
+        verify_channel_url_against_state=_verify_channel_url_against_state,
+    )
 
 
 # COMPAT_STABLE_SHIM: historical snake_case helper name.
@@ -1625,7 +1292,6 @@ def _handle_ota_update(
     )
 
 
-
 def _print_set_field_choices(node: Any, pref_names: Sequence[str]) -> None:
     """Print historical field-not-found guidance for one or more --set names.
 
@@ -1690,8 +1356,7 @@ def _format_set_preflight_exception(pref_name: str, exc: Exception) -> str:
         return str(exc)
     if _is_secret_pref(pref_name):
         return (
-            f"{pref_name}: invalid value {_REDACTED_PREF_VALUE} "
-            f"({type(exc).__name__})"
+            f"{pref_name}: invalid value {_REDACTED_PREF_VALUE} ({type(exc).__name__})"
         )
     return f"{pref_name}: {exc}"
 
@@ -1881,8 +1546,7 @@ def _handle_set_command(
         except (TypeError, ValueError, OverflowError, binascii.Error) as exc:
             detail = _format_set_preflight_exception(normalized_pref_name, exc)
             _cli_exit(
-                "ERROR: --set apply diverged after successful preflight:\n"
-                f"  - {detail}"
+                f"ERROR: --set apply diverged after successful preflight:\n  - {detail}"
             )
         if not found:
             _cli_exit(
@@ -1904,359 +1568,27 @@ def _handle_set_command(
 
 
 def _pace_configure_write(
-    remaining_writes: int,
-    *,
-    sleep_fn: Callable[[float], None] = time.sleep,
+    remaining_writes: int, *, sleep_fn: Callable[[float], None] = time.sleep
 ) -> None:
-    """Yield briefly between section writes while keeping transactions short."""
-    if remaining_writes > 0:
-        sleep_fn(CONFIG_WRITE_PACE_SECONDS)
+    """Compatibility wrapper for configure write pacing."""
+    cli_configure_actions._pace_configure_write(remaining_writes, sleep_fn=sleep_fn)
 
 
 def _apply_configure_channel_url(
-    target_node: Any,
-    raw_channel_url: Any,
-    *,
-    config_key: str,
+    target_node: Any, raw_channel_url: Any, *, config_key: str
 ) -> bool:
-    """Validate and apply one configured channel URL without exposing it."""
-    if not isinstance(raw_channel_url, str):
-        _cli_exit(f"ERROR: {config_key} must be a string.")
-    requested_channel_url = raw_channel_url.strip()
-    if not requested_channel_url:
-        _cli_exit(f"ERROR: {config_key} must not be blank.")
-
-    if _channel_url_matches_current_device_state(target_node, requested_channel_url):
-        _cli_print("Channel url already matches device state; skipping apply.")
-        logger.info("Skipping setURL apply because channel URL already matches.")
-        return False
-
-    _cli_print("Setting channel url to <redacted>")
-    target_node.setURL(requested_channel_url)
-    time.sleep(CONFIG_SETURL_DELAY_SECONDS)
-    return True
+    """Compatibility wrapper for configure channel URL application."""
+    return cli_configure_actions._apply_configure_channel_url(
+        _configure_hooks(), target_node, raw_channel_url, config_key=config_key
+    )
 
 
 def _handle_configure_command(
-    interface: MeshInterface,
-    args: Any,
-    getNode_kwargs: dict[str, Any],
+    interface: MeshInterface, args: Any, getNode_kwargs: dict[str, Any]
 ) -> tuple[bool, bool]:
-    try:
-        with open(args.configure[0], encoding="utf8") as file:
-            raw_text = file.read()
-        configuration = yaml.safe_load(raw_text)
-    except (yaml.YAMLError, UnicodeDecodeError) as exc:
-        _cli_exit(f"ERROR: Failed to parse YAML configuration: {exc}")
-
-    if configuration is None:
-        _cli_exit("ERROR: YAML configuration file is empty")
-    if not isinstance(configuration, dict):
-        _cli_exit(
-            f"ERROR: YAML configuration must be a mapping/dictionary, got {type(configuration).__name__}"
-        )
-    if not configuration:
-        _cli_exit("ERROR: Configuration file is empty; nothing to configure.")
-    _unknown_keys = set(configuration.keys()) - _ALLOWED_CONFIGURE_KEYS
-    if _unknown_keys:
-        _cli_exit(
-            f"ERROR: Unknown top-level key(s) in YAML: {', '.join(sorted(_unknown_keys))}"
-        )
-
-    if "channel_url" in configuration and "channelUrl" in configuration:
-        _cli_exit(
-            "ERROR: Cannot specify both 'channel_url' and 'channelUrl' in the same configuration file; use one."
-        )
-    if "owner_short" in configuration and "ownerShort" in configuration:
-        _cli_exit(
-            "ERROR: Cannot specify both 'owner_short' and 'ownerShort' in the same configuration file; use one."
-        )
-
-    # Pre-validate config/module_config shapes before any Phase-1 mutations.
-    validated_config_sections: dict[str, dict[str, Any]] = {}
-    validated_module_config_sections: dict[str, dict[str, Any]] = {}
-    if "config" in configuration:
-        _cfg_val = configuration["config"]
-        if not isinstance(_cfg_val, dict) or not _cfg_val:
-            _cli_exit(
-                f"ERROR: 'config' must be a non-empty mapping, got "
-                f"{type(_cfg_val).__name__}{' (empty)' if isinstance(_cfg_val, dict) else ''}"
-            )
-        validated_config_sections = _validate_non_empty_mapping_sections(
-            top_level_key="config",
-            section_mapping=_cfg_val,
-        )
-    if "module_config" in configuration:
-        _mcfg_val = configuration["module_config"]
-        if not isinstance(_mcfg_val, dict) or not _mcfg_val:
-            _cli_exit(
-                f"ERROR: 'module_config' must be a non-empty mapping, got "
-                f"{type(_mcfg_val).__name__}{' (empty)' if isinstance(_mcfg_val, dict) else ''}"
-            )
-        validated_module_config_sections = _validate_non_empty_mapping_sections(
-            top_level_key="module_config",
-            section_mapping=_mcfg_val,
-        )
-
-    target_node = interface.getNode(args.dest, False, **getNode_kwargs)
-    if validated_config_sections or validated_module_config_sections:
-        _preflight_configure_sections(
-            target_node,
-            config_sections=validated_config_sections,
-            module_config_sections=validated_module_config_sections,
-        )
-
-    phase1_started = False
-    phase1_may_reconnect = False
-    seturl_executed = False
-
-    if "owner" in configuration:
-        if not phase1_started:
-            _cli_print(CONFIGURE_PHASE1_HEADER)
-            phase1_started = True
-        owner_name = str(configuration["owner"]).strip()
-        if not owner_name:
-            _cli_exit(
-                "ERROR: Long Name cannot be empty or contain only whitespace characters"
-            )
-        _cli_print(f"Setting device owner to {owner_name}")
-        target_node.setOwner(long_name=owner_name)
-        time.sleep(CONFIG_APPLY_DELAY_SECONDS)
-
-    if "owner_short" in configuration:
-        if not phase1_started:
-            _cli_print(CONFIGURE_PHASE1_HEADER)
-            phase1_started = True
-        owner_short_name = str(configuration["owner_short"]).strip()
-        if not owner_short_name:
-            _cli_exit(
-                "ERROR: Short Name cannot be empty or contain only whitespace characters"
-            )
-        _cli_print(f"Setting device owner short to {owner_short_name}")
-        target_node.setOwner(long_name=None, short_name=owner_short_name)
-        time.sleep(CONFIG_APPLY_DELAY_SECONDS)
-
-    if "ownerShort" in configuration:
-        if not phase1_started:
-            _cli_print(CONFIGURE_PHASE1_HEADER)
-            phase1_started = True
-        owner_short_name = str(configuration["ownerShort"]).strip()
-        if not owner_short_name:
-            _cli_exit(
-                "ERROR: Short Name cannot be empty or contain only whitespace characters"
-            )
-        _cli_print(f"Setting device owner short to {owner_short_name}")
-        target_node.setOwner(long_name=None, short_name=owner_short_name)
-        time.sleep(CONFIG_APPLY_DELAY_SECONDS)
-
-    if "location" in configuration:
-        if not phase1_started:
-            _cli_print(CONFIGURE_PHASE1_HEADER)
-            phase1_started = True
-        _loc = configuration["location"]
-        if not isinstance(_loc, dict) or not _loc:
-            _cli_exit(
-                "location must be a non-empty mapping with lat, lon, and optional alt"
-            )
-        _allowed_loc_keys = {"lat", "lon", "alt"}
-        _unknown_loc_keys = set(_loc.keys()) - _allowed_loc_keys
-        if _unknown_loc_keys:
-            _cli_exit(
-                f"location contains unknown keys: {', '.join(sorted(_unknown_loc_keys))}. "
-                f"Allowed: lat, lon, alt"
-            )
-        if "lat" not in _loc or "lon" not in _loc:
-            _cli_exit("location requires both lat and lon")
-        try:
-            lat = float(_loc["lat"])
-        except (ValueError, TypeError):
-            _cli_exit(f"location.lat must be a number, got: {_loc['lat']!r}")
-        try:
-            lon = float(_loc["lon"])
-        except (ValueError, TypeError):
-            _cli_exit(f"location.lon must be a number, got: {_loc['lon']!r}")
-        alt = 0
-        if "alt" in _loc:
-            try:
-                alt = int(_loc["alt"])
-            except (ValueError, TypeError):
-                _cli_exit(f"location.alt must be an integer, got: {_loc['alt']!r}")
-            _cli_print(f"Fixing altitude at {alt} meters")
-        _cli_print(f"Fixing latitude at {lat} degrees")
-        _cli_print(f"Fixing longitude at {lon} degrees")
-        _cli_print("Setting device position")
-        target_node.setFixedPosition(lat, lon, alt)
-        time.sleep(CONFIG_APPLY_DELAY_SECONDS)
-
-    if "canned_messages" in configuration:
-        if not phase1_started:
-            _cli_print(CONFIGURE_PHASE1_HEADER)
-            phase1_started = True
-        _cli_print(
-            f"Setting canned message messages to {configuration['canned_messages']}",
-        )
-        target_node.set_canned_message(configuration["canned_messages"])
-        time.sleep(CONFIG_APPLY_DELAY_SECONDS)
-
-    if "ringtone" in configuration:
-        if not phase1_started:
-            _cli_print(CONFIGURE_PHASE1_HEADER)
-            phase1_started = True
-        _cli_print(f"Setting ringtone to {configuration['ringtone']}")
-        target_node.set_ringtone(configuration["ringtone"])
-        time.sleep(CONFIG_APPLY_DELAY_SECONDS)
-
-    channel_url_key = "channel_url" if "channel_url" in configuration else "channelUrl"
-    if channel_url_key in configuration:
-        if not phase1_started:
-            _cli_print(CONFIGURE_PHASE1_HEADER)
-            phase1_started = True
-        seturl_executed = _apply_configure_channel_url(
-            target_node,
-            configuration[channel_url_key],
-            config_key=channel_url_key,
-        )
-        phase1_may_reconnect = seturl_executed
-
-    if phase1_started:
-        _cli_print("Phase 1 complete.")
-
-    settings_transaction_started = False
-    has_valid_config_section = bool(
-        validated_config_sections or validated_module_config_sections
-    )
-    if seturl_executed and has_valid_config_section:
-        if _is_local_destination(interface, args.dest):
-            if not _post_seturl_stability_check(
-                interface, timeout=SETURL_STABILITY_TIMEOUT_SECONDS
-            ):
-                _cli_exit(
-                    "ERROR: channel_url applied, but transport did not stabilize "
-                    "for additional configuration writes; aborting before Phase 2."
-                )
-        else:
-            _cli_exit(
-                "ERROR: Combining channel_url with additional configuration "
-                "writes is not supported for remote nodes. Apply channel_url "
-                "and configuration in separate operations."
-            )
-    if has_valid_config_section:
-        _cli_print(
-            "Phase 2: Applying configuration transaction (may trigger device reboot)..."
-        )
-        target_node.beginSettingsTransaction()
-        settings_transaction_started = True
-
-    remaining_config_writes = len(validated_config_sections) + len(
-        validated_module_config_sections
-    )
-
-    if validated_config_sections:
-        localConfig = target_node.localConfig
-        for section, section_values in validated_config_sections.items():
-            failed_config_fields: list[str] = []
-            applied = traverseConfig(
-                section,
-                section_values,
-                localConfig,
-                failed_fields=failed_config_fields,
-            )
-            if failed_config_fields:
-                logger.warning(
-                    "Skipped %d unknown field(s) in config section %s: %s",
-                    len(failed_config_fields),
-                    section,
-                    ", ".join(repr(f) for f in failed_config_fields),
-                )
-            if not applied:
-                _cli_exit(
-                    f"Failed to apply config section {section!r} due to structural errors."
-                )
-            target_node.writeConfig(meshtastic.util.camel_to_snake(section))
-            remaining_config_writes -= 1
-            _pace_configure_write(remaining_config_writes)
-
-    if validated_module_config_sections:
-        moduleConfig = target_node.moduleConfig
-        for section, section_values in validated_module_config_sections.items():
-            failed_module_fields: list[str] = []
-            applied = traverseConfig(
-                section,
-                section_values,
-                moduleConfig,
-                failed_fields=failed_module_fields,
-            )
-            if failed_module_fields:
-                logger.warning(
-                    "Skipped %d unknown field(s) in module_config section %s: %s",
-                    len(failed_module_fields),
-                    section,
-                    ", ".join(repr(f) for f in failed_module_fields),
-                )
-            if not applied:
-                _cli_exit(
-                    f"Failed to apply module_config section {section!r} due to structural errors."
-                )
-            target_node.writeConfig(meshtastic.util.camel_to_snake(section))
-            remaining_config_writes -= 1
-            _pace_configure_write(remaining_config_writes)
-
-    if settings_transaction_started:
-        target_node.commitSettingsTransaction()
-        time.sleep(CONFIG_COMMIT_SETTLE_SECONDS)
-        _cli_print(
-            "Configuration transaction committed. Device may reboot to apply changes."
-        )
-
-    if settings_transaction_started:
-        _verify_channel_url = configuration.get("channel_url") or configuration.get(
-            "channelUrl"
-        )
-        _verify_config_fields = validated_config_sections or None
-        _verify_module_config_fields = validated_module_config_sections or None
-        if _is_local_destination(interface, args.dest):
-            _reconnect_result = _post_configure_reconnect_and_verify(
-                interface,
-                timeout=CONFIG_RECONNECT_WAIT_SECONDS,
-                node_dest=args.dest,
-                verify_channel_url=_verify_channel_url,
-                verify_config_fields=_verify_config_fields,
-                verify_module_config_fields=_verify_module_config_fields,
-            )
-            if _reconnect_result == _ConfigureReconnectResult.VERIFIED:
-                _cli_print(
-                    "Phase 3: Device reconnected and config reloaded. All settings verified."
-                )
-            elif _reconnect_result == _ConfigureReconnectResult.VERIFICATION_INCOMPLETE:
-                _cli_print(
-                    "Phase 3: Device reconnected and config reloaded. "
-                    "Could not fully verify applied settings."
-                )
-            elif _reconnect_result == _ConfigureReconnectResult.CONFIG_RELOAD_FAILED:
-                _cli_print(
-                    "Phase 3: Device reconnected but config reload failed. "
-                    "Settings may still be applying."
-                )
-            elif _reconnect_result == _ConfigureReconnectResult.RECONNECT_FAILED:
-                _cli_print(
-                    "Phase 3: Device did not reconnect within timeout. "
-                    "Configuration may still be applying."
-                )
-        else:
-            _cli_print(
-                "Phase 3: Reboot/reconnect verification skipped for remote target. "
-                "Local transport state does not confirm remote node reload status."
-            )
-    else:
-        if phase1_may_reconnect:
-            _cli_print(
-                "Configuration applied. Channel URL updates may still trigger reconnect/reboot."
-            )
-        else:
-            _cli_print("Configuration applied (no reboot expected).")
-
-    return settings_transaction_started, (
-        seturl_executed and _is_local_destination(interface, args.dest)
+    """Compatibility wrapper for configure-file transaction execution."""
+    return cli_configure_actions._handle_configure_command(
+        _configure_hooks(), interface, args, getNode_kwargs
     )
 
 
@@ -2483,39 +1815,16 @@ def onConnected(interface: MeshInterface) -> None:
                         time.sleep(GPIO_WATCH_INTERVAL_SECONDS)
 
         # handle settings
-        if args.set:
-            outcome.close_now = True
-            outcome.wait_for_ack_nak = True
-            _handle_set_command(interface, args, getNode_kwargs)
-
-        if args.configure:
-            outcome.close_now = True
-            outcome.wait_for_ack_nak = True
-            _settings_transaction_started, _phase1_channel_url_applied = (
-                _handle_configure_command(interface, args, getNode_kwargs)
-            )
-            if _settings_transaction_started or _phase1_channel_url_applied:
-                outcome.wait_for_ack_nak = False
-                outcome.skip_ack_wait = True
-
-        if args.export_config:
-            if args.dest != BROADCAST_ADDR:
-                print("Exporting configuration of remote nodes is not supported.")
-                return
-
-            outcome.close_now = True
-            config_txt = exportConfig(interface)
-
-            if args.export_config == "-":
-                # Output to stdout (preserves legacy use of `> file.yaml`)
-                print(config_txt)
-            else:
-                try:
-                    with open(args.export_config, "w", encoding="utf-8") as f:
-                        f.write(config_txt)
-                    _cli_print(f"Exported configuration to {args.export_config}")
-                except Exception as e:
-                    _cli_exit(f"ERROR: Failed to write config file: {e}")
+        configure_action_hooks = cli_configure_actions.ConfigureActionHooks(
+            handle_set_command=_handle_set_command,
+            handle_configure_command=_handle_configure_command,
+            export_config=exportConfig,
+            cli_exit=_cli_exit,
+            cli_print=_cli_print,
+        )
+        cli_configure_actions.handle_configure_actions(context, configure_action_hooks)
+        if outcome.stop_processing:
+            return
 
         if args.ch_set_url:
             outcome.close_now = True

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -16,7 +16,6 @@ import os
 import platform
 import sys
 import textwrap
-import threading
 import time
 from collections.abc import Callable, Iterator, Sequence
 from types import ModuleType
@@ -28,6 +27,7 @@ from google.protobuf.json_format import MessageToDict
 from pubsub import pub
 
 import meshtastic.cli.config_io as cli_config_io
+import meshtastic.cli.device_actions as cli_device_actions
 import meshtastic.cli.runtime as cli_runtime
 from meshtastic.cli.context import ActionOutcome, CliContext
 import meshtastic.ota
@@ -35,7 +35,7 @@ import meshtastic.serial_interface
 import meshtastic.tcp_interface
 import meshtastic.util
 from meshtastic import mt_config, remote_hardware
-from meshtastic._core_constants import BROADCAST_ADDR, LOCAL_ADDR
+from meshtastic._core_constants import BROADCAST_ADDR, LOCAL_ADDR  # noqa: F401
 
 # COMPAT_STABLE_SHIM: Preserve legacy imports from meshtastic.cli.parser.
 # pylint: disable=unused-import
@@ -78,7 +78,7 @@ from meshtastic.lockdown import (
 from meshtastic.mesh_interface import MeshInterface
 from meshtastic.mesh_interface_runtime import node_data
 from meshtastic.protobuf import (
-    admin_pb2,
+    admin_pb2,  # noqa: F401 - legacy __main__ compatibility export
     channel_pb2,
     config_pb2,
     localonly_pb2,
@@ -232,13 +232,13 @@ CONFIG_RECONNECT_WAIT_SECONDS = 15.0
 SETURL_STABILITY_TIMEOUT_SECONDS = 30.0
 """Timeout for post-setURL transport stability before opening Phase 2 writes."""
 
-FACTORY_RESET_READY_PROBE_TIMEOUT_SECONDS = 20.0
+FACTORY_RESET_READY_PROBE_TIMEOUT_SECONDS = cli_device_actions.FACTORY_RESET_READY_PROBE_TIMEOUT_SECONDS
 """Timeout for post-reset reconnect probe inside factory-reset command."""
 
-FACTORY_RESET_ACCEPTANCE_TIMEOUT_SECONDS = 20.0
+FACTORY_RESET_ACCEPTANCE_TIMEOUT_SECONDS = cli_device_actions.FACTORY_RESET_ACCEPTANCE_TIMEOUT_SECONDS
 """Maximum time to observe a local reset ACK/NAK or reboot disconnect."""
 
-FACTORY_RESET_ACCEPTANCE_POLL_SECONDS = 0.05
+FACTORY_RESET_ACCEPTANCE_POLL_SECONDS = cli_device_actions.FACTORY_RESET_ACCEPTANCE_POLL_SECONDS
 """Polling interval while waiting for local reset command acceptance."""
 
 CONFIGURE_PHASE1_HEADER = (
@@ -273,9 +273,9 @@ GPIO_READ_MAX_POLLS = 10
 POWER_ON_BOOT_DELAY_SECONDS = 5.0
 
 # OTA CLI timing and retry delay
-OTA_REBOOT_WAIT_SECONDS: float = 5.0
-OTA_RETRY_DELAY_SECONDS: float = 2.0
-OTA_MAX_RETRIES: int = 5
+OTA_REBOOT_WAIT_SECONDS = cli_device_actions.OTA_REBOOT_WAIT_SECONDS
+OTA_RETRY_DELAY_SECONDS = cli_device_actions.OTA_RETRY_DELAY_SECONDS
+OTA_MAX_RETRIES = cli_device_actions.OTA_MAX_RETRIES
 
 # Keep-alive sleep interval for main loop (effectively infinite wait)
 """Sleep duration for the CLI main loop when listening on non-serial interfaces."""
@@ -620,241 +620,27 @@ def _send_local_factory_reset_and_wait(
     full: bool,
     timeout: float | None = None,
 ) -> mesh_pb2.MeshPacket | None:
-    """Send a local factory reset and wait for ACK/NAK or reboot transport loss.
+    """Compatibility wrapper for the canonical device reset helper."""
+    return cli_device_actions.send_local_factory_reset_and_wait(
+        reset_node, full=full, timeout=timeout, cli_print=_cli_print
+    )
 
-    Firmware 2.7 can execute the reset and schedule its reboot without forwarding
-    the resulting routing ACK to PhoneAPI after the reset clears the channel
-    table.  Firmware 2.8 normally forwards the ACK.  For this destructive local
-    operation, a transport interruption observed *after* the request was queued
-    is therefore also evidence that firmware accepted the command.
-
-    Explicit routing errors and a deadline with neither signal remain hard
-    failures.  The caller still reconnects and verifies the post-reset state.
-    """
-    reset_interface = reset_node.iface
-    disconnect_observed = threading.Event()
-    request_queued = threading.Event()
-
-    def _on_connection_lost(interface: MeshInterface) -> None:
-        if request_queued.is_set() and interface is reset_interface:
-            disconnect_observed.set()
-
-    acknowledgment = getattr(reset_interface, "_acknowledgment", None)
-    reset_acknowledgment = getattr(acknowledgment, "reset", None)
-    if callable(reset_acknowledgment):
-        # A stale compatibility flag from an earlier command must never satisfy
-        # this destructive request's acceptance wait.
-        reset_acknowledgment()
-
-    pub.subscribe(_on_connection_lost, "meshtastic.connection.lost")
-    request: mesh_pb2.MeshPacket | None = None
-    request_id: int | None = None
-    try:
-        request = reset_node.factoryReset(full=full)
-        if request is None:
-            return None
-
-        raw_request_id = getattr(request, "id", None)
-        if isinstance(raw_request_id, int) and not isinstance(raw_request_id, bool):
-            request_id = raw_request_id if raw_request_id > 0 else None
-        request_queued.set()
-
-        # Snapshot the active transport only after sendData returned a concrete
-        # packet.  A stale disconnect or reconnect that happened before the send
-        # completed cannot prove this reset was accepted.
-        missing_transport = object()
-        socket_after_send = getattr(reset_interface, "socket", missing_transport)
-        stream_after_send = getattr(reset_interface, "stream", missing_transport)
-
-        acceptance_timeout = (
-            FACTORY_RESET_ACCEPTANCE_TIMEOUT_SECONDS
-            if timeout is None
-            else float(timeout)
-        )
-        if acceptance_timeout <= 0:
-            raise ValueError("factory reset acceptance timeout must be positive")
-
-        wait_for_request_ack = getattr(reset_interface, "_wait_for_request_ack", None)
-        raise_wait_error = getattr(
-            reset_interface, "_raise_wait_error_if_present", None
-        )
-        scoped_wait_available = (
-            request_id is not None
-            and callable(wait_for_request_ack)
-            and callable(raise_wait_error)
-        )
-
-        _cli_print("Waiting for factory reset acknowledgment or reboot disconnect")
-        deadline = time.monotonic() + acceptance_timeout
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                break
-
-            if (
-                scoped_wait_available
-                and callable(wait_for_request_ack)
-                and callable(raise_wait_error)
-            ):
-                completed = wait_for_request_ack(
-                    "receivedNak",
-                    request_id,
-                    timeout_seconds=min(
-                        FACTORY_RESET_ACCEPTANCE_POLL_SECONDS,
-                        remaining,
-                    ),
-                )
-                if completed:
-                    # Request-scoped wait state distinguishes a successful ACK
-                    # from an explicit routing error.  The legacy receivedNak
-                    # attribute is only a completion latch and is not itself
-                    # evidence of rejection.
-                    raise_wait_error("receivedNak", request_id=request_id)
-                    return request
-            else:
-                # Compatibility fallback for minimal/legacy interfaces without
-                # request-scoped wait helpers.  Check actual ACK kinds before the
-                # shared receivedNak completion flag because implicit ACK handling
-                # can set both in older runtimes.
-                if callable(raise_wait_error):
-                    raise_wait_error("receivedNak", request_id=request_id)
-                received_ack = bool(getattr(acknowledgment, "receivedAck", False))
-                received_implicit_ack = bool(
-                    getattr(acknowledgment, "receivedImplAck", False)
-                )
-                if received_ack or received_implicit_ack:
-                    return request
-                if bool(getattr(acknowledgment, "receivedNak", False)):
-                    raise reset_interface.MeshInterfaceError(
-                        "Factory reset request was rejected by the device"
-                    )
-                time.sleep(
-                    min(
-                        FACTORY_RESET_ACCEPTANCE_POLL_SECONDS,
-                        remaining,
-                    )
-                )
-
-            connected_event = getattr(reset_interface, "isConnected", None)
-            connected = True
-            is_set = getattr(connected_event, "is_set", None)
-            if callable(is_set):
-                connected = bool(is_set())
-
-            current_socket = getattr(reset_interface, "socket", missing_transport)
-            current_stream = getattr(reset_interface, "stream", missing_transport)
-            socket_replaced = (
-                socket_after_send is not missing_transport
-                and current_socket is not socket_after_send
-            )
-            stream_replaced = (
-                stream_after_send is not missing_transport
-                and current_stream is not stream_after_send
-            )
-            if (
-                disconnect_observed.is_set()
-                or not connected
-                or socket_replaced
-                or stream_replaced
-            ):
-                # Check request-scoped errors one final time so an explicit NAK
-                # wins over a nearly simultaneous transport loss.
-                if callable(raise_wait_error):
-                    raise_wait_error("receivedNak", request_id=request_id)
-                logger.info(
-                    "Device transport changed after local factory reset request; "
-                    "treating reboot as command acceptance."
-                )
-                return request
-
-        if callable(raise_wait_error):
-            raise_wait_error("receivedNak", request_id=request_id)
-        raise reset_interface.MeshInterfaceError(
-            "Timed out waiting for a factory reset acknowledgment or reboot disconnect"
-        )
-    finally:
-        retire_wait = getattr(reset_interface, "_retire_wait_request", None)
-        if callable(retire_wait) and request_id is not None:
-            retire_wait("receivedNak", request_id=request_id)
-        if callable(reset_acknowledgment):
-            reset_acknowledgment()
-        try:
-            pub.unsubscribe(_on_connection_lost, "meshtastic.connection.lost")
-        except Exception:
-            logger.debug(
-                "Factory reset: failed to remove connection-loss observer.",
-                exc_info=True,
-            )
-
-    return None
 
 
 @contextlib.contextmanager
 def _temporary_instance_attributes(
     instance: Any, overrides: dict[str, Any]
 ) -> Iterator[None]:
-    """Temporarily override instance attributes and restore their exact prior state."""
-    missing = object()
-    instance_values = vars(instance)
-    previous_values = {name: instance_values.get(name, missing) for name in overrides}
-    try:
-        for name, value in overrides.items():
-            setattr(instance, name, value)
+    """Compatibility wrapper for temporary instance attribute overrides."""
+    with cli_device_actions.temporary_instance_attributes(instance, overrides):
         yield
-    finally:
-        for name, previous in previous_values.items():
-            if previous is missing:
-                with contextlib.suppress(AttributeError):
-                    delattr(instance, name)
-            else:
-                setattr(instance, name, previous)
+
 
 
 def _post_factory_reset_ready_probe(interface: MeshInterface) -> None:
-    """Close, briefly probe serial readiness, then release the port for the next command."""
-    if not isinstance(interface, meshtastic.serial_interface.SerialInterface):
-        return
+    """Compatibility wrapper for the canonical factory-reset readiness probe."""
+    cli_device_actions.post_factory_reset_ready_probe(interface)
 
-    logger.debug("Factory reset: closing serial interface to release port.")
-    try:
-        interface.close()
-    except Exception:
-        logger.debug(
-            "Factory reset: initial serial close failed.",
-            exc_info=True,
-        )
-
-    logger.debug(
-        "Factory reset: probing reconnect readiness (timeout=%.1fs)...",
-        FACTORY_RESET_READY_PROBE_TIMEOUT_SECONDS,
-    )
-    probe_overrides = {
-        "_connect_wait_timeout_seconds": FACTORY_RESET_READY_PROBE_TIMEOUT_SECONDS,
-        "_connect_retry_budget_seconds": FACTORY_RESET_READY_PROBE_TIMEOUT_SECONDS,
-        "_suppress_connect_failure_logging": True,
-    }
-    probe_start = time.monotonic()
-    with _temporary_instance_attributes(interface, probe_overrides):
-        try:
-            interface.connect()
-            logger.debug(
-                "Factory reset: reconnect probe succeeded in %.2fs.",
-                time.monotonic() - probe_start,
-            )
-        except Exception as exc:
-            logger.info(
-                "Factory reset accepted; device is still rebooting after %.1fs "
-                "and the next command will reconnect normally (%s).",
-                time.monotonic() - probe_start,
-                exc,
-            )
-    try:
-        interface.close()
-    except Exception:
-        logger.debug(
-            "Factory reset: final serial close failed.",
-            exc_info=True,
-        )
 
 
 def _validate_non_empty_mapping_sections(
@@ -1828,56 +1614,16 @@ def _handle_ota_update(
     args: Any,
     getNode_kwargs: dict[str, Any],
 ) -> None:
-    """Initiate a Wi-Fi OTA update for the directly connected local node.
-
-    Parameters
-    ----------
-    interface : MeshInterface
-        TCP interface connected to the target node.
-    args : Any
-        CLI arguments containing the OTA update path and destination.
-    getNode_kwargs : dict[str, Any]
-        Additional arguments for retrieving the local node.
-    """
-    if not isinstance(interface, meshtastic.tcp_interface.TCPInterface):
-        _cli_exit(
-            "Error: OTA update currently requires a TCP connection to the node (use --host)."
-        )
-    if not _is_local_destination(interface, args.dest):
-        _cli_exit(
-            "Error: OTA update only supports the directly connected local node; omit --dest or use --dest ^local."
-        )
-    ota_dest = LOCAL_ADDR
-
-    try:
-        ota = meshtastic.ota.ESP32WiFiOTA(args.ota_update, interface.hostname)
-    except meshtastic.ota.OTAError as e:
-        _cli_exit(f"OTA update failed: {e}")
-
-    _cli_print(f"Triggering OTA update on {interface.hostname}...")
-    interface.getNode(ota_dest, requestChannels=False, **getNode_kwargs).startOTA(
-        mode=admin_pb2.OTAMode.OTA_WIFI, ota_file_hash=ota.hash_bytes()
+    """Compatibility wrapper for the canonical Wi-Fi OTA action."""
+    cli_device_actions.handle_ota_update(
+        interface,
+        args,
+        getNode_kwargs,
+        cli_exit=_cli_exit,
+        cli_print=_cli_print,
+        is_local_destination=_is_local_destination,
     )
 
-    _cli_print("Waiting for device to reboot into OTA mode...")
-    time.sleep(OTA_REBOOT_WAIT_SECONDS)
-
-    retries = OTA_MAX_RETRIES
-    while retries > 0:
-        try:
-            ota.update()
-            break
-
-        except meshtastic.ota.OTATransportError as e:
-            retries -= 1
-            if retries == 0:
-                _cli_exit(f"OTA update failed: {e}")
-
-            time.sleep(OTA_RETRY_DELAY_SECONDS)
-        except meshtastic.ota.OTAError as e:
-            _cli_exit(f"OTA update failed: {e}")
-
-    _cli_print("\nOTA update completed successfully!")
 
 
 def _print_set_field_choices(node: Any, pref_names: Sequence[str]) -> None:
@@ -2593,277 +2339,22 @@ def onConnected(interface: MeshInterface) -> None:
             else:
                 _cli_print("Connected to radio")
 
-        if args.set_time is not None:
-            interface.getNode(args.dest, False, **getNode_kwargs).setTime(args.set_time)
-
-        if args.remove_position:
-            outcome.close_now = True
-            outcome.wait_for_ack_nak = True
-
-            _cli_print("Removing fixed position and disabling fixed position setting")
-            interface.getNode(args.dest, False, **getNode_kwargs).removeFixedPosition()
-        elif args.setlat or args.setlon or args.setalt:
-            outcome.close_now = True
-            outcome.wait_for_ack_nak = True
-
-            alt = 0
-            lat = 0.0
-            lon = 0.0
-            if args.setalt:
-                alt = int(args.setalt)
-                _cli_print(f"Fixing altitude at {alt} meters")
-            if args.setlat:
-                try:
-                    lat = int(args.setlat)
-                except ValueError:
-                    lat = float(args.setlat)
-                _cli_print(f"Fixing latitude at {lat} degrees")
-            if args.setlon:
-                try:
-                    lon = int(args.setlon)
-                except ValueError:
-                    lon = float(args.setlon)
-                _cli_print(f"Fixing longitude at {lon} degrees")
-
-            _cli_print("Setting device position and enabling fixed position setting")
-            # can include lat/long/alt etc: latitude = 37.5, longitude = -122.1
-            interface.getNode(args.dest, False, **getNode_kwargs).setFixedPosition(
-                lat, lon, alt
-            )
-
-        if args.set_owner or args.set_owner_short or args.set_is_unmessageable:
-            outcome.close_now = True
-            outcome.wait_for_ack_nak = True
-
-            long_name = args.set_owner.strip() if args.set_owner else None
-            short_name = args.set_owner_short.strip() if args.set_owner_short else None
-
-            if long_name is not None and not long_name:
-                _cli_exit(
-                    "ERROR: Long Name cannot be empty or contain only whitespace characters"
-                )
-
-            if short_name is not None and not short_name:
-                _cli_exit(
-                    "ERROR: Short Name cannot be empty or contain only whitespace characters"
-                )
-
-            if long_name and short_name:
-                _cli_print(
-                    f"Setting device owner to {long_name} and short name to {short_name}"
-                )
-            elif long_name:
-                _cli_print(f"Setting device owner to {long_name}")
-            elif short_name:
-                _cli_print(f"Setting device owner short to {short_name}")
-
-            unmessagable = None
-            if args.set_is_unmessageable is not None:
-                unmessagable = (
-                    meshtastic.util.fromStr(args.set_is_unmessageable)
-                    if isinstance(args.set_is_unmessageable, str)
-                    else args.set_is_unmessageable
-                )
-                _cli_print(f"Setting device owner is_unmessageable to {unmessagable}")
-
-            interface.getNode(args.dest, False, **getNode_kwargs).setOwner(
-                long_name=long_name, short_name=short_name, is_unmessagable=unmessagable
-            )
-
-        if args.set_canned_message:
-            outcome.close_now = True
-            outcome.wait_for_ack_nak = True
-            node = interface.getNode(args.dest, False, **getNode_kwargs)
-            if node.module_available(mesh_pb2.CANNEDMSG_CONFIG):
-                _cli_print(
-                    f"Setting canned plugin message to {args.set_canned_message}"
-                )
-                node.set_canned_message(args.set_canned_message)
-            else:
-                logger.warning(
-                    "Canned Message module is excluded by firmware; skipping set."
-                )
-
-        if args.set_ringtone:
-            outcome.close_now = True
-            outcome.wait_for_ack_nak = True
-            node = interface.getNode(args.dest, False, **getNode_kwargs)
-            if node.module_available(mesh_pb2.EXTNOTIF_CONFIG):
-                _cli_print(f"Setting ringtone to {args.set_ringtone}")
-                node.set_ringtone(args.set_ringtone)
-            else:
-                logger.warning(
-                    "External Notification is excluded by firmware; skipping ringtone set."
-                )
-
-        if args.pos_fields:
-            # If --pos-fields invoked with args, set position fields
-            outcome.close_now = True
-            positionConfig = interface.getNode(
-                args.dest, **getNode_kwargs
-            ).localConfig.position
-            allFields = 0
-
-            try:
-                for field in args.pos_fields:
-                    v_field = positionConfig.PositionFlags.Value(field)
-                    allFields |= v_field
-
-            except ValueError:
-                print("ERROR: supported position fields are:")
-                print(positionConfig.PositionFlags.keys())
-                print(
-                    "If no fields are specified, will read and display current value."
-                )
-
-            else:
-                _cli_print(f"Setting position fields to {allFields}")
-                setPref(positionConfig, "position_flags", f"{allFields:d}")
-                _cli_print("Writing modified preferences to device")
-                interface.getNode(args.dest, **getNode_kwargs).writeConfig("position")
-
-        elif args.pos_fields is not None:
-            # If --pos-fields invoked without args, read and display current value
-            outcome.close_now = True
-            positionConfig = interface.getNode(
-                args.dest, **getNode_kwargs
-            ).localConfig.position
-
-            fieldNames = []
-            for bit in positionConfig.PositionFlags.values():
-                if positionConfig.position_flags & bit:
-                    fieldNames.append(positionConfig.PositionFlags.Name(bit))
-            print(" ".join(fieldNames))
-
-        if args.set_ham:
-            ham_id = args.set_ham.strip()
-            if not ham_id:
-                _cli_exit(
-                    "ERROR: Ham radio callsign cannot be empty or contain only whitespace characters"
-                )
-            outcome.close_now = True
-            _cli_print(f"Setting Ham ID to {ham_id} and turning off encryption")
-            interface.getNode(args.dest, **getNode_kwargs).setOwner(
-                ham_id, is_licensed=True
-            )
-            # Must turn off encryption on primary channel
-            interface.getNode(
-                args.dest, **getNode_kwargs
-            ).turnOffEncryptionOnPrimaryChannel()
-
-        if args.reboot:
-            outcome.close_now = True
-            outcome.wait_for_ack_nak = True
-            outcome.skip_ack_wait = True
-            interface.getNode(args.dest, False, **getNode_kwargs).reboot()
-
-        if args.reboot_ota:
-            outcome.close_now = True
-            outcome.wait_for_ack_nak = True
-            outcome.skip_ack_wait = True
-            interface.getNode(args.dest, False, **getNode_kwargs).rebootOTA()
-
-        if args.ota_update:
-            outcome.close_now = True
-            outcome.skip_ack_wait = True
-            _handle_ota_update(interface, args, getNode_kwargs)
+        device_hooks = cli_device_actions.DeviceActionHooks(
+            cli_exit=_cli_exit,
+            cli_print=_cli_print,
+            set_pref=setPref,
+            is_local_destination=_is_local_destination,
+            send_local_factory_reset_and_wait=_send_local_factory_reset_and_wait,
+            post_factory_reset_ready_probe=_post_factory_reset_ready_probe,
+            handle_ota_update=_handle_ota_update,
+            build_lockdown_auth=build_lockdown_auth,
+            read_lockdown_passphrase_file=read_lockdown_passphrase_file,
+            send_lockdown_auth=send_lockdown_auth,
+            validate_lockdown_passphrase=validate_lockdown_passphrase,
+        )
+        cli_device_actions.handle_device_actions(context, device_hooks)
+        if outcome.stop_processing:
             return
-
-        if args.enter_dfu:
-            outcome.close_now = True
-            outcome.wait_for_ack_nak = True
-            outcome.skip_ack_wait = True
-            interface.getNode(args.dest, False, **getNode_kwargs).enterDFUMode()
-
-        if args.shutdown:
-            outcome.close_now = True
-            outcome.wait_for_ack_nak = True
-            outcome.skip_ack_wait = True
-            interface.getNode(args.dest, False, **getNode_kwargs).shutdown()
-
-        if args.device_metadata:
-            outcome.close_now = True
-            interface.getNode(args.dest, False, **getNode_kwargs).getMetadata()
-
-        if args.begin_edit:
-            outcome.close_now = True
-            interface.getNode(
-                args.dest, False, **getNode_kwargs
-            ).beginSettingsTransaction()
-
-        if args.commit_edit:
-            outcome.close_now = True
-            interface.getNode(
-                args.dest, False, **getNode_kwargs
-            ).commitSettingsTransaction()
-
-        if args.factory_reset or args.factory_reset_device:
-            outcome.close_now = True
-            outcome.wait_for_ack_nak = True
-            outcome.skip_ack_wait = True
-
-            full = bool(args.factory_reset_device)
-            reset_node = interface.getNode(args.dest, False, **getNode_kwargs)
-            is_local_reset = _is_local_destination(interface, args.dest)
-            if is_local_reset:
-                _send_local_factory_reset_and_wait(
-                    reset_node,
-                    full=full,
-                )
-            else:
-                # Remote Node.factoryReset() owns its ACK wait.
-                reset_node.factoryReset(full=full)
-            # Guard the isinstance check: SerialInterface may be a mock or not resolve in tests.
-            _serial_interface_cls = getattr(
-                meshtastic.serial_interface, "SerialInterface", None
-            )
-            if (
-                full
-                and _is_local_destination(interface, args.dest)
-                and isinstance(_serial_interface_cls, type)
-                and isinstance(interface, _serial_interface_cls)
-            ):
-                _post_factory_reset_ready_probe(interface)
-
-        if args.remove_node:
-            outcome.close_now = True
-            outcome.wait_for_ack_nak = True
-            interface.getNode(args.dest, False, **getNode_kwargs).removeNode(
-                args.remove_node
-            )
-
-        if args.set_favorite_node:
-            outcome.close_now = True
-            outcome.wait_for_ack_nak = True
-            interface.getNode(args.dest, False, **getNode_kwargs).setFavorite(
-                args.set_favorite_node
-            )
-
-        if args.remove_favorite_node:
-            outcome.close_now = True
-            outcome.wait_for_ack_nak = True
-            interface.getNode(args.dest, False, **getNode_kwargs).removeFavorite(
-                args.remove_favorite_node
-            )
-
-        if args.set_ignored_node:
-            outcome.close_now = True
-            outcome.wait_for_ack_nak = True
-            interface.getNode(args.dest, False, **getNode_kwargs).setIgnored(
-                args.set_ignored_node
-            )
-
-        if args.remove_ignored_node:
-            outcome.close_now = True
-            outcome.wait_for_ack_nak = True
-            interface.getNode(args.dest, False, **getNode_kwargs).removeIgnored(
-                args.remove_ignored_node
-            )
-
-        if args.reset_nodedb:
-            outcome.close_now = True
-            outcome.wait_for_ack_nak = True
-            interface.getNode(args.dest, False, **getNode_kwargs).resetNodeDb()
 
         if args.add_contact:
             outcome.close_now = True
@@ -3291,95 +2782,7 @@ def onConnected(interface: MeshInterface) -> None:
                         f"presets={','.join(preset_names)}"
                     )
 
-        lockdown_action = next(
-            (
-                name
-                for name, enabled in (
-                    ("provision", args.lockdown_provision),
-                    ("unlock", args.lockdown_unlock),
-                    ("lock-now", args.lockdown_lock_now),
-                    ("disable", args.lockdown_disable),
-                )
-                if enabled
-            ),
-            None,
-        )
-        if lockdown_action is not None:
-            outcome.close_now = True
-            if not _is_local_destination(interface, args.dest):
-                _cli_exit(
-                    "Lockdown commands apply only to the directly connected local node."
-                )
-            if (
-                lockdown_action in {"provision", "lock-now", "disable"}
-                and not args.lockdown_yes
-            ):
-                confirmation = (
-                    input(f"Type 'yes' to confirm lockdown {lockdown_action}: ")
-                    .strip()
-                    .casefold()
-                )
-                if confirmation != "yes":
-                    _cli_exit("Aborted.")
-            try:
-                passphrase = b""
-                if lockdown_action != "lock-now":
-                    if args.lockdown_passphrase_file:
-                        passphrase = read_lockdown_passphrase_file(
-                            args.lockdown_passphrase_file
-                        )
-                    elif args.lockdown_passphrase is not None:
-                        if not args.insecure_lockdown_passphrase_on_command_line:
-                            _cli_exit(
-                                "--lockdown-passphrase requires "
-                                "--insecure-lockdown-passphrase-on-command-line; "
-                                "prefer an operator-only file or interactive entry."
-                            )
-                        passphrase = validate_lockdown_passphrase(
-                            args.lockdown_passphrase.encode("utf-8")
-                        )
-                    else:
-                        entered = getpass.getpass("Lockdown passphrase: ")
-                        if lockdown_action == "provision":
-                            confirmed = getpass.getpass(
-                                "Lockdown passphrase (confirm): "
-                            )
-                            if entered != confirmed:
-                                _cli_exit("Lockdown passphrases do not match.")
-                        passphrase = validate_lockdown_passphrase(
-                            entered.encode("utf-8")
-                        )
-                auth = build_lockdown_auth(
-                    passphrase,
-                    boots_remaining=args.lockdown_boots,
-                    valid_until_epoch=args.lockdown_valid_until,
-                    max_session_seconds=args.lockdown_max_session_seconds,
-                    lock_now=lockdown_action == "lock-now",
-                    disable=lockdown_action == "disable",
-                )
-            except (OSError, ValueError) as exc:
-                _cli_exit(f"Invalid lockdown options: {exc}")
-            try:
-                status = send_lockdown_auth(
-                    interface,
-                    auth,
-                    timeout=args.lockdown_wait,
-                    allow_reboot_without_status=lockdown_action == "lock-now",
-                )
-            except (TimeoutError, ValueError, RuntimeError) as exc:
-                _cli_exit(f"Lockdown command failed: {exc}")
-            if status is None:
-                print("Lockdown command accepted; device may already be rebooting.")
-            else:
-                try:
-                    state_name = mesh_pb2.LockdownStatus.State.Name(status.state)
-                except ValueError:
-                    state_name = f"STATE_{status.state}"
-                print(f"Lockdown status: {state_name}")
-                if status.backoff_seconds:
-                    print(f"Retry backoff: {status.backoff_seconds}s")
-                if status.state == mesh_pb2.LockdownStatus.UNLOCK_FAILED:
-                    _cli_exit("Lockdown authentication failed.")
+        cli_device_actions.handle_lockdown_action(context, device_hooks)
 
         if args.info:
             print("")
@@ -3512,7 +2915,7 @@ def onConnected(interface: MeshInterface) -> None:
             _cli_print(
                 "Waiting for an acknowledgment from remote node (this could take a while)"
             )
-            interface.getNode(args.dest, False, **getNode_kwargs).iface.outcome.wait_for_ack_nak()
+            interface.getNode(args.dest, False, **getNode_kwargs).iface.waitForAckNak()
 
         if args.wait_to_disconnect:
             _cli_print(

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1972,6 +1972,9 @@ def common() -> None:
             printAvailableConfigFields()
             return
 
+        if args.configure and len(args.configure) != 1:
+            parser.error("--configure may be specified only once per invocation")
+
         # Early validation for owner names before attempting device connection
         if args.set_owner is not None:
             stripped_long_name = args.set_owner.strip()

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -469,8 +469,12 @@ def _post_factory_reset_ready_probe(interface: MeshInterface) -> None:
 def _validate_non_empty_mapping_sections(
     *, top_level_key: str, section_mapping: dict[str, Any]
 ) -> dict[str, dict[str, Any]]:
-    """Compatibility wrapper for configure section validation."""
-    return cli_configure_actions._validate_non_empty_mapping_sections(
+    """Compatibility wrapper for configure section mapping validation.
+
+    The legacy helper name is intentionally retained for external callers even
+    though empty mappings are valid protobuf-default section payloads.
+    """
+    return cli_configure_actions._validate_mapping_sections(
         _configure_hooks(),
         top_level_key=top_level_key,
         section_mapping=section_mapping,

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -18,13 +18,14 @@ import textwrap
 import time
 from collections.abc import Callable, Iterator, Sequence
 from types import ModuleType
-from typing import Any, NoReturn, Protocol, cast
+from typing import Any, NoReturn, Protocol
 
 from google.protobuf.descriptor import FieldDescriptor
 from google.protobuf.json_format import MessageToDict
 from pubsub import pub
 
 import meshtastic.cli.config_io as cli_config_io
+import meshtastic.cli.channel_contact_actions as cli_channel_contact_actions
 import meshtastic.cli.configure_actions as cli_configure_actions
 import meshtastic.cli.device_actions as cli_device_actions
 import meshtastic.cli.runtime as cli_runtime
@@ -1688,13 +1689,21 @@ def onConnected(interface: MeshInterface) -> None:
         if outcome.stop_processing:
             return
 
-        if args.add_contact:
-            outcome.close_now = True
-            outcome.wait_for_ack_nak = True
-            outcome.skip_ack_wait = True  # addContactURL() owns the remote ACK wait
-            interface.getNode(args.dest, False, **getNode_kwargs).addContactURL(
-                args.add_contact
-            )
+        channel_contact_hooks = cli_channel_contact_actions.ChannelContactHooks(
+            cli_exit=_cli_exit,
+            cli_print=_cli_print,
+            get_channel_index=lambda: mt_config.channel_index,
+            set_channel_index=lambda value: setattr(mt_config, "channel_index", value),
+            resolve_pref=_resolve_pref,
+            set_pref=setPref,
+            fatal_preference_value_errors=_fatal_preference_value_errors,
+            preference_value_error=_PreferenceValueError,
+            print_channel_field_choices=_print_channel_field_choices,
+            is_local_destination=_is_local_destination,
+            modem_preset_shorthands=_MODEM_PRESET_SHORTHANDS,
+            qr_create=pyqrcode.create if pyqrcode is not None else None,
+        )
+        cli_channel_contact_actions.handle_contact_import(context)
 
         if args.sendtext:
             outcome.close_now = True
@@ -1826,215 +1835,9 @@ def onConnected(interface: MeshInterface) -> None:
         if outcome.stop_processing:
             return
 
-        if args.ch_set_url:
-            outcome.close_now = True
-            interface.getNode(args.dest, **getNode_kwargs).setURL(
-                args.ch_set_url, addOnly=False
-            )
-
-        # handle changing channels
-
-        if args.ch_add_url:
-            outcome.close_now = True
-            interface.getNode(args.dest, **getNode_kwargs).setURL(
-                args.ch_add_url, addOnly=True
-            )
-
-        if args.ch_add:
-            ch_add_idx = mt_config.channel_index
-            if ch_add_idx is not None:
-                # Since we set the channel index after adding a channel, don't allow --ch-index
-                _cli_exit(
-                    "Warning: --ch-add chooses the next free channel index automatically; "
-                    "remove --ch-index and retry. Use --ch-set, --ch-del, --ch-enable, "
-                    "or --ch-disable when targeting a specific index."
-                )
-            outcome.close_now = True
-            if len(args.ch_add) > 10:
-                _cli_exit("Warning: Channel name must be shorter. Channel not added.")
-            n = interface.getNode(args.dest, **getNode_kwargs)
-            ch = n.getChannelByName(args.ch_add)
-            if ch:
-                _cli_exit(
-                    f"Warning: This node already has a '{args.ch_add}' channel. No changes were made."
-                )
-            else:
-                # get the first channel that is disabled (i.e., available)
-                ch = n.getDisabledChannel()
-                if not ch:
-                    _cli_exit("Warning: No free channels were found")
-                chs = channel_pb2.ChannelSettings()
-                chs.psk = meshtastic.util.genPSK256()
-                chs.name = args.ch_add
-                ch.settings.CopyFrom(chs)
-                ch.role = channel_pb2.Channel.Role.SECONDARY
-                _cli_print("Writing modified channels to device")
-                n.writeChannel(ch.index)
-                _cli_print(
-                    f"Setting newly-added channel's {ch.index} as '--ch-index' for further modifications"
-                )
-                mt_config.channel_index = ch.index
-
-        if args.ch_del:
-            outcome.close_now = True
-
-            ch_del_idx = mt_config.channel_index
-            if ch_del_idx is None:
-                _cli_exit("Warning: Need to specify '--ch-index' for '--ch-del'.", 1)
-            else:
-                if ch_del_idx == 0:
-                    _cli_exit("Warning: Cannot delete primary channel.", 1)
-                else:
-                    _cli_print(f"Deleting channel {ch_del_idx}")
-                    interface.getNode(args.dest, **getNode_kwargs).deleteChannel(
-                        ch_del_idx
-                    )
-
-        def _set_simple_config(
-            modem_preset: config_pb2.Config.LoRaConfig.ModemPreset.ValueType,
-        ) -> None:
-            """Set and persist the LORA modem preset on the device's primary channel.
-
-            If the configured channel is not the primary channel, the function exits
-            with a warning and does not change device state. When applied, the modem
-            preset is written into the node's local LORA configuration and
-            persisted to the device.
-
-            Parameters
-            ----------
-            modem_preset : int | EnumValue
-                Modem preset identifier to apply (numeric index or enum value understood by firmware).
-            """
-            channelIndex = mt_config.channel_index
-            if channelIndex is not None and channelIndex > 0:
-                _cli_exit("Warning: Cannot set modem preset for non-primary channel", 1)
-            # Overwrite modem_preset
-            node = interface.getNode(args.dest, False, **getNode_kwargs)
-            if len(node.localConfig.ListFields()) == 0:
-                lora_descriptor = node.localConfig.DESCRIPTOR.fields_by_name.get("lora")
-                if lora_descriptor is None:
-                    _cli_exit(
-                        "The active protobuf schema does not provide LoRa configuration",
-                        1,
-                    )
-                node.requestConfig(lora_descriptor)
-            node.localConfig.lora.modem_preset = modem_preset
-            node.writeConfig("lora")
-
-        # Resolve the final modem preset across historical shorthands (later
-        # wins) and the schema-driven --ch-preset, then write exactly once.
-        preset_val = None
-        for _, destination, preset_name, _ in _MODEM_PRESET_SHORTHANDS:
-            if getattr(args, destination, False):
-                preset_val = config_pb2.Config.LoRaConfig.ModemPreset.Value(preset_name)
-
-        generic_preset_name = getattr(args, "ch_preset", None)
-        if generic_preset_name is not None:
-            # Accept integer enum values from programmatic callers; CLI always
-            # produces a string via _parse_modem_preset_name.
-            if isinstance(generic_preset_name, int):
-                # Validate by round-tripping through the name so bad integers
-                # fail with a clear error instead of silently corrupting config.
-                config_pb2.Config.LoRaConfig.ModemPreset.Name(
-                    generic_preset_name  # type: ignore[arg-type]
-                )
-                preset_val = generic_preset_name  # type: ignore[assignment]
-            else:
-                preset_val = config_pb2.Config.LoRaConfig.ModemPreset.Value(
-                    generic_preset_name
-                )
-
-        if preset_val is not None:
-            _set_simple_config(preset_val)
-
-        if args.ch_set or args.ch_enable or args.ch_disable:
-            outcome.close_now = True
-
-            _idx: int | None = mt_config.channel_index
-            if _idx is None:
-                _cli_exit("Warning: Need to specify '--ch-index'.", 1)
-            # _idx is now narrowed to int due to NoReturn from _cli_exit
-            node = interface.getNode(args.dest, **getNode_kwargs)
-            channels = node.channels
-            if channels is None:
-                _cli_exit("Warning: Device channels are not available.", 1)
-            # Reject negative indices explicitly (security fix)
-            if _idx < 0:
-                _cli_exit(
-                    f"Warning: Channel index {_idx} is out of range.",
-                    1,
-                )
-            # Try to access channel - IndexError catches out-of-range positive indices
-            # TypeError handles case where channels is not indexable (e.g., mocked in tests)
-            try:
-                ch = channels[_idx]
-            except (IndexError, TypeError):
-                _cli_exit(
-                    f"Warning: Channel index {_idx} is out of range.",
-                    1,
-                )
-
-            enable: bool = True  # default to enable
-            if args.ch_enable or args.ch_disable:
-                _cli_print(
-                    "Warning: --ch-enable and --ch-disable can produce noncontiguous channels, "
-                    "which can cause errors in some clients. Whenever possible, use --ch-add and --ch-del instead."
-                )
-                if _idx == 0:
-                    _cli_exit("Warning: Cannot enable/disable PRIMARY channel.")
-
-                enable = True  # default to enable
-                if args.ch_enable:
-                    enable = True
-                if args.ch_disable:
-                    enable = False
-
-            # Validate channel settings on a copy so a later invalid entry cannot
-            # leave earlier values partially mutated in the local cache.
-            pending_settings = type(ch.settings)()
-            pending_settings.CopyFrom(ch.settings)
-            channel_update_valid = True
-            for pref in args.ch_set or []:
-                if pref[0] == "psk":
-                    try:
-                        pending_settings.psk = meshtastic.util.fromPSK(pref[1])
-                    except ValueError as exc:
-                        _cli_exit(f"Invalid channel PSK: {exc}", 1)
-                else:
-                    if not _resolve_pref(pending_settings, pref[0]):
-                        _print_channel_field_choices(pending_settings, pref[0])
-                        channel_update_valid = False
-                        continue
-                    try:
-                        with _fatal_preference_value_errors():
-                            found = setPref(pending_settings, pref[0], pref[1])
-                    except _PreferenceValueError as exc:
-                        _cli_exit(str(exc), 1)
-                    if not found:
-                        _cli_exit(f"Invalid value for channel setting {pref[0]}.", 1)
-
-                enable = True  # If we set any pref, assume the user wants to enable the channel
-
-            if channel_update_valid:
-                if args.ch_set:
-                    ch.settings.CopyFrom(pending_settings)
-
-                if enable:
-                    ch.role = (
-                        channel_pb2.Channel.Role.PRIMARY
-                        if (_idx == 0)
-                        else channel_pb2.Channel.Role.SECONDARY
-                    )
-                else:
-                    ch.role = channel_pb2.Channel.Role.DISABLED
-
-                _cli_print("Writing modified channels to device")
-                node.writeChannel(_idx)
-            else:
-                _cli_exit(
-                    "Warning: Unknown channel setting name. No changes were made.",
-                    1,
-                )
+        cli_channel_contact_actions.handle_channel_mutations(
+            context, channel_contact_hooks
+        )
 
         if args.get_canned_message:
             outcome.close_now = True
@@ -2050,46 +1853,9 @@ def onConnected(interface: MeshInterface) -> None:
             ringtone = interface.getNode(args.dest, **getNode_kwargs).get_ringtone()
             print(f"ringtone:{ringtone}")
 
-        if args.show_region_presets:
-            outcome.close_now = True
-            if not _is_local_destination(interface, args.dest):
-                print(
-                    "Region/preset capabilities are available only from the local node."
-                )
-            elif not interface.regionPresets:
-                print(
-                    "This firmware did not provide usable region/preset compatibility metadata; "
-                    "preset choices remain unconstrained."
-                )
-            else:
-                for region, info in sorted(interface.regionPresets.items()):
-                    try:
-                        region_name = config_pb2.Config.LoRaConfig.RegionCode.Name(
-                            cast(Any, region)
-                        )
-                    except ValueError:
-                        region_name = f"REGION_{region}"
-                    preset_names = []
-                    for value in info.presets:
-                        try:
-                            preset_names.append(
-                                config_pb2.Config.LoRaConfig.ModemPreset.Name(
-                                    cast(Any, value)
-                                )
-                            )
-                        except ValueError:
-                            preset_names.append(f"PRESET_{value}")
-                    try:
-                        default_name = config_pb2.Config.LoRaConfig.ModemPreset.Name(
-                            cast(Any, info.default_preset)
-                        )
-                    except ValueError:
-                        default_name = f"PRESET_{info.default_preset}"
-                    license_note = " licensed-only" if info.licensed_only else ""
-                    print(
-                        f"{region_name}: default={default_name}{license_note}; "
-                        f"presets={','.join(preset_names)}"
-                    )
+        cli_channel_contact_actions.handle_region_preset_display(
+            context, channel_contact_hooks
+        )
 
         cli_device_actions.handle_lockdown_action(context, device_hooks)
 
@@ -2137,35 +1903,9 @@ def onConnected(interface: MeshInterface) -> None:
             print("--show-fields can only be used with --nodes")
             return
 
-        if args.qr or args.qr_all:
-            outcome.close_now = True
-            url = interface.getNode(args.dest, True, **getNode_kwargs).getURL(
-                includeAll=args.qr_all
-            )
-            if args.qr_all:
-                urldesc = "Complete URL (includes all channels)"
-            else:
-                urldesc = "Primary channel URL"
-            print(f"{urldesc}: {url}")
-            if pyqrcode is not None:
-                qr = pyqrcode.create(url)
-                print(qr.terminal())
-            else:
-                print("Install pyqrcode to view a QR code printed to terminal.")
-
-        if args.contact_qr:
-            outcome.close_now = True
-            url = interface.localNode.getContactURL(
-                args.contact_qr,
-                should_ignore=args.contact_ignore,
-                manually_verified=args.contact_verified,
-            )
-            print(f"Contact URL: {url}")
-            if pyqrcode is not None:
-                qr = pyqrcode.create(url)
-                print(qr.terminal())
-            else:
-                print("Install pyqrcode to view a QR code printed to terminal.")
+        cli_channel_contact_actions.handle_channel_contact_display(
+            context, channel_contact_hooks
+        )
 
         log_set: Any = None
         # we need to keep a reference to the logset so it doesn't get GCed early

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -28,6 +28,7 @@ import meshtastic.cli.config_io as cli_config_io
 import meshtastic.cli.channel_contact_actions as cli_channel_contact_actions
 import meshtastic.cli.configure_actions as cli_configure_actions
 import meshtastic.cli.device_actions as cli_device_actions
+import meshtastic.cli.dispatch as cli_dispatch
 import meshtastic.cli.messaging_service_actions as cli_messaging_service_actions
 import meshtastic.cli.runtime as cli_runtime
 from meshtastic.cli.context import ActionOutcome, CliContext
@@ -1619,173 +1620,83 @@ def _validate_cli_show_fields(interface: MeshInterface, show_fields: list[str]) 
         )
 
 
+def _build_connected_dispatch_hooks() -> cli_dispatch.DispatchHooks:
+    """Build connected-action hooks from historical ``__main__`` seams."""
+    device_hooks = cli_device_actions.DeviceActionHooks(
+        cli_exit=_cli_exit,
+        cli_print=_cli_print,
+        set_pref=setPref,
+        is_local_destination=_is_local_destination,
+        send_local_factory_reset_and_wait=_send_local_factory_reset_and_wait,
+        post_factory_reset_ready_probe=_post_factory_reset_ready_probe,
+        handle_ota_update=_handle_ota_update,
+        build_lockdown_auth=build_lockdown_auth,
+        read_lockdown_passphrase_file=read_lockdown_passphrase_file,
+        send_lockdown_auth=send_lockdown_auth,
+        validate_lockdown_passphrase=validate_lockdown_passphrase,
+    )
+    channel_contact_hooks = cli_channel_contact_actions.ChannelContactHooks(
+        cli_exit=_cli_exit,
+        cli_print=_cli_print,
+        get_channel_index=lambda: mt_config.channel_index,
+        set_channel_index=lambda value: setattr(mt_config, "channel_index", value),
+        resolve_pref=_resolve_pref,
+        set_pref=setPref,
+        fatal_preference_value_errors=_fatal_preference_value_errors,
+        preference_value_error=_PreferenceValueError,
+        print_channel_field_choices=_print_channel_field_choices,
+        is_local_destination=_is_local_destination,
+        modem_preset_shorthands=_MODEM_PRESET_SHORTHANDS,
+        qr_create=pyqrcode.create if pyqrcode is not None else None,
+    )
+    configure_hooks = cli_configure_actions.ConfigureActionHooks(
+        handle_set_command=_handle_set_command,
+        handle_configure_command=_handle_configure_command,
+        export_config=exportConfig,
+        cli_exit=_cli_exit,
+        cli_print=_cli_print,
+    )
+    service_hooks = cli_messaging_service_actions.MessagingServiceHooks(
+        cli_exit=_cli_exit,
+        cli_print=_cli_print,
+        get_channel_index=lambda: mt_config.channel_index,
+        check_channel=checkChannel,
+        remote_hardware_client=remote_hardware.RemoteHardwareClient,
+        get_pref=getPref,
+        validate_cli_show_fields=_validate_cli_show_fields,
+        newer_version=meshtastic.util.check_if_newer_version,
+        install_upgrade_hint=INSTALL_UPGRADE_HINT,
+        powermon_available=lambda: have_powermon,
+        powermon_error=lambda: powermon_exception,
+        log_set_factory=LogSet,
+        power_stress_factory=PowerStress,
+        get_meter=lambda: meter,
+    )
+    return cli_dispatch.DispatchHooks(
+        cli_print=_cli_print,
+        device=device_hooks,
+        channel_contact=channel_contact_hooks,
+        configure=configure_hooks,
+        services=service_hooks,
+    )
+
+
 def onConnected(interface: MeshInterface) -> None:
-    """Execute CLI actions specified by parsed command-line arguments using the provided MeshInterface.
-
-    Performs whichever device or network operations were requested via mt_config.args (for
-    example: updating time or owner, configuring position or channels, sending
-    text/telemetry/position messages, node administration, exporting/importing
-    configuration, reboot/shutdown, starting tunnels or power-monitoring, and related
-    read/write operations). Actions may modify remote devices, start long-running
-    services, wait for acknowledgments, close the interface, or exit the process on
-    fatal errors.
-
-    Parameters
-    ----------
-    interface : MeshInterface
-        An established mesh interface used to perform the requested device and network operations.
-
-    Raises
-    ------
-    RuntimeError
-        If `mt_config.args` is not set up before calling this function.
-    """
+    """Execute parsed connected CLI actions on an established interface."""
     try:
         args = mt_config.args
         if args is None:
             raise RuntimeError("onConnected called without args being set up")
-
-        # convenient place to store any keyword args we pass to getNode
-        getNode_kwargs = {
-            "requestChannelAttempts": args.channel_fetch_attempts,
-            "timeout": args.timeout,
-        }
         context = CliContext(
             interface=interface,
             args=args,
-            get_node_kwargs=getNode_kwargs,
+            get_node_kwargs={
+                "requestChannelAttempts": args.channel_fetch_attempts,
+                "timeout": args.timeout,
+            },
             outcome=ActionOutcome(wait_for_ack_nak=False),
         )
-        outcome = context.outcome
-
-        # do not print this line if we are exporting the config
-        if not args.export_config:
-            dev_path = getattr(interface, "devPath", "")
-            if dev_path:
-                tty_name = os.path.basename(dev_path)
-                stable_path = getattr(interface, "_stable_path", None)
-                if stable_path and stable_path != dev_path:
-                    _cli_print(
-                        f"Connected to radio on {tty_name} (stable: {stable_path})"
-                    )
-                else:
-                    _cli_print(f"Connected to radio on {tty_name}")
-            else:
-                _cli_print("Connected to radio")
-
-        device_hooks = cli_device_actions.DeviceActionHooks(
-            cli_exit=_cli_exit,
-            cli_print=_cli_print,
-            set_pref=setPref,
-            is_local_destination=_is_local_destination,
-            send_local_factory_reset_and_wait=_send_local_factory_reset_and_wait,
-            post_factory_reset_ready_probe=_post_factory_reset_ready_probe,
-            handle_ota_update=_handle_ota_update,
-            build_lockdown_auth=build_lockdown_auth,
-            read_lockdown_passphrase_file=read_lockdown_passphrase_file,
-            send_lockdown_auth=send_lockdown_auth,
-            validate_lockdown_passphrase=validate_lockdown_passphrase,
-        )
-        cli_device_actions.handle_device_actions(context, device_hooks)
-        if outcome.stop_processing:
-            return
-
-        channel_contact_hooks = cli_channel_contact_actions.ChannelContactHooks(
-            cli_exit=_cli_exit,
-            cli_print=_cli_print,
-            get_channel_index=lambda: mt_config.channel_index,
-            set_channel_index=lambda value: setattr(mt_config, "channel_index", value),
-            resolve_pref=_resolve_pref,
-            set_pref=setPref,
-            fatal_preference_value_errors=_fatal_preference_value_errors,
-            preference_value_error=_PreferenceValueError,
-            print_channel_field_choices=_print_channel_field_choices,
-            is_local_destination=_is_local_destination,
-            modem_preset_shorthands=_MODEM_PRESET_SHORTHANDS,
-            qr_create=pyqrcode.create if pyqrcode is not None else None,
-        )
-        service_hooks = cli_messaging_service_actions.MessagingServiceHooks(
-            cli_exit=_cli_exit,
-            cli_print=_cli_print,
-            get_channel_index=lambda: mt_config.channel_index,
-            check_channel=checkChannel,
-            remote_hardware_client=remote_hardware.RemoteHardwareClient,
-            get_pref=getPref,
-            validate_cli_show_fields=_validate_cli_show_fields,
-            newer_version=meshtastic.util.check_if_newer_version,
-            install_upgrade_hint=INSTALL_UPGRADE_HINT,
-            powermon_available=lambda: have_powermon,
-            powermon_error=lambda: powermon_exception,
-            log_set_factory=LogSet,
-            power_stress_factory=PowerStress,
-            get_meter=lambda: meter,
-        )
-        cli_channel_contact_actions.handle_contact_import(context)
-        cli_messaging_service_actions.handle_messaging_actions(context, service_hooks)
-
-        # handle settings
-        configure_action_hooks = cli_configure_actions.ConfigureActionHooks(
-            handle_set_command=_handle_set_command,
-            handle_configure_command=_handle_configure_command,
-            export_config=exportConfig,
-            cli_exit=_cli_exit,
-            cli_print=_cli_print,
-        )
-        cli_configure_actions.handle_configure_actions(context, configure_action_hooks)
-        if outcome.stop_processing:
-            return
-
-        cli_channel_contact_actions.handle_channel_mutations(
-            context, channel_contact_hooks
-        )
-
-        cli_messaging_service_actions.handle_content_reads(context)
-
-        cli_channel_contact_actions.handle_region_preset_display(
-            context, channel_contact_hooks
-        )
-
-        cli_device_actions.handle_lockdown_action(context, device_hooks)
-
-        cli_messaging_service_actions.handle_information_actions(
-            context, service_hooks
-        )
-        if outcome.stop_processing:
-            return
-
-        cli_channel_contact_actions.handle_channel_contact_display(
-            context, channel_contact_hooks
-        )
-
-        cli_messaging_service_actions.handle_long_running_services(
-            context, service_hooks
-        )
-
-        if not outcome.skip_ack_wait and (
-            args.ack or (args.dest != BROADCAST_ADDR and outcome.wait_for_ack_nak)
-        ):
-            _cli_print(
-                "Waiting for an acknowledgment from remote node (this could take a while)"
-            )
-            interface.getNode(args.dest, False, **getNode_kwargs).iface.waitForAckNak()
-
-        if args.wait_to_disconnect:
-            _cli_print(
-                f"Waiting {args.wait_to_disconnect} seconds before disconnecting"
-            )
-            time.sleep(int(args.wait_to_disconnect))
-
-        # if the user didn't ask for serial debugging output, we might want to exit after we've done our operation
-        if (not args.seriallog) and outcome.close_now:
-            try:
-                interface.close()
-            except Exception:
-                logger.debug("Error during interface close", exc_info=True)
-
-        # Release resources retained by connected long-running actions.
-        for cleanup in reversed(outcome.cleanup_callbacks):
-            cleanup()
-
+        cli_dispatch.dispatch_connected(context, _build_connected_dispatch_hooks())
     except Exception as ex:
         logger.exception("Unhandled exception in onConnected: %s", ex)
         _cli_exit(f"Aborting due to: {ex}", 1)

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -449,7 +449,7 @@ def _send_local_factory_reset_and_wait(
     timeout: float | None = None,
 ) -> mesh_pb2.MeshPacket | None:
     """Compatibility wrapper for the canonical device reset helper."""
-    return cli_device_actions.send_local_factory_reset_and_wait(
+    return cli_device_actions._send_local_factory_reset_and_wait(
         reset_node, full=full, timeout=timeout, cli_print=_cli_print
     )
 
@@ -465,7 +465,7 @@ def _temporary_instance_attributes(
 
 def _post_factory_reset_ready_probe(interface: MeshInterface) -> None:
     """Compatibility wrapper for the canonical factory-reset readiness probe."""
-    cli_device_actions.post_factory_reset_ready_probe(interface)
+    cli_device_actions._post_factory_reset_ready_probe(interface)
 
 
 def _validate_non_empty_mapping_sections(
@@ -1299,7 +1299,7 @@ def _handle_ota_update(
     getNode_kwargs: dict[str, Any],
 ) -> None:
     """Compatibility wrapper for the canonical Wi-Fi OTA action."""
-    cli_device_actions.handle_ota_update(
+    cli_device_actions._handle_ota_update(
         interface,
         args,
         getNode_kwargs,
@@ -1712,7 +1712,7 @@ def onConnected(interface: MeshInterface) -> None:
             },
             outcome=ActionOutcome(),
         )
-        cli_dispatch.dispatch_connected(context, _build_connected_dispatch_hooks())
+        cli_dispatch._dispatch_connected(context, _build_connected_dispatch_hooks())
     except Exception as ex:
         logger.exception("Unhandled exception in onConnected: %s", ex)
         _cli_exit(f"Aborting due to: {ex}", 1)

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -28,6 +28,7 @@ import meshtastic.cli.config_io as cli_config_io
 import meshtastic.cli.channel_contact_actions as cli_channel_contact_actions
 import meshtastic.cli.configure_actions as cli_configure_actions
 import meshtastic.cli.device_actions as cli_device_actions
+import meshtastic.cli.messaging_service_actions as cli_messaging_service_actions
 import meshtastic.cli.runtime as cli_runtime
 from meshtastic.cli.context import ActionOutcome, CliContext
 import meshtastic.ota
@@ -1703,125 +1704,24 @@ def onConnected(interface: MeshInterface) -> None:
             modem_preset_shorthands=_MODEM_PRESET_SHORTHANDS,
             qr_create=pyqrcode.create if pyqrcode is not None else None,
         )
+        service_hooks = cli_messaging_service_actions.MessagingServiceHooks(
+            cli_exit=_cli_exit,
+            cli_print=_cli_print,
+            get_channel_index=lambda: mt_config.channel_index,
+            check_channel=checkChannel,
+            remote_hardware_client=remote_hardware.RemoteHardwareClient,
+            get_pref=getPref,
+            validate_cli_show_fields=_validate_cli_show_fields,
+            newer_version=meshtastic.util.check_if_newer_version,
+            install_upgrade_hint=INSTALL_UPGRADE_HINT,
+            powermon_available=lambda: have_powermon,
+            powermon_error=lambda: powermon_exception,
+            log_set_factory=LogSet,
+            power_stress_factory=PowerStress,
+            get_meter=lambda: meter,
+        )
         cli_channel_contact_actions.handle_contact_import(context)
-
-        if args.sendtext:
-            outcome.close_now = True
-            channelIndex = mt_config.channel_index or 0
-            if checkChannel(interface, channelIndex):
-                _cli_print(
-                    f"Sending text message {args.sendtext} to {args.dest} on channelIndex:{channelIndex}"
-                    f" {'using PRIVATE_APP port' if args.private else ''}"
-                )
-                interface.sendText(
-                    args.sendtext,
-                    args.dest,
-                    wantAck=True,
-                    channelIndex=channelIndex,
-                    onResponse=interface.getNode(
-                        args.dest, False, **getNode_kwargs
-                    ).onAckNak,
-                    portNum=(
-                        portnums_pb2.PortNum.PRIVATE_APP
-                        if args.private
-                        else portnums_pb2.PortNum.TEXT_MESSAGE_APP
-                    ),
-                )
-            else:
-                _cli_exit(
-                    f"Warning: {channelIndex} is not a valid channel. Channel must not be DISABLED."
-                )
-
-        if args.traceroute:
-            loraConfig = interface.localNode.localConfig.lora
-            hopLimit = loraConfig.hop_limit
-            dest = str(args.traceroute)
-            channelIndex = mt_config.channel_index or 0
-            if checkChannel(interface, channelIndex):
-                _cli_print(
-                    f"Sending traceroute request to {dest} on channelIndex:{channelIndex} (this could take a while)"
-                )
-                interface.sendTraceRoute(dest, hopLimit, channelIndex=channelIndex)
-
-        if args.request_telemetry:
-            if args.dest == BROADCAST_ADDR:
-                _cli_exit("Warning: Must use a destination node ID.")
-            else:
-                channelIndex = mt_config.channel_index or 0
-                if checkChannel(interface, channelIndex):
-                    telemMap = {
-                        "device": "device_metrics",
-                        "environment": "environment_metrics",
-                        "air_quality": "air_quality_metrics",
-                        "airquality": "air_quality_metrics",
-                        "power": "power_metrics",
-                        "localstats": "local_stats",
-                        "local_stats": "local_stats",
-                    }
-                    telemType = telemMap.get(args.request_telemetry, "device_metrics")
-                    _cli_print(
-                        f"Sending {telemType} telemetry request to {args.dest} on channelIndex:{channelIndex} (this could take a while)"
-                    )
-                    interface.sendTelemetry(
-                        destinationId=args.dest,
-                        wantResponse=True,
-                        channelIndex=channelIndex,
-                        telemetryType=telemType,
-                    )
-
-        if args.request_position:
-            if args.dest == BROADCAST_ADDR:
-                _cli_exit("Warning: Must use a destination node ID.")
-            else:
-                channelIndex = mt_config.channel_index or 0
-                if checkChannel(interface, channelIndex):
-                    _cli_print(
-                        f"Sending position request to {args.dest} on channelIndex:{channelIndex} (this could take a while)"
-                    )
-                    interface.sendPosition(
-                        destinationId=args.dest,
-                        wantResponse=True,
-                        channelIndex=channelIndex,
-                    )
-
-        if args.gpio_wrb or args.gpio_rd or args.gpio_watch:
-            if args.dest == BROADCAST_ADDR:
-                _cli_exit("Warning: Must use a destination node ID.")
-            else:
-                rhc = remote_hardware.RemoteHardwareClient(interface)
-
-                if args.gpio_wrb:
-                    bitmask = 0
-                    bitval = 0
-                    for wrpair in args.gpio_wrb or []:
-                        bitmask |= 1 << int(wrpair[0])
-                        bitval |= int(wrpair[1]) << int(wrpair[0])
-                    _cli_print(
-                        f"Writing GPIO mask 0x{bitmask:x} with value 0x{bitval:x} to {args.dest}"
-                    )
-                    rhc.writeGPIOs(args.dest, bitmask, bitval)
-                    outcome.close_now = True
-
-                if args.gpio_rd:
-                    bitmask = int(args.gpio_rd, 16)
-                    _cli_print(f"Reading GPIO mask 0x{bitmask:x} from {args.dest}")
-                    interface.mask = bitmask
-                    rhc.readGPIOs(args.dest, bitmask, None)
-                    # wait up to X seconds for a response
-                    for _ in range(GPIO_READ_MAX_POLLS):
-                        time.sleep(GPIO_READ_POLL_INTERVAL_SECONDS)
-                        if interface.gotResponse:
-                            break
-                    logger.debug("end of gpio_rd")
-
-                if args.gpio_watch:
-                    bitmask = int(args.gpio_watch, 16)
-                    _cli_print(
-                        f"Watching GPIO mask 0x{bitmask:x} from {args.dest}. Press ctrl-c to exit"
-                    )
-                    while True:
-                        rhc.watchGPIOs(args.dest, bitmask)
-                        time.sleep(GPIO_WATCH_INTERVAL_SECONDS)
+        cli_messaging_service_actions.handle_messaging_actions(context, service_hooks)
 
         # handle settings
         configure_action_hooks = cli_configure_actions.ConfigureActionHooks(
@@ -1839,19 +1739,7 @@ def onConnected(interface: MeshInterface) -> None:
             context, channel_contact_hooks
         )
 
-        if args.get_canned_message:
-            outcome.close_now = True
-            print("")
-            messages = interface.getNode(
-                args.dest, **getNode_kwargs
-            ).get_canned_message()
-            print(f"canned_plugin_message:{messages}")
-
-        if args.get_ringtone:
-            outcome.close_now = True
-            print("")
-            ringtone = interface.getNode(args.dest, **getNode_kwargs).get_ringtone()
-            print(f"ringtone:{ringtone}")
+        cli_messaging_service_actions.handle_content_reads(context)
 
         cli_channel_contact_actions.handle_region_preset_display(
             context, channel_contact_hooks
@@ -1859,104 +1747,19 @@ def onConnected(interface: MeshInterface) -> None:
 
         cli_device_actions.handle_lockdown_action(context, device_hooks)
 
-        if args.info:
-            print("")
-            # If we aren't trying to talk to our local node, don't show it
-            if args.dest == BROADCAST_ADDR:
-                interface.showInfo()
-                print("")
-                interface.getNode(args.dest, **getNode_kwargs).showInfo()
-                outcome.close_now = True
-                print("")
-                pypi_version = meshtastic.util.check_if_newer_version()
-                if pypi_version:
-                    print(
-                        f"*** A newer version v{pypi_version} is available!"
-                        f' Consider running "{INSTALL_UPGRADE_HINT}" ***\n'
-                    )
-            else:
-                print("Showing info of remote node is not supported.")
-                print(
-                    "Use the '--get' command for a specific configuration (e.g. 'lora') instead."
-                )
-
-        if args.get:
-            outcome.close_now = True
-            node = interface.getNode(args.dest, False, **getNode_kwargs)
-            found = False
-            for pref in args.get:
-                found = getPref(node, pref[0])
-
-            if found:
-                _cli_print("Completed getting preferences")
-
-        if args.nodes:
-            outcome.close_now = True
-            if args.dest != BROADCAST_ADDR:
-                print("Showing node list of a remote node is not supported.")
-                return
-            if args.show_fields:
-                _validate_cli_show_fields(interface, args.show_fields)
-            interface.showNodes(True, args.show_fields)
-
-        if args.show_fields and not args.nodes:
-            print("--show-fields can only be used with --nodes")
+        cli_messaging_service_actions.handle_information_actions(
+            context, service_hooks
+        )
+        if outcome.stop_processing:
             return
 
         cli_channel_contact_actions.handle_channel_contact_display(
             context, channel_contact_hooks
         )
 
-        log_set: Any = None
-        # we need to keep a reference to the logset so it doesn't get GCed early
-
-        if args.slog or args.power_stress:
-            if have_powermon:
-                global meter  # pylint: disable=global-variable-not-assigned
-                if args.slog:
-                    if LogSet is None:
-                        _cli_exit(
-                            "LogSet is required for --slog but not available. "
-                            "The powermon module loaded incompletely."
-                        )
-                    log_set = LogSet(
-                        interface, args.slog if args.slog != "default" else None, meter
-                    )
-
-                if args.power_stress:
-                    if PowerStress is None:
-                        _cli_exit(
-                            "PowerStress is required for --power-stress but not available. "
-                            "The powermon module loaded incompletely."
-                        )
-                    stress = PowerStress(interface)
-                    stress.run()
-                    outcome.close_now = True  # exit immediately after stress test
-            else:
-                _cli_exit(
-                    "The powermon module could not be loaded. "
-                    "You may need to run `poetry install --with powermon`. "
-                    f"Import Error was: {powermon_exception}"
-                )
-
-        if args.listen:
-            outcome.close_now = False
-
-        have_tunnel = platform.system() == "Linux"
-        if have_tunnel and args.tunnel:
-            if args.dest != BROADCAST_ADDR:
-                _cli_exit("A tunnel can only be created using the local node.", 1)
-            # Even if others said we could close, stay open if the user asked for a tunnel
-            outcome.close_now = False
-            if interface.noProto:
-                logger.warning("Not starting Tunnel - disabled by noProto")
-            else:
-                from . import tunnel  # pylint: disable=C0415
-
-                if args.tunnel_net:
-                    tunnel.Tunnel(interface, subnet=args.tunnel_net)
-                else:
-                    tunnel.Tunnel(interface)
+        cli_messaging_service_actions.handle_long_running_services(
+            context, service_hooks
+        )
 
         if not outcome.skip_ack_wait and (
             args.ack or (args.dest != BROADCAST_ADDR and outcome.wait_for_ack_nak)
@@ -1979,9 +1782,9 @@ def onConnected(interface: MeshInterface) -> None:
             except Exception:
                 logger.debug("Error during interface close", exc_info=True)
 
-        # Close any structured logs after we've done all of our API operations
-        if log_set:
-            log_set.close()
+        # Release resources retained by connected long-running actions.
+        for cleanup in reversed(outcome.cleanup_callbacks):
+            cleanup()
 
     except Exception as ex:
         logger.exception("Unhandled exception in onConnected: %s", ex)

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -459,7 +459,7 @@ def _temporary_instance_attributes(
     instance: Any, overrides: dict[str, Any]
 ) -> Iterator[None]:
     """Compatibility wrapper for temporary instance attribute overrides."""
-    with cli_device_actions.temporary_instance_attributes(instance, overrides):
+    with cli_device_actions._temporary_instance_attributes(instance, overrides):
         yield
 
 

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -239,7 +239,7 @@ CONFIG_RECONNECT_WAIT_SECONDS = cli_configure_actions.CONFIG_RECONNECT_WAIT_SECO
 SETURL_STABILITY_TIMEOUT_SECONDS = (
     cli_configure_actions.SETURL_STABILITY_TIMEOUT_SECONDS
 )
-"""Timeout for post-setURL transport stability before opening Phase 2 writes."""
+"""Timeout for post-setURL transport stability before transactional writes."""
 
 FACTORY_RESET_READY_PROBE_TIMEOUT_SECONDS = (
     cli_device_actions.FACTORY_RESET_READY_PROBE_TIMEOUT_SECONDS
@@ -256,8 +256,10 @@ FACTORY_RESET_ACCEPTANCE_POLL_SECONDS = (
 )
 """Polling interval while waiting for local reset command acceptance."""
 
-CONFIGURE_PHASE1_HEADER = cli_configure_actions.CONFIGURE_PHASE1_HEADER
-"""Printed once when --configure starts applying Phase 1 settings."""
+CONFIGURE_DIRECT_SETTINGS_HEADER = (
+    cli_configure_actions.CONFIGURE_DIRECT_SETTINGS_HEADER
+)
+"""Printed once when --configure starts applying non-transactional values."""
 
 _ALLOWED_CONFIGURE_KEYS = cli_configure_actions.ALLOWED_CONFIGURE_KEYS
 

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1602,7 +1602,7 @@ def _apply_configure_channel_url(
 
 def _handle_configure_command(
     interface: MeshInterface, args: Any, getNode_kwargs: dict[str, Any]
-) -> tuple[bool, bool]:
+) -> cli_configure_actions._ConfigureCommandResult:
     """Compatibility wrapper for configure-file transaction execution."""
     return cli_configure_actions._handle_configure_command(
         _configure_hooks(), interface, args, getNode_kwargs

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -37,7 +37,13 @@ import meshtastic.serial_interface
 import meshtastic.tcp_interface
 import meshtastic.util
 from meshtastic import mt_config, remote_hardware
-from meshtastic._core_constants import BROADCAST_ADDR, LOCAL_ADDR  # noqa: F401
+# COMPAT_STABLE_SHIM: LOCAL_ADDR remains importable from meshtastic.__main__.
+# pylint: disable=unused-import
+from meshtastic._core_constants import (
+    BROADCAST_ADDR,
+    LOCAL_ADDR,  # noqa: F401
+)
+# pylint: enable=unused-import
 
 # COMPAT_STABLE_SHIM: Preserve legacy imports from meshtastic.cli.parser.
 # pylint: disable=unused-import
@@ -424,7 +430,9 @@ def _post_configure_reconnect_and_verify(
 
 
 def _post_seturl_stability_check(
-    interface: MeshInterface, *, timeout: float = 15.0
+    interface: MeshInterface,
+    *,
+    timeout: float = cli_configure_actions.SETURL_STABILITY_TIMEOUT_SECONDS,
 ) -> bool:
     """Compatibility wrapper for post-SetURL transport stabilization."""
     return cli_configure_actions._post_seturl_stability_check(
@@ -1655,6 +1663,7 @@ def _build_connected_dispatch_hooks() -> cli_dispatch.DispatchHooks:
         export_config=exportConfig,
         cli_exit=_cli_exit,
         cli_print=_cli_print,
+        is_local_destination=_is_local_destination,
     )
     service_hooks = cli_messaging_service_actions.MessagingServiceHooks(
         cli_exit=_cli_exit,
@@ -1678,6 +1687,7 @@ def _build_connected_dispatch_hooks() -> cli_dispatch.DispatchHooks:
         channel_contact=channel_contact_hooks,
         configure=configure_hooks,
         services=service_hooks,
+        sleep=time.sleep,
     )
 
 
@@ -1694,7 +1704,7 @@ def onConnected(interface: MeshInterface) -> None:
                 "requestChannelAttempts": args.channel_fetch_attempts,
                 "timeout": args.timeout,
             },
-            outcome=ActionOutcome(wait_for_ack_nak=False),
+            outcome=ActionOutcome(),
         )
         cli_dispatch.dispatch_connected(context, _build_connected_dispatch_hooks())
     except Exception as ex:

--- a/meshtastic/cli/channel_contact_actions.py
+++ b/meshtastic/cli/channel_contact_actions.py
@@ -314,6 +314,29 @@ def _handle_channel_mutations(context: CliContext, hooks: ChannelContactHooks) -
     _handle_channel_update(context, hooks)
 
 
+def _enum_name_or_fallback(enum_wrapper: Any, value: Any, prefix: str) -> str:
+    """Return a protobuf enum name or a stable numeric fallback.
+
+    Parameters
+    ----------
+    enum_wrapper : Any
+        Protobuf enum wrapper exposing ``Name``.
+    value : Any
+        Enum numeric value to render.
+    prefix : str
+        Prefix for unknown numeric values.
+
+    Returns
+    -------
+    str
+        Schema enum name, or ``prefix`` followed by the numeric value.
+    """
+    try:
+        return cast(str, enum_wrapper.Name(cast(Any, value)))
+    except ValueError:
+        return f"{prefix}{value}"
+
+
 def _handle_region_preset_display(
     context: CliContext, hooks: ChannelContactHooks
 ) -> None:
@@ -337,26 +360,20 @@ def _handle_region_preset_display(
         return
 
     for region, info in sorted(interface.regionPresets.items()):
-        try:
-            region_name = config_pb2.Config.LoRaConfig.RegionCode.Name(
-                cast(Any, region)
+        region_name = _enum_name_or_fallback(
+            config_pb2.Config.LoRaConfig.RegionCode, region, "REGION_"
+        )
+        preset_names = [
+            _enum_name_or_fallback(
+                config_pb2.Config.LoRaConfig.ModemPreset, value, "PRESET_"
             )
-        except ValueError:
-            region_name = f"REGION_{region}"
-        preset_names: list[str] = []
-        for value in info.presets:
-            try:
-                preset_names.append(
-                    config_pb2.Config.LoRaConfig.ModemPreset.Name(cast(Any, value))
-                )
-            except ValueError:
-                preset_names.append(f"PRESET_{value}")
-        try:
-            default_name = config_pb2.Config.LoRaConfig.ModemPreset.Name(
-                cast(Any, info.default_preset)
-            )
-        except ValueError:
-            default_name = f"PRESET_{info.default_preset}"
+            for value in info.presets
+        ]
+        default_name = _enum_name_or_fallback(
+            config_pb2.Config.LoRaConfig.ModemPreset,
+            info.default_preset,
+            "PRESET_",
+        )
         license_note = " licensed-only" if info.licensed_only else ""
         hooks.cli_print(
             f"{region_name}: default={default_name}{license_note}; "

--- a/meshtastic/cli/channel_contact_actions.py
+++ b/meshtastic/cli/channel_contact_actions.py
@@ -232,7 +232,7 @@ def _handle_channel_update(context: CliContext, hooks: ChannelContactHooks) -> N
             1,
         )
 
-    enable = True
+    enable = not args.ch_disable
     if args.ch_enable or args.ch_disable:
         hooks.cli_print(
             "Warning: --ch-enable and --ch-disable can produce noncontiguous channels, "
@@ -243,8 +243,6 @@ def _handle_channel_update(context: CliContext, hooks: ChannelContactHooks) -> N
             _terminate_cli(
                 hooks.cli_exit, "Warning: Cannot enable/disable PRIMARY channel."
             )
-        enable = not args.ch_disable
-
     pending_settings = type(channel.settings)()
     pending_settings.CopyFrom(channel.settings)
     channel_update_valid = True
@@ -268,8 +266,6 @@ def _handle_channel_update(context: CliContext, hooks: ChannelContactHooks) -> N
                 _terminate_cli(
                     hooks.cli_exit, f"Invalid value for channel setting {pref[0]}.", 1
                 )
-        enable = True
-
     if not channel_update_valid:
         _terminate_cli(
             hooks.cli_exit,

--- a/meshtastic/cli/channel_contact_actions.py
+++ b/meshtastic/cli/channel_contact_actions.py
@@ -12,7 +12,7 @@ from meshtastic.cli.context import CliContext, CliExit, _terminate_cli
 from meshtastic.protobuf import channel_pb2, config_pb2
 
 
-MAX_CHANNEL_NAME_LENGTH = 10
+MAX_CHANNEL_NAME_LENGTH: int = 10
 
 
 @dataclass(frozen=True, slots=True)

--- a/meshtastic/cli/channel_contact_actions.py
+++ b/meshtastic/cli/channel_contact_actions.py
@@ -1,0 +1,337 @@
+"""Connected CLI actions for channel and contact management."""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from typing import Any, Callable, NoReturn, cast
+
+import meshtastic.util
+from meshtastic.cli.context import CliContext
+from meshtastic.protobuf import channel_pb2, config_pb2
+
+
+@dataclass(frozen=True, slots=True)
+class ChannelContactHooks:
+    """Compatibility and process-state seams used by channel/contact actions."""
+
+    cli_exit: Callable[..., NoReturn]
+    cli_print: Callable[[str], None]
+    get_channel_index: Callable[[], int | None]
+    set_channel_index: Callable[[int], None]
+    resolve_pref: Callable[[Any, str], bool]
+    set_pref: Callable[[Any, str, Any], bool]
+    fatal_preference_value_errors: Callable[[], AbstractContextManager[None]]
+    preference_value_error: type[Exception]
+    print_channel_field_choices: Callable[[Any, str], None]
+    is_local_destination: Callable[[Any, str], bool]
+    modem_preset_shorthands: tuple[tuple[str, str, str, str], ...]
+    qr_create: Callable[[str], Any] | None = None
+
+
+def handle_contact_import(context: CliContext) -> None:
+    """Import a contact URL before other connected message actions."""
+    args = context.args
+    if not args.add_contact:
+        return
+
+    context.outcome.close_now = True
+    context.outcome.wait_for_ack_nak = True
+    context.outcome.skip_ack_wait = True  # addContactURL owns the remote ACK wait.
+    context.interface.getNode(
+        args.dest, False, **context.get_node_kwargs
+    ).addContactURL(args.add_contact)
+
+
+def _set_simple_config(
+    context: CliContext,
+    hooks: ChannelContactHooks,
+    modem_preset: config_pb2.Config.LoRaConfig.ModemPreset.ValueType,
+) -> None:
+    """Set and persist the LoRa modem preset on the primary channel."""
+    channel_index = hooks.get_channel_index()
+    if channel_index is not None and channel_index > 0:
+        hooks.cli_exit("Warning: Cannot set modem preset for non-primary channel", 1)
+
+    node = context.interface.getNode(
+        context.args.dest, False, **context.get_node_kwargs
+    )
+    if len(node.localConfig.ListFields()) == 0:
+        lora_descriptor = node.localConfig.DESCRIPTOR.fields_by_name.get("lora")
+        if lora_descriptor is None:
+            hooks.cli_exit(
+                "The active protobuf schema does not provide LoRa configuration", 1
+            )
+        node.requestConfig(lora_descriptor)
+    node.localConfig.lora.modem_preset = modem_preset
+    node.writeConfig("lora")
+
+
+def _resolve_requested_modem_preset(
+    context: CliContext, hooks: ChannelContactHooks
+) -> config_pb2.Config.LoRaConfig.ModemPreset.ValueType | None:
+    """Resolve historical shorthand and schema-driven modem-preset arguments."""
+    args = context.args
+    preset_val: config_pb2.Config.LoRaConfig.ModemPreset.ValueType | None = None
+    for _, destination, preset_name, _ in hooks.modem_preset_shorthands:
+        if getattr(args, destination, False):
+            preset_val = config_pb2.Config.LoRaConfig.ModemPreset.Value(preset_name)
+
+    generic_preset_name = getattr(args, "ch_preset", None)
+    if generic_preset_name is None:
+        return preset_val
+
+    if isinstance(generic_preset_name, int):
+        # Round-trip the value through Name() so invalid integers fail clearly.
+        config_pb2.Config.LoRaConfig.ModemPreset.Name(
+            generic_preset_name  # type: ignore[arg-type]
+        )
+        return cast(
+            config_pb2.Config.LoRaConfig.ModemPreset.ValueType,
+            generic_preset_name,
+        )
+    return config_pb2.Config.LoRaConfig.ModemPreset.Value(generic_preset_name)
+
+
+def _handle_channel_add(context: CliContext, hooks: ChannelContactHooks) -> None:
+    args = context.args
+    if not args.ch_add:
+        return
+
+    if hooks.get_channel_index() is not None:
+        hooks.cli_exit(
+            "Warning: --ch-add chooses the next free channel index automatically; "
+            "remove --ch-index and retry. Use --ch-set, --ch-del, --ch-enable, "
+            "or --ch-disable when targeting a specific index."
+        )
+    context.outcome.close_now = True
+    if len(args.ch_add) > 10:
+        hooks.cli_exit("Warning: Channel name must be shorter. Channel not added.")
+
+    node = context.interface.getNode(args.dest, **context.get_node_kwargs)
+    channel = node.getChannelByName(args.ch_add)
+    if channel:
+        hooks.cli_exit(
+            f"Warning: This node already has a '{args.ch_add}' channel. "
+            "No changes were made."
+        )
+
+    channel = node.getDisabledChannel()
+    if not channel:
+        hooks.cli_exit("Warning: No free channels were found")
+    settings = channel_pb2.ChannelSettings()
+    settings.psk = meshtastic.util.genPSK256()
+    settings.name = args.ch_add
+    channel.settings.CopyFrom(settings)
+    channel.role = channel_pb2.Channel.Role.SECONDARY
+    hooks.cli_print("Writing modified channels to device")
+    node.writeChannel(channel.index)
+    hooks.cli_print(
+        f"Setting newly-added channel's {channel.index} as '--ch-index' "
+        "for further modifications"
+    )
+    hooks.set_channel_index(channel.index)
+
+
+def _handle_channel_delete(context: CliContext, hooks: ChannelContactHooks) -> None:
+    args = context.args
+    if not args.ch_del:
+        return
+
+    context.outcome.close_now = True
+    channel_index = hooks.get_channel_index()
+    if channel_index is None:
+        hooks.cli_exit("Warning: Need to specify '--ch-index' for '--ch-del'.", 1)
+    if channel_index == 0:
+        hooks.cli_exit("Warning: Cannot delete primary channel.", 1)
+
+    hooks.cli_print(f"Deleting channel {channel_index}")
+    context.interface.getNode(args.dest, **context.get_node_kwargs).deleteChannel(
+        channel_index
+    )
+
+
+def _handle_channel_update(context: CliContext, hooks: ChannelContactHooks) -> None:
+    args = context.args
+    if not (args.ch_set or args.ch_enable or args.ch_disable):
+        return
+
+    context.outcome.close_now = True
+    channel_index = hooks.get_channel_index()
+    if channel_index is None:
+        hooks.cli_exit("Warning: Need to specify '--ch-index'.", 1)
+
+    node = context.interface.getNode(args.dest, **context.get_node_kwargs)
+    channels = node.channels
+    if channels is None:
+        hooks.cli_exit("Warning: Device channels are not available.", 1)
+    if channel_index < 0:
+        hooks.cli_exit(f"Warning: Channel index {channel_index} is out of range.", 1)
+    try:
+        channel = channels[channel_index]
+    except (IndexError, TypeError):
+        hooks.cli_exit(f"Warning: Channel index {channel_index} is out of range.", 1)
+
+    enable = True
+    if args.ch_enable or args.ch_disable:
+        hooks.cli_print(
+            "Warning: --ch-enable and --ch-disable can produce noncontiguous channels, "
+            "which can cause errors in some clients. Whenever possible, use --ch-add "
+            "and --ch-del instead."
+        )
+        if channel_index == 0:
+            hooks.cli_exit("Warning: Cannot enable/disable PRIMARY channel.")
+        enable = not args.ch_disable
+
+    pending_settings = type(channel.settings)()
+    pending_settings.CopyFrom(channel.settings)
+    channel_update_valid = True
+    for pref in args.ch_set or []:
+        if pref[0] == "psk":
+            try:
+                pending_settings.psk = meshtastic.util.fromPSK(pref[1])
+            except ValueError as exc:
+                hooks.cli_exit(f"Invalid channel PSK: {exc}", 1)
+        else:
+            if not hooks.resolve_pref(pending_settings, pref[0]):
+                hooks.print_channel_field_choices(pending_settings, pref[0])
+                channel_update_valid = False
+                continue
+            try:
+                with hooks.fatal_preference_value_errors():
+                    found = hooks.set_pref(pending_settings, pref[0], pref[1])
+            except hooks.preference_value_error as exc:
+                hooks.cli_exit(str(exc), 1)
+            if not found:
+                hooks.cli_exit(f"Invalid value for channel setting {pref[0]}.", 1)
+        enable = True
+
+    if not channel_update_valid:
+        hooks.cli_exit(
+            "Warning: Unknown channel setting name. No changes were made.", 1
+        )
+
+    if args.ch_set:
+        channel.settings.CopyFrom(pending_settings)
+    if enable:
+        channel.role = (
+            channel_pb2.Channel.Role.PRIMARY
+            if channel_index == 0
+            else channel_pb2.Channel.Role.SECONDARY
+        )
+    else:
+        channel.role = channel_pb2.Channel.Role.DISABLED
+
+    hooks.cli_print("Writing modified channels to device")
+    node.writeChannel(channel_index)
+
+
+def handle_channel_mutations(
+    context: CliContext, hooks: ChannelContactHooks
+) -> None:
+    """Apply channel URL, add/delete, preset, and setting mutations in CLI order."""
+    args = context.args
+    interface = context.interface
+
+    if args.ch_set_url:
+        context.outcome.close_now = True
+        interface.getNode(args.dest, **context.get_node_kwargs).setURL(
+            args.ch_set_url, addOnly=False
+        )
+    if args.ch_add_url:
+        context.outcome.close_now = True
+        interface.getNode(args.dest, **context.get_node_kwargs).setURL(
+            args.ch_add_url, addOnly=True
+        )
+
+    _handle_channel_add(context, hooks)
+    _handle_channel_delete(context, hooks)
+
+    preset_val = _resolve_requested_modem_preset(context, hooks)
+    if preset_val is not None:
+        _set_simple_config(context, hooks, preset_val)
+
+    _handle_channel_update(context, hooks)
+
+
+def handle_region_preset_display(
+    context: CliContext, hooks: ChannelContactHooks
+) -> None:
+    """Print firmware-provided region/preset compatibility metadata."""
+    args = context.args
+    interface = context.interface
+    if not args.show_region_presets:
+        return
+
+    context.outcome.close_now = True
+    if not hooks.is_local_destination(interface, args.dest):
+        print("Region/preset capabilities are available only from the local node.")
+        return
+    if not interface.regionPresets:
+        print(
+            "This firmware did not provide usable region/preset compatibility metadata; "
+            "preset choices remain unconstrained."
+        )
+        return
+
+    for region, info in sorted(interface.regionPresets.items()):
+        try:
+            region_name = config_pb2.Config.LoRaConfig.RegionCode.Name(cast(Any, region))
+        except ValueError:
+            region_name = f"REGION_{region}"
+        preset_names: list[str] = []
+        for value in info.presets:
+            try:
+                preset_names.append(
+                    config_pb2.Config.LoRaConfig.ModemPreset.Name(cast(Any, value))
+                )
+            except ValueError:
+                preset_names.append(f"PRESET_{value}")
+        try:
+            default_name = config_pb2.Config.LoRaConfig.ModemPreset.Name(
+                cast(Any, info.default_preset)
+            )
+        except ValueError:
+            default_name = f"PRESET_{info.default_preset}"
+        license_note = " licensed-only" if info.licensed_only else ""
+        print(
+            f"{region_name}: default={default_name}{license_note}; "
+            f"presets={','.join(preset_names)}"
+        )
+
+
+def _print_qr(url: str, *, description: str, qr_create: Callable[[str], Any] | None) -> None:
+    print(f"{description}: {url}")
+    if qr_create is None:
+        print("Install pyqrcode to view a QR code printed to terminal.")
+        return
+    print(qr_create(url).terminal())
+
+
+def handle_channel_contact_display(
+    context: CliContext, hooks: ChannelContactHooks
+) -> None:
+    """Render channel and contact URLs/QR codes in their historical CLI position."""
+    args = context.args
+    interface = context.interface
+
+    if args.qr or args.qr_all:
+        context.outcome.close_now = True
+        url = interface.getNode(args.dest, True, **context.get_node_kwargs).getURL(
+            includeAll=args.qr_all
+        )
+        description = (
+            "Complete URL (includes all channels)"
+            if args.qr_all
+            else "Primary channel URL"
+        )
+        _print_qr(url, description=description, qr_create=hooks.qr_create)
+
+    if args.contact_qr:
+        context.outcome.close_now = True
+        url = interface.localNode.getContactURL(
+            args.contact_qr,
+            should_ignore=args.contact_ignore,
+            manually_verified=args.contact_verified,
+        )
+        _print_qr(url, description="Contact URL", qr_create=hooks.qr_create)

--- a/meshtastic/cli/channel_contact_actions.py
+++ b/meshtastic/cli/channel_contact_actions.py
@@ -12,6 +12,9 @@ from meshtastic.cli.context import CliContext, CliExit, _terminate_cli
 from meshtastic.protobuf import channel_pb2, config_pb2
 
 
+MAX_CHANNEL_NAME_LENGTH = 10
+
+
 @dataclass(frozen=True, slots=True)
 class ChannelContactHooks:
     """Compatibility and process-state seams used by channel/contact actions."""
@@ -130,7 +133,7 @@ def _handle_channel_add(context: CliContext, hooks: ChannelContactHooks) -> None
             "or --ch-disable when targeting a specific index.",
         )
     context.outcome.close_now = True
-    if len(args.ch_add) > 10:
+    if len(args.ch_add) > MAX_CHANNEL_NAME_LENGTH:
         _terminate_cli(
             hooks.cli_exit, "Warning: Channel name must be shorter. Channel not added."
         )

--- a/meshtastic/cli/channel_contact_actions.py
+++ b/meshtastic/cli/channel_contact_actions.py
@@ -103,6 +103,16 @@ def _resolve_requested_modem_preset(
 
 
 def _handle_channel_add(context: CliContext, hooks: ChannelContactHooks) -> None:
+    """Add one secondary channel using the next disabled channel slot.
+
+    Parameters
+    ----------
+    context : CliContext
+        Connected invocation state. ``close_now`` is enabled when an add is
+        requested and the selected channel index is updated after success.
+    hooks : ChannelContactHooks
+        Channel-index, reporting, preference, and exit seams.
+    """
     args = context.args
     if not args.ch_add:
         return
@@ -143,6 +153,15 @@ def _handle_channel_add(context: CliContext, hooks: ChannelContactHooks) -> None
 
 
 def _handle_channel_delete(context: CliContext, hooks: ChannelContactHooks) -> None:
+    """Delete the explicitly selected non-primary channel.
+
+    Parameters
+    ----------
+    context : CliContext
+        Connected invocation state. ``close_now`` is enabled for a delete.
+    hooks : ChannelContactHooks
+        Channel-index, reporting, and exit seams.
+    """
     args = context.args
     if not args.ch_del:
         return
@@ -161,6 +180,16 @@ def _handle_channel_delete(context: CliContext, hooks: ChannelContactHooks) -> N
 
 
 def _handle_channel_update(context: CliContext, hooks: ChannelContactHooks) -> None:
+    """Apply channel settings or role changes to the selected channel.
+
+    Parameters
+    ----------
+    context : CliContext
+        Connected invocation state. ``close_now`` is enabled for channel
+        mutation requests.
+    hooks : ChannelContactHooks
+        Channel-index, preference, reporting, and exit seams.
+    """
     args = context.args
     if not (args.ch_set or args.ch_enable or args.ch_disable):
         return

--- a/meshtastic/cli/channel_contact_actions.py
+++ b/meshtastic/cli/channel_contact_actions.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import Any, cast
 
 import meshtastic.util
-from meshtastic.cli.context import CliContext, CliExit
+from meshtastic.cli.context import CliContext, CliExit, _terminate_cli
 from meshtastic.protobuf import channel_pb2, config_pb2
 
 
@@ -52,7 +52,11 @@ def _set_simple_config(
     """Set and persist the LoRa modem preset on the primary channel."""
     channel_index = hooks.get_channel_index()
     if channel_index is not None and channel_index > 0:
-        hooks.cli_exit("Warning: Cannot set modem preset for non-primary channel", 1)
+        _terminate_cli(
+            hooks.cli_exit,
+            "Warning: Cannot set modem preset for non-primary channel",
+            1,
+        )
 
     node = context.interface.getNode(
         context.args.dest, False, **context.get_node_kwargs
@@ -60,8 +64,10 @@ def _set_simple_config(
     if len(node.localConfig.ListFields()) == 0:
         lora_descriptor = node.localConfig.DESCRIPTOR.fields_by_name.get("lora")
         if lora_descriptor is None:
-            hooks.cli_exit(
-                "The active protobuf schema does not provide LoRa configuration", 1
+            _terminate_cli(
+                hooks.cli_exit,
+                "The active protobuf schema does not provide LoRa configuration",
+                1,
             )
         node.requestConfig(lora_descriptor)
     node.localConfig.lora.modem_preset = modem_preset
@@ -89,8 +95,7 @@ def _resolve_requested_modem_preset(
                 generic_preset_name  # type: ignore[arg-type]
             )
         except ValueError as exc:
-            hooks.cli_exit(f"Invalid modem preset: {exc}", 1)
-            raise AssertionError("cli_exit returned unexpectedly") from exc
+            _terminate_cli(hooks.cli_exit, f"Invalid modem preset: {exc}", 1)
         return cast(
             config_pb2.Config.LoRaConfig.ModemPreset.ValueType,
             generic_preset_name,
@@ -98,8 +103,7 @@ def _resolve_requested_modem_preset(
     try:
         return config_pb2.Config.LoRaConfig.ModemPreset.Value(generic_preset_name)
     except ValueError as exc:
-        hooks.cli_exit(f"Invalid modem preset: {exc}", 1)
-        raise AssertionError("cli_exit returned unexpectedly") from exc
+        _terminate_cli(hooks.cli_exit, f"Invalid modem preset: {exc}", 1)
 
 
 def _handle_channel_add(context: CliContext, hooks: ChannelContactHooks) -> None:
@@ -118,26 +122,30 @@ def _handle_channel_add(context: CliContext, hooks: ChannelContactHooks) -> None
         return
 
     if hooks.get_channel_index() is not None:
-        hooks.cli_exit(
+        _terminate_cli(
+            hooks.cli_exit,
             "Warning: --ch-add chooses the next free channel index automatically; "
             "remove --ch-index and retry. Use --ch-set, --ch-del, --ch-enable, "
-            "or --ch-disable when targeting a specific index."
+            "or --ch-disable when targeting a specific index.",
         )
     context.outcome.close_now = True
     if len(args.ch_add) > 10:
-        hooks.cli_exit("Warning: Channel name must be shorter. Channel not added.")
+        _terminate_cli(
+            hooks.cli_exit, "Warning: Channel name must be shorter. Channel not added."
+        )
 
     node = context.interface.getNode(args.dest, **context.get_node_kwargs)
     channel = node.getChannelByName(args.ch_add)
     if channel:
-        hooks.cli_exit(
+        _terminate_cli(
+            hooks.cli_exit,
             f"Warning: This node already has a '{args.ch_add}' channel. "
-            "No changes were made."
+            "No changes were made.",
         )
 
     channel = node.getDisabledChannel()
     if not channel:
-        hooks.cli_exit("Warning: No free channels were found")
+        _terminate_cli(hooks.cli_exit, "Warning: No free channels were found")
     settings = channel_pb2.ChannelSettings()
     settings.psk = meshtastic.util.genPSK256()
     settings.name = args.ch_add
@@ -169,9 +177,11 @@ def _handle_channel_delete(context: CliContext, hooks: ChannelContactHooks) -> N
     context.outcome.close_now = True
     channel_index = hooks.get_channel_index()
     if channel_index is None:
-        hooks.cli_exit("Warning: Need to specify '--ch-index' for '--ch-del'.", 1)
+        _terminate_cli(
+            hooks.cli_exit, "Warning: Need to specify '--ch-index' for '--ch-del'.", 1
+        )
     if channel_index == 0:
-        hooks.cli_exit("Warning: Cannot delete primary channel.", 1)
+        _terminate_cli(hooks.cli_exit, "Warning: Cannot delete primary channel.", 1)
 
     hooks.cli_print(f"Deleting channel {channel_index}")
     context.interface.getNode(args.dest, **context.get_node_kwargs).deleteChannel(
@@ -197,18 +207,26 @@ def _handle_channel_update(context: CliContext, hooks: ChannelContactHooks) -> N
     context.outcome.close_now = True
     channel_index = hooks.get_channel_index()
     if channel_index is None:
-        hooks.cli_exit("Warning: Need to specify '--ch-index'.", 1)
+        _terminate_cli(hooks.cli_exit, "Warning: Need to specify '--ch-index'.", 1)
 
     node = context.interface.getNode(args.dest, **context.get_node_kwargs)
     channels = node.channels
     if channels is None:
-        hooks.cli_exit("Warning: Device channels are not available.", 1)
+        _terminate_cli(hooks.cli_exit, "Warning: Device channels are not available.", 1)
     if channel_index < 0:
-        hooks.cli_exit(f"Warning: Channel index {channel_index} is out of range.", 1)
+        _terminate_cli(
+            hooks.cli_exit,
+            f"Warning: Channel index {channel_index} is out of range.",
+            1,
+        )
     try:
         channel = channels[channel_index]
     except (IndexError, TypeError):
-        hooks.cli_exit(f"Warning: Channel index {channel_index} is out of range.", 1)
+        _terminate_cli(
+            hooks.cli_exit,
+            f"Warning: Channel index {channel_index} is out of range.",
+            1,
+        )
 
     enable = True
     if args.ch_enable or args.ch_disable:
@@ -218,7 +236,9 @@ def _handle_channel_update(context: CliContext, hooks: ChannelContactHooks) -> N
             "and --ch-del instead."
         )
         if channel_index == 0:
-            hooks.cli_exit("Warning: Cannot enable/disable PRIMARY channel.")
+            _terminate_cli(
+                hooks.cli_exit, "Warning: Cannot enable/disable PRIMARY channel."
+            )
         enable = not args.ch_disable
 
     pending_settings = type(channel.settings)()
@@ -229,7 +249,7 @@ def _handle_channel_update(context: CliContext, hooks: ChannelContactHooks) -> N
             try:
                 pending_settings.psk = meshtastic.util.fromPSK(pref[1])
             except ValueError as exc:
-                hooks.cli_exit(f"Invalid channel PSK: {exc}", 1)
+                _terminate_cli(hooks.cli_exit, f"Invalid channel PSK: {exc}", 1)
         else:
             if not hooks.resolve_pref(pending_settings, pref[0]):
                 hooks.print_channel_field_choices(pending_settings, pref[0])
@@ -239,14 +259,18 @@ def _handle_channel_update(context: CliContext, hooks: ChannelContactHooks) -> N
                 with hooks.fatal_preference_value_errors():
                     found = hooks.set_pref(pending_settings, pref[0], pref[1])
             except hooks.preference_value_error as exc:
-                hooks.cli_exit(str(exc), 1)
+                _terminate_cli(hooks.cli_exit, str(exc), 1)
             if not found:
-                hooks.cli_exit(f"Invalid value for channel setting {pref[0]}.", 1)
+                _terminate_cli(
+                    hooks.cli_exit, f"Invalid value for channel setting {pref[0]}.", 1
+                )
         enable = True
 
     if not channel_update_valid:
-        hooks.cli_exit(
-            "Warning: Unknown channel setting name. No changes were made.", 1
+        _terminate_cli(
+            hooks.cli_exit,
+            "Warning: Unknown channel setting name. No changes were made.",
+            1,
         )
 
     if args.ch_set:
@@ -264,9 +288,7 @@ def _handle_channel_update(context: CliContext, hooks: ChannelContactHooks) -> N
     node.writeChannel(channel_index)
 
 
-def _handle_channel_mutations(
-    context: CliContext, hooks: ChannelContactHooks
-) -> None:
+def _handle_channel_mutations(context: CliContext, hooks: ChannelContactHooks) -> None:
     """Apply channel URL, add/delete, preset, and setting mutations in CLI order."""
     args = context.args
     interface = context.interface
@@ -303,7 +325,9 @@ def _handle_region_preset_display(
 
     context.outcome.close_now = True
     if not hooks.is_local_destination(interface, args.dest):
-        hooks.cli_print("Region/preset capabilities are available only from the local node.")
+        hooks.cli_print(
+            "Region/preset capabilities are available only from the local node."
+        )
         return
     if not interface.regionPresets:
         hooks.cli_print(
@@ -314,7 +338,9 @@ def _handle_region_preset_display(
 
     for region, info in sorted(interface.regionPresets.items()):
         try:
-            region_name = config_pb2.Config.LoRaConfig.RegionCode.Name(cast(Any, region))
+            region_name = config_pb2.Config.LoRaConfig.RegionCode.Name(
+                cast(Any, region)
+            )
         except ValueError:
             region_name = f"REGION_{region}"
         preset_names: list[str] = []

--- a/meshtastic/cli/channel_contact_actions.py
+++ b/meshtastic/cli/channel_contact_actions.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
-from typing import Any, Callable, NoReturn, cast
+from typing import Any, cast
 
 import meshtastic.util
-from meshtastic.cli.context import CliContext
+from meshtastic.cli.context import CliContext, CliExit
 from meshtastic.protobuf import channel_pb2, config_pb2
 
 
@@ -15,7 +16,7 @@ from meshtastic.protobuf import channel_pb2, config_pb2
 class ChannelContactHooks:
     """Compatibility and process-state seams used by channel/contact actions."""
 
-    cli_exit: Callable[..., NoReturn]
+    cli_exit: CliExit
     cli_print: Callable[[str], None]
     get_channel_index: Callable[[], int | None]
     set_channel_index: Callable[[int], None]
@@ -25,11 +26,11 @@ class ChannelContactHooks:
     preference_value_error: type[Exception]
     print_channel_field_choices: Callable[[Any, str], None]
     is_local_destination: Callable[[Any, str], bool]
-    modem_preset_shorthands: tuple[tuple[str, str, str, str], ...]
+    modem_preset_shorthands: tuple[tuple[tuple[str, ...], str, str, str], ...]
     qr_create: Callable[[str], Any] | None = None
 
 
-def handle_contact_import(context: CliContext) -> None:
+def _handle_contact_import(context: CliContext) -> None:
     """Import a contact URL before other connected message actions."""
     args = context.args
     if not args.add_contact:
@@ -83,14 +84,22 @@ def _resolve_requested_modem_preset(
 
     if isinstance(generic_preset_name, int):
         # Round-trip the value through Name() so invalid integers fail clearly.
-        config_pb2.Config.LoRaConfig.ModemPreset.Name(
-            generic_preset_name  # type: ignore[arg-type]
-        )
+        try:
+            config_pb2.Config.LoRaConfig.ModemPreset.Name(
+                generic_preset_name  # type: ignore[arg-type]
+            )
+        except ValueError as exc:
+            hooks.cli_exit(f"Invalid modem preset: {exc}", 1)
+            raise AssertionError("cli_exit returned unexpectedly") from exc
         return cast(
             config_pb2.Config.LoRaConfig.ModemPreset.ValueType,
             generic_preset_name,
         )
-    return config_pb2.Config.LoRaConfig.ModemPreset.Value(generic_preset_name)
+    try:
+        return config_pb2.Config.LoRaConfig.ModemPreset.Value(generic_preset_name)
+    except ValueError as exc:
+        hooks.cli_exit(f"Invalid modem preset: {exc}", 1)
+        raise AssertionError("cli_exit returned unexpectedly") from exc
 
 
 def _handle_channel_add(context: CliContext, hooks: ChannelContactHooks) -> None:
@@ -226,7 +235,7 @@ def _handle_channel_update(context: CliContext, hooks: ChannelContactHooks) -> N
     node.writeChannel(channel_index)
 
 
-def handle_channel_mutations(
+def _handle_channel_mutations(
     context: CliContext, hooks: ChannelContactHooks
 ) -> None:
     """Apply channel URL, add/delete, preset, and setting mutations in CLI order."""
@@ -254,7 +263,7 @@ def handle_channel_mutations(
     _handle_channel_update(context, hooks)
 
 
-def handle_region_preset_display(
+def _handle_region_preset_display(
     context: CliContext, hooks: ChannelContactHooks
 ) -> None:
     """Print firmware-provided region/preset compatibility metadata."""
@@ -265,10 +274,10 @@ def handle_region_preset_display(
 
     context.outcome.close_now = True
     if not hooks.is_local_destination(interface, args.dest):
-        print("Region/preset capabilities are available only from the local node.")
+        hooks.cli_print("Region/preset capabilities are available only from the local node.")
         return
     if not interface.regionPresets:
-        print(
+        hooks.cli_print(
             "This firmware did not provide usable region/preset compatibility metadata; "
             "preset choices remain unconstrained."
         )
@@ -294,21 +303,28 @@ def handle_region_preset_display(
         except ValueError:
             default_name = f"PRESET_{info.default_preset}"
         license_note = " licensed-only" if info.licensed_only else ""
-        print(
+        hooks.cli_print(
             f"{region_name}: default={default_name}{license_note}; "
             f"presets={','.join(preset_names)}"
         )
 
 
-def _print_qr(url: str, *, description: str, qr_create: Callable[[str], Any] | None) -> None:
-    print(f"{description}: {url}")
+def _print_qr(
+    url: str,
+    *,
+    description: str,
+    qr_create: Callable[[str], Any] | None,
+    cli_print: Callable[[str], None],
+) -> None:
+    """Render a channel/contact URL and optional terminal QR through CLI reporting."""
+    cli_print(f"{description}: {url}")
     if qr_create is None:
-        print("Install pyqrcode to view a QR code printed to terminal.")
+        cli_print("Install pyqrcode to view a QR code printed to terminal.")
         return
-    print(qr_create(url).terminal())
+    cli_print(qr_create(url).terminal())
 
 
-def handle_channel_contact_display(
+def _handle_channel_contact_display(
     context: CliContext, hooks: ChannelContactHooks
 ) -> None:
     """Render channel and contact URLs/QR codes in their historical CLI position."""
@@ -325,7 +341,12 @@ def handle_channel_contact_display(
             if args.qr_all
             else "Primary channel URL"
         )
-        _print_qr(url, description=description, qr_create=hooks.qr_create)
+        _print_qr(
+            url,
+            description=description,
+            qr_create=hooks.qr_create,
+            cli_print=hooks.cli_print,
+        )
 
     if args.contact_qr:
         context.outcome.close_now = True
@@ -334,4 +355,9 @@ def handle_channel_contact_display(
             should_ignore=args.contact_ignore,
             manually_verified=args.contact_verified,
         )
-        _print_qr(url, description="Contact URL", qr_create=hooks.qr_create)
+        _print_qr(
+            url,
+            description="Contact URL",
+            qr_create=hooks.qr_create,
+            cli_print=hooks.cli_print,
+        )

--- a/meshtastic/cli/channel_contact_actions.py
+++ b/meshtastic/cli/channel_contact_actions.py
@@ -71,6 +71,7 @@ def _set_simple_config(
             )
         node.requestConfig(lora_descriptor)
     node.localConfig.lora.modem_preset = modem_preset
+    context.outcome.close_now = True
     node.writeConfig("lora")
 
 

--- a/meshtastic/cli/channel_contact_actions.py
+++ b/meshtastic/cli/channel_contact_actions.py
@@ -51,7 +51,7 @@ def _set_simple_config(
 ) -> None:
     """Set and persist the LoRa modem preset on the primary channel."""
     channel_index = hooks.get_channel_index()
-    if channel_index is not None and channel_index > 0:
+    if channel_index not in (None, 0):
         _terminate_cli(
             hooks.cli_exit,
             "Warning: Cannot set modem preset for non-primary channel",

--- a/meshtastic/cli/configure_actions.py
+++ b/meshtastic/cli/configure_actions.py
@@ -1,0 +1,991 @@
+"""Configure/set execution runtime for the connected Meshtastic CLI.
+
+The public entrypoint remains :mod:`meshtastic.__main__`. This module owns the
+configure transaction lifecycle, SetURL stability handling, reconnect verification,
+and configure-file action dispatch. Preference parsing remains a separately preserved
+entrypoint compatibility seam and is injected explicitly.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import enum
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, NoReturn
+
+import yaml
+
+import meshtastic.util
+from meshtastic._core_constants import BROADCAST_ADDR
+from meshtastic.cli.context import CliContext
+from meshtastic.configure_verify import (
+    _verify_channel_url_against_state,
+    _verify_requested_fields,
+)
+from meshtastic.mesh_interface import MeshInterface
+
+logger = logging.getLogger(__name__)
+
+CONFIG_APPLY_DELAY_SECONDS = 0.5
+CONFIG_WRITE_PACE_SECONDS = 0.1
+CONFIG_SETURL_DELAY_SECONDS = 2.0
+CONFIG_COMMIT_SETTLE_SECONDS = 1.0
+CONFIG_RECONNECT_WAIT_SECONDS = 15.0
+SETURL_STABILITY_TIMEOUT_SECONDS = 30.0
+CONFIGURE_PHASE1_HEADER = (
+    "Phase 1: Applying direct configuration "
+    "(channel URL updates may trigger reconnect/reboot)..."
+)
+ALLOWED_CONFIGURE_KEYS = frozenset(
+    {
+        "owner",
+        "owner_short",
+        "ownerShort",
+        "channel_url",
+        "channelUrl",
+        "canned_messages",
+        "ringtone",
+        "location",
+        "config",
+        "module_config",
+    }
+)
+
+
+class ConfigureReconnectResult(enum.Enum):
+    """Outcome of local reconnect/config reload verification after configure."""
+
+    RECONNECT_FAILED = "reconnect_failed"
+    CONFIG_RELOAD_FAILED = "config_reload_failed"
+    VERIFICATION_INCOMPLETE = "verification_incomplete"
+    VERIFIED = "verified"
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigureHooks:
+    """Entrypoint-owned dependencies used by configure execution.
+
+    Parameters
+    ----------
+    cli_exit : Callable[[str, int], NoReturn]
+        User-facing exit handler.
+    cli_print : Callable[[str], None]
+        Quiet-aware reporter.
+    traverse_config : Callable[..., bool]
+        Preference-tree application compatibility seam.
+    preflight_mode : contextvars.ContextVar[bool]
+        Context flag shared with preference assignment output suppression.
+    is_local_destination : Callable[[Any, str], bool]
+        Destination classifier.
+    """
+
+    cli_exit: Callable[[str, int], NoReturn]
+    cli_print: Callable[[str], None]
+    traverse_config: Callable[..., bool]
+    preflight_mode: contextvars.ContextVar[bool]
+    is_local_destination: Callable[[Any, str], bool]
+    post_seturl_stability_check: Callable[..., bool]
+    post_configure_reconnect_and_verify: Callable[..., ConfigureReconnectResult]
+    channel_url_matches_current_device_state: Callable[[Any, str], bool]
+    pace_configure_write: Callable[..., None]
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigureActionHooks:
+    """Compatibility seams used by connected configure action dispatch."""
+
+    handle_set_command: Callable[[MeshInterface, Any, dict[str, Any]], None]
+    handle_configure_command: Callable[
+        [MeshInterface, Any, dict[str, Any]], tuple[bool, bool]
+    ]
+    export_config: Callable[[MeshInterface], str]
+    cli_exit: Callable[[str, int], NoReturn]
+    cli_print: Callable[[str], None]
+
+
+def _post_configure_reconnect_and_verify(
+    interface: MeshInterface,
+    *,
+    timeout: float,
+    node_dest: str,
+    verify_channel_url: str | None = None,
+    verify_config_fields: dict[str, dict[str, Any]] | None = None,
+    verify_module_config_fields: dict[str, dict[str, Any]] | None = None,
+    verify_channel_url_against_state: Callable[..., bool] = (
+        _verify_channel_url_against_state
+    ),
+) -> ConfigureReconnectResult:
+    """Reconnect after a configure commit, reload config, and verify values.
+
+    After ``commitSettingsTransaction()``, the firmware may reboot the device.
+    This helper:
+
+    1. Waits for the interface to disconnect and reconnect within *timeout*.
+    2. Calls ``waitForConfig()`` to reload the device configuration.
+    3. If any verification targets were provided (channel URL, config fields,
+       or module config fields), performs value-aware comparison of the
+       explicitly requested settings against what the device reports.
+
+    Returns a ConfigureReconnectResult indicating the outcome.
+    """
+    deadline = time.monotonic() + timeout
+
+    disconnect_window = 2.0
+    logger.debug(
+        "Waiting up to %.1fs for device disconnect (reboot indication)...",
+        disconnect_window,
+    )
+    disconnect_deadline = time.monotonic() + disconnect_window
+    disconnected = False
+    while time.monotonic() < disconnect_deadline:
+        if not interface.isConnected.is_set():
+            disconnected = True
+            logger.info("Device disconnected (reboot indication received).")
+            break
+        time.sleep(0.2)
+
+    if not disconnected:
+        logger.debug(
+            "No disconnect detected within %.1fs; device may not require reboot.",
+            disconnect_window,
+        )
+
+    reconnect_deadline = deadline
+    if disconnected:
+        logger.debug(
+            "Waiting up to %.1fs for device reconnect...",
+            reconnect_deadline - time.monotonic(),
+        )
+    while time.monotonic() < reconnect_deadline:
+        if interface.isConnected.is_set():
+            logger.info("Device reconnected.")
+            break
+        time.sleep(0.2)
+
+    if not interface.isConnected.is_set():
+        logger.warning(
+            "Device did not reconnect within %.1fs after configure commit. "
+            "Configuration may still be applying.",
+            timeout,
+        )
+        return ConfigureReconnectResult.RECONNECT_FAILED
+
+    try:
+        interface.waitForConfig()
+        logger.info("Device config reloaded after reboot.")
+    except Exception:
+        logger.warning(
+            "Device reconnected but config reload failed; "
+            "configuration may still be applying.",
+            exc_info=True,
+        )
+        return ConfigureReconnectResult.CONFIG_RELOAD_FAILED
+
+    has_verification = (
+        verify_channel_url or verify_config_fields or verify_module_config_fields
+    )
+    if not has_verification:
+        return ConfigureReconnectResult.VERIFIED
+
+    if not disconnected:
+        try:
+            _refresh_no_disconnect_verify_state(
+                interface.getNode(node_dest),
+                verify_channel_url=verify_channel_url,
+                verify_config_fields=verify_config_fields,
+                verify_module_config_fields=verify_module_config_fields,
+            )
+            interface.waitForConfig()
+            logger.debug(
+                "No disconnect observed; touched config/channel state refreshed before verification."
+            )
+        except Exception:
+            logger.warning(
+                "No-disconnect verify refresh failed while reloading config.",
+                exc_info=True,
+            )
+            return ConfigureReconnectResult.CONFIG_RELOAD_FAILED
+
+    try:
+        result = _verify_post_reconnect_config(
+            interface,
+            node_dest,
+            verify_channel_url=verify_channel_url,
+            verify_config_fields=verify_config_fields,
+            verify_module_config_fields=verify_module_config_fields,
+            verify_channel_url_against_state=verify_channel_url_against_state,
+        )
+    except Exception:
+        logger.warning(
+            "Post-reconnect verification failed unexpectedly.",
+            exc_info=True,
+        )
+        return ConfigureReconnectResult.VERIFICATION_INCOMPLETE
+
+    return result
+
+
+def _post_seturl_stability_check(
+    interface: MeshInterface,
+    *,
+    timeout: float = 15.0,
+) -> bool:
+    _MAX_STABILITY_ATTEMPTS = 3
+    _STABILITY_WINDOW_SECONDS = 1.5
+    _RECONNECT_WAIT_SECONDS = 10.0
+
+    deadline = time.monotonic() + timeout
+
+    is_connected_event = getattr(interface, "isConnected", None)
+
+    def _event_is_set() -> bool:
+        return bool(
+            is_connected_event is not None
+            and hasattr(is_connected_event, "is_set")
+            and is_connected_event.is_set()
+        )
+
+    def _event_wait(timeout_seconds: float) -> bool:
+        return bool(
+            is_connected_event is not None
+            and hasattr(is_connected_event, "wait")
+            and is_connected_event.wait(timeout_seconds)
+        )
+
+    def _trigger_reconnect() -> bool:
+        reconnect = getattr(interface, "_attempt_reconnect", None)
+        if callable(reconnect):
+            try:
+                if reconnect():
+                    return _event_is_set()
+            except Exception:
+                logger.debug(
+                    "post-setURL reconnect hook failed.",
+                    exc_info=True,
+                )
+        connect = getattr(interface, "connect", None)
+        if callable(connect):
+            try:
+                connect()
+            except Exception:
+                logger.debug(
+                    "post-setURL connect() trigger failed.",
+                    exc_info=True,
+                )
+        return _event_is_set()
+
+    for _attempt in range(_MAX_STABILITY_ATTEMPTS):
+        if time.monotonic() >= deadline:
+            return False
+
+        if not _event_is_set():
+            _trigger_reconnect()
+            remaining = deadline - time.monotonic()
+            if remaining > 0:
+                _event_wait(min(_RECONNECT_WAIT_SECONDS, remaining))
+
+        if not _event_is_set():
+            logger.warning(
+                "Transport not connected after setURL (attempt %d/%d)",
+                _attempt + 1,
+                _MAX_STABILITY_ATTEMPTS,
+            )
+            continue
+
+        stability_end = time.monotonic() + _STABILITY_WINDOW_SECONDS
+        stable = True
+        while time.monotonic() < stability_end:
+            if not _event_is_set():
+                stable = False
+                break
+            time.sleep(0.1)
+
+        if not stable:
+            logger.warning(
+                "Transport dropped during stability window (attempt %d/%d)",
+                _attempt + 1,
+                _MAX_STABILITY_ATTEMPTS,
+            )
+            continue
+
+        try:
+            interface.waitForConfig()
+            return True
+        except Exception:
+            logger.warning(
+                "Config reload failed after setURL (attempt %d/%d)",
+                _attempt + 1,
+                _MAX_STABILITY_ATTEMPTS,
+                exc_info=True,
+            )
+            continue
+
+    return False
+
+
+def _validate_non_empty_mapping_sections(
+    hooks: ConfigureHooks,
+    *,
+    top_level_key: str,
+    section_mapping: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    """Validate that each section payload is a mapping.
+
+    Empty mappings (e.g., ``audio: {}``) are allowed — they represent
+    protobuf default values and are emitted by ``--export-config``.
+    """
+    validated_sections: dict[str, dict[str, Any]] = {}
+    for section_name, section_value in section_mapping.items():
+        if not isinstance(section_value, dict):
+            hooks.cli_exit(
+                f"ERROR: '{top_level_key}.{section_name}' must be a non-empty mapping, got "
+                f"{type(section_value).__name__}"
+            )
+        validated_sections[section_name] = section_value
+    return validated_sections
+
+
+def _preflight_configure_sections(
+    hooks: ConfigureHooks,
+    target_node: Any,
+    *,
+    config_sections: dict[str, dict[str, Any]],
+    module_config_sections: dict[str, dict[str, Any]],
+) -> None:
+    """Validate configuration values on protobuf copies before device mutation."""
+    roots = (
+        ("config", target_node.localConfig, config_sections),
+        ("module_config", target_node.moduleConfig, module_config_sections),
+    )
+    token = hooks.preflight_mode.set(True)
+    try:
+        for top_level_key, source_message, sections in roots:
+            if not sections:
+                continue
+            candidate = type(source_message)()
+            candidate.CopyFrom(source_message)
+            for section, section_values in sections.items():
+                failed_fields: list[str] = []
+                applied = hooks.traverse_config(
+                    section,
+                    section_values,
+                    candidate,
+                    failed_fields=failed_fields,
+                )
+                if applied:
+                    continue
+                field_suffix = (
+                    f" Invalid field: {failed_fields[0]}." if failed_fields else ""
+                )
+                hooks.cli_exit(
+                    f"Failed to apply {top_level_key} section {section!r} "
+                    f"due to structural errors.{field_suffix}"
+                )
+    finally:
+        hooks.preflight_mode.reset(token)
+
+
+def _refresh_no_disconnect_verify_state(
+    target_node: Any,
+    *,
+    verify_channel_url: str | None,
+    verify_config_fields: dict[str, dict[str, Any]] | None,
+    verify_module_config_fields: dict[str, dict[str, Any]] | None,
+) -> None:
+    """Invalidate touched cached state and request fresh values for Phase 3 verification."""
+    request_config = getattr(target_node, "requestConfig", None)
+
+    for section_name in verify_config_fields or {}:
+        section_snake = meshtastic.util.camel_to_snake(section_name)
+        field_desc = target_node.localConfig.DESCRIPTOR.fields_by_name.get(
+            section_snake
+        )
+        if field_desc is None:
+            logger.warning(
+                "Skipping config refresh for unknown section %r.",
+                section_name,
+            )
+            continue
+        target_node.localConfig.ClearField(section_snake)
+        if callable(request_config):
+            request_config(field_desc)
+
+    for section_name in verify_module_config_fields or {}:
+        section_snake = meshtastic.util.camel_to_snake(section_name)
+        field_desc = target_node.moduleConfig.DESCRIPTOR.fields_by_name.get(
+            section_snake
+        )
+        if field_desc is None:
+            logger.warning(
+                "Skipping module_config refresh for unknown section %r.",
+                section_name,
+            )
+            continue
+        target_node.moduleConfig.ClearField(section_snake)
+        if callable(request_config):
+            request_config(field_desc)
+
+    if verify_channel_url:
+        target_node.channels = None
+        target_node.partialChannels = []
+        request_channels = getattr(target_node, "requestChannels", None)
+        if callable(request_channels):
+            request_channels(0)
+
+
+def _channel_url_matches_current_device_state(
+    target_node: Any,
+    requested_channel_url: str,
+    *,
+    verify_channel_url_against_state: Callable[..., bool] = (
+        _verify_channel_url_against_state
+    ),
+) -> bool:
+    """Return True when requested channel URL already matches loaded device state."""
+    local_config = getattr(target_node, "localConfig", None)
+    has_field = getattr(local_config, "HasField", None)
+    if local_config is None or not callable(has_field) or not has_field("lora"):
+        return False
+    return verify_channel_url_against_state(
+        requested_channel_url,
+        device_channels=getattr(target_node, "channels", None),
+        device_lora_config=local_config.lora,
+        emit_warnings=False,
+    )
+
+
+def _flatten_leaf_paths(prefix: str, mapping: dict[str, Any]) -> list[str]:
+    """Recursively flatten a nested mapping into dotted leaf paths."""
+    paths: list[str] = []
+    for key, value in mapping.items():
+        dotted = f"{prefix}.{key}"
+        if isinstance(value, dict) and value:
+            paths.extend(_flatten_leaf_paths(dotted, value))
+        else:
+            paths.append(dotted)
+    return paths
+
+
+def _verify_config_sections(
+    config_fields: dict[str, dict[str, Any]],
+    proto_config: Any,
+    label: str,
+    verified_fields: list[str] | None = None,
+) -> bool:
+    for section_name, yaml_values in config_fields.items():
+        section_snake = meshtastic.util.camel_to_snake(section_name)
+        if not proto_config.HasField(section_snake):
+            logger.warning(
+                "%s section %r not present after reload.",
+                label,
+                section_name,
+            )
+            return False
+        proto_section = getattr(proto_config, section_snake)
+        mismatches = _verify_requested_fields(yaml_values, proto_section, section_name)
+        if mismatches:
+            logger.warning(
+                "%s section %r field mismatches: %s",
+                label,
+                section_name,
+                ", ".join(mismatches),
+            )
+            return False
+        if verified_fields is not None:
+            verified_fields.extend(_flatten_leaf_paths(section_snake, yaml_values))
+        logger.debug(
+            "%s section %r verified (all requested field values match).",
+            label,
+            section_name,
+        )
+    return True
+
+
+def _verify_post_reconnect_config(
+    interface: MeshInterface,
+    node_dest: str,
+    *,
+    verify_channel_url: str | None = None,
+    verify_config_fields: dict[str, dict[str, Any]] | None = None,
+    verify_module_config_fields: dict[str, dict[str, Any]] | None = None,
+    verify_channel_url_against_state: Callable[..., bool] = (
+        _verify_channel_url_against_state
+    ),
+) -> ConfigureReconnectResult:
+    if not interface.isConnected.is_set():
+        logger.warning("Post-reconnect verification skipped: transport disconnected.")
+        return ConfigureReconnectResult.VERIFICATION_INCOMPLETE
+
+    target_node = interface.getNode(node_dest)
+    verified_fields: list[str] = []
+
+    if verify_channel_url:
+        local_config = getattr(target_node, "localConfig", None)
+        has_field = getattr(local_config, "HasField", None)
+        device_lora_config = (
+            local_config.lora
+            if local_config is not None and callable(has_field) and has_field("lora")
+            else None
+        )
+        if not verify_channel_url_against_state(
+            verify_channel_url,
+            device_channels=getattr(target_node, "channels", None),
+            device_lora_config=device_lora_config,
+        ):
+            logger.warning(
+                "Channel URL verification: device state does not match requested URL."
+            )
+            return ConfigureReconnectResult.VERIFICATION_INCOMPLETE
+        verified_fields.append("channel_url")
+
+    if verify_config_fields and not _verify_config_sections(
+        verify_config_fields,
+        target_node.localConfig,
+        "Config",
+        verified_fields=verified_fields,
+    ):
+        return ConfigureReconnectResult.VERIFICATION_INCOMPLETE
+
+    if verify_module_config_fields and not _verify_config_sections(
+        verify_module_config_fields,
+        target_node.moduleConfig,
+        "Module config",
+        verified_fields=verified_fields,
+    ):
+        return ConfigureReconnectResult.VERIFICATION_INCOMPLETE
+
+    if not interface.isConnected.is_set():
+        logger.warning(
+            "Post-reconnect verification did not complete: transport disconnected."
+        )
+        return ConfigureReconnectResult.VERIFICATION_INCOMPLETE
+
+    if verified_fields:
+        logger.info("Verified: %s", ", ".join(verified_fields))
+
+    return ConfigureReconnectResult.VERIFIED
+
+
+def _pace_configure_write(
+    remaining_writes: int,
+    *,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> None:
+    """Yield briefly between section writes while keeping transactions short."""
+    if remaining_writes > 0:
+        sleep_fn(CONFIG_WRITE_PACE_SECONDS)
+
+
+def _apply_configure_channel_url(
+    hooks: ConfigureHooks,
+    target_node: Any,
+    raw_channel_url: Any,
+    *,
+    config_key: str,
+) -> bool:
+    """Validate and apply one configured channel URL without exposing it."""
+    if not isinstance(raw_channel_url, str):
+        hooks.cli_exit(f"ERROR: {config_key} must be a string.")
+    requested_channel_url = raw_channel_url.strip()
+    if not requested_channel_url:
+        hooks.cli_exit(f"ERROR: {config_key} must not be blank.")
+
+    if hooks.channel_url_matches_current_device_state(
+        target_node, requested_channel_url
+    ):
+        hooks.cli_print("Channel url already matches device state; skipping apply.")
+        logger.info("Skipping setURL apply because channel URL already matches.")
+        return False
+
+    hooks.cli_print("Setting channel url to <redacted>")
+    target_node.setURL(requested_channel_url)
+    time.sleep(CONFIG_SETURL_DELAY_SECONDS)
+    return True
+
+
+def _handle_configure_command(
+    hooks: ConfigureHooks,
+    interface: MeshInterface,
+    args: Any,
+    getNode_kwargs: dict[str, Any],
+) -> tuple[bool, bool]:
+    try:
+        with open(args.configure[0], encoding="utf8") as file:
+            raw_text = file.read()
+        configuration = yaml.safe_load(raw_text)
+    except (yaml.YAMLError, UnicodeDecodeError) as exc:
+        hooks.cli_exit(f"ERROR: Failed to parse YAML configuration: {exc}")
+
+    if configuration is None:
+        hooks.cli_exit("ERROR: YAML configuration file is empty")
+    if not isinstance(configuration, dict):
+        hooks.cli_exit(
+            f"ERROR: YAML configuration must be a mapping/dictionary, got {type(configuration).__name__}"
+        )
+    if not configuration:
+        hooks.cli_exit("ERROR: Configuration file is empty; nothing to configure.")
+    _unknown_keys = set(configuration.keys()) - ALLOWED_CONFIGURE_KEYS
+    if _unknown_keys:
+        hooks.cli_exit(
+            f"ERROR: Unknown top-level key(s) in YAML: {', '.join(sorted(_unknown_keys))}"
+        )
+
+    if "channel_url" in configuration and "channelUrl" in configuration:
+        hooks.cli_exit(
+            "ERROR: Cannot specify both 'channel_url' and 'channelUrl' in the same configuration file; use one."
+        )
+    if "owner_short" in configuration and "ownerShort" in configuration:
+        hooks.cli_exit(
+            "ERROR: Cannot specify both 'owner_short' and 'ownerShort' in the same configuration file; use one."
+        )
+
+    # Pre-validate config/module_config shapes before any Phase-1 mutations.
+    validated_config_sections: dict[str, dict[str, Any]] = {}
+    validated_module_config_sections: dict[str, dict[str, Any]] = {}
+    if "config" in configuration:
+        _cfg_val = configuration["config"]
+        if not isinstance(_cfg_val, dict) or not _cfg_val:
+            hooks.cli_exit(
+                f"ERROR: 'config' must be a non-empty mapping, got "
+                f"{type(_cfg_val).__name__}{' (empty)' if isinstance(_cfg_val, dict) else ''}"
+            )
+        validated_config_sections = _validate_non_empty_mapping_sections(
+            hooks,
+            top_level_key="config",
+            section_mapping=_cfg_val,
+        )
+    if "module_config" in configuration:
+        _mcfg_val = configuration["module_config"]
+        if not isinstance(_mcfg_val, dict) or not _mcfg_val:
+            hooks.cli_exit(
+                f"ERROR: 'module_config' must be a non-empty mapping, got "
+                f"{type(_mcfg_val).__name__}{' (empty)' if isinstance(_mcfg_val, dict) else ''}"
+            )
+        validated_module_config_sections = _validate_non_empty_mapping_sections(
+            hooks,
+            top_level_key="module_config",
+            section_mapping=_mcfg_val,
+        )
+
+    target_node = interface.getNode(args.dest, False, **getNode_kwargs)
+    if validated_config_sections or validated_module_config_sections:
+        _preflight_configure_sections(
+            hooks,
+            target_node,
+            config_sections=validated_config_sections,
+            module_config_sections=validated_module_config_sections,
+        )
+
+    phase1_started = False
+    phase1_may_reconnect = False
+    seturl_executed = False
+
+    if "owner" in configuration:
+        if not phase1_started:
+            hooks.cli_print(CONFIGURE_PHASE1_HEADER)
+            phase1_started = True
+        owner_name = str(configuration["owner"]).strip()
+        if not owner_name:
+            hooks.cli_exit(
+                "ERROR: Long Name cannot be empty or contain only whitespace characters"
+            )
+        hooks.cli_print(f"Setting device owner to {owner_name}")
+        target_node.setOwner(long_name=owner_name)
+        time.sleep(CONFIG_APPLY_DELAY_SECONDS)
+
+    if "owner_short" in configuration:
+        if not phase1_started:
+            hooks.cli_print(CONFIGURE_PHASE1_HEADER)
+            phase1_started = True
+        owner_short_name = str(configuration["owner_short"]).strip()
+        if not owner_short_name:
+            hooks.cli_exit(
+                "ERROR: Short Name cannot be empty or contain only whitespace characters"
+            )
+        hooks.cli_print(f"Setting device owner short to {owner_short_name}")
+        target_node.setOwner(long_name=None, short_name=owner_short_name)
+        time.sleep(CONFIG_APPLY_DELAY_SECONDS)
+
+    if "ownerShort" in configuration:
+        if not phase1_started:
+            hooks.cli_print(CONFIGURE_PHASE1_HEADER)
+            phase1_started = True
+        owner_short_name = str(configuration["ownerShort"]).strip()
+        if not owner_short_name:
+            hooks.cli_exit(
+                "ERROR: Short Name cannot be empty or contain only whitespace characters"
+            )
+        hooks.cli_print(f"Setting device owner short to {owner_short_name}")
+        target_node.setOwner(long_name=None, short_name=owner_short_name)
+        time.sleep(CONFIG_APPLY_DELAY_SECONDS)
+
+    if "location" in configuration:
+        if not phase1_started:
+            hooks.cli_print(CONFIGURE_PHASE1_HEADER)
+            phase1_started = True
+        _loc = configuration["location"]
+        if not isinstance(_loc, dict) or not _loc:
+            hooks.cli_exit(
+                "location must be a non-empty mapping with lat, lon, and optional alt"
+            )
+        _allowed_loc_keys = {"lat", "lon", "alt"}
+        _unknown_loc_keys = set(_loc.keys()) - _allowed_loc_keys
+        if _unknown_loc_keys:
+            hooks.cli_exit(
+                f"location contains unknown keys: {', '.join(sorted(_unknown_loc_keys))}. "
+                f"Allowed: lat, lon, alt"
+            )
+        if "lat" not in _loc or "lon" not in _loc:
+            hooks.cli_exit("location requires both lat and lon")
+        try:
+            lat = float(_loc["lat"])
+        except (ValueError, TypeError):
+            hooks.cli_exit(f"location.lat must be a number, got: {_loc['lat']!r}")
+        try:
+            lon = float(_loc["lon"])
+        except (ValueError, TypeError):
+            hooks.cli_exit(f"location.lon must be a number, got: {_loc['lon']!r}")
+        alt = 0
+        if "alt" in _loc:
+            try:
+                alt = int(_loc["alt"])
+            except (ValueError, TypeError):
+                hooks.cli_exit(f"location.alt must be an integer, got: {_loc['alt']!r}")
+            hooks.cli_print(f"Fixing altitude at {alt} meters")
+        hooks.cli_print(f"Fixing latitude at {lat} degrees")
+        hooks.cli_print(f"Fixing longitude at {lon} degrees")
+        hooks.cli_print("Setting device position")
+        target_node.setFixedPosition(lat, lon, alt)
+        time.sleep(CONFIG_APPLY_DELAY_SECONDS)
+
+    if "canned_messages" in configuration:
+        if not phase1_started:
+            hooks.cli_print(CONFIGURE_PHASE1_HEADER)
+            phase1_started = True
+        hooks.cli_print(
+            f"Setting canned message messages to {configuration['canned_messages']}",
+        )
+        target_node.set_canned_message(configuration["canned_messages"])
+        time.sleep(CONFIG_APPLY_DELAY_SECONDS)
+
+    if "ringtone" in configuration:
+        if not phase1_started:
+            hooks.cli_print(CONFIGURE_PHASE1_HEADER)
+            phase1_started = True
+        hooks.cli_print(f"Setting ringtone to {configuration['ringtone']}")
+        target_node.set_ringtone(configuration["ringtone"])
+        time.sleep(CONFIG_APPLY_DELAY_SECONDS)
+
+    channel_url_key = "channel_url" if "channel_url" in configuration else "channelUrl"
+    if channel_url_key in configuration:
+        if not phase1_started:
+            hooks.cli_print(CONFIGURE_PHASE1_HEADER)
+            phase1_started = True
+        seturl_executed = _apply_configure_channel_url(
+            hooks,
+            target_node,
+            configuration[channel_url_key],
+            config_key=channel_url_key,
+        )
+        phase1_may_reconnect = seturl_executed
+
+    if phase1_started:
+        hooks.cli_print("Phase 1 complete.")
+
+    settings_transaction_started = False
+    has_valid_config_section = bool(
+        validated_config_sections or validated_module_config_sections
+    )
+    if seturl_executed and has_valid_config_section:
+        if hooks.is_local_destination(interface, args.dest):
+            if not hooks.post_seturl_stability_check(
+                interface, timeout=SETURL_STABILITY_TIMEOUT_SECONDS
+            ):
+                hooks.cli_exit(
+                    "ERROR: channel_url applied, but transport did not stabilize "
+                    "for additional configuration writes; aborting before Phase 2."
+                )
+        else:
+            hooks.cli_exit(
+                "ERROR: Combining channel_url with additional configuration "
+                "writes is not supported for remote nodes. Apply channel_url "
+                "and configuration in separate operations."
+            )
+    if has_valid_config_section:
+        hooks.cli_print(
+            "Phase 2: Applying configuration transaction (may trigger device reboot)..."
+        )
+        target_node.beginSettingsTransaction()
+        settings_transaction_started = True
+
+    remaining_config_writes = len(validated_config_sections) + len(
+        validated_module_config_sections
+    )
+
+    if validated_config_sections:
+        localConfig = target_node.localConfig
+        for section, section_values in validated_config_sections.items():
+            failed_config_fields: list[str] = []
+            applied = hooks.traverse_config(
+                section,
+                section_values,
+                localConfig,
+                failed_fields=failed_config_fields,
+            )
+            if failed_config_fields:
+                logger.warning(
+                    "Skipped %d unknown field(s) in config section %s: %s",
+                    len(failed_config_fields),
+                    section,
+                    ", ".join(repr(f) for f in failed_config_fields),
+                )
+            if not applied:
+                hooks.cli_exit(
+                    f"Failed to apply config section {section!r} due to structural errors."
+                )
+            target_node.writeConfig(meshtastic.util.camel_to_snake(section))
+            remaining_config_writes -= 1
+            hooks.pace_configure_write(remaining_config_writes)
+
+    if validated_module_config_sections:
+        moduleConfig = target_node.moduleConfig
+        for section, section_values in validated_module_config_sections.items():
+            failed_module_fields: list[str] = []
+            applied = hooks.traverse_config(
+                section,
+                section_values,
+                moduleConfig,
+                failed_fields=failed_module_fields,
+            )
+            if failed_module_fields:
+                logger.warning(
+                    "Skipped %d unknown field(s) in module_config section %s: %s",
+                    len(failed_module_fields),
+                    section,
+                    ", ".join(repr(f) for f in failed_module_fields),
+                )
+            if not applied:
+                hooks.cli_exit(
+                    f"Failed to apply module_config section {section!r} due to structural errors."
+                )
+            target_node.writeConfig(meshtastic.util.camel_to_snake(section))
+            remaining_config_writes -= 1
+            hooks.pace_configure_write(remaining_config_writes)
+
+    if settings_transaction_started:
+        target_node.commitSettingsTransaction()
+        time.sleep(CONFIG_COMMIT_SETTLE_SECONDS)
+        hooks.cli_print(
+            "Configuration transaction committed. Device may reboot to apply changes."
+        )
+
+    if settings_transaction_started:
+        _verify_channel_url = configuration.get("channel_url") or configuration.get(
+            "channelUrl"
+        )
+        _verify_config_fields = validated_config_sections or None
+        _verify_module_config_fields = validated_module_config_sections or None
+        if hooks.is_local_destination(interface, args.dest):
+            _reconnect_result = hooks.post_configure_reconnect_and_verify(
+                interface,
+                timeout=CONFIG_RECONNECT_WAIT_SECONDS,
+                node_dest=args.dest,
+                verify_channel_url=_verify_channel_url,
+                verify_config_fields=_verify_config_fields,
+                verify_module_config_fields=_verify_module_config_fields,
+            )
+            if _reconnect_result == ConfigureReconnectResult.VERIFIED:
+                hooks.cli_print(
+                    "Phase 3: Device reconnected and config reloaded. All settings verified."
+                )
+            elif _reconnect_result == ConfigureReconnectResult.VERIFICATION_INCOMPLETE:
+                hooks.cli_print(
+                    "Phase 3: Device reconnected and config reloaded. "
+                    "Could not fully verify applied settings."
+                )
+            elif _reconnect_result == ConfigureReconnectResult.CONFIG_RELOAD_FAILED:
+                hooks.cli_print(
+                    "Phase 3: Device reconnected but config reload failed. "
+                    "Settings may still be applying."
+                )
+            elif _reconnect_result == ConfigureReconnectResult.RECONNECT_FAILED:
+                hooks.cli_print(
+                    "Phase 3: Device did not reconnect within timeout. "
+                    "Configuration may still be applying."
+                )
+        else:
+            hooks.cli_print(
+                "Phase 3: Reboot/reconnect verification skipped for remote target. "
+                "Local transport state does not confirm remote node reload status."
+            )
+    else:
+        if phase1_may_reconnect:
+            hooks.cli_print(
+                "Configuration applied. Channel URL updates may still trigger reconnect/reboot."
+            )
+        else:
+            hooks.cli_print("Configuration applied (no reboot expected).")
+
+    return settings_transaction_started, (
+        seturl_executed and hooks.is_local_destination(interface, args.dest)
+    )
+
+
+def handle_configure_actions(
+    context: CliContext,
+    hooks: ConfigureActionHooks,
+) -> None:
+    """Execute ``--set``, ``--configure``, and ``--export-config`` actions.
+
+    Parameters
+    ----------
+    context : CliContext
+        Connected invocation state and accumulated lifecycle outcome.
+    hooks : ConfigureActionHooks
+        Entrypoint-owned compatibility seams for preference/config handlers.
+    """
+    args = context.args
+    outcome = context.outcome
+
+    if args.set:
+        outcome.close_now = True
+        outcome.wait_for_ack_nak = True
+        hooks.handle_set_command(context.interface, args, context.get_node_kwargs)
+
+    if args.configure:
+        outcome.close_now = True
+        outcome.wait_for_ack_nak = True
+        settings_transaction_started, phase1_channel_url_applied = (
+            hooks.handle_configure_command(
+                context.interface,
+                args,
+                context.get_node_kwargs,
+            )
+        )
+        if settings_transaction_started or phase1_channel_url_applied:
+            outcome.wait_for_ack_nak = False
+            outcome.skip_ack_wait = True
+
+    if not args.export_config:
+        return
+
+    if args.dest != BROADCAST_ADDR:
+        print("Exporting configuration of remote nodes is not supported.")
+        outcome.stop_processing = True
+        return
+
+    outcome.close_now = True
+    config_text = hooks.export_config(context.interface)
+    if args.export_config == "-":
+        print(config_text)
+        return
+
+    try:
+        with open(args.export_config, "w", encoding="utf-8") as output_file:
+            output_file.write(config_text)
+    except OSError as exc:
+        hooks.cli_exit(f"ERROR: Failed to write config file: {exc}", 1)
+    hooks.cli_print(f"Exported configuration to {args.export_config}")

--- a/meshtastic/cli/configure_actions.py
+++ b/meshtastic/cli/configure_actions.py
@@ -19,7 +19,7 @@ from typing import Any, NamedTuple
 import yaml
 
 import meshtastic.util
-from meshtastic.cli.context import CliContext, CliExit
+from meshtastic.cli.context import CliContext, CliExit, _terminate_cli
 from meshtastic.configure_verify import (
     _verify_channel_url_against_state,
     _verify_requested_fields,
@@ -90,20 +90,26 @@ class _Phase1ConfigureValues:
         Normalized short owner name when requested.
     location : tuple[float, float, int] | None
         Validated latitude, longitude, and altitude when requested.
+    altitude_specified : bool
+        Whether the input location explicitly contained an altitude.
     canned_messages : str | None
         Canned-message payload when requested.
     ringtone : str | None
         Ringtone payload when requested.
     channel_url : str | None
         Stripped channel URL when requested.
+    channel_url_key : str | None
+        Original accepted channel-URL alias used by the input document.
     """
 
     owner: str | None = None
     owner_short: str | None = None
     location: tuple[float, float, int] | None = None
+    altitude_specified: bool = False
     canned_messages: str | None = None
     ringtone: str | None = None
     channel_url: str | None = None
+    channel_url_key: str | None = None
 
 
 class _PreparedConfigureDocument(NamedTuple):
@@ -111,8 +117,6 @@ class _PreparedConfigureDocument(NamedTuple):
 
     Attributes
     ----------
-    configuration : dict[str, Any]
-        Validated top-level YAML mapping.
     phase1 : _Phase1ConfigureValues
         Normalized direct-write values.
     config_sections : dict[str, dict[str, Any]]
@@ -121,7 +125,6 @@ class _PreparedConfigureDocument(NamedTuple):
         Validated LocalModuleConfig section mappings.
     """
 
-    configuration: dict[str, Any]
     phase1: _Phase1ConfigureValues
     config_sections: dict[str, dict[str, Any]]
     module_config_sections: dict[str, dict[str, Any]]
@@ -476,9 +479,10 @@ def _validate_mapping_sections(
     validated_sections: dict[str, dict[str, Any]] = {}
     for section_name, section_value in section_mapping.items():
         if not isinstance(section_value, dict):
-            hooks.cli_exit(
+            _terminate_cli(
+                hooks.cli_exit,
                 f"ERROR: '{top_level_key}.{section_name}' must be a mapping, got "
-                f"{type(section_value).__name__}"
+                f"{type(section_value).__name__}",
             )
         validated_sections[section_name] = section_value
     return validated_sections
@@ -516,9 +520,10 @@ def _preflight_configure_sections(
                 field_suffix = (
                     f" Invalid field: {failed_fields[0]}." if failed_fields else ""
                 )
-                hooks.cli_exit(
+                _terminate_cli(
+                    hooks.cli_exit,
                     f"Failed to apply {top_level_key} section {section!r} "
-                    f"due to structural errors.{field_suffix}"
+                    f"due to structural errors.{field_suffix}",
                 )
     finally:
         hooks.preflight_mode.reset(token)
@@ -763,10 +768,10 @@ def _apply_configure_channel_url(
 ) -> bool:
     """Validate and apply one configured channel URL without exposing it."""
     if not isinstance(raw_channel_url, str):
-        hooks.cli_exit(f"ERROR: {config_key} must be a string.")
+        _terminate_cli(hooks.cli_exit, f"ERROR: {config_key} must be a string.")
     requested_channel_url = raw_channel_url.strip()
     if not requested_channel_url:
-        hooks.cli_exit(f"ERROR: {config_key} must not be blank.")
+        _terminate_cli(hooks.cli_exit, f"ERROR: {config_key} must not be blank.")
 
     if hooks.channel_url_matches_current_device_state(
         target_node, requested_channel_url
@@ -865,79 +870,92 @@ def _validate_phase1_configuration(
         raw_owner = configuration["owner"]
         owner = "" if raw_owner is None else str(raw_owner).strip()
         if not owner:
-            hooks.cli_exit(
-                "ERROR: Long Name cannot be empty or contain only whitespace characters"
+            _terminate_cli(
+                hooks.cli_exit,
+                "ERROR: Long Name cannot be empty or contain only whitespace characters",
             )
 
     owner_short: str | None = None
-    owner_short_key = (
-        "owner_short" if "owner_short" in configuration else "ownerShort"
-    )
+    owner_short_key = "owner_short" if "owner_short" in configuration else "ownerShort"
     if owner_short_key in configuration:
         raw_owner_short = configuration[owner_short_key]
-        owner_short = (
-            "" if raw_owner_short is None else str(raw_owner_short).strip()
-        )
+        owner_short = "" if raw_owner_short is None else str(raw_owner_short).strip()
         if not owner_short:
-            hooks.cli_exit(
-                "ERROR: Short Name cannot be empty or contain only whitespace characters"
+            _terminate_cli(
+                hooks.cli_exit,
+                "ERROR: Short Name cannot be empty or contain only whitespace characters",
             )
 
     location_values: tuple[float, float, int] | None = None
+    altitude_specified = False
     if "location" in configuration:
         location = configuration["location"]
         if not isinstance(location, dict) or not location:
-            hooks.cli_exit(
-                "location must be a non-empty mapping with lat, lon, and optional alt"
+            _terminate_cli(
+                hooks.cli_exit,
+                "location must be a non-empty mapping with lat, lon, and optional alt",
             )
         unknown_location_keys = set(location) - {"lat", "lon", "alt"}
         if unknown_location_keys:
-            hooks.cli_exit(
+            _terminate_cli(
+                hooks.cli_exit,
                 "location contains unknown keys: "
-                f"{', '.join(sorted(unknown_location_keys))}. Allowed: lat, lon, alt"
+                f"{', '.join(sorted(unknown_location_keys))}. Allowed: lat, lon, alt",
             )
         if "lat" not in location or "lon" not in location:
-            hooks.cli_exit("location requires both lat and lon")
+            _terminate_cli(hooks.cli_exit, "location requires both lat and lon")
         if isinstance(location["lat"], bool):
-            hooks.cli_exit(
-                f"location.lat must be a number, got: {location['lat']!r}"
+            _terminate_cli(
+                hooks.cli_exit,
+                f"location.lat must be a number, got: {location['lat']!r}",
             )
         try:
             lat = float(location["lat"])
         except (ValueError, TypeError):
-            hooks.cli_exit(
-                f"location.lat must be a number, got: {location['lat']!r}"
+            _terminate_cli(
+                hooks.cli_exit,
+                f"location.lat must be a number, got: {location['lat']!r}",
             )
         if isinstance(location["lon"], bool):
-            hooks.cli_exit(
-                f"location.lon must be a number, got: {location['lon']!r}"
+            _terminate_cli(
+                hooks.cli_exit,
+                f"location.lon must be a number, got: {location['lon']!r}",
             )
         try:
             lon = float(location["lon"])
         except (ValueError, TypeError):
-            hooks.cli_exit(
-                f"location.lon must be a number, got: {location['lon']!r}"
+            _terminate_cli(
+                hooks.cli_exit,
+                f"location.lon must be a number, got: {location['lon']!r}",
             )
         if not -90.0 <= lat <= 90.0:
-            hooks.cli_exit(f"location.lat must be between -90 and 90, got: {lat}")
+            _terminate_cli(
+                hooks.cli_exit, f"location.lat must be between -90 and 90, got: {lat}"
+            )
         if not -180.0 <= lon <= 180.0:
-            hooks.cli_exit(f"location.lon must be between -180 and 180, got: {lon}")
+            _terminate_cli(
+                hooks.cli_exit, f"location.lon must be between -180 and 180, got: {lon}"
+            )
         alt = 0
-        if "alt" in location:
+        altitude_specified = "alt" in location
+        if altitude_specified:
             if isinstance(location["alt"], bool):
-                hooks.cli_exit(
-                    f"location.alt must be an integer, got: {location['alt']!r}"
+                _terminate_cli(
+                    hooks.cli_exit,
+                    f"location.alt must be an integer, got: {location['alt']!r}",
                 )
             try:
                 alt = int(location["alt"])
             except (ValueError, TypeError):
-                hooks.cli_exit(
-                    f"location.alt must be an integer, got: {location['alt']!r}"
+                _terminate_cli(
+                    hooks.cli_exit,
+                    f"location.alt must be an integer, got: {location['alt']!r}",
                 )
             if not POSITION_ALTITUDE_MIN <= alt <= POSITION_ALTITUDE_MAX:
-                hooks.cli_exit(
+                _terminate_cli(
+                    hooks.cli_exit,
                     "location.alt must fit the signed 32-bit position field, "
-                    f"got: {alt}"
+                    f"got: {alt}",
                 )
         location_values = (lat, lon, alt)
 
@@ -958,28 +976,37 @@ def _validate_phase1_configuration(
             return None
         value = configuration[key]
         if not isinstance(value, str):
-            hooks.cli_exit(f"ERROR: {key} must be a string.")
+            _terminate_cli(hooks.cli_exit, f"ERROR: {key} must be a string.")
         return value
 
-    channel_url_key = (
-        "channel_url" if "channel_url" in configuration else "channelUrl"
-    )
+    channel_url_key: str | None = None
+    if "channel_url" in configuration:
+        channel_url_key = "channel_url"
+    elif "channelUrl" in configuration:
+        channel_url_key = "channelUrl"
+
     channel_url: str | None = None
-    if channel_url_key in configuration:
+    if channel_url_key is not None:
         raw_channel_url = configuration[channel_url_key]
         if not isinstance(raw_channel_url, str):
-            hooks.cli_exit(f"ERROR: {channel_url_key} must be a string.")
+            _terminate_cli(
+                hooks.cli_exit, f"ERROR: {channel_url_key} must be a string."
+            )
         channel_url = raw_channel_url.strip()
         if not channel_url:
-            hooks.cli_exit(f"ERROR: {channel_url_key} must not be blank.")
+            _terminate_cli(
+                hooks.cli_exit, f"ERROR: {channel_url_key} must not be blank."
+            )
 
     return _Phase1ConfigureValues(
         owner=owner,
         owner_short=owner_short,
         location=location_values,
+        altitude_specified=altitude_specified,
         canned_messages=_optional_string("canned_messages"),
         ringtone=_optional_string("ringtone"),
         channel_url=channel_url,
+        channel_url_key=channel_url_key,
     )
 
 
@@ -1007,34 +1034,44 @@ def _load_and_validate_configure_document(
             raw_text = file.read()
         configuration = yaml.safe_load(raw_text)
     except OSError as exc:
-        hooks.cli_exit(f"ERROR: Failed to read configuration file: {exc}")
+        _terminate_cli(
+            hooks.cli_exit, f"ERROR: Failed to read configuration file: {exc}"
+        )
     except (yaml.YAMLError, UnicodeDecodeError) as exc:
-        hooks.cli_exit(f"ERROR: Failed to parse YAML configuration: {exc}")
+        _terminate_cli(
+            hooks.cli_exit, f"ERROR: Failed to parse YAML configuration: {exc}"
+        )
 
     if configuration is None:
-        hooks.cli_exit("ERROR: YAML configuration file is empty")
+        _terminate_cli(hooks.cli_exit, "ERROR: YAML configuration file is empty")
     if not isinstance(configuration, dict):
-        hooks.cli_exit(
+        _terminate_cli(
+            hooks.cli_exit,
             "ERROR: YAML configuration must be a mapping/dictionary, got "
-            f"{type(configuration).__name__}"
+            f"{type(configuration).__name__}",
         )
     if not configuration:
-        hooks.cli_exit("ERROR: Configuration file is empty; nothing to configure.")
+        _terminate_cli(
+            hooks.cli_exit, "ERROR: Configuration file is empty; nothing to configure."
+        )
 
     unknown_keys = set(configuration) - ALLOWED_CONFIGURE_KEYS
     if unknown_keys:
-        hooks.cli_exit(
-            f"ERROR: Unknown top-level key(s) in YAML: {', '.join(sorted(unknown_keys))}"
+        _terminate_cli(
+            hooks.cli_exit,
+            f"ERROR: Unknown top-level key(s) in YAML: {', '.join(sorted(unknown_keys))}",
         )
     if "channel_url" in configuration and "channelUrl" in configuration:
-        hooks.cli_exit(
+        _terminate_cli(
+            hooks.cli_exit,
             "ERROR: Cannot specify both 'channel_url' and 'channelUrl' in the same "
-            "configuration file; use one."
+            "configuration file; use one.",
         )
     if "owner_short" in configuration and "ownerShort" in configuration:
-        hooks.cli_exit(
+        _terminate_cli(
+            hooks.cli_exit,
             "ERROR: Cannot specify both 'owner_short' and 'ownerShort' in the same "
-            "configuration file; use one."
+            "configuration file; use one.",
         )
 
     phase1_values = _validate_phase1_configuration(hooks, configuration)
@@ -1043,10 +1080,11 @@ def _load_and_validate_configure_document(
     if "config" in configuration:
         config_value = configuration["config"]
         if not isinstance(config_value, dict) or not config_value:
-            hooks.cli_exit(
+            _terminate_cli(
+                hooks.cli_exit,
                 "ERROR: 'config' must be a non-empty mapping, got "
                 f"{type(config_value).__name__}"
-                f"{' (empty)' if isinstance(config_value, dict) else ''}"
+                f"{' (empty)' if isinstance(config_value, dict) else ''}",
             )
         config_sections = _validate_mapping_sections(
             hooks, top_level_key="config", section_mapping=config_value
@@ -1056,10 +1094,11 @@ def _load_and_validate_configure_document(
     if "module_config" in configuration:
         module_config_value = configuration["module_config"]
         if not isinstance(module_config_value, dict) or not module_config_value:
-            hooks.cli_exit(
+            _terminate_cli(
+                hooks.cli_exit,
                 "ERROR: 'module_config' must be a non-empty mapping, got "
                 f"{type(module_config_value).__name__}"
-                f"{' (empty)' if isinstance(module_config_value, dict) else ''}"
+                f"{' (empty)' if isinstance(module_config_value, dict) else ''}",
             )
         module_config_sections = _validate_mapping_sections(
             hooks,
@@ -1068,7 +1107,6 @@ def _load_and_validate_configure_document(
         )
 
     return _PreparedConfigureDocument(
-        configuration=configuration,
         phase1=phase1_values,
         config_sections=config_sections,
         module_config_sections=module_config_sections,
@@ -1096,7 +1134,6 @@ def _apply_phase1_configuration(
     bool
         ``True`` only when a channel URL write was actually sent.
     """
-    configuration = prepared.configuration
     values = prepared.phase1
     phase1_started = False
 
@@ -1122,7 +1159,7 @@ def _apply_phase1_configuration(
     if values.location is not None:
         _begin_phase1()
         lat, lon, alt = values.location
-        if "alt" in configuration["location"]:
+        if values.altitude_specified:
             hooks.cli_print(f"Fixing altitude at {alt} meters")
         hooks.cli_print(f"Fixing latitude at {lat} degrees")
         hooks.cli_print(f"Fixing longitude at {lon} degrees")
@@ -1145,13 +1182,13 @@ def _apply_phase1_configuration(
     seturl_executed = False
     if values.channel_url is not None:
         _begin_phase1()
+        if values.channel_url_key is None:
+            raise AssertionError("normalized channel URL is missing its source key")
         seturl_executed = _apply_configure_channel_url(
             hooks,
             target_node,
             values.channel_url,
-            config_key=(
-                "channel_url" if "channel_url" in configuration else "channelUrl"
-            ),
+            config_key=values.channel_url_key,
         )
 
     if phase1_started:
@@ -1220,8 +1257,9 @@ def _apply_settings_transaction(
                     ", ".join(repr(field) for field in failed_fields),
                 )
             if not applied:
-                hooks.cli_exit(
-                    f"Failed to apply {label} section {section!r} due to structural errors."
+                _terminate_cli(
+                    hooks.cli_exit,
+                    f"Failed to apply {label} section {section!r} due to structural errors.",
                 )
             target_node.writeConfig(meshtastic.util.camel_to_snake(section))
             remaining_writes -= 1
@@ -1355,7 +1393,9 @@ def _handle_configure_command(
     """
     prepared = _load_and_validate_configure_document(hooks, args.configure[0])
     target_node = interface.getNode(args.dest, False, **get_node_kwargs)
-    has_config_writes = bool(prepared.config_sections or prepared.module_config_sections)
+    has_config_writes = bool(
+        prepared.config_sections or prepared.module_config_sections
+    )
     is_local_target = hooks.is_local_destination(interface, args.dest)
 
     if has_config_writes:
@@ -1366,10 +1406,11 @@ def _handle_configure_command(
             module_config_sections=prepared.module_config_sections,
         )
         if prepared.phase1.channel_url is not None and not is_local_target:
-            hooks.cli_exit(
+            _terminate_cli(
+                hooks.cli_exit,
                 "ERROR: Combining channel_url with additional configuration writes "
                 "is not supported for remote nodes. Apply channel_url and "
-                "configuration in separate operations."
+                "configuration in separate operations.",
             )
 
     seturl_executed = _apply_phase1_configuration(hooks, target_node, prepared)
@@ -1377,9 +1418,10 @@ def _handle_configure_command(
         if not hooks.post_seturl_stability_check(
             interface, timeout=SETURL_STABILITY_TIMEOUT_SECONDS
         ):
-            hooks.cli_exit(
+            _terminate_cli(
+                hooks.cli_exit,
                 "ERROR: channel_url applied, but transport did not stabilize for "
-                "additional configuration writes; aborting before Phase 2."
+                "additional configuration writes; aborting before Phase 2.",
             )
 
     settings_transaction_started = has_config_writes
@@ -1406,6 +1448,7 @@ def _handle_configure_command(
         settings_transaction_started=settings_transaction_started,
         phase1_channel_url_applied=seturl_executed and is_local_target,
     )
+
 
 def _handle_configure_actions(
     context: CliContext,
@@ -1460,5 +1503,5 @@ def _handle_configure_actions(
         with open(args.export_config, "w", encoding="utf-8") as output_file:
             output_file.write(config_text)
     except OSError as exc:
-        hooks.cli_exit(f"ERROR: Failed to write config file: {exc}", 1)
+        _terminate_cli(hooks.cli_exit, f"ERROR: Failed to write config file: {exc}", 1)
     hooks.cli_print(f"Exported configuration to {args.export_config}")

--- a/meshtastic/cli/configure_actions.py
+++ b/meshtastic/cli/configure_actions.py
@@ -17,6 +17,7 @@ from typing import Any, NamedTuple
 import yaml
 
 import meshtastic.util
+from meshtastic.cli import configure_values
 from meshtastic.cli.context import CliContext, CliExit, _terminate_cli
 from meshtastic.configure_verify import (
     _verify_channel_url_against_state,
@@ -38,8 +39,6 @@ SETURL_STABILITY_MAX_ATTEMPTS = 3
 SETURL_STABILITY_WINDOW_SECONDS = 1.5
 SETURL_RECONNECT_WAIT_SECONDS = 10.0
 SETURL_STABILITY_POLL_SECONDS = 0.1
-POSITION_ALTITUDE_MIN = -(1 << 31)
-POSITION_ALTITUDE_MAX = (1 << 31) - 1
 CONFIGURE_DIRECT_SETTINGS_HEADER = (
     "Applying direct configuration values "
     "(channel URL updates may trigger reconnect/reboot)..."
@@ -146,60 +145,12 @@ class _ConfigureCommandResult(tuple[bool, bool]):
         return self[1]
 
 
-@dataclass(frozen=True, slots=True)
-class _DirectConfigureValues:
-    """Validated non-transactional configuration values ready for device writes.
-
-    Attributes
-    ----------
-    owner : str | None
-        Normalized long owner name when requested.
-    owner_short : str | None
-        Normalized short owner name when requested.
-    location : tuple[float, float, int] | None
-        Validated latitude, longitude, and altitude when requested.
-    altitude_specified : bool
-        Whether the input location explicitly contained an altitude.
-    canned_messages : str | None
-        Canned-message payload when requested.
-    ringtone : str | None
-        Ringtone payload when requested.
-    channel_url : str | None
-        Stripped channel URL when requested.
-    channel_url_key : str | None
-        Original accepted channel-URL alias used by the input document.
-    """
-
-    owner: str | None = None
-    owner_short: str | None = None
-    location: tuple[float, float, int] | None = None
-    altitude_specified: bool = False
-    canned_messages: str | None = None
-    ringtone: str | None = None
-    channel_url: str | None = None
-    channel_url_key: str | None = None
-
-    @property
-    def has_non_url_writes(self) -> bool:
-        """Return whether validated direct values require a non-URL device write."""
-        return any(
-            value is not None
-            for value in (
-                self.owner,
-                self.owner_short,
-                self.location,
-                self.canned_messages,
-                self.ringtone,
-            )
-        )
-
-
 class _PreparedConfigureDocument(NamedTuple):
     """Validated YAML document and normalized values ready for device access.
 
     Attributes
     ----------
-    direct_values : _DirectConfigureValues
+    direct_values : configure_values._DirectConfigureValues
         Normalized direct-write values.
     config_sections : dict[str, dict[str, Any]]
         Validated LocalConfig section mappings.
@@ -207,7 +158,7 @@ class _PreparedConfigureDocument(NamedTuple):
         Validated LocalModuleConfig section mappings.
     """
 
-    direct_values: _DirectConfigureValues
+    direct_values: configure_values._DirectConfigureValues
     config_sections: dict[str, dict[str, Any]]
     module_config_sections: dict[str, dict[str, Any]]
 
@@ -558,6 +509,11 @@ def _validate_mapping_sections(
         mappings (for example ``audio: {}``) are valid because exports use them
         to represent protobuf default values.
     """
+    _validate_string_mapping_keys(
+        hooks,
+        section_mapping,
+        path=top_level_key,
+    )
     validated_sections: dict[str, dict[str, Any]] = {}
     for section_name, section_value in section_mapping.items():
         if not isinstance(section_value, dict):
@@ -568,6 +524,28 @@ def _validate_mapping_sections(
             )
         validated_sections[section_name] = section_value
     return validated_sections
+
+
+def _validate_string_mapping_keys(
+    hooks: ConfigureHooks,
+    mapping: dict[Any, Any],
+    *,
+    path: str,
+) -> None:
+    """Reject YAML mapping keys that cannot name configuration fields."""
+    for key, value in mapping.items():
+        if not isinstance(key, str):
+            _terminate_cli(
+                hooks.cli_exit,
+                f"ERROR: {path} keys must be strings, got {key!r} "
+                f"({type(key).__name__}).",
+            )
+        if isinstance(value, dict):
+            _validate_string_mapping_keys(
+                hooks,
+                value,
+                path=f"{path}.{key}",
+            )
 
 
 def _preflight_configure_sections(
@@ -940,176 +918,6 @@ def _close_failed_settings_transaction(
         )
 
 
-def _validate_direct_configuration(
-    hooks: ConfigureHooks,
-    configuration: dict[str, Any],
-) -> _DirectConfigureValues:
-    """Validate and normalize non-transactional configuration before device mutation.
-
-    Parameters
-    ----------
-    hooks : ConfigureHooks
-        CLI reporting and exit hooks.
-    configuration : dict[str, Any]
-        Parsed top-level YAML mapping.
-
-    Returns
-    -------
-    _DirectConfigureValues
-        Normalized values for all present direct-write actions. Missing actions
-        remain ``None``.
-
-    Notes
-    -----
-    Validation is intentionally completed before any device mutation. This
-    prevents a later malformed value from leaving an avoidable partially applied
-    configuration.
-    """
-    owner: str | None = None
-    if "owner" in configuration:
-        raw_owner = configuration["owner"]
-        owner = "" if raw_owner is None else str(raw_owner).strip()
-        if not owner:
-            _terminate_cli(
-                hooks.cli_exit,
-                "ERROR: Long Name cannot be empty or contain only whitespace characters",
-            )
-
-    owner_short: str | None = None
-    owner_short_key = "owner_short" if "owner_short" in configuration else "ownerShort"
-    if owner_short_key in configuration:
-        raw_owner_short = configuration[owner_short_key]
-        owner_short = "" if raw_owner_short is None else str(raw_owner_short).strip()
-        if not owner_short:
-            _terminate_cli(
-                hooks.cli_exit,
-                "ERROR: Short Name cannot be empty or contain only whitespace characters",
-            )
-
-    location_values: tuple[float, float, int] | None = None
-    altitude_specified = False
-    if "location" in configuration:
-        location = configuration["location"]
-        if not isinstance(location, dict) or not location:
-            _terminate_cli(
-                hooks.cli_exit,
-                "location must be a non-empty mapping with lat, lon, and optional alt",
-            )
-        unknown_location_keys = set(location) - {"lat", "lon", "alt"}
-        if unknown_location_keys:
-            _terminate_cli(
-                hooks.cli_exit,
-                "location contains unknown keys: "
-                f"{', '.join(sorted(unknown_location_keys))}. Allowed: lat, lon, alt",
-            )
-        if "lat" not in location or "lon" not in location:
-            _terminate_cli(hooks.cli_exit, "location requires both lat and lon")
-        if isinstance(location["lat"], bool):
-            _terminate_cli(
-                hooks.cli_exit,
-                f"location.lat must be a number, got: {location['lat']!r}",
-            )
-        try:
-            lat = float(location["lat"])
-        except (ValueError, TypeError):
-            _terminate_cli(
-                hooks.cli_exit,
-                f"location.lat must be a number, got: {location['lat']!r}",
-            )
-        if isinstance(location["lon"], bool):
-            _terminate_cli(
-                hooks.cli_exit,
-                f"location.lon must be a number, got: {location['lon']!r}",
-            )
-        try:
-            lon = float(location["lon"])
-        except (ValueError, TypeError):
-            _terminate_cli(
-                hooks.cli_exit,
-                f"location.lon must be a number, got: {location['lon']!r}",
-            )
-        if not -90.0 <= lat <= 90.0:
-            _terminate_cli(
-                hooks.cli_exit, f"location.lat must be between -90 and 90, got: {lat}"
-            )
-        if not -180.0 <= lon <= 180.0:
-            _terminate_cli(
-                hooks.cli_exit, f"location.lon must be between -180 and 180, got: {lon}"
-            )
-        alt = 0
-        altitude_specified = "alt" in location
-        if altitude_specified:
-            if isinstance(location["alt"], bool):
-                _terminate_cli(
-                    hooks.cli_exit,
-                    f"location.alt must be an integer, got: {location['alt']!r}",
-                )
-            try:
-                alt = int(location["alt"])
-            except (ValueError, TypeError):
-                _terminate_cli(
-                    hooks.cli_exit,
-                    f"location.alt must be an integer, got: {location['alt']!r}",
-                )
-            if not POSITION_ALTITUDE_MIN <= alt <= POSITION_ALTITUDE_MAX:
-                _terminate_cli(
-                    hooks.cli_exit,
-                    "location.alt must fit the signed 32-bit position field, "
-                    f"got: {alt}",
-                )
-        location_values = (lat, lon, alt)
-
-    def _optional_string(key: str) -> str | None:
-        """Return an optional top-level string value after type validation.
-
-        Parameters
-        ----------
-        key : str
-            Top-level configuration key to inspect.
-
-        Returns
-        -------
-        str | None
-            String value when present, otherwise ``None``.
-        """
-        if key not in configuration:
-            return None
-        value = configuration[key]
-        if not isinstance(value, str):
-            _terminate_cli(hooks.cli_exit, f"ERROR: {key} must be a string.")
-        return value
-
-    channel_url_key: str | None = None
-    if "channel_url" in configuration:
-        channel_url_key = "channel_url"
-    elif "channelUrl" in configuration:
-        channel_url_key = "channelUrl"
-
-    channel_url: str | None = None
-    if channel_url_key is not None:
-        raw_channel_url = configuration[channel_url_key]
-        if not isinstance(raw_channel_url, str):
-            _terminate_cli(
-                hooks.cli_exit, f"ERROR: {channel_url_key} must be a string."
-            )
-        channel_url = raw_channel_url.strip()
-        if not channel_url:
-            _terminate_cli(
-                hooks.cli_exit, f"ERROR: {channel_url_key} must not be blank."
-            )
-
-    return _DirectConfigureValues(
-        owner=owner,
-        owner_short=owner_short,
-        location=location_values,
-        altitude_specified=altitude_specified,
-        canned_messages=_optional_string("canned_messages"),
-        ringtone=_optional_string("ringtone"),
-        channel_url=channel_url,
-        channel_url_key=channel_url_key,
-    )
-
-
 def _load_and_validate_configure_document(
     hooks: ConfigureHooks,
     path: str,
@@ -1155,6 +963,8 @@ def _load_and_validate_configure_document(
             hooks.cli_exit, "ERROR: Configuration file is empty; nothing to configure."
         )
 
+    _validate_string_mapping_keys(hooks, configuration, path="configuration")
+
     unknown_keys = set(configuration) - ALLOWED_CONFIGURE_KEYS
     if unknown_keys:
         _terminate_cli(
@@ -1174,7 +984,9 @@ def _load_and_validate_configure_document(
             "configuration file; use one.",
         )
 
-    direct_values = _validate_direct_configuration(hooks, configuration)
+    direct_values = configure_values._validate_direct_configuration(
+        hooks, configuration
+    )
 
     config_sections: dict[str, dict[str, Any]] = {}
     if "config" in configuration:
@@ -1474,6 +1286,11 @@ def _handle_configure_command(
         Named lifecycle flags describing whether a settings transaction ran and whether
         a local channel URL write was actually performed.
     """
+    if len(args.configure) != 1:
+        _terminate_cli(
+            hooks.cli_exit,
+            "ERROR: --configure may be specified only once per invocation.",
+        )
     prepared = _load_and_validate_configure_document(hooks, args.configure[0])
     target_node = interface.getNode(args.dest, False, **get_node_kwargs)
     has_config_writes = bool(

--- a/meshtastic/cli/configure_actions.py
+++ b/meshtastic/cli/configure_actions.py
@@ -201,7 +201,27 @@ def _post_configure_reconnect_and_verify(
        or module config fields), performs value-aware comparison of the
        explicitly requested settings against what the device reports.
 
-    Returns a ConfigureReconnectResult indicating the outcome.
+    Parameters
+    ----------
+    interface : MeshInterface
+        Connected interface observed for disconnect/reconnect.
+    timeout : float
+        Total reconnect budget in seconds.
+    node_dest : str
+        Destination whose configuration is reloaded and verified.
+    verify_channel_url : str | None
+        Normalized channel URL expected after reload.
+    verify_config_fields : dict[str, dict[str, Any]] | None
+        Requested local-config sections and fields to compare.
+    verify_module_config_fields : dict[str, dict[str, Any]] | None
+        Requested module-config sections and fields to compare.
+    verify_channel_url_against_state : Callable[..., bool]
+        Channel-state comparison seam.
+
+    Returns
+    -------
+    ConfigureReconnectResult
+        Reconnect, reload, and requested-value verification outcome.
     """
     deadline = time.monotonic() + timeout
 
@@ -325,6 +345,7 @@ def _post_seturl_stability_check(
     is_connected_event = getattr(interface, "isConnected", None)
 
     def _event_is_set() -> bool:
+        """Return whether the interface exposes a currently-set connection event."""
         return bool(
             is_connected_event is not None
             and hasattr(is_connected_event, "is_set")
@@ -332,6 +353,18 @@ def _post_seturl_stability_check(
         )
 
     def _event_wait(timeout_seconds: float) -> bool:
+        """Wait on the interface connection event when that seam is available.
+
+        Parameters
+        ----------
+        timeout_seconds : float
+            Maximum wait in seconds.
+
+        Returns
+        -------
+        bool
+            Event wait result, or ``False`` when no compatible event exists.
+        """
         return bool(
             is_connected_event is not None
             and hasattr(is_connected_event, "wait")
@@ -339,6 +372,13 @@ def _post_seturl_stability_check(
         )
 
     def _trigger_reconnect() -> bool:
+        """Best-effort trigger one reconnect attempt and report connected state.
+
+        Returns
+        -------
+        bool
+            ``True`` when the interface is connected after the reconnect trigger.
+        """
         reconnect = getattr(interface, "_attempt_reconnect", None)
         if callable(reconnect):
             try:
@@ -902,6 +942,18 @@ def _validate_phase1_configuration(
         location_values = (lat, lon, alt)
 
     def _optional_string(key: str) -> str | None:
+        """Return an optional top-level string value after type validation.
+
+        Parameters
+        ----------
+        key : str
+            Top-level configuration key to inspect.
+
+        Returns
+        -------
+        str | None
+            String value when present, otherwise ``None``.
+        """
         if key not in configuration:
             return None
         value = configuration[key]
@@ -1049,6 +1101,7 @@ def _apply_phase1_configuration(
     phase1_started = False
 
     def _begin_phase1() -> None:
+        """Print the direct-write phase header exactly once."""
         nonlocal phase1_started
         if not phase1_started:
             hooks.cli_print(CONFIGURE_PHASE1_HEADER)
@@ -1138,6 +1191,17 @@ def _apply_settings_transaction(
         protobuf_root: Any,
         label: str,
     ) -> None:
+        """Apply one validated section group and pace each device write.
+
+        Parameters
+        ----------
+        sections : dict[str, dict[str, Any]]
+            Validated configuration sections to traverse and write.
+        protobuf_root : Any
+            Protobuf configuration root mutated by ``traverse_config``.
+        label : str
+            Human-readable section group used in diagnostics.
+        """
         nonlocal remaining_writes
         for section, section_values in sections.items():
             failed_fields: list[str] = []

--- a/meshtastic/cli/configure_actions.py
+++ b/meshtastic/cli/configure_actions.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import contextvars
 import enum
 import logging
+import os
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -39,6 +40,7 @@ SETURL_STABILITY_MAX_ATTEMPTS = 3
 SETURL_STABILITY_WINDOW_SECONDS = 1.5
 SETURL_RECONNECT_WAIT_SECONDS = 10.0
 SETURL_STABILITY_POLL_SECONDS = 0.1
+PRIVATE_CONFIG_FILE_MODE: int = 0o600
 CONFIGURE_DIRECT_SETTINGS_HEADER = (
     "Applying direct configuration values "
     "(channel URL updates may trigger reconnect/reboot)..."
@@ -1410,8 +1412,24 @@ def _handle_configure_actions(
         return
 
     try:
-        with open(args.export_config, "w", encoding="utf-8") as output_file:
-            output_file.write(config_text)
+        descriptor = os.open(
+            args.export_config,
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            PRIVATE_CONFIG_FILE_MODE,
+        )
+        try:
+            # ``os.open(..., mode=...)`` does not alter an existing file's mode.
+            # Tighten it before writing because exports may contain private and
+            # administrative keys.
+            fchmod = getattr(os, "fchmod", None)
+            if callable(fchmod):
+                fchmod(descriptor, PRIVATE_CONFIG_FILE_MODE)
+            with os.fdopen(descriptor, "w", encoding="utf-8") as output_file:
+                descriptor = -1
+                output_file.write(config_text)
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
     except OSError as exc:
         _terminate_cli(hooks.cli_exit, f"ERROR: Failed to write config file: {exc}", 1)
     hooks.cli_print(f"Exported configuration to {args.export_config}")

--- a/meshtastic/cli/configure_actions.py
+++ b/meshtastic/cli/configure_actions.py
@@ -42,8 +42,8 @@ SETURL_RECONNECT_WAIT_SECONDS = 10.0
 SETURL_STABILITY_POLL_SECONDS = 0.1
 POSITION_ALTITUDE_MIN = -(1 << 31)
 POSITION_ALTITUDE_MAX = (1 << 31) - 1
-CONFIGURE_PHASE1_HEADER = (
-    "Phase 1: Applying direct configuration "
+CONFIGURE_DIRECT_SETTINGS_HEADER = (
+    "Applying direct configuration values "
     "(channel URL updates may trigger reconnect/reboot)..."
 )
 ALLOWED_CONFIGURE_KEYS = frozenset(
@@ -75,12 +75,12 @@ class _ConfigureCommandResult(NamedTuple):
     """Outcome flags returned by one ``--configure`` execution."""
 
     settings_transaction_started: bool
-    phase1_channel_url_applied: bool
+    local_channel_url_applied: bool
 
 
 @dataclass(frozen=True, slots=True)
-class _Phase1ConfigureValues:
-    """Validated direct-write values that are safe to apply in Phase 1.
+class _DirectConfigureValues:
+    """Validated non-transactional configuration values ready for device writes.
 
     Attributes
     ----------
@@ -117,7 +117,7 @@ class _PreparedConfigureDocument(NamedTuple):
 
     Attributes
     ----------
-    phase1 : _Phase1ConfigureValues
+    direct_values : _DirectConfigureValues
         Normalized direct-write values.
     config_sections : dict[str, dict[str, Any]]
         Validated LocalConfig section mappings.
@@ -125,7 +125,7 @@ class _PreparedConfigureDocument(NamedTuple):
         Validated LocalModuleConfig section mappings.
     """
 
-    phase1: _Phase1ConfigureValues
+    direct_values: _DirectConfigureValues
     config_sections: dict[str, dict[str, Any]]
     module_config_sections: dict[str, dict[str, Any]]
 
@@ -570,7 +570,11 @@ def _refresh_no_disconnect_verify_state(
             request_config(field_desc)
 
     if verify_channel_url:
-        target_node._invalidate_channel_cache()  # noqa: SLF001 - Node cache owner API
+        invalidate_channel_cache = getattr(
+            target_node, "_invalidate_channel_cache", None
+        )
+        if callable(invalidate_channel_cache):
+            invalidate_channel_cache()  # noqa: SLF001 - Node cache owner API
         request_channels = getattr(target_node, "requestChannels", None)
         if callable(request_channels):
             request_channels(0)
@@ -805,7 +809,7 @@ def _close_failed_settings_transaction(
     *,
     commit_attempted: bool,
 ) -> None:
-    """Best-effort close an open settings transaction after Phase 2 failure.
+    """Best-effort close an open settings transaction after a configuration failure.
 
     Parameters
     ----------
@@ -818,9 +822,10 @@ def _close_failed_settings_transaction(
 
     Notes
     -----
-    Firmware exposes begin/commit but no rollback/cancel operation. When Phase 2
-    fails before commit is attempted, committing is the only available way to
-    close the transaction; writes already accepted may therefore be applied. If
+    Firmware exposes begin/commit but no rollback/cancel operation. When a
+    configuration transaction fails before commit is attempted, committing is the
+    only available way to close the transaction; writes already accepted may therefore
+    be applied. If
     the normal commit itself failed, final device-side state is unknown and a
     second commit is intentionally not sent.
     """
@@ -834,8 +839,8 @@ def _close_failed_settings_transaction(
         return
 
     message = (
-        "Configuration failed during Phase 2; attempting to close the settings "
-        "transaction. Any writes already accepted may be committed."
+        "Configuration failed before the settings transaction completed; attempting "
+        "to close it. Any writes already accepted may be committed."
     )
     logger.warning(message)
     hooks.cli_print(f"WARNING: {message}")
@@ -853,11 +858,11 @@ def _close_failed_settings_transaction(
         )
 
 
-def _validate_phase1_configuration(
+def _validate_direct_configuration(
     hooks: ConfigureHooks,
     configuration: dict[str, Any],
-) -> _Phase1ConfigureValues:
-    """Validate and normalize every deterministic Phase-1 input before writes.
+) -> _DirectConfigureValues:
+    """Validate and normalize non-transactional configuration before device mutation.
 
     Parameters
     ----------
@@ -868,15 +873,15 @@ def _validate_phase1_configuration(
 
     Returns
     -------
-    _Phase1ConfigureValues
+    _DirectConfigureValues
         Normalized values for all present direct-write actions. Missing actions
         remain ``None``.
 
     Notes
     -----
     Validation is intentionally completed before any device mutation. This
-    prevents a later malformed direct-write value from leaving an avoidable
-    partially applied Phase-1 configuration.
+    prevents a later malformed value from leaving an avoidable partially applied
+    configuration.
     """
     owner: str | None = None
     if "owner" in configuration:
@@ -1011,7 +1016,7 @@ def _validate_phase1_configuration(
                 hooks.cli_exit, f"ERROR: {channel_url_key} must not be blank."
             )
 
-    return _Phase1ConfigureValues(
+    return _DirectConfigureValues(
         owner=owner,
         owner_short=owner_short,
         location=location_values,
@@ -1087,7 +1092,7 @@ def _load_and_validate_configure_document(
             "configuration file; use one.",
         )
 
-    phase1_values = _validate_phase1_configuration(hooks, configuration)
+    direct_values = _validate_direct_configuration(hooks, configuration)
 
     config_sections: dict[str, dict[str, Any]] = {}
     if "config" in configuration:
@@ -1120,18 +1125,18 @@ def _load_and_validate_configure_document(
         )
 
     return _PreparedConfigureDocument(
-        phase1=phase1_values,
+        direct_values=direct_values,
         config_sections=config_sections,
         module_config_sections=module_config_sections,
     )
 
 
-def _apply_phase1_configuration(
+def _apply_direct_configuration(
     hooks: ConfigureHooks,
     target_node: Any,
     prepared: _PreparedConfigureDocument,
 ) -> bool:
-    """Apply validated direct-write values in historical Phase-1 order.
+    """Apply validated non-transactional values in compatibility-preserving order.
 
     Parameters
     ----------
@@ -1147,30 +1152,30 @@ def _apply_phase1_configuration(
     bool
         ``True`` only when a channel URL write was actually sent.
     """
-    values = prepared.phase1
-    phase1_started = False
+    values = prepared.direct_values
+    direct_writes_started = False
 
-    def _begin_phase1() -> None:
-        """Print the direct-write phase header exactly once."""
-        nonlocal phase1_started
-        if not phase1_started:
-            hooks.cli_print(CONFIGURE_PHASE1_HEADER)
-            phase1_started = True
+    def _begin_direct_writes() -> None:
+        """Print the direct-configuration header exactly once."""
+        nonlocal direct_writes_started
+        if not direct_writes_started:
+            hooks.cli_print(CONFIGURE_DIRECT_SETTINGS_HEADER)
+            direct_writes_started = True
 
     if values.owner is not None:
-        _begin_phase1()
+        _begin_direct_writes()
         hooks.cli_print(f"Setting device owner to {values.owner}")
         target_node.setOwner(long_name=values.owner)
         time.sleep(CONFIG_APPLY_DELAY_SECONDS)
 
     if values.owner_short is not None:
-        _begin_phase1()
+        _begin_direct_writes()
         hooks.cli_print(f"Setting device owner short to {values.owner_short}")
         target_node.setOwner(long_name=None, short_name=values.owner_short)
         time.sleep(CONFIG_APPLY_DELAY_SECONDS)
 
     if values.location is not None:
-        _begin_phase1()
+        _begin_direct_writes()
         lat, lon, alt = values.location
         if values.altitude_specified:
             hooks.cli_print(f"Fixing altitude at {alt} meters")
@@ -1181,20 +1186,20 @@ def _apply_phase1_configuration(
         time.sleep(CONFIG_APPLY_DELAY_SECONDS)
 
     if values.canned_messages is not None:
-        _begin_phase1()
+        _begin_direct_writes()
         hooks.cli_print(f"Setting canned message messages to {values.canned_messages}")
         target_node.set_canned_message(values.canned_messages)
         time.sleep(CONFIG_APPLY_DELAY_SECONDS)
 
     if values.ringtone is not None:
-        _begin_phase1()
+        _begin_direct_writes()
         hooks.cli_print(f"Setting ringtone to {values.ringtone}")
         target_node.set_ringtone(values.ringtone)
         time.sleep(CONFIG_APPLY_DELAY_SECONDS)
 
     seturl_executed = False
     if values.channel_url is not None:
-        _begin_phase1()
+        _begin_direct_writes()
         if values.channel_url_key is None:
             raise AssertionError("normalized channel URL is missing its source key")
         seturl_executed = _apply_configure_channel_url(
@@ -1204,8 +1209,8 @@ def _apply_phase1_configuration(
             config_key=values.channel_url_key,
         )
 
-    if phase1_started:
-        hooks.cli_print("Phase 1 complete.")
+    if direct_writes_started:
+        hooks.cli_print("Direct configuration values applied.")
     return seturl_executed
 
 
@@ -1230,7 +1235,7 @@ def _apply_settings_transaction(
         Validated LocalModuleConfig sections.
     """
     hooks.cli_print(
-        "Phase 2: Applying configuration transaction (may trigger device reboot)..."
+        "Applying configuration transaction (may trigger device reboot)..."
     )
     target_node.beginSettingsTransaction()
     remaining_writes = len(config_sections) + len(module_config_sections)
@@ -1326,9 +1331,9 @@ def _report_configure_result(
     is_local_target : bool
         Whether *destination* resolves to the directly connected node.
     settings_transaction_started : bool
-        Whether Phase 2 ran and therefore may have triggered a reboot.
+        Whether the settings transaction ran and therefore may have triggered a reboot.
     seturl_executed : bool
-        Whether Phase 1 actually wrote a channel URL.
+        Whether direct writes actually wrote a channel URL.
     channel_url : str | None
         Normalized requested channel URL for verification.
     config_sections : dict[str, dict[str, Any]]
@@ -1402,8 +1407,8 @@ def _handle_configure_command(
     Returns
     -------
     _ConfigureCommandResult
-        Named lifecycle flags describing whether Phase 2 opened a transaction
-        and whether a local Phase-1 channel URL write was actually performed.
+        Named lifecycle flags describing whether a settings transaction ran and whether
+        a local channel URL write was actually performed.
     """
     prepared = _load_and_validate_configure_document(hooks, args.configure[0])
     target_node = interface.getNode(args.dest, False, **get_node_kwargs)
@@ -1419,7 +1424,7 @@ def _handle_configure_command(
             config_sections=prepared.config_sections,
             module_config_sections=prepared.module_config_sections,
         )
-        if prepared.phase1.channel_url is not None and not is_local_target:
+        if prepared.direct_values.channel_url is not None and not is_local_target:
             _terminate_cli(
                 hooks.cli_exit,
                 "ERROR: Combining channel_url with additional configuration writes "
@@ -1427,7 +1432,7 @@ def _handle_configure_command(
                 "configuration in separate operations.",
             )
 
-    seturl_executed = _apply_phase1_configuration(hooks, target_node, prepared)
+    seturl_executed = _apply_direct_configuration(hooks, target_node, prepared)
     if seturl_executed and has_config_writes and is_local_target:
         if not hooks.post_seturl_stability_check(
             interface, timeout=SETURL_STABILITY_TIMEOUT_SECONDS
@@ -1435,7 +1440,8 @@ def _handle_configure_command(
             _terminate_cli(
                 hooks.cli_exit,
                 "ERROR: channel_url applied, but transport did not stabilize for "
-                "additional configuration writes; aborting before Phase 2.",
+                "additional configuration writes; aborting before the configuration "
+                "transaction.",
             )
 
     settings_transaction_started = has_config_writes
@@ -1454,13 +1460,13 @@ def _handle_configure_command(
         is_local_target=is_local_target,
         settings_transaction_started=settings_transaction_started,
         seturl_executed=seturl_executed,
-        channel_url=prepared.phase1.channel_url,
+        channel_url=prepared.direct_values.channel_url,
         config_sections=prepared.config_sections,
         module_config_sections=prepared.module_config_sections,
     )
     return _ConfigureCommandResult(
         settings_transaction_started=settings_transaction_started,
-        phase1_channel_url_applied=seturl_executed and is_local_target,
+        local_channel_url_applied=seturl_executed and is_local_target,
     )
 
 
@@ -1488,14 +1494,14 @@ def _handle_configure_actions(
     if args.configure:
         outcome.close_now = True
         outcome.wait_for_ack_nak = True
-        settings_transaction_started, phase1_channel_url_applied = (
+        settings_transaction_started, local_channel_url_applied = (
             hooks.handle_configure_command(
                 context.interface,
                 args,
                 context.get_node_kwargs,
             )
         )
-        if settings_transaction_started or phase1_channel_url_applied:
+        if settings_transaction_started or local_channel_url_applied:
             outcome.wait_for_ack_nak = False
             outcome.skip_ack_wait = True
 

--- a/meshtastic/cli/configure_actions.py
+++ b/meshtastic/cli/configure_actions.py
@@ -14,13 +14,12 @@ import logging
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, NoReturn
+from typing import Any, NamedTuple
 
 import yaml
 
 import meshtastic.util
-from meshtastic._core_constants import BROADCAST_ADDR
-from meshtastic.cli.context import CliContext
+from meshtastic.cli.context import CliContext, CliExit
 from meshtastic.configure_verify import (
     _verify_channel_url_against_state,
     _verify_requested_fields,
@@ -34,7 +33,15 @@ CONFIG_WRITE_PACE_SECONDS = 0.1
 CONFIG_SETURL_DELAY_SECONDS = 2.0
 CONFIG_COMMIT_SETTLE_SECONDS = 1.0
 CONFIG_RECONNECT_WAIT_SECONDS = 15.0
+CONFIG_DISCONNECT_WINDOW_SECONDS = 2.0
+CONFIG_POLL_INTERVAL_SECONDS = 0.2
 SETURL_STABILITY_TIMEOUT_SECONDS = 30.0
+SETURL_STABILITY_MAX_ATTEMPTS = 3
+SETURL_STABILITY_WINDOW_SECONDS = 1.5
+SETURL_RECONNECT_WAIT_SECONDS = 10.0
+SETURL_STABILITY_POLL_SECONDS = 0.1
+POSITION_ALTITUDE_MIN = -(1 << 31)
+POSITION_ALTITUDE_MAX = (1 << 31) - 1
 CONFIGURE_PHASE1_HEADER = (
     "Phase 1: Applying direct configuration "
     "(channel URL updates may trigger reconnect/reboot)..."
@@ -64,14 +71,70 @@ class ConfigureReconnectResult(enum.Enum):
     VERIFIED = "verified"
 
 
+class _ConfigureCommandResult(NamedTuple):
+    """Outcome flags returned by one ``--configure`` execution."""
+
+    settings_transaction_started: bool
+    phase1_channel_url_applied: bool
+
+
+@dataclass(frozen=True, slots=True)
+class _Phase1ConfigureValues:
+    """Validated direct-write values that are safe to apply in Phase 1.
+
+    Attributes
+    ----------
+    owner : str | None
+        Normalized long owner name when requested.
+    owner_short : str | None
+        Normalized short owner name when requested.
+    location : tuple[float, float, int] | None
+        Validated latitude, longitude, and altitude when requested.
+    canned_messages : str | None
+        Canned-message payload when requested.
+    ringtone : str | None
+        Ringtone payload when requested.
+    channel_url : str | None
+        Stripped channel URL when requested.
+    """
+
+    owner: str | None = None
+    owner_short: str | None = None
+    location: tuple[float, float, int] | None = None
+    canned_messages: str | None = None
+    ringtone: str | None = None
+    channel_url: str | None = None
+
+
+class _PreparedConfigureDocument(NamedTuple):
+    """Validated YAML document and normalized values ready for device access.
+
+    Attributes
+    ----------
+    configuration : dict[str, Any]
+        Validated top-level YAML mapping.
+    phase1 : _Phase1ConfigureValues
+        Normalized direct-write values.
+    config_sections : dict[str, dict[str, Any]]
+        Validated LocalConfig section mappings.
+    module_config_sections : dict[str, dict[str, Any]]
+        Validated LocalModuleConfig section mappings.
+    """
+
+    configuration: dict[str, Any]
+    phase1: _Phase1ConfigureValues
+    config_sections: dict[str, dict[str, Any]]
+    module_config_sections: dict[str, dict[str, Any]]
+
+
 @dataclass(frozen=True, slots=True)
 class ConfigureHooks:
     """Entrypoint-owned dependencies used by configure execution.
 
     Parameters
     ----------
-    cli_exit : Callable[[str, int], NoReturn]
-        User-facing exit handler.
+    cli_exit : CliExit
+        User-facing exit handler with an optional status code.
     cli_print : Callable[[str], None]
         Quiet-aware reporter.
     traverse_config : Callable[..., bool]
@@ -80,9 +143,17 @@ class ConfigureHooks:
         Context flag shared with preference assignment output suppression.
     is_local_destination : Callable[[Any, str], bool]
         Destination classifier.
+    post_seturl_stability_check : Callable[..., bool]
+        Transport-stability verifier used after a local channel URL write.
+    post_configure_reconnect_and_verify : Callable[..., ConfigureReconnectResult]
+        Reconnect and value-verification helper used after transaction commit.
+    channel_url_matches_current_device_state : Callable[[Any, str], bool]
+        Comparator used to skip redundant channel URL writes.
+    pace_configure_write : Callable[..., None]
+        Inter-write pacing hook used while applying a transaction.
     """
 
-    cli_exit: Callable[[str, int], NoReturn]
+    cli_exit: CliExit
     cli_print: Callable[[str], None]
     traverse_config: Callable[..., bool]
     preflight_mode: contextvars.ContextVar[bool]
@@ -102,8 +173,9 @@ class ConfigureActionHooks:
         [MeshInterface, Any, dict[str, Any]], tuple[bool, bool]
     ]
     export_config: Callable[[MeshInterface], str]
-    cli_exit: Callable[[str, int], NoReturn]
+    cli_exit: CliExit
     cli_print: Callable[[str], None]
+    is_local_destination: Callable[[Any, str], bool]
 
 
 def _post_configure_reconnect_and_verify(
@@ -133,7 +205,7 @@ def _post_configure_reconnect_and_verify(
     """
     deadline = time.monotonic() + timeout
 
-    disconnect_window = 2.0
+    disconnect_window = CONFIG_DISCONNECT_WINDOW_SECONDS
     logger.debug(
         "Waiting up to %.1fs for device disconnect (reboot indication)...",
         disconnect_window,
@@ -145,7 +217,7 @@ def _post_configure_reconnect_and_verify(
             disconnected = True
             logger.info("Device disconnected (reboot indication received).")
             break
-        time.sleep(0.2)
+        time.sleep(CONFIG_POLL_INTERVAL_SECONDS)
 
     if not disconnected:
         logger.debug(
@@ -163,7 +235,7 @@ def _post_configure_reconnect_and_verify(
         if interface.isConnected.is_set():
             logger.info("Device reconnected.")
             break
-        time.sleep(0.2)
+        time.sleep(CONFIG_POLL_INTERVAL_SECONDS)
 
     if not interface.isConnected.is_set():
         logger.warning(
@@ -231,12 +303,23 @@ def _post_configure_reconnect_and_verify(
 def _post_seturl_stability_check(
     interface: MeshInterface,
     *,
-    timeout: float = 15.0,
+    timeout: float = SETURL_STABILITY_TIMEOUT_SECONDS,
 ) -> bool:
-    _MAX_STABILITY_ATTEMPTS = 3
-    _STABILITY_WINDOW_SECONDS = 1.5
-    _RECONNECT_WAIT_SECONDS = 10.0
+    """Confirm that the transport stabilizes after a local ``setURL`` write.
 
+    Parameters
+    ----------
+    interface : MeshInterface
+        Connected interface whose transport and config reload are observed.
+    timeout : float
+        Total reconnect/stability budget in seconds.
+
+    Returns
+    -------
+    bool
+        ``True`` when the transport remains connected through a stability window
+        and ``waitForConfig()`` succeeds; otherwise ``False``.
+    """
     deadline = time.monotonic() + timeout
 
     is_connected_event = getattr(interface, "isConnected", None)
@@ -277,7 +360,7 @@ def _post_seturl_stability_check(
                 )
         return _event_is_set()
 
-    for _attempt in range(_MAX_STABILITY_ATTEMPTS):
+    for _attempt in range(SETURL_STABILITY_MAX_ATTEMPTS):
         if time.monotonic() >= deadline:
             return False
 
@@ -285,29 +368,29 @@ def _post_seturl_stability_check(
             _trigger_reconnect()
             remaining = deadline - time.monotonic()
             if remaining > 0:
-                _event_wait(min(_RECONNECT_WAIT_SECONDS, remaining))
+                _event_wait(min(SETURL_RECONNECT_WAIT_SECONDS, remaining))
 
         if not _event_is_set():
             logger.warning(
                 "Transport not connected after setURL (attempt %d/%d)",
                 _attempt + 1,
-                _MAX_STABILITY_ATTEMPTS,
+                SETURL_STABILITY_MAX_ATTEMPTS,
             )
             continue
 
-        stability_end = time.monotonic() + _STABILITY_WINDOW_SECONDS
+        stability_end = time.monotonic() + SETURL_STABILITY_WINDOW_SECONDS
         stable = True
         while time.monotonic() < stability_end:
             if not _event_is_set():
                 stable = False
                 break
-            time.sleep(0.1)
+            time.sleep(SETURL_STABILITY_POLL_SECONDS)
 
         if not stable:
             logger.warning(
                 "Transport dropped during stability window (attempt %d/%d)",
                 _attempt + 1,
-                _MAX_STABILITY_ATTEMPTS,
+                SETURL_STABILITY_MAX_ATTEMPTS,
             )
             continue
 
@@ -318,7 +401,7 @@ def _post_seturl_stability_check(
             logger.warning(
                 "Config reload failed after setURL (attempt %d/%d)",
                 _attempt + 1,
-                _MAX_STABILITY_ATTEMPTS,
+                SETURL_STABILITY_MAX_ATTEMPTS,
                 exc_info=True,
             )
             continue
@@ -326,7 +409,7 @@ def _post_seturl_stability_check(
     return False
 
 
-def _validate_non_empty_mapping_sections(
+def _validate_mapping_sections(
     hooks: ConfigureHooks,
     *,
     top_level_key: str,
@@ -334,14 +417,27 @@ def _validate_non_empty_mapping_sections(
 ) -> dict[str, dict[str, Any]]:
     """Validate that each section payload is a mapping.
 
-    Empty mappings (e.g., ``audio: {}``) are allowed — they represent
-    protobuf default values and are emitted by ``--export-config``.
+    Parameters
+    ----------
+    hooks : ConfigureHooks
+        CLI exit/reporting hooks used for validation failures.
+    top_level_key : str
+        Parent YAML key used to build diagnostics.
+    section_mapping : dict[str, Any]
+        Section names and their raw YAML payloads.
+
+    Returns
+    -------
+    dict[str, dict[str, Any]]
+        The same section mapping narrowed to mapping-valued payloads. Empty
+        mappings (for example ``audio: {}``) are valid because exports use them
+        to represent protobuf default values.
     """
     validated_sections: dict[str, dict[str, Any]] = {}
     for section_name, section_value in section_mapping.items():
         if not isinstance(section_value, dict):
             hooks.cli_exit(
-                f"ERROR: '{top_level_key}.{section_name}' must be a non-empty mapping, got "
+                f"ERROR: '{top_level_key}.{section_name}' must be a mapping, got "
                 f"{type(section_value).__name__}"
             )
         validated_sections[section_name] = section_value
@@ -429,8 +525,7 @@ def _refresh_no_disconnect_verify_state(
             request_config(field_desc)
 
     if verify_channel_url:
-        target_node.channels = None
-        target_node.partialChannels = []
+        target_node._invalidate_channel_cache()  # noqa: SLF001 - Node cache owner API
         request_channels = getattr(target_node, "requestChannels", None)
         if callable(request_channels):
             request_channels(0)
@@ -475,6 +570,24 @@ def _verify_config_sections(
     label: str,
     verified_fields: list[str] | None = None,
 ) -> bool:
+    """Verify requested configuration sections against a reloaded protobuf.
+
+    Parameters
+    ----------
+    config_fields : dict[str, dict[str, Any]]
+        Requested section/value mappings from the configure document.
+    proto_config : Any
+        Reloaded protobuf configuration root.
+    label : str
+        Human-readable label used in diagnostics.
+    verified_fields : list[str] | None
+        Optional list mutated in place with verified dotted leaf paths.
+
+    Returns
+    -------
+    bool
+        ``True`` only when every requested section and field matches.
+    """
     for section_name, yaml_values in config_fields.items():
         section_snake = meshtastic.util.camel_to_snake(section_name)
         if not proto_config.HasField(section_snake):
@@ -515,6 +628,28 @@ def _verify_post_reconnect_config(
         _verify_channel_url_against_state
     ),
 ) -> ConfigureReconnectResult:
+    """Verify requested values after reconnect/config reload.
+
+    Parameters
+    ----------
+    interface : MeshInterface
+        Reconnected interface containing refreshed device state.
+    node_dest : str
+        Destination whose configuration is verified.
+    verify_channel_url : str | None
+        Normalized channel URL expected after reload.
+    verify_config_fields : dict[str, dict[str, Any]] | None
+        Requested local-config sections/fields to compare.
+    verify_module_config_fields : dict[str, dict[str, Any]] | None
+        Requested module-config sections/fields to compare.
+    verify_channel_url_against_state : Callable[..., bool]
+        Channel-state comparison seam.
+
+    Returns
+    -------
+    ConfigureReconnectResult
+        ``VERIFIED`` on a complete match, otherwise ``VERIFICATION_INCOMPLETE``.
+    """
     if not interface.isConnected.is_set():
         logger.warning("Post-reconnect verification skipped: transport disconnected.")
         return ConfigureReconnectResult.VERIFICATION_INCOMPLETE
@@ -606,16 +741,221 @@ def _apply_configure_channel_url(
     return True
 
 
-def _handle_configure_command(
+def _close_failed_settings_transaction(
     hooks: ConfigureHooks,
-    interface: MeshInterface,
-    args: Any,
-    getNode_kwargs: dict[str, Any],
-) -> tuple[bool, bool]:
+    target_node: Any,
+    *,
+    commit_attempted: bool,
+) -> None:
+    """Best-effort close an open settings transaction after Phase 2 failure.
+
+    Parameters
+    ----------
+    hooks : ConfigureHooks
+        CLI reporting hooks used to surface partial-application risk.
+    target_node : Any
+        Node whose settings transaction was opened.
+    commit_attempted : bool
+        Whether the normal commit call was already attempted.
+
+    Notes
+    -----
+    Firmware exposes begin/commit but no rollback/cancel operation. When Phase 2
+    fails before commit is attempted, committing is the only available way to
+    close the transaction; writes already accepted may therefore be applied. If
+    the normal commit itself failed, final device-side state is unknown and a
+    second commit is intentionally not sent.
+    """
+    if commit_attempted:
+        message = (
+            "Settings transaction commit failed; device transaction state is unknown "
+            "and configuration may be partially applied."
+        )
+        logger.warning(message)
+        hooks.cli_print(f"WARNING: {message}")
+        return
+
+    message = (
+        "Configuration failed during Phase 2; attempting to close the settings "
+        "transaction. Any writes already accepted may be committed."
+    )
+    logger.warning(message)
+    hooks.cli_print(f"WARNING: {message}")
     try:
-        with open(args.configure[0], encoding="utf8") as file:
+        target_node.commitSettingsTransaction()
+    except Exception:
+        logger.warning(
+            "Failed to close settings transaction after configure failure; "
+            "device transaction may remain open.",
+            exc_info=True,
+        )
+        hooks.cli_print(
+            "WARNING: Could not close the failed settings transaction; the device "
+            "may still have an open transaction."
+        )
+
+
+def _validate_phase1_configuration(
+    hooks: ConfigureHooks,
+    configuration: dict[str, Any],
+) -> _Phase1ConfigureValues:
+    """Validate and normalize every deterministic Phase-1 input before writes.
+
+    Parameters
+    ----------
+    hooks : ConfigureHooks
+        CLI reporting and exit hooks.
+    configuration : dict[str, Any]
+        Parsed top-level YAML mapping.
+
+    Returns
+    -------
+    _Phase1ConfigureValues
+        Normalized values for all present direct-write actions. Missing actions
+        remain ``None``.
+
+    Notes
+    -----
+    Validation is intentionally completed before any device mutation. This
+    prevents a later malformed direct-write value from leaving an avoidable
+    partially applied Phase-1 configuration.
+    """
+    owner: str | None = None
+    if "owner" in configuration:
+        raw_owner = configuration["owner"]
+        owner = "" if raw_owner is None else str(raw_owner).strip()
+        if not owner:
+            hooks.cli_exit(
+                "ERROR: Long Name cannot be empty or contain only whitespace characters"
+            )
+
+    owner_short: str | None = None
+    owner_short_key = (
+        "owner_short" if "owner_short" in configuration else "ownerShort"
+    )
+    if owner_short_key in configuration:
+        raw_owner_short = configuration[owner_short_key]
+        owner_short = (
+            "" if raw_owner_short is None else str(raw_owner_short).strip()
+        )
+        if not owner_short:
+            hooks.cli_exit(
+                "ERROR: Short Name cannot be empty or contain only whitespace characters"
+            )
+
+    location_values: tuple[float, float, int] | None = None
+    if "location" in configuration:
+        location = configuration["location"]
+        if not isinstance(location, dict) or not location:
+            hooks.cli_exit(
+                "location must be a non-empty mapping with lat, lon, and optional alt"
+            )
+        unknown_location_keys = set(location) - {"lat", "lon", "alt"}
+        if unknown_location_keys:
+            hooks.cli_exit(
+                "location contains unknown keys: "
+                f"{', '.join(sorted(unknown_location_keys))}. Allowed: lat, lon, alt"
+            )
+        if "lat" not in location or "lon" not in location:
+            hooks.cli_exit("location requires both lat and lon")
+        if isinstance(location["lat"], bool):
+            hooks.cli_exit(
+                f"location.lat must be a number, got: {location['lat']!r}"
+            )
+        try:
+            lat = float(location["lat"])
+        except (ValueError, TypeError):
+            hooks.cli_exit(
+                f"location.lat must be a number, got: {location['lat']!r}"
+            )
+        if isinstance(location["lon"], bool):
+            hooks.cli_exit(
+                f"location.lon must be a number, got: {location['lon']!r}"
+            )
+        try:
+            lon = float(location["lon"])
+        except (ValueError, TypeError):
+            hooks.cli_exit(
+                f"location.lon must be a number, got: {location['lon']!r}"
+            )
+        if not -90.0 <= lat <= 90.0:
+            hooks.cli_exit(f"location.lat must be between -90 and 90, got: {lat}")
+        if not -180.0 <= lon <= 180.0:
+            hooks.cli_exit(f"location.lon must be between -180 and 180, got: {lon}")
+        alt = 0
+        if "alt" in location:
+            if isinstance(location["alt"], bool):
+                hooks.cli_exit(
+                    f"location.alt must be an integer, got: {location['alt']!r}"
+                )
+            try:
+                alt = int(location["alt"])
+            except (ValueError, TypeError):
+                hooks.cli_exit(
+                    f"location.alt must be an integer, got: {location['alt']!r}"
+                )
+            if not POSITION_ALTITUDE_MIN <= alt <= POSITION_ALTITUDE_MAX:
+                hooks.cli_exit(
+                    "location.alt must fit the signed 32-bit position field, "
+                    f"got: {alt}"
+                )
+        location_values = (lat, lon, alt)
+
+    def _optional_string(key: str) -> str | None:
+        if key not in configuration:
+            return None
+        value = configuration[key]
+        if not isinstance(value, str):
+            hooks.cli_exit(f"ERROR: {key} must be a string.")
+        return value
+
+    channel_url_key = (
+        "channel_url" if "channel_url" in configuration else "channelUrl"
+    )
+    channel_url: str | None = None
+    if channel_url_key in configuration:
+        raw_channel_url = configuration[channel_url_key]
+        if not isinstance(raw_channel_url, str):
+            hooks.cli_exit(f"ERROR: {channel_url_key} must be a string.")
+        channel_url = raw_channel_url.strip()
+        if not channel_url:
+            hooks.cli_exit(f"ERROR: {channel_url_key} must not be blank.")
+
+    return _Phase1ConfigureValues(
+        owner=owner,
+        owner_short=owner_short,
+        location=location_values,
+        canned_messages=_optional_string("canned_messages"),
+        ringtone=_optional_string("ringtone"),
+        channel_url=channel_url,
+    )
+
+
+def _load_and_validate_configure_document(
+    hooks: ConfigureHooks,
+    path: str,
+) -> _PreparedConfigureDocument:
+    """Load, structurally validate, and normalize one configure YAML document.
+
+    Parameters
+    ----------
+    hooks : ConfigureHooks
+        CLI reporting and validation hooks.
+    path : str
+        YAML document path.
+
+    Returns
+    -------
+    _PreparedConfigureDocument
+        Validated top-level mapping, normalized direct-write values, and narrowed
+        config/module-config section mappings.
+    """
+    try:
+        with open(path, encoding="utf8") as file:
             raw_text = file.read()
         configuration = yaml.safe_load(raw_text)
+    except OSError as exc:
+        hooks.cli_exit(f"ERROR: Failed to read configuration file: {exc}")
     except (yaml.YAMLError, UnicodeDecodeError) as exc:
         hooks.cli_exit(f"ERROR: Failed to parse YAML configuration: {exc}")
 
@@ -623,137 +963,113 @@ def _handle_configure_command(
         hooks.cli_exit("ERROR: YAML configuration file is empty")
     if not isinstance(configuration, dict):
         hooks.cli_exit(
-            f"ERROR: YAML configuration must be a mapping/dictionary, got {type(configuration).__name__}"
+            "ERROR: YAML configuration must be a mapping/dictionary, got "
+            f"{type(configuration).__name__}"
         )
     if not configuration:
         hooks.cli_exit("ERROR: Configuration file is empty; nothing to configure.")
-    _unknown_keys = set(configuration.keys()) - ALLOWED_CONFIGURE_KEYS
-    if _unknown_keys:
-        hooks.cli_exit(
-            f"ERROR: Unknown top-level key(s) in YAML: {', '.join(sorted(_unknown_keys))}"
-        )
 
+    unknown_keys = set(configuration) - ALLOWED_CONFIGURE_KEYS
+    if unknown_keys:
+        hooks.cli_exit(
+            f"ERROR: Unknown top-level key(s) in YAML: {', '.join(sorted(unknown_keys))}"
+        )
     if "channel_url" in configuration and "channelUrl" in configuration:
         hooks.cli_exit(
-            "ERROR: Cannot specify both 'channel_url' and 'channelUrl' in the same configuration file; use one."
+            "ERROR: Cannot specify both 'channel_url' and 'channelUrl' in the same "
+            "configuration file; use one."
         )
     if "owner_short" in configuration and "ownerShort" in configuration:
         hooks.cli_exit(
-            "ERROR: Cannot specify both 'owner_short' and 'ownerShort' in the same configuration file; use one."
+            "ERROR: Cannot specify both 'owner_short' and 'ownerShort' in the same "
+            "configuration file; use one."
         )
 
-    # Pre-validate config/module_config shapes before any Phase-1 mutations.
-    validated_config_sections: dict[str, dict[str, Any]] = {}
-    validated_module_config_sections: dict[str, dict[str, Any]] = {}
+    phase1_values = _validate_phase1_configuration(hooks, configuration)
+
+    config_sections: dict[str, dict[str, Any]] = {}
     if "config" in configuration:
-        _cfg_val = configuration["config"]
-        if not isinstance(_cfg_val, dict) or not _cfg_val:
+        config_value = configuration["config"]
+        if not isinstance(config_value, dict) or not config_value:
             hooks.cli_exit(
-                f"ERROR: 'config' must be a non-empty mapping, got "
-                f"{type(_cfg_val).__name__}{' (empty)' if isinstance(_cfg_val, dict) else ''}"
+                "ERROR: 'config' must be a non-empty mapping, got "
+                f"{type(config_value).__name__}"
+                f"{' (empty)' if isinstance(config_value, dict) else ''}"
             )
-        validated_config_sections = _validate_non_empty_mapping_sections(
-            hooks,
-            top_level_key="config",
-            section_mapping=_cfg_val,
+        config_sections = _validate_mapping_sections(
+            hooks, top_level_key="config", section_mapping=config_value
         )
+
+    module_config_sections: dict[str, dict[str, Any]] = {}
     if "module_config" in configuration:
-        _mcfg_val = configuration["module_config"]
-        if not isinstance(_mcfg_val, dict) or not _mcfg_val:
+        module_config_value = configuration["module_config"]
+        if not isinstance(module_config_value, dict) or not module_config_value:
             hooks.cli_exit(
-                f"ERROR: 'module_config' must be a non-empty mapping, got "
-                f"{type(_mcfg_val).__name__}{' (empty)' if isinstance(_mcfg_val, dict) else ''}"
+                "ERROR: 'module_config' must be a non-empty mapping, got "
+                f"{type(module_config_value).__name__}"
+                f"{' (empty)' if isinstance(module_config_value, dict) else ''}"
             )
-        validated_module_config_sections = _validate_non_empty_mapping_sections(
+        module_config_sections = _validate_mapping_sections(
             hooks,
             top_level_key="module_config",
-            section_mapping=_mcfg_val,
+            section_mapping=module_config_value,
         )
 
-    target_node = interface.getNode(args.dest, False, **getNode_kwargs)
-    if validated_config_sections or validated_module_config_sections:
-        _preflight_configure_sections(
-            hooks,
-            target_node,
-            config_sections=validated_config_sections,
-            module_config_sections=validated_module_config_sections,
-        )
+    return _PreparedConfigureDocument(
+        configuration=configuration,
+        phase1=phase1_values,
+        config_sections=config_sections,
+        module_config_sections=module_config_sections,
+    )
 
+
+def _apply_phase1_configuration(
+    hooks: ConfigureHooks,
+    target_node: Any,
+    prepared: _PreparedConfigureDocument,
+) -> bool:
+    """Apply validated direct-write values in historical Phase-1 order.
+
+    Parameters
+    ----------
+    hooks : ConfigureHooks
+        CLI reporting and channel-URL hooks.
+    target_node : Any
+        Node receiving the direct writes.
+    prepared : _PreparedConfigureDocument
+        Fully validated configure document.
+
+    Returns
+    -------
+    bool
+        ``True`` only when a channel URL write was actually sent.
+    """
+    configuration = prepared.configuration
+    values = prepared.phase1
     phase1_started = False
-    phase1_may_reconnect = False
-    seturl_executed = False
 
-    if "owner" in configuration:
+    def _begin_phase1() -> None:
+        nonlocal phase1_started
         if not phase1_started:
             hooks.cli_print(CONFIGURE_PHASE1_HEADER)
             phase1_started = True
-        owner_name = str(configuration["owner"]).strip()
-        if not owner_name:
-            hooks.cli_exit(
-                "ERROR: Long Name cannot be empty or contain only whitespace characters"
-            )
-        hooks.cli_print(f"Setting device owner to {owner_name}")
-        target_node.setOwner(long_name=owner_name)
+
+    if values.owner is not None:
+        _begin_phase1()
+        hooks.cli_print(f"Setting device owner to {values.owner}")
+        target_node.setOwner(long_name=values.owner)
         time.sleep(CONFIG_APPLY_DELAY_SECONDS)
 
-    if "owner_short" in configuration:
-        if not phase1_started:
-            hooks.cli_print(CONFIGURE_PHASE1_HEADER)
-            phase1_started = True
-        owner_short_name = str(configuration["owner_short"]).strip()
-        if not owner_short_name:
-            hooks.cli_exit(
-                "ERROR: Short Name cannot be empty or contain only whitespace characters"
-            )
-        hooks.cli_print(f"Setting device owner short to {owner_short_name}")
-        target_node.setOwner(long_name=None, short_name=owner_short_name)
+    if values.owner_short is not None:
+        _begin_phase1()
+        hooks.cli_print(f"Setting device owner short to {values.owner_short}")
+        target_node.setOwner(long_name=None, short_name=values.owner_short)
         time.sleep(CONFIG_APPLY_DELAY_SECONDS)
 
-    if "ownerShort" in configuration:
-        if not phase1_started:
-            hooks.cli_print(CONFIGURE_PHASE1_HEADER)
-            phase1_started = True
-        owner_short_name = str(configuration["ownerShort"]).strip()
-        if not owner_short_name:
-            hooks.cli_exit(
-                "ERROR: Short Name cannot be empty or contain only whitespace characters"
-            )
-        hooks.cli_print(f"Setting device owner short to {owner_short_name}")
-        target_node.setOwner(long_name=None, short_name=owner_short_name)
-        time.sleep(CONFIG_APPLY_DELAY_SECONDS)
-
-    if "location" in configuration:
-        if not phase1_started:
-            hooks.cli_print(CONFIGURE_PHASE1_HEADER)
-            phase1_started = True
-        _loc = configuration["location"]
-        if not isinstance(_loc, dict) or not _loc:
-            hooks.cli_exit(
-                "location must be a non-empty mapping with lat, lon, and optional alt"
-            )
-        _allowed_loc_keys = {"lat", "lon", "alt"}
-        _unknown_loc_keys = set(_loc.keys()) - _allowed_loc_keys
-        if _unknown_loc_keys:
-            hooks.cli_exit(
-                f"location contains unknown keys: {', '.join(sorted(_unknown_loc_keys))}. "
-                f"Allowed: lat, lon, alt"
-            )
-        if "lat" not in _loc or "lon" not in _loc:
-            hooks.cli_exit("location requires both lat and lon")
-        try:
-            lat = float(_loc["lat"])
-        except (ValueError, TypeError):
-            hooks.cli_exit(f"location.lat must be a number, got: {_loc['lat']!r}")
-        try:
-            lon = float(_loc["lon"])
-        except (ValueError, TypeError):
-            hooks.cli_exit(f"location.lon must be a number, got: {_loc['lon']!r}")
-        alt = 0
-        if "alt" in _loc:
-            try:
-                alt = int(_loc["alt"])
-            except (ValueError, TypeError):
-                hooks.cli_exit(f"location.alt must be an integer, got: {_loc['alt']!r}")
+    if values.location is not None:
+        _begin_phase1()
+        lat, lon, alt = values.location
+        if "alt" in configuration["location"]:
             hooks.cli_print(f"Fixing altitude at {alt} meters")
         hooks.cli_print(f"Fixing latitude at {lat} degrees")
         hooks.cli_print(f"Fixing longitude at {lon} degrees")
@@ -761,180 +1077,273 @@ def _handle_configure_command(
         target_node.setFixedPosition(lat, lon, alt)
         time.sleep(CONFIG_APPLY_DELAY_SECONDS)
 
-    if "canned_messages" in configuration:
-        if not phase1_started:
-            hooks.cli_print(CONFIGURE_PHASE1_HEADER)
-            phase1_started = True
-        hooks.cli_print(
-            f"Setting canned message messages to {configuration['canned_messages']}",
-        )
-        target_node.set_canned_message(configuration["canned_messages"])
+    if values.canned_messages is not None:
+        _begin_phase1()
+        hooks.cli_print(f"Setting canned message messages to {values.canned_messages}")
+        target_node.set_canned_message(values.canned_messages)
         time.sleep(CONFIG_APPLY_DELAY_SECONDS)
 
-    if "ringtone" in configuration:
-        if not phase1_started:
-            hooks.cli_print(CONFIGURE_PHASE1_HEADER)
-            phase1_started = True
-        hooks.cli_print(f"Setting ringtone to {configuration['ringtone']}")
-        target_node.set_ringtone(configuration["ringtone"])
+    if values.ringtone is not None:
+        _begin_phase1()
+        hooks.cli_print(f"Setting ringtone to {values.ringtone}")
+        target_node.set_ringtone(values.ringtone)
         time.sleep(CONFIG_APPLY_DELAY_SECONDS)
 
-    channel_url_key = "channel_url" if "channel_url" in configuration else "channelUrl"
-    if channel_url_key in configuration:
-        if not phase1_started:
-            hooks.cli_print(CONFIGURE_PHASE1_HEADER)
-            phase1_started = True
+    seturl_executed = False
+    if values.channel_url is not None:
+        _begin_phase1()
         seturl_executed = _apply_configure_channel_url(
             hooks,
             target_node,
-            configuration[channel_url_key],
-            config_key=channel_url_key,
+            values.channel_url,
+            config_key=(
+                "channel_url" if "channel_url" in configuration else "channelUrl"
+            ),
         )
-        phase1_may_reconnect = seturl_executed
 
     if phase1_started:
         hooks.cli_print("Phase 1 complete.")
+    return seturl_executed
 
-    settings_transaction_started = False
-    has_valid_config_section = bool(
-        validated_config_sections or validated_module_config_sections
+
+def _apply_settings_transaction(
+    hooks: ConfigureHooks,
+    target_node: Any,
+    *,
+    config_sections: dict[str, dict[str, Any]],
+    module_config_sections: dict[str, dict[str, Any]],
+) -> None:
+    """Apply validated config sections inside one firmware settings transaction.
+
+    Parameters
+    ----------
+    hooks : ConfigureHooks
+        Traversal, pacing, and reporting hooks.
+    target_node : Any
+        Node receiving the configuration writes.
+    config_sections : dict[str, dict[str, Any]]
+        Validated LocalConfig sections.
+    module_config_sections : dict[str, dict[str, Any]]
+        Validated LocalModuleConfig sections.
+    """
+    hooks.cli_print(
+        "Phase 2: Applying configuration transaction (may trigger device reboot)..."
     )
-    if seturl_executed and has_valid_config_section:
-        if hooks.is_local_destination(interface, args.dest):
-            if not hooks.post_seturl_stability_check(
-                interface, timeout=SETURL_STABILITY_TIMEOUT_SECONDS
-            ):
-                hooks.cli_exit(
-                    "ERROR: channel_url applied, but transport did not stabilize "
-                    "for additional configuration writes; aborting before Phase 2."
-                )
-        else:
-            hooks.cli_exit(
-                "ERROR: Combining channel_url with additional configuration "
-                "writes is not supported for remote nodes. Apply channel_url "
-                "and configuration in separate operations."
+    target_node.beginSettingsTransaction()
+    remaining_writes = len(config_sections) + len(module_config_sections)
+    commit_attempted = False
+
+    def _apply_sections(
+        sections: dict[str, dict[str, Any]],
+        protobuf_root: Any,
+        label: str,
+    ) -> None:
+        nonlocal remaining_writes
+        for section, section_values in sections.items():
+            failed_fields: list[str] = []
+            applied = hooks.traverse_config(
+                section,
+                section_values,
+                protobuf_root,
+                failed_fields=failed_fields,
             )
-    if has_valid_config_section:
-        hooks.cli_print(
-            "Phase 2: Applying configuration transaction (may trigger device reboot)..."
+            if failed_fields:
+                logger.warning(
+                    "Skipped %d unknown field(s) in %s section %s: %s",
+                    len(failed_fields),
+                    label,
+                    section,
+                    ", ".join(repr(field) for field in failed_fields),
+                )
+            if not applied:
+                hooks.cli_exit(
+                    f"Failed to apply {label} section {section!r} due to structural errors."
+                )
+            target_node.writeConfig(meshtastic.util.camel_to_snake(section))
+            remaining_writes -= 1
+            hooks.pace_configure_write(remaining_writes)
+
+    try:
+        _apply_sections(config_sections, target_node.localConfig, "config")
+        _apply_sections(
+            module_config_sections,
+            target_node.moduleConfig,
+            "module_config",
         )
-        target_node.beginSettingsTransaction()
-        settings_transaction_started = True
-
-    remaining_config_writes = len(validated_config_sections) + len(
-        validated_module_config_sections
-    )
-
-    if validated_config_sections:
-        localConfig = target_node.localConfig
-        for section, section_values in validated_config_sections.items():
-            failed_config_fields: list[str] = []
-            applied = hooks.traverse_config(
-                section,
-                section_values,
-                localConfig,
-                failed_fields=failed_config_fields,
-            )
-            if failed_config_fields:
-                logger.warning(
-                    "Skipped %d unknown field(s) in config section %s: %s",
-                    len(failed_config_fields),
-                    section,
-                    ", ".join(repr(f) for f in failed_config_fields),
-                )
-            if not applied:
-                hooks.cli_exit(
-                    f"Failed to apply config section {section!r} due to structural errors."
-                )
-            target_node.writeConfig(meshtastic.util.camel_to_snake(section))
-            remaining_config_writes -= 1
-            hooks.pace_configure_write(remaining_config_writes)
-
-    if validated_module_config_sections:
-        moduleConfig = target_node.moduleConfig
-        for section, section_values in validated_module_config_sections.items():
-            failed_module_fields: list[str] = []
-            applied = hooks.traverse_config(
-                section,
-                section_values,
-                moduleConfig,
-                failed_fields=failed_module_fields,
-            )
-            if failed_module_fields:
-                logger.warning(
-                    "Skipped %d unknown field(s) in module_config section %s: %s",
-                    len(failed_module_fields),
-                    section,
-                    ", ".join(repr(f) for f in failed_module_fields),
-                )
-            if not applied:
-                hooks.cli_exit(
-                    f"Failed to apply module_config section {section!r} due to structural errors."
-                )
-            target_node.writeConfig(meshtastic.util.camel_to_snake(section))
-            remaining_config_writes -= 1
-            hooks.pace_configure_write(remaining_config_writes)
-
-    if settings_transaction_started:
+        commit_attempted = True
         target_node.commitSettingsTransaction()
-        time.sleep(CONFIG_COMMIT_SETTLE_SECONDS)
-        hooks.cli_print(
-            "Configuration transaction committed. Device may reboot to apply changes."
+    except BaseException:
+        _close_failed_settings_transaction(
+            hooks,
+            target_node,
+            commit_attempted=commit_attempted,
         )
+        raise
 
+    time.sleep(CONFIG_COMMIT_SETTLE_SECONDS)
+    hooks.cli_print(
+        "Configuration transaction committed. Device may reboot to apply changes."
+    )
+
+
+def _report_configure_result(
+    hooks: ConfigureHooks,
+    interface: MeshInterface,
+    *,
+    destination: str,
+    is_local_target: bool,
+    settings_transaction_started: bool,
+    seturl_executed: bool,
+    channel_url: str | None,
+    config_sections: dict[str, dict[str, Any]],
+    module_config_sections: dict[str, dict[str, Any]],
+) -> None:
+    """Report post-apply reconnect/verification status for one configure run.
+
+    Parameters
+    ----------
+    hooks : ConfigureHooks
+        Reconnect-verification and output hooks.
+    interface : MeshInterface
+        Connected interface whose post-apply state is observed.
+    destination : str
+        Configured node destination.
+    is_local_target : bool
+        Whether *destination* resolves to the directly connected node.
+    settings_transaction_started : bool
+        Whether Phase 2 ran and therefore may have triggered a reboot.
+    seturl_executed : bool
+        Whether Phase 1 actually wrote a channel URL.
+    channel_url : str | None
+        Normalized requested channel URL for verification.
+    config_sections : dict[str, dict[str, Any]]
+        LocalConfig fields requested by the document.
+    module_config_sections : dict[str, dict[str, Any]]
+        LocalModuleConfig fields requested by the document.
+    """
     if settings_transaction_started:
-        _verify_channel_url = configuration.get("channel_url") or configuration.get(
-            "channelUrl"
-        )
-        _verify_config_fields = validated_config_sections or None
-        _verify_module_config_fields = validated_module_config_sections or None
-        if hooks.is_local_destination(interface, args.dest):
-            _reconnect_result = hooks.post_configure_reconnect_and_verify(
+        if is_local_target:
+            reconnect_result = hooks.post_configure_reconnect_and_verify(
                 interface,
                 timeout=CONFIG_RECONNECT_WAIT_SECONDS,
-                node_dest=args.dest,
-                verify_channel_url=_verify_channel_url,
-                verify_config_fields=_verify_config_fields,
-                verify_module_config_fields=_verify_module_config_fields,
+                node_dest=destination,
+                verify_channel_url=channel_url,
+                verify_config_fields=config_sections or None,
+                verify_module_config_fields=module_config_sections or None,
             )
-            if _reconnect_result == ConfigureReconnectResult.VERIFIED:
-                hooks.cli_print(
+            messages = {
+                ConfigureReconnectResult.VERIFIED: (
                     "Phase 3: Device reconnected and config reloaded. All settings verified."
-                )
-            elif _reconnect_result == ConfigureReconnectResult.VERIFICATION_INCOMPLETE:
-                hooks.cli_print(
-                    "Phase 3: Device reconnected and config reloaded. "
-                    "Could not fully verify applied settings."
-                )
-            elif _reconnect_result == ConfigureReconnectResult.CONFIG_RELOAD_FAILED:
-                hooks.cli_print(
-                    "Phase 3: Device reconnected but config reload failed. "
-                    "Settings may still be applying."
-                )
-            elif _reconnect_result == ConfigureReconnectResult.RECONNECT_FAILED:
-                hooks.cli_print(
-                    "Phase 3: Device did not reconnect within timeout. "
-                    "Configuration may still be applying."
-                )
+                ),
+                ConfigureReconnectResult.VERIFICATION_INCOMPLETE: (
+                    "Phase 3: Device reconnected and config reloaded. Could not fully "
+                    "verify applied settings."
+                ),
+                ConfigureReconnectResult.CONFIG_RELOAD_FAILED: (
+                    "Phase 3: Device reconnected but config reload failed. Settings may "
+                    "still be applying."
+                ),
+                ConfigureReconnectResult.RECONNECT_FAILED: (
+                    "Phase 3: Device did not reconnect within timeout. Configuration may "
+                    "still be applying."
+                ),
+            }
+            hooks.cli_print(messages[reconnect_result])
         else:
             hooks.cli_print(
                 "Phase 3: Reboot/reconnect verification skipped for remote target. "
                 "Local transport state does not confirm remote node reload status."
             )
-    else:
-        if phase1_may_reconnect:
-            hooks.cli_print(
-                "Configuration applied. Channel URL updates may still trigger reconnect/reboot."
-            )
-        else:
-            hooks.cli_print("Configuration applied (no reboot expected).")
+        return
 
-    return settings_transaction_started, (
-        seturl_executed and hooks.is_local_destination(interface, args.dest)
+    if seturl_executed:
+        hooks.cli_print(
+            "Configuration applied. Channel URL updates may still trigger reconnect/reboot."
+        )
+    else:
+        hooks.cli_print("Configuration applied (no reboot expected).")
+
+
+def _handle_configure_command(
+    hooks: ConfigureHooks,
+    interface: MeshInterface,
+    args: Any,
+    get_node_kwargs: dict[str, Any],
+) -> _ConfigureCommandResult:
+    """Load and apply one YAML configuration document.
+
+    Parameters
+    ----------
+    hooks : ConfigureHooks
+        Entrypoint-owned compatibility and reporting seams.
+    interface : MeshInterface
+        Connected interface used to resolve the target node.
+    args : Any
+        Parsed CLI arguments containing ``configure`` and destination values.
+    get_node_kwargs : dict[str, Any]
+        Historical keyword arguments forwarded to ``MeshInterface.getNode``.
+
+    Returns
+    -------
+    _ConfigureCommandResult
+        Named lifecycle flags describing whether Phase 2 opened a transaction
+        and whether a local Phase-1 channel URL write was actually performed.
+    """
+    prepared = _load_and_validate_configure_document(hooks, args.configure[0])
+    target_node = interface.getNode(args.dest, False, **get_node_kwargs)
+    has_config_writes = bool(prepared.config_sections or prepared.module_config_sections)
+    is_local_target = hooks.is_local_destination(interface, args.dest)
+
+    if has_config_writes:
+        _preflight_configure_sections(
+            hooks,
+            target_node,
+            config_sections=prepared.config_sections,
+            module_config_sections=prepared.module_config_sections,
+        )
+        if prepared.phase1.channel_url is not None and not is_local_target:
+            hooks.cli_exit(
+                "ERROR: Combining channel_url with additional configuration writes "
+                "is not supported for remote nodes. Apply channel_url and "
+                "configuration in separate operations."
+            )
+
+    seturl_executed = _apply_phase1_configuration(hooks, target_node, prepared)
+    if seturl_executed and has_config_writes and is_local_target:
+        if not hooks.post_seturl_stability_check(
+            interface, timeout=SETURL_STABILITY_TIMEOUT_SECONDS
+        ):
+            hooks.cli_exit(
+                "ERROR: channel_url applied, but transport did not stabilize for "
+                "additional configuration writes; aborting before Phase 2."
+            )
+
+    settings_transaction_started = has_config_writes
+    if has_config_writes:
+        _apply_settings_transaction(
+            hooks,
+            target_node,
+            config_sections=prepared.config_sections,
+            module_config_sections=prepared.module_config_sections,
+        )
+
+    _report_configure_result(
+        hooks,
+        interface,
+        destination=args.dest,
+        is_local_target=is_local_target,
+        settings_transaction_started=settings_transaction_started,
+        seturl_executed=seturl_executed,
+        channel_url=prepared.phase1.channel_url,
+        config_sections=prepared.config_sections,
+        module_config_sections=prepared.module_config_sections,
+    )
+    return _ConfigureCommandResult(
+        settings_transaction_started=settings_transaction_started,
+        phase1_channel_url_applied=seturl_executed and is_local_target,
     )
 
-
-def handle_configure_actions(
+def _handle_configure_actions(
     context: CliContext,
     hooks: ConfigureActionHooks,
 ) -> None:
@@ -972,12 +1381,12 @@ def handle_configure_actions(
     if not args.export_config:
         return
 
-    if args.dest != BROADCAST_ADDR:
-        print("Exporting configuration of remote nodes is not supported.")
+    outcome.close_now = True
+    if not hooks.is_local_destination(context.interface, args.dest):
+        hooks.cli_print("Exporting configuration of remote nodes is not supported.")
         outcome.stop_processing = True
         return
 
-    outcome.close_now = True
     config_text = hooks.export_config(context.interface)
     if args.export_config == "-":
         print(config_text)

--- a/meshtastic/cli/configure_actions.py
+++ b/meshtastic/cli/configure_actions.py
@@ -576,6 +576,26 @@ def _refresh_no_disconnect_verify_state(
             request_channels(0)
 
 
+def _device_lora_config(target_node: Any) -> Any | None:
+    """Return the loaded device LoRa config, or ``None`` when unavailable.
+
+    Parameters
+    ----------
+    target_node : Any
+        Node whose loaded local configuration is inspected.
+
+    Returns
+    -------
+    Any | None
+        Loaded LoRa protobuf message when present, otherwise ``None``.
+    """
+    local_config = getattr(target_node, "localConfig", None)
+    has_field = getattr(local_config, "HasField", None)
+    if local_config is None or not callable(has_field) or not has_field("lora"):
+        return None
+    return local_config.lora
+
+
 def _channel_url_matches_current_device_state(
     target_node: Any,
     requested_channel_url: str,
@@ -585,14 +605,13 @@ def _channel_url_matches_current_device_state(
     ),
 ) -> bool:
     """Return True when requested channel URL already matches loaded device state."""
-    local_config = getattr(target_node, "localConfig", None)
-    has_field = getattr(local_config, "HasField", None)
-    if local_config is None or not callable(has_field) or not has_field("lora"):
+    device_lora_config = _device_lora_config(target_node)
+    if device_lora_config is None:
         return False
     return verify_channel_url_against_state(
         requested_channel_url,
         device_channels=getattr(target_node, "channels", None),
-        device_lora_config=local_config.lora,
+        device_lora_config=device_lora_config,
         emit_warnings=False,
     )
 
@@ -703,13 +722,7 @@ def _verify_post_reconnect_config(
     verified_fields: list[str] = []
 
     if verify_channel_url:
-        local_config = getattr(target_node, "localConfig", None)
-        has_field = getattr(local_config, "HasField", None)
-        device_lora_config = (
-            local_config.lora
-            if local_config is not None and callable(has_field) and has_field("lora")
-            else None
-        )
+        device_lora_config = _device_lora_config(target_node)
         if not verify_channel_url_against_state(
             verify_channel_url,
             device_channels=getattr(target_node, "channels", None),

--- a/meshtastic/cli/configure_actions.py
+++ b/meshtastic/cli/configure_actions.py
@@ -536,7 +536,7 @@ def _refresh_no_disconnect_verify_state(
     verify_config_fields: dict[str, dict[str, Any]] | None,
     verify_module_config_fields: dict[str, dict[str, Any]] | None,
 ) -> None:
-    """Invalidate touched cached state and request fresh values for Phase 3 verification."""
+    """Invalidate touched cached state before post-reconnect verification."""
     request_config = getattr(target_node, "requestConfig", None)
 
     for section_name in verify_config_fields or {}:
@@ -1348,26 +1348,27 @@ def _report_configure_result(
             )
             messages = {
                 ConfigureReconnectResult.VERIFIED: (
-                    "Phase 3: Device reconnected and config reloaded. All settings verified."
+                    "Post-reconnect verification: device reconnected, configuration "
+                    "reloaded, and all requested settings were verified."
                 ),
                 ConfigureReconnectResult.VERIFICATION_INCOMPLETE: (
-                    "Phase 3: Device reconnected and config reloaded. Could not fully "
-                    "verify applied settings."
+                    "Post-reconnect verification: device reconnected and configuration "
+                    "reloaded, but not all requested settings could be verified."
                 ),
                 ConfigureReconnectResult.CONFIG_RELOAD_FAILED: (
-                    "Phase 3: Device reconnected but config reload failed. Settings may "
-                    "still be applying."
+                    "Post-reconnect verification: device reconnected, but configuration "
+                    "reload failed. Settings may still be applying."
                 ),
                 ConfigureReconnectResult.RECONNECT_FAILED: (
-                    "Phase 3: Device did not reconnect within timeout. Configuration may "
-                    "still be applying."
+                    "Post-reconnect verification: device did not reconnect within the "
+                    "timeout. Configuration may still be applying."
                 ),
             }
             hooks.cli_print(messages[reconnect_result])
         else:
             hooks.cli_print(
-                "Phase 3: Reboot/reconnect verification skipped for remote target. "
-                "Local transport state does not confirm remote node reload status."
+                "Post-reconnect verification skipped for remote target. Local transport "
+                "state does not confirm remote node reload status."
             )
         return
 

--- a/meshtastic/cli/configure_actions.py
+++ b/meshtastic/cli/configure_actions.py
@@ -1,9 +1,7 @@
 """Configure/set execution runtime for the connected Meshtastic CLI.
 
-The public entrypoint remains :mod:`meshtastic.__main__`. This module owns the
-configure transaction lifecycle, SetURL stability handling, reconnect verification,
-and configure-file action dispatch. Preference parsing remains a separately preserved
-entrypoint compatibility seam and is injected explicitly.
+Owns the configure transaction lifecycle, SetURL stability handling, reconnect
+verification, and configure-file dispatch; preference parsing is injected explicitly.
 """
 
 from __future__ import annotations

--- a/meshtastic/cli/configure_actions.py
+++ b/meshtastic/cli/configure_actions.py
@@ -71,11 +71,81 @@ class ConfigureReconnectResult(enum.Enum):
     VERIFIED = "verified"
 
 
-class _ConfigureCommandResult(NamedTuple):
-    """Outcome flags returned by one ``--configure`` execution."""
+CONFIGURE_RECONNECT_MESSAGES: dict[ConfigureReconnectResult, str] = {
+    ConfigureReconnectResult.VERIFIED: (
+        "Post-reconnect verification: device reconnected, configuration reloaded, "
+        "and all requested settings were verified."
+    ),
+    ConfigureReconnectResult.VERIFICATION_INCOMPLETE: (
+        "Post-reconnect verification: device reconnected and configuration reloaded, "
+        "but not all requested settings could be verified."
+    ),
+    ConfigureReconnectResult.CONFIG_RELOAD_FAILED: (
+        "Post-reconnect verification: device reconnected, but configuration reload "
+        "failed. Settings may still be applying."
+    ),
+    ConfigureReconnectResult.RECONNECT_FAILED: (
+        "Post-reconnect verification: device did not reconnect within the timeout. "
+        "Configuration may still be applying."
+    ),
+}
 
-    settings_transaction_started: bool
-    local_channel_url_applied: bool
+
+def _configure_reconnect_message(result: ConfigureReconnectResult) -> str:
+    """Return a fail-soft status message for reconnect verification.
+
+    Parameters
+    ----------
+    result : ConfigureReconnectResult
+        Verification result returned by the reconnect compatibility seam.
+
+    Returns
+    -------
+    str
+        Stable human-readable status, including a conservative fallback for an
+        unrecognized future result.
+    """
+    return CONFIGURE_RECONNECT_MESSAGES.get(
+        result,
+        "Post-reconnect verification: unrecognized verification result "
+        f"{result!r}. Configuration may still be applying.",
+    )
+
+
+class _ConfigureCommandResult(tuple[bool, bool]):
+    """Two-item compatibility result with internal request-sent metadata.
+
+    The tuple payload intentionally remains ``(settings_transaction_started,
+    local_channel_url_applied)`` so existing private compatibility callers can
+    continue unpacking or comparing the historical two-item result. Dispatch also
+    consumes ``request_sent`` to avoid waiting for an ACK after a true no-op.
+    """
+
+    request_sent: bool
+
+    def __new__(
+        cls,
+        settings_transaction_started: bool,
+        local_channel_url_applied: bool,
+        *,
+        request_sent: bool,
+    ) -> _ConfigureCommandResult:
+        """Create a compatibility tuple carrying internal lifecycle metadata."""
+        result = super().__new__(
+            cls, (settings_transaction_started, local_channel_url_applied)
+        )
+        result.request_sent = request_sent
+        return result
+
+    @property
+    def settings_transaction_started(self) -> bool:
+        """Return whether a firmware settings transaction was started."""
+        return self[0]
+
+    @property
+    def local_channel_url_applied(self) -> bool:
+        """Return whether a local channel URL write was actually sent."""
+        return self[1]
 
 
 @dataclass(frozen=True, slots=True)
@@ -110,6 +180,20 @@ class _DirectConfigureValues:
     ringtone: str | None = None
     channel_url: str | None = None
     channel_url_key: str | None = None
+
+    @property
+    def has_non_url_writes(self) -> bool:
+        """Return whether validated direct values require a non-URL device write."""
+        return any(
+            value is not None
+            for value in (
+                self.owner,
+                self.owner_short,
+                self.location,
+                self.canned_messages,
+                self.ringtone,
+            )
+        )
 
 
 class _PreparedConfigureDocument(NamedTuple):
@@ -1351,25 +1435,7 @@ def _report_configure_result(
                 verify_config_fields=config_sections or None,
                 verify_module_config_fields=module_config_sections or None,
             )
-            messages = {
-                ConfigureReconnectResult.VERIFIED: (
-                    "Post-reconnect verification: device reconnected, configuration "
-                    "reloaded, and all requested settings were verified."
-                ),
-                ConfigureReconnectResult.VERIFICATION_INCOMPLETE: (
-                    "Post-reconnect verification: device reconnected and configuration "
-                    "reloaded, but not all requested settings could be verified."
-                ),
-                ConfigureReconnectResult.CONFIG_RELOAD_FAILED: (
-                    "Post-reconnect verification: device reconnected, but configuration "
-                    "reload failed. Settings may still be applying."
-                ),
-                ConfigureReconnectResult.RECONNECT_FAILED: (
-                    "Post-reconnect verification: device did not reconnect within the "
-                    "timeout. Configuration may still be applying."
-                ),
-            }
-            hooks.cli_print(messages[reconnect_result])
+            hooks.cli_print(_configure_reconnect_message(reconnect_result))
         else:
             hooks.cli_print(
                 "Post-reconnect verification skipped for remote target. Local transport "
@@ -1467,6 +1533,11 @@ def _handle_configure_command(
     return _ConfigureCommandResult(
         settings_transaction_started=settings_transaction_started,
         local_channel_url_applied=seturl_executed and is_local_target,
+        request_sent=(
+            prepared.direct_values.has_non_url_writes
+            or seturl_executed
+            or settings_transaction_started
+        ),
     )
 
 
@@ -1494,16 +1565,17 @@ def _handle_configure_actions(
     if args.configure:
         outcome.close_now = True
         outcome.wait_for_ack_nak = True
-        settings_transaction_started, local_channel_url_applied = (
-            hooks.handle_configure_command(
-                context.interface,
-                args,
-                context.get_node_kwargs,
-            )
+        configure_result = hooks.handle_configure_command(
+            context.interface,
+            args,
+            context.get_node_kwargs,
         )
+        settings_transaction_started, local_channel_url_applied = configure_result
         if settings_transaction_started or local_channel_url_applied:
             outcome.wait_for_ack_nak = False
             outcome.skip_ack_wait = True
+        elif isinstance(configure_result, _ConfigureCommandResult):
+            outcome.wait_for_ack_nak = configure_result.request_sent
 
     if not args.export_config:
         return

--- a/meshtastic/cli/configure_actions.py
+++ b/meshtastic/cli/configure_actions.py
@@ -1563,6 +1563,7 @@ def _handle_configure_actions(
         hooks.handle_set_command(context.interface, args, context.get_node_kwargs)
 
     if args.configure:
+        prior_wait_for_ack_nak = outcome.wait_for_ack_nak
         outcome.close_now = True
         outcome.wait_for_ack_nak = True
         configure_result = hooks.handle_configure_command(
@@ -1575,7 +1576,9 @@ def _handle_configure_actions(
             outcome.wait_for_ack_nak = False
             outcome.skip_ack_wait = True
         elif isinstance(configure_result, _ConfigureCommandResult):
-            outcome.wait_for_ack_nak = configure_result.request_sent
+            outcome.wait_for_ack_nak = (
+                prior_wait_for_ack_nak or configure_result.request_sent
+            )
 
     if not args.export_config:
         return

--- a/meshtastic/cli/configure_values.py
+++ b/meshtastic/cli/configure_values.py
@@ -1,0 +1,237 @@
+"""Validation and normalization for direct-write configure document values."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from meshtastic.cli.context import CliExit, _terminate_cli
+
+POSITION_ALTITUDE_MIN = -(1 << 31)
+POSITION_ALTITUDE_MAX = (1 << 31) - 1
+
+
+class _ConfigureValueHooks(Protocol):
+    """Minimum reporting contract required by configure value validation."""
+
+    @property
+    def cli_exit(self) -> CliExit:
+        """Return the non-returning CLI failure reporter."""
+
+
+@dataclass(frozen=True, slots=True)
+class _DirectConfigureValues:
+    """Validated non-transactional values ready for device writes."""
+
+    owner: str | None = None
+    owner_short: str | None = None
+    location: tuple[float, float, int] | None = None
+    altitude_specified: bool = False
+    canned_messages: str | None = None
+    ringtone: str | None = None
+    channel_url: str | None = None
+    channel_url_key: str | None = None
+
+    @property
+    def has_non_url_writes(self) -> bool:
+        """Return whether validated values require a non-URL device write."""
+        return any(
+            value is not None
+            for value in (
+                self.owner,
+                self.owner_short,
+                self.location,
+                self.canned_messages,
+                self.ringtone,
+            )
+        )
+
+
+def _normalize_name(
+    hooks: _ConfigureValueHooks,
+    configuration: dict[str, Any],
+    *,
+    key: str,
+    empty_message: str,
+) -> str | None:
+    """Normalize one optional owner name while preserving scalar compatibility."""
+    if key not in configuration:
+        return None
+    raw_value = configuration[key]
+    value = "" if raw_value is None else str(raw_value).strip()
+    if not value:
+        _terminate_cli(hooks.cli_exit, empty_message)
+    return value
+
+
+def _validate_coordinate(
+    hooks: _ConfigureValueHooks,
+    location: dict[str, Any],
+    *,
+    key: str,
+    limit: float,
+) -> float:
+    """Return one finite coordinate within its geographic range."""
+    raw_value = location[key]
+    if isinstance(raw_value, bool):
+        _terminate_cli(
+            hooks.cli_exit,
+            f"location.{key} must be a number, got: {raw_value!r}",
+        )
+    try:
+        value = float(raw_value)
+    except (TypeError, ValueError):
+        _terminate_cli(
+            hooks.cli_exit,
+            f"location.{key} must be a number, got: {raw_value!r}",
+        )
+    if not -limit <= value <= limit:
+        _terminate_cli(
+            hooks.cli_exit,
+            f"location.{key} must be between {-limit:g} and {limit:g}, got: {value}",
+        )
+    return value
+
+
+def _validate_altitude(hooks: _ConfigureValueHooks, raw_value: Any) -> int:
+    """Return an integral altitude representable by the protobuf int32 field."""
+    if isinstance(raw_value, bool):
+        _terminate_cli(
+            hooks.cli_exit,
+            f"location.alt must be an integer, got: {raw_value!r}",
+        )
+    try:
+        altitude = int(raw_value)
+    except (OverflowError, TypeError, ValueError):
+        _terminate_cli(
+            hooks.cli_exit,
+            f"location.alt must be an integer, got: {raw_value!r}",
+        )
+    if isinstance(raw_value, float) and raw_value != altitude:
+        _terminate_cli(
+            hooks.cli_exit,
+            f"location.alt must be an integer, got: {raw_value!r}",
+        )
+    if not POSITION_ALTITUDE_MIN <= altitude <= POSITION_ALTITUDE_MAX:
+        _terminate_cli(
+            hooks.cli_exit,
+            "location.alt must fit the signed 32-bit position field, "
+            f"got: {altitude}",
+        )
+    return altitude
+
+
+def _validate_location(
+    hooks: _ConfigureValueHooks,
+    configuration: dict[str, Any],
+) -> tuple[tuple[float, float, int] | None, bool]:
+    """Normalize an optional location mapping and altitude-presence flag."""
+    if "location" not in configuration:
+        return None, False
+
+    location = configuration["location"]
+    if not isinstance(location, dict) or not location:
+        _terminate_cli(
+            hooks.cli_exit,
+            "location must be a non-empty mapping with lat, lon, and optional alt",
+        )
+    non_string_keys = [key for key in location if not isinstance(key, str)]
+    if non_string_keys:
+        rendered_keys = ", ".join(sorted(repr(key) for key in non_string_keys))
+        _terminate_cli(
+            hooks.cli_exit,
+            f"location keys must be strings, got: {rendered_keys}",
+        )
+    unknown_keys = set(location) - {"lat", "lon", "alt"}
+    if unknown_keys:
+        _terminate_cli(
+            hooks.cli_exit,
+            "location contains unknown keys: "
+            f"{', '.join(sorted(unknown_keys))}. Allowed: lat, lon, alt",
+        )
+    if "lat" not in location or "lon" not in location:
+        _terminate_cli(hooks.cli_exit, "location requires both lat and lon")
+
+    latitude = _validate_coordinate(hooks, location, key="lat", limit=90.0)
+    longitude = _validate_coordinate(hooks, location, key="lon", limit=180.0)
+    altitude_specified = "alt" in location
+    altitude = _validate_altitude(hooks, location["alt"]) if altitude_specified else 0
+    return (latitude, longitude, altitude), altitude_specified
+
+
+def _optional_string(
+    hooks: _ConfigureValueHooks,
+    configuration: dict[str, Any],
+    key: str,
+) -> str | None:
+    """Return one optional top-level value after string type validation."""
+    if key not in configuration:
+        return None
+    value = configuration[key]
+    if not isinstance(value, str):
+        _terminate_cli(hooks.cli_exit, f"ERROR: {key} must be a string.")
+    return value
+
+
+def _normalize_channel_url(
+    hooks: _ConfigureValueHooks,
+    configuration: dict[str, Any],
+) -> tuple[str | None, str | None]:
+    """Return a normalized channel URL and the alias used by the document."""
+    channel_url_key: str | None = None
+    if "channel_url" in configuration:
+        channel_url_key = "channel_url"
+    elif "channelUrl" in configuration:
+        channel_url_key = "channelUrl"
+    if channel_url_key is None:
+        return None, None
+
+    raw_channel_url = configuration[channel_url_key]
+    if not isinstance(raw_channel_url, str):
+        _terminate_cli(
+            hooks.cli_exit,
+            f"ERROR: {channel_url_key} must be a string.",
+        )
+    channel_url = raw_channel_url.strip()
+    if not channel_url:
+        _terminate_cli(
+            hooks.cli_exit,
+            f"ERROR: {channel_url_key} must not be blank.",
+        )
+    return channel_url, channel_url_key
+
+
+def _validate_direct_configuration(
+    hooks: _ConfigureValueHooks,
+    configuration: dict[str, Any],
+) -> _DirectConfigureValues:
+    """Validate all direct values before allowing any device mutation."""
+    owner = _normalize_name(
+        hooks,
+        configuration,
+        key="owner",
+        empty_message=(
+            "ERROR: Long Name cannot be empty or contain only whitespace characters"
+        ),
+    )
+    owner_short_key = "owner_short" if "owner_short" in configuration else "ownerShort"
+    owner_short = _normalize_name(
+        hooks,
+        configuration,
+        key=owner_short_key,
+        empty_message=(
+            "ERROR: Short Name cannot be empty or contain only whitespace characters"
+        ),
+    )
+    location, altitude_specified = _validate_location(hooks, configuration)
+    channel_url, channel_url_key = _normalize_channel_url(hooks, configuration)
+    return _DirectConfigureValues(
+        owner=owner,
+        owner_short=owner_short,
+        location=location,
+        altitude_specified=altitude_specified,
+        canned_messages=_optional_string(hooks, configuration, "canned_messages"),
+        ringtone=_optional_string(hooks, configuration, "ringtone"),
+        channel_url=channel_url,
+        channel_url_key=channel_url_key,
+    )

--- a/meshtastic/cli/context.py
+++ b/meshtastic/cli/context.py
@@ -28,11 +28,14 @@ class ActionOutcome:
     skip_ack_wait : bool
         Whether an action owns its acknowledgment/reboot completion and the
         shared final ACK/NAK wait must be skipped.
+    stop_processing : bool
+        Whether action dispatch should return immediately after the current group.
     """
 
     close_now: bool = False
     wait_for_ack_nak: bool = True
     skip_ack_wait: bool = False
+    stop_processing: bool = False
 
 
 @dataclass(slots=True)

--- a/meshtastic/cli/context.py
+++ b/meshtastic/cli/context.py
@@ -1,0 +1,69 @@
+"""Internal connected-CLI execution context.
+
+This module deliberately owns no CLI command behavior. It provides the small,
+explicit state contract shared by the connected action runtimes so command
+handlers do not need to reach back into ``meshtastic.__main__`` globals.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from meshtastic.mesh_interface import MeshInterface
+
+
+@dataclass(slots=True)
+class ActionOutcome:
+    """Track connection-lifecycle decisions made by connected CLI actions.
+
+    Attributes
+    ----------
+    close_now : bool
+        Whether the connected interface should be closed after actions finish.
+    wait_for_ack_nak : bool
+        Whether a remote operation expects the shared final ACK/NAK wait.
+    skip_ack_wait : bool
+        Whether an action owns its acknowledgment/reboot completion and the
+        shared final ACK/NAK wait must be skipped.
+    """
+
+    close_now: bool = False
+    wait_for_ack_nak: bool = True
+    skip_ack_wait: bool = False
+
+
+@dataclass(slots=True)
+class CliContext:
+    """State shared by connected CLI action handlers.
+
+    Parameters
+    ----------
+    interface : MeshInterface
+        Connected interface on which actions operate.
+    args : argparse.Namespace
+        Parsed command-line arguments for this invocation.
+    get_node_kwargs : dict[str, Any]
+        Keyword arguments historically forwarded to ``MeshInterface.getNode``.
+    outcome : ActionOutcome
+        Mutable lifecycle outcome accumulated across compatible actions.
+    """
+
+    interface: MeshInterface
+    args: argparse.Namespace
+    get_node_kwargs: dict[str, Any]
+    outcome: ActionOutcome = field(default_factory=ActionOutcome)
+
+    @property
+    def destination(self) -> str:
+        """Return the selected destination address.
+
+        Returns
+        -------
+        str
+            Destination value from parsed CLI arguments.
+        """
+
+        return str(self.args.dest)

--- a/meshtastic/cli/context.py
+++ b/meshtastic/cli/context.py
@@ -10,10 +10,17 @@ from __future__ import annotations
 import argparse
 from dataclasses import dataclass, field
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn, Protocol
 
 if TYPE_CHECKING:
     from meshtastic.mesh_interface import MeshInterface
+
+
+class CliExit(Protocol):
+    """Callable contract for terminating CLI execution with an optional status."""
+
+    def __call__(self, message: str, return_value: int = 1) -> NoReturn:
+        """Report *message* and terminate with *return_value*."""
 
 
 @dataclass(slots=True)
@@ -36,7 +43,7 @@ class ActionOutcome:
     """
 
     close_now: bool = False
-    wait_for_ack_nak: bool = True
+    wait_for_ack_nak: bool = False
     skip_ack_wait: bool = False
     stop_processing: bool = False
     cleanup_callbacks: list[Callable[[], None]] = field(default_factory=list)

--- a/meshtastic/cli/context.py
+++ b/meshtastic/cli/context.py
@@ -23,6 +23,33 @@ class CliExit(Protocol):
         """Report *message* and terminate with *return_value*."""
 
 
+def _terminate_cli(cli_exit: CliExit, message: str, return_value: int = 1) -> NoReturn:
+    """Invoke a CLI exit seam and fail closed if an injected seam returns.
+
+    Parameters
+    ----------
+    cli_exit : CliExit
+        Exit callable supplied by the entrypoint or a test seam.
+    message : str
+        User-facing failure message.
+    return_value : int
+        Process exit status forwarded to ``cli_exit``.
+
+    Raises
+    ------
+    AssertionError
+        If a non-conforming injected ``cli_exit`` returns instead of terminating.
+
+    Notes
+    -----
+    Production ``cli_exit`` implementations are non-returning. Keeping this guard
+    in one place makes extracted action runtimes fail closed even when tests or
+    downstream compatibility seams inject a returning callable.
+    """
+    cli_exit(message, return_value)
+    raise AssertionError("cli_exit returned unexpectedly") from None
+
+
 @dataclass(slots=True)
 class ActionOutcome:
     """Track connection-lifecycle decisions made by connected CLI actions.

--- a/meshtastic/cli/context.py
+++ b/meshtastic/cli/context.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass, field
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -30,12 +31,15 @@ class ActionOutcome:
         shared final ACK/NAK wait must be skipped.
     stop_processing : bool
         Whether action dispatch should return immediately after the current group.
+    cleanup_callbacks : list[Callable[[], None]]
+        Resource cleanup callbacks to run after connected actions complete.
     """
 
     close_now: bool = False
     wait_for_ack_nak: bool = True
     skip_ack_wait: bool = False
     stop_processing: bool = False
+    cleanup_callbacks: list[Callable[[], None]] = field(default_factory=list)
 
 
 @dataclass(slots=True)

--- a/meshtastic/cli/context.py
+++ b/meshtastic/cli/context.py
@@ -8,8 +8,8 @@ handlers do not need to reach back into ``meshtastic.__main__`` globals.
 from __future__ import annotations
 
 import argparse
-from dataclasses import dataclass, field
 from collections.abc import Callable
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, NoReturn, Protocol
 
 if TYPE_CHECKING:
@@ -65,15 +65,19 @@ class ActionOutcome:
         shared final ACK/NAK wait must be skipped.
     stop_processing : bool
         Whether action dispatch should return immediately after the current group.
-    cleanup_callbacks : list[Callable[[], None]]
-        Resource cleanup callbacks to run after connected actions complete.
+    failure_cleanup_callbacks : list[Callable[[], None]]
+        Rollback callbacks for resources that must survive successful dispatch but
+        be released if connected action processing fails.
+    interface_close_attempted : bool
+        Whether dispatch has already consumed the one-shot interface-close request.
     """
 
     close_now: bool = False
     wait_for_ack_nak: bool = False
     skip_ack_wait: bool = False
     stop_processing: bool = False
-    cleanup_callbacks: list[Callable[[], None]] = field(default_factory=list)
+    failure_cleanup_callbacks: list[Callable[[], None]] = field(default_factory=list)
+    interface_close_attempted: bool = False
 
 
 @dataclass(slots=True)

--- a/meshtastic/cli/device_actions.py
+++ b/meshtastic/cli/device_actions.py
@@ -1,0 +1,755 @@
+"""Connected CLI actions that mutate or administer a node/device.
+
+The public CLI entrypoint remains ``meshtastic.__main__``. This module owns the
+internal execution policy for device-oriented actions while dependencies that
+are established compatibility/test seams are supplied explicitly by the
+entrypoint.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import getpass
+import logging
+import threading
+import time
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from typing import Any, NoReturn
+
+from pubsub import pub
+
+import meshtastic.ota
+import meshtastic.serial_interface
+import meshtastic.tcp_interface
+import meshtastic.util
+from meshtastic._core_constants import LOCAL_ADDR
+from meshtastic.cli.context import CliContext
+from meshtastic.mesh_interface import MeshInterface
+from meshtastic.protobuf import admin_pb2, mesh_pb2
+
+logger = logging.getLogger(__name__)
+
+FACTORY_RESET_READY_PROBE_TIMEOUT_SECONDS = 20.0
+FACTORY_RESET_ACCEPTANCE_TIMEOUT_SECONDS = 20.0
+FACTORY_RESET_ACCEPTANCE_POLL_SECONDS = 0.05
+OTA_REBOOT_WAIT_SECONDS: float = 5.0
+OTA_RETRY_DELAY_SECONDS: float = 2.0
+OTA_MAX_RETRIES: int = 5
+
+
+@dataclass(frozen=True, slots=True)
+class DeviceActionHooks:
+    """Entrypoint-owned dependencies used by device action execution.
+
+    Parameters
+    ----------
+    cli_exit : Callable[[str, int], NoReturn]
+        User-facing CLI exit function.
+    cli_print : Callable[[str], None]
+        Quiet-aware CLI reporter.
+    set_pref : Callable[[Any, str, Any], bool]
+        Preference assignment compatibility seam.
+    is_local_destination : Callable[[Any, str], bool]
+        Destination classifier.
+    send_local_factory_reset_and_wait : Callable[..., Any]
+        Local destructive-reset acceptance helper.
+    post_factory_reset_ready_probe : Callable[[MeshInterface], None]
+        Best-effort serial readiness probe used after a full local reset.
+    handle_ota_update : Callable[[MeshInterface, Any, dict[str, Any]], None]
+        Wi-Fi OTA execution helper.
+    build_lockdown_auth, read_lockdown_passphrase_file, send_lockdown_auth,
+    validate_lockdown_passphrase : Callable[..., Any]
+        Lockdown compatibility seams retained by the entrypoint.
+    """
+
+    cli_exit: Callable[[str, int], NoReturn]
+    cli_print: Callable[[str], None]
+    set_pref: Callable[[Any, str, Any], bool]
+    is_local_destination: Callable[[Any, str], bool]
+    send_local_factory_reset_and_wait: Callable[..., Any]
+    post_factory_reset_ready_probe: Callable[[MeshInterface], None]
+    handle_ota_update: Callable[[MeshInterface, Any, dict[str, Any]], None]
+    build_lockdown_auth: Callable[..., Any]
+    read_lockdown_passphrase_file: Callable[[str], bytes]
+    send_lockdown_auth: Callable[..., Any]
+    validate_lockdown_passphrase: Callable[[bytes], bytes]
+
+
+def send_local_factory_reset_and_wait(
+    reset_node: Any,
+    *,
+    full: bool,
+    cli_print: Callable[[str], None],
+    timeout: float | None = None,
+) -> mesh_pb2.MeshPacket | None:
+    """Send a local factory reset and wait for ACK/NAK or reboot transport loss.
+
+    Parameters
+    ----------
+    reset_node : Any
+        Local node whose interface transports the destructive reset request.
+    full : bool
+        Whether to request a complete device factory reset.
+    cli_print : Callable[[str], None]
+        Quiet-aware CLI reporter used for the acceptance wait message.
+    timeout : float | None
+        Optional acceptance deadline override.
+
+    Returns
+    -------
+    mesh_pb2.MeshPacket | None
+        Sent request packet, or ``None`` when the node returns no packet.
+
+    Raises
+    ------
+    ValueError
+        If the supplied timeout is not positive.
+    MeshInterface.MeshInterfaceError
+        If the request is rejected or no acceptance/reboot signal arrives.
+    """
+    reset_interface = reset_node.iface
+    disconnect_observed = threading.Event()
+    request_queued = threading.Event()
+
+    def _on_connection_lost(interface: MeshInterface) -> None:
+        if request_queued.is_set() and interface is reset_interface:
+            disconnect_observed.set()
+
+    acknowledgment = getattr(reset_interface, "_acknowledgment", None)
+    reset_acknowledgment = getattr(acknowledgment, "reset", None)
+    if callable(reset_acknowledgment):
+        reset_acknowledgment()
+
+    pub.subscribe(_on_connection_lost, "meshtastic.connection.lost")
+    request: mesh_pb2.MeshPacket | None = None
+    request_id: int | None = None
+    try:
+        request = reset_node.factoryReset(full=full)
+        if request is None:
+            return None
+
+        raw_request_id = getattr(request, "id", None)
+        if isinstance(raw_request_id, int) and not isinstance(raw_request_id, bool):
+            request_id = raw_request_id if raw_request_id > 0 else None
+        request_queued.set()
+
+        missing_transport = object()
+        socket_after_send = getattr(reset_interface, "socket", missing_transport)
+        stream_after_send = getattr(reset_interface, "stream", missing_transport)
+        acceptance_timeout = (
+            FACTORY_RESET_ACCEPTANCE_TIMEOUT_SECONDS
+            if timeout is None
+            else float(timeout)
+        )
+        if acceptance_timeout <= 0:
+            raise ValueError("factory reset acceptance timeout must be positive")
+
+        wait_for_request_ack = getattr(reset_interface, "_wait_for_request_ack", None)
+        raise_wait_error = getattr(reset_interface, "_raise_wait_error_if_present", None)
+        scoped_wait_available = (
+            request_id is not None
+            and callable(wait_for_request_ack)
+            and callable(raise_wait_error)
+        )
+
+        cli_print("Waiting for factory reset acknowledgment or reboot disconnect")
+        deadline = time.monotonic() + acceptance_timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+
+            if (
+                scoped_wait_available
+                and callable(wait_for_request_ack)
+                and callable(raise_wait_error)
+            ):
+                completed = wait_for_request_ack(
+                    "receivedNak",
+                    request_id,
+                    timeout_seconds=min(FACTORY_RESET_ACCEPTANCE_POLL_SECONDS, remaining),
+                )
+                if completed:
+                    raise_wait_error("receivedNak", request_id=request_id)
+                    return request
+            else:
+                if callable(raise_wait_error):
+                    raise_wait_error("receivedNak", request_id=request_id)
+                received_ack = bool(getattr(acknowledgment, "receivedAck", False))
+                received_implicit_ack = bool(
+                    getattr(acknowledgment, "receivedImplAck", False)
+                )
+                if received_ack or received_implicit_ack:
+                    return request
+                if bool(getattr(acknowledgment, "receivedNak", False)):
+                    raise reset_interface.MeshInterfaceError(
+                        "Factory reset request was rejected by the device"
+                    )
+                time.sleep(min(FACTORY_RESET_ACCEPTANCE_POLL_SECONDS, remaining))
+
+            connected_event = getattr(reset_interface, "isConnected", None)
+            connected = True
+            is_set = getattr(connected_event, "is_set", None)
+            if callable(is_set):
+                connected = bool(is_set())
+
+            current_socket = getattr(reset_interface, "socket", missing_transport)
+            current_stream = getattr(reset_interface, "stream", missing_transport)
+            socket_replaced = (
+                socket_after_send is not missing_transport
+                and current_socket is not socket_after_send
+            )
+            stream_replaced = (
+                stream_after_send is not missing_transport
+                and current_stream is not stream_after_send
+            )
+            if (
+                disconnect_observed.is_set()
+                or not connected
+                or socket_replaced
+                or stream_replaced
+            ):
+                if callable(raise_wait_error):
+                    raise_wait_error("receivedNak", request_id=request_id)
+                logger.info(
+                    "Device transport changed after local factory reset request; "
+                    "treating reboot as command acceptance."
+                )
+                return request
+
+        if callable(raise_wait_error):
+            raise_wait_error("receivedNak", request_id=request_id)
+        raise reset_interface.MeshInterfaceError(
+            "Timed out waiting for a factory reset acknowledgment or reboot disconnect"
+        )
+    finally:
+        retire_wait = getattr(reset_interface, "_retire_wait_request", None)
+        if callable(retire_wait) and request_id is not None:
+            retire_wait("receivedNak", request_id=request_id)
+        if callable(reset_acknowledgment):
+            reset_acknowledgment()
+        try:
+            pub.unsubscribe(_on_connection_lost, "meshtastic.connection.lost")
+        except Exception:
+            logger.debug(
+                "Factory reset: failed to remove connection-loss observer.",
+                exc_info=True,
+            )
+
+    return None
+
+
+@contextlib.contextmanager
+def temporary_instance_attributes(
+    instance: Any, overrides: dict[str, Any]
+) -> Iterator[None]:
+    """Temporarily override instance attributes and restore exact prior state.
+
+    Parameters
+    ----------
+    instance : Any
+        Object whose instance dictionary is temporarily modified.
+    overrides : dict[str, Any]
+        Attribute/value overrides to install for the duration of the context.
+
+    Yields
+    ------
+    None
+        Control while the overrides are active.
+    """
+    missing = object()
+    instance_values = vars(instance)
+    previous_values = {name: instance_values.get(name, missing) for name in overrides}
+    try:
+        for name, value in overrides.items():
+            setattr(instance, name, value)
+        yield
+    finally:
+        for name, previous in previous_values.items():
+            if previous is missing:
+                with contextlib.suppress(AttributeError):
+                    delattr(instance, name)
+            else:
+                setattr(instance, name, previous)
+
+
+def post_factory_reset_ready_probe(interface: MeshInterface) -> None:
+    """Close, briefly probe serial readiness, then release the serial port.
+
+    Parameters
+    ----------
+    interface : MeshInterface
+        Connected interface; non-serial transports are ignored.
+    """
+    if not isinstance(interface, meshtastic.serial_interface.SerialInterface):
+        return
+
+    logger.debug("Factory reset: closing serial interface to release port.")
+    try:
+        interface.close()
+    except Exception:
+        logger.debug("Factory reset: initial serial close failed.", exc_info=True)
+
+    logger.debug(
+        "Factory reset: probing reconnect readiness (timeout=%.1fs)...",
+        FACTORY_RESET_READY_PROBE_TIMEOUT_SECONDS,
+    )
+    probe_overrides = {
+        "_connect_wait_timeout_seconds": FACTORY_RESET_READY_PROBE_TIMEOUT_SECONDS,
+        "_connect_retry_budget_seconds": FACTORY_RESET_READY_PROBE_TIMEOUT_SECONDS,
+        "_suppress_connect_failure_logging": True,
+    }
+    probe_start = time.monotonic()
+    with temporary_instance_attributes(interface, probe_overrides):
+        try:
+            interface.connect()
+            logger.debug(
+                "Factory reset: reconnect probe succeeded in %.2fs.",
+                time.monotonic() - probe_start,
+            )
+        except Exception as exc:
+            logger.info(
+                "Factory reset accepted; device is still rebooting after %.1fs "
+                "and the next command will reconnect normally (%s).",
+                time.monotonic() - probe_start,
+                exc,
+            )
+    try:
+        interface.close()
+    except Exception:
+        logger.debug("Factory reset: final serial close failed.", exc_info=True)
+
+
+def handle_ota_update(
+    interface: MeshInterface,
+    args: Any,
+    get_node_kwargs: dict[str, Any],
+    *,
+    cli_exit: Callable[[str, int], NoReturn],
+    cli_print: Callable[[str], None],
+    is_local_destination: Callable[[Any, str], bool],
+) -> None:
+    """Initiate a Wi-Fi OTA update for the directly connected local node.
+
+    Parameters
+    ----------
+    interface : MeshInterface
+        TCP interface connected to the target node.
+    args : Any
+        CLI arguments containing the OTA update path and destination.
+    get_node_kwargs : dict[str, Any]
+        Additional arguments for retrieving the local node.
+    cli_exit : Callable[[str, int], NoReturn]
+        User-facing exit handler.
+    cli_print : Callable[[str], None]
+        Quiet-aware reporter.
+    is_local_destination : Callable[[Any, str], bool]
+        Destination classifier.
+    """
+    if not isinstance(interface, meshtastic.tcp_interface.TCPInterface):
+        cli_exit(
+            "Error: OTA update currently requires a TCP connection to the node (use --host).",
+            1,
+        )
+    if not is_local_destination(interface, args.dest):
+        cli_exit(
+            "Error: OTA update only supports the directly connected local node; "
+            "omit --dest or use --dest ^local.",
+            1,
+        )
+
+    try:
+        ota = meshtastic.ota.ESP32WiFiOTA(args.ota_update, interface.hostname)
+    except meshtastic.ota.OTAError as exc:
+        cli_exit(f"OTA update failed: {exc}", 1)
+
+    cli_print(f"Triggering OTA update on {interface.hostname}...")
+    interface.getNode(LOCAL_ADDR, requestChannels=False, **get_node_kwargs).startOTA(
+        mode=admin_pb2.OTAMode.OTA_WIFI, ota_file_hash=ota.hash_bytes()
+    )
+    cli_print("Waiting for device to reboot into OTA mode...")
+    time.sleep(OTA_REBOOT_WAIT_SECONDS)
+
+    retries = OTA_MAX_RETRIES
+    while retries > 0:
+        try:
+            ota.update()
+            break
+        except meshtastic.ota.OTATransportError as exc:
+            retries -= 1
+            if retries == 0:
+                cli_exit(f"OTA update failed: {exc}", 1)
+            time.sleep(OTA_RETRY_DELAY_SECONDS)
+        except meshtastic.ota.OTAError as exc:
+            cli_exit(f"OTA update failed: {exc}", 1)
+
+    cli_print("\nOTA update completed successfully!")
+
+
+def handle_device_actions(context: CliContext, hooks: DeviceActionHooks) -> None:
+    """Execute device- and node-administration actions in historical CLI order.
+
+    Parameters
+    ----------
+    context : CliContext
+        Connected invocation state and lifecycle outcome.
+    hooks : DeviceActionHooks
+        Entrypoint-owned compatibility dependencies.
+    """
+    interface = context.interface
+    args = context.args
+    get_node_kwargs = context.get_node_kwargs
+    outcome = context.outcome
+
+    if args.set_time is not None:
+        interface.getNode(args.dest, False, **get_node_kwargs).setTime(args.set_time)
+
+    if args.remove_position:
+        outcome.close_now = True
+        outcome.wait_for_ack_nak = True
+        hooks.cli_print("Removing fixed position and disabling fixed position setting")
+        interface.getNode(args.dest, False, **get_node_kwargs).removeFixedPosition()
+    elif args.setlat or args.setlon or args.setalt:
+        outcome.close_now = True
+        outcome.wait_for_ack_nak = True
+        alt = int(args.setalt) if args.setalt else 0
+        lat = _parse_coordinate(args.setlat, "latitude", hooks.cli_print)
+        lon = _parse_coordinate(args.setlon, "longitude", hooks.cli_print)
+        if args.setalt:
+            hooks.cli_print(f"Fixing altitude at {alt} meters")
+        hooks.cli_print("Setting device position and enabling fixed position setting")
+        interface.getNode(args.dest, False, **get_node_kwargs).setFixedPosition(
+            lat, lon, alt
+        )
+
+    if args.set_owner or args.set_owner_short or args.set_is_unmessageable:
+        outcome.close_now = True
+        outcome.wait_for_ack_nak = True
+        long_name = args.set_owner.strip() if args.set_owner else None
+        short_name = args.set_owner_short.strip() if args.set_owner_short else None
+        if long_name is not None and not long_name:
+            hooks.cli_exit(
+                "ERROR: Long Name cannot be empty or contain only whitespace characters",
+                1,
+            )
+        if short_name is not None and not short_name:
+            hooks.cli_exit(
+                "ERROR: Short Name cannot be empty or contain only whitespace characters",
+                1,
+            )
+        if long_name and short_name:
+            hooks.cli_print(
+                f"Setting device owner to {long_name} and short name to {short_name}"
+            )
+        elif long_name:
+            hooks.cli_print(f"Setting device owner to {long_name}")
+        elif short_name:
+            hooks.cli_print(f"Setting device owner short to {short_name}")
+
+        unmessagable = None
+        if args.set_is_unmessageable is not None:
+            unmessagable = (
+                meshtastic.util.fromStr(args.set_is_unmessageable)
+                if isinstance(args.set_is_unmessageable, str)
+                else args.set_is_unmessageable
+            )
+            hooks.cli_print(f"Setting device owner is_unmessageable to {unmessagable}")
+        interface.getNode(args.dest, False, **get_node_kwargs).setOwner(
+            long_name=long_name,
+            short_name=short_name,
+            is_unmessagable=unmessagable,
+        )
+
+    _handle_content_updates(context, hooks)
+    _handle_position_fields(context, hooks)
+
+    if args.set_ham:
+        ham_id = args.set_ham.strip()
+        if not ham_id:
+            hooks.cli_exit(
+                "ERROR: Ham radio callsign cannot be empty or contain only whitespace characters",
+                1,
+            )
+        outcome.close_now = True
+        hooks.cli_print(f"Setting Ham ID to {ham_id} and turning off encryption")
+        interface.getNode(args.dest, **get_node_kwargs).setOwner(
+            ham_id, is_licensed=True
+        )
+        interface.getNode(args.dest, **get_node_kwargs).turnOffEncryptionOnPrimaryChannel()
+
+    _handle_reboot_and_reset_actions(context, hooks)
+    if outcome.stop_processing:
+        return
+    _handle_node_database_actions(context)
+
+
+def _parse_coordinate(
+    raw_value: Any,
+    coordinate_name: str,
+    cli_print: Callable[[str], None],
+) -> float:
+    if raw_value is None:
+        return 0.0
+    try:
+        value: float = int(raw_value)
+    except ValueError:
+        value = float(raw_value)
+    cli_print(f"Fixing {coordinate_name} at {value} degrees")
+    return value
+
+
+def _handle_content_updates(context: CliContext, hooks: DeviceActionHooks) -> None:
+    interface, args, kwargs, outcome = (
+        context.interface,
+        context.args,
+        context.get_node_kwargs,
+        context.outcome,
+    )
+    if args.set_canned_message:
+        outcome.close_now = True
+        outcome.wait_for_ack_nak = True
+        node = interface.getNode(args.dest, False, **kwargs)
+        if node.module_available(mesh_pb2.CANNEDMSG_CONFIG):
+            hooks.cli_print(f"Setting canned plugin message to {args.set_canned_message}")
+            node.set_canned_message(args.set_canned_message)
+        else:
+            logger.warning("Canned Message module is excluded by firmware; skipping set.")
+    if args.set_ringtone:
+        outcome.close_now = True
+        outcome.wait_for_ack_nak = True
+        node = interface.getNode(args.dest, False, **kwargs)
+        if node.module_available(mesh_pb2.EXTNOTIF_CONFIG):
+            hooks.cli_print(f"Setting ringtone to {args.set_ringtone}")
+            node.set_ringtone(args.set_ringtone)
+        else:
+            logger.warning(
+                "External Notification is excluded by firmware; skipping ringtone set."
+            )
+
+
+def _handle_position_fields(context: CliContext, hooks: DeviceActionHooks) -> None:
+    interface, args, kwargs, outcome = (
+        context.interface,
+        context.args,
+        context.get_node_kwargs,
+        context.outcome,
+    )
+    if args.pos_fields:
+        outcome.close_now = True
+        position_config = interface.getNode(args.dest, **kwargs).localConfig.position
+        all_fields = 0
+        try:
+            for field in args.pos_fields:
+                all_fields |= position_config.PositionFlags.Value(field)
+        except ValueError:
+            print("ERROR: supported position fields are:")
+            print(position_config.PositionFlags.keys())
+            print("If no fields are specified, will read and display current value.")
+        else:
+            hooks.cli_print(f"Setting position fields to {all_fields}")
+            hooks.set_pref(position_config, "position_flags", f"{all_fields:d}")
+            hooks.cli_print("Writing modified preferences to device")
+            interface.getNode(args.dest, **kwargs).writeConfig("position")
+    elif args.pos_fields is not None:
+        outcome.close_now = True
+        position_config = interface.getNode(args.dest, **kwargs).localConfig.position
+        field_names = [
+            position_config.PositionFlags.Name(bit)
+            for bit in position_config.PositionFlags.values()
+            if position_config.position_flags & bit
+        ]
+        print(" ".join(field_names))
+
+
+def _handle_reboot_and_reset_actions(
+    context: CliContext, hooks: DeviceActionHooks
+) -> None:
+    interface, args, kwargs, outcome = (
+        context.interface,
+        context.args,
+        context.get_node_kwargs,
+        context.outcome,
+    )
+    reboot_actions = (
+        (args.reboot, "reboot"),
+        (args.reboot_ota, "rebootOTA"),
+        (args.enter_dfu, "enterDFUMode"),
+        (args.shutdown, "shutdown"),
+    )
+    for enabled, method_name in reboot_actions:
+        if not enabled:
+            continue
+        outcome.close_now = True
+        outcome.wait_for_ack_nak = True
+        outcome.skip_ack_wait = True
+        getattr(interface.getNode(args.dest, False, **kwargs), method_name)()
+
+    if args.ota_update:
+        outcome.close_now = True
+        outcome.skip_ack_wait = True
+        hooks.handle_ota_update(interface, args, kwargs)
+        outcome.stop_processing = True
+        return
+
+    if args.device_metadata:
+        outcome.close_now = True
+        interface.getNode(args.dest, False, **kwargs).getMetadata()
+    if args.begin_edit:
+        outcome.close_now = True
+        interface.getNode(args.dest, False, **kwargs).beginSettingsTransaction()
+    if args.commit_edit:
+        outcome.close_now = True
+        interface.getNode(args.dest, False, **kwargs).commitSettingsTransaction()
+
+    if args.factory_reset or args.factory_reset_device:
+        outcome.close_now = True
+        outcome.wait_for_ack_nak = True
+        outcome.skip_ack_wait = True
+        full = bool(args.factory_reset_device)
+        reset_node = interface.getNode(args.dest, False, **kwargs)
+        is_local_reset = hooks.is_local_destination(interface, args.dest)
+        if is_local_reset:
+            hooks.send_local_factory_reset_and_wait(reset_node, full=full)
+        else:
+            reset_node.factoryReset(full=full)
+        serial_interface_cls = getattr(
+            meshtastic.serial_interface, "SerialInterface", None
+        )
+        if (
+            full
+            and is_local_reset
+            and isinstance(serial_interface_cls, type)
+            and isinstance(interface, serial_interface_cls)
+        ):
+            hooks.post_factory_reset_ready_probe(interface)
+
+
+def _handle_node_database_actions(context: CliContext) -> None:
+    interface, args, kwargs, outcome = (
+        context.interface,
+        context.args,
+        context.get_node_kwargs,
+        context.outcome,
+    )
+    actions = (
+        (args.remove_node, "removeNode"),
+        (args.set_favorite_node, "setFavorite"),
+        (args.remove_favorite_node, "removeFavorite"),
+        (args.set_ignored_node, "setIgnored"),
+        (args.remove_ignored_node, "removeIgnored"),
+    )
+    for value, method_name in actions:
+        if value:
+            outcome.close_now = True
+            outcome.wait_for_ack_nak = True
+            getattr(interface.getNode(args.dest, False, **kwargs), method_name)(value)
+    if args.reset_nodedb:
+        outcome.close_now = True
+        outcome.wait_for_ack_nak = True
+        interface.getNode(args.dest, False, **kwargs).resetNodeDb()
+
+
+def handle_lockdown_action(context: CliContext, hooks: DeviceActionHooks) -> None:
+    """Execute the mutually exclusive firmware-lockdown action, if requested.
+
+    Parameters
+    ----------
+    context : CliContext
+        Connected invocation state.
+    hooks : DeviceActionHooks
+        Entrypoint-owned lockdown and reporting dependencies.
+    """
+    args = context.args
+    lockdown_action = next(
+        (
+            name
+            for name, enabled in (
+                ("provision", args.lockdown_provision),
+                ("unlock", args.lockdown_unlock),
+                ("lock-now", args.lockdown_lock_now),
+                ("disable", args.lockdown_disable),
+            )
+            if enabled
+        ),
+        None,
+    )
+    if lockdown_action is None:
+        return
+
+    context.outcome.close_now = True
+    if not hooks.is_local_destination(context.interface, args.dest):
+        hooks.cli_exit(
+            "Lockdown commands apply only to the directly connected local node.", 1
+        )
+    if lockdown_action in {"provision", "lock-now", "disable"} and not args.lockdown_yes:
+        confirmation = (
+            input(f"Type 'yes' to confirm lockdown {lockdown_action}: ")
+            .strip()
+            .casefold()
+        )
+        if confirmation != "yes":
+            hooks.cli_exit("Aborted.", 1)
+
+    try:
+        passphrase = _read_lockdown_passphrase(args, lockdown_action, hooks)
+        auth = hooks.build_lockdown_auth(
+            passphrase,
+            boots_remaining=args.lockdown_boots,
+            valid_until_epoch=args.lockdown_valid_until,
+            max_session_seconds=args.lockdown_max_session_seconds,
+            lock_now=lockdown_action == "lock-now",
+            disable=lockdown_action == "disable",
+        )
+    except (OSError, ValueError) as exc:
+        hooks.cli_exit(f"Invalid lockdown options: {exc}", 1)
+
+    try:
+        status = hooks.send_lockdown_auth(
+            context.interface,
+            auth,
+            timeout=args.lockdown_wait,
+            allow_reboot_without_status=lockdown_action == "lock-now",
+        )
+    except (TimeoutError, ValueError, RuntimeError) as exc:
+        hooks.cli_exit(f"Lockdown command failed: {exc}", 1)
+
+    if status is None:
+        print("Lockdown command accepted; device may already be rebooting.")
+        return
+    try:
+        state_name = mesh_pb2.LockdownStatus.State.Name(status.state)
+    except ValueError:
+        state_name = f"STATE_{status.state}"
+    print(f"Lockdown status: {state_name}")
+    if status.backoff_seconds:
+        print(f"Retry backoff: {status.backoff_seconds}s")
+    if status.state == mesh_pb2.LockdownStatus.UNLOCK_FAILED:
+        hooks.cli_exit("Lockdown authentication failed.", 1)
+
+
+def _read_lockdown_passphrase(
+    args: Any, lockdown_action: str, hooks: DeviceActionHooks
+) -> bytes:
+    if lockdown_action == "lock-now":
+        return b""
+    if args.lockdown_passphrase_file:
+        return hooks.read_lockdown_passphrase_file(args.lockdown_passphrase_file)
+    if args.lockdown_passphrase is not None:
+        if not args.insecure_lockdown_passphrase_on_command_line:
+            hooks.cli_exit(
+                "--lockdown-passphrase requires "
+                "--insecure-lockdown-passphrase-on-command-line; "
+                "prefer an operator-only file or interactive entry.",
+                1,
+            )
+        return hooks.validate_lockdown_passphrase(
+            args.lockdown_passphrase.encode("utf-8")
+        )
+
+    entered = getpass.getpass("Lockdown passphrase: ")
+    if lockdown_action == "provision":
+        confirmed = getpass.getpass("Lockdown passphrase (confirm): ")
+        if entered != confirmed:
+            hooks.cli_exit("Lockdown passphrases do not match.", 1)
+    return hooks.validate_lockdown_passphrase(entered.encode("utf-8"))

--- a/meshtastic/cli/device_actions.py
+++ b/meshtastic/cli/device_actions.py
@@ -78,7 +78,7 @@ class DeviceActionHooks:
     validate_lockdown_passphrase: Callable[[bytes], bytes]
 
 
-def send_local_factory_reset_and_wait(  # pylint: disable=inconsistent-return-statements
+def _send_local_factory_reset_and_wait(  # pylint: disable=inconsistent-return-statements
     reset_node: Any,
     *,
     full: bool,
@@ -277,7 +277,7 @@ def _temporary_instance_attributes(
                 setattr(instance, name, previous)
 
 
-def post_factory_reset_ready_probe(interface: MeshInterface) -> None:
+def _post_factory_reset_ready_probe(interface: MeshInterface) -> None:
     """Close, briefly probe serial readiness, then release the serial port.
 
     Parameters
@@ -329,7 +329,7 @@ def post_factory_reset_ready_probe(interface: MeshInterface) -> None:
         logger.debug("Factory reset: final serial close failed.", exc_info=True)
 
 
-def handle_ota_update(
+def _handle_ota_update(
     interface: MeshInterface,
     args: Any,
     get_node_kwargs: dict[str, Any],
@@ -609,8 +609,9 @@ def _handle_content_updates(context: CliContext, hooks: DeviceActionHooks) -> No
     Parameters
     ----------
     context : CliContext
-        Connected invocation state. ``close_now`` and ``wait_for_ack_nak`` are
-        enabled for requested one-shot content writes.
+        Connected invocation state. ``close_now`` is enabled for every requested
+        one-shot update, while ``wait_for_ack_nak`` is enabled only when the
+        firmware exposes the target module and a write packet is actually sent.
     hooks : DeviceActionHooks
         Reporting and compatibility seams used by the updates.
     """
@@ -620,30 +621,38 @@ def _handle_content_updates(context: CliContext, hooks: DeviceActionHooks) -> No
         context.get_node_kwargs,
         context.outcome,
     )
-    if args.set_canned_message:
+    content_updates = (
+        (
+            args.set_canned_message,
+            mesh_pb2.CANNEDMSG_CONFIG,
+            "set_canned_message",
+            "Setting canned plugin message to {value}",
+            "Canned Message module is excluded by firmware; skipping set.",
+        ),
+        (
+            args.set_ringtone,
+            mesh_pb2.EXTNOTIF_CONFIG,
+            "set_ringtone",
+            "Setting ringtone to {value}",
+            "External Notification is excluded by firmware; skipping ringtone set.",
+        ),
+    )
+    for value, module_id, method_name, message, skip_warning in content_updates:
+        if not value:
+            continue
+
+        # A requested content update remains a completed one-shot CLI operation even
+        # when firmware excludes the corresponding module. Only arm the shared ACK
+        # wait after a packet is actually sent.
         outcome.close_now = True
-        outcome.wait_for_ack_nak = True
         node = interface.getNode(args.dest, False, **kwargs)
-        if node.module_available(mesh_pb2.CANNEDMSG_CONFIG):
-            hooks.cli_print(
-                f"Setting canned plugin message to {args.set_canned_message}"
-            )
-            node.set_canned_message(args.set_canned_message)
-        else:
-            logger.warning(
-                "Canned Message module is excluded by firmware; skipping set."
-            )
-    if args.set_ringtone:
-        outcome.close_now = True
+        if not node.module_available(module_id):
+            logger.warning(skip_warning)
+            continue
+
         outcome.wait_for_ack_nak = True
-        node = interface.getNode(args.dest, False, **kwargs)
-        if node.module_available(mesh_pb2.EXTNOTIF_CONFIG):
-            hooks.cli_print(f"Setting ringtone to {args.set_ringtone}")
-            node.set_ringtone(args.set_ringtone)
-        else:
-            logger.warning(
-                "External Notification is excluded by firmware; skipping ringtone set."
-            )
+        hooks.cli_print(message.format(value=value))
+        getattr(node, method_name)(value)
 
 
 def _handle_position_fields(context: CliContext, hooks: DeviceActionHooks) -> None:

--- a/meshtastic/cli/device_actions.py
+++ b/meshtastic/cli/device_actions.py
@@ -15,7 +15,7 @@ import threading
 import time
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
-from typing import Any, NoReturn
+from typing import Any
 
 from pubsub import pub
 
@@ -24,7 +24,7 @@ import meshtastic.serial_interface
 import meshtastic.tcp_interface
 import meshtastic.util
 from meshtastic._core_constants import LOCAL_ADDR
-from meshtastic.cli.context import CliContext
+from meshtastic.cli.context import CliContext, CliExit
 from meshtastic.mesh_interface import MeshInterface
 from meshtastic.protobuf import admin_pb2, mesh_pb2
 
@@ -33,6 +33,8 @@ logger = logging.getLogger(__name__)
 FACTORY_RESET_READY_PROBE_TIMEOUT_SECONDS = 20.0
 FACTORY_RESET_ACCEPTANCE_TIMEOUT_SECONDS = 20.0
 FACTORY_RESET_ACCEPTANCE_POLL_SECONDS = 0.05
+POSITION_ALTITUDE_MIN = -(1 << 31)
+POSITION_ALTITUDE_MAX = (1 << 31) - 1
 OTA_REBOOT_WAIT_SECONDS: float = 5.0
 OTA_RETRY_DELAY_SECONDS: float = 2.0
 OTA_MAX_RETRIES: int = 5
@@ -44,7 +46,7 @@ class DeviceActionHooks:
 
     Parameters
     ----------
-    cli_exit : Callable[[str, int], NoReturn]
+    cli_exit : CliExit
         User-facing CLI exit function.
     cli_print : Callable[[str], None]
         Quiet-aware CLI reporter.
@@ -63,7 +65,7 @@ class DeviceActionHooks:
         Lockdown compatibility seams retained by the entrypoint.
     """
 
-    cli_exit: Callable[[str, int], NoReturn]
+    cli_exit: CliExit
     cli_print: Callable[[str], None]
     set_pref: Callable[[Any, str, Any], bool]
     is_local_destination: Callable[[Any, str], bool]
@@ -76,7 +78,7 @@ class DeviceActionHooks:
     validate_lockdown_passphrase: Callable[[bytes], bytes]
 
 
-def send_local_factory_reset_and_wait(
+def send_local_factory_reset_and_wait(  # pylint: disable=inconsistent-return-statements
     reset_node: Any,
     *,
     full: bool,
@@ -109,6 +111,12 @@ def send_local_factory_reset_and_wait(
         If the request is rejected or no acceptance/reboot signal arrives.
     """
     reset_interface = reset_node.iface
+    acceptance_timeout = (
+        FACTORY_RESET_ACCEPTANCE_TIMEOUT_SECONDS if timeout is None else float(timeout)
+    )
+    if acceptance_timeout <= 0:
+        raise ValueError("factory reset acceptance timeout must be positive")
+
     disconnect_observed = threading.Event()
     request_queued = threading.Event()
 
@@ -137,14 +145,6 @@ def send_local_factory_reset_and_wait(
         missing_transport = object()
         socket_after_send = getattr(reset_interface, "socket", missing_transport)
         stream_after_send = getattr(reset_interface, "stream", missing_transport)
-        acceptance_timeout = (
-            FACTORY_RESET_ACCEPTANCE_TIMEOUT_SECONDS
-            if timeout is None
-            else float(timeout)
-        )
-        if acceptance_timeout <= 0:
-            raise ValueError("factory reset acceptance timeout must be positive")
-
         wait_for_request_ack = getattr(reset_interface, "_wait_for_request_ack", None)
         raise_wait_error = getattr(reset_interface, "_raise_wait_error_if_present", None)
         scoped_wait_available = (
@@ -237,8 +237,6 @@ def send_local_factory_reset_and_wait(
                 exc_info=True,
             )
 
-    return None
-
 
 @contextlib.contextmanager
 def temporary_instance_attributes(
@@ -326,7 +324,7 @@ def handle_ota_update(
     args: Any,
     get_node_kwargs: dict[str, Any],
     *,
-    cli_exit: Callable[[str, int], NoReturn],
+    cli_exit: CliExit,
     cli_print: Callable[[str], None],
     is_local_destination: Callable[[Any, str], bool],
 ) -> None:
@@ -340,7 +338,7 @@ def handle_ota_update(
         CLI arguments containing the OTA update path and destination.
     get_node_kwargs : dict[str, Any]
         Additional arguments for retrieving the local node.
-    cli_exit : Callable[[str, int], NoReturn]
+    cli_exit : CliExit
         User-facing exit handler.
     cli_print : Callable[[str], None]
         Quiet-aware reporter.
@@ -387,7 +385,7 @@ def handle_ota_update(
     cli_print("\nOTA update completed successfully!")
 
 
-def handle_device_actions(context: CliContext, hooks: DeviceActionHooks) -> None:
+def _handle_device_actions(context: CliContext, hooks: DeviceActionHooks) -> None:
     """Execute device- and node-administration actions in historical CLI order.
 
     Parameters
@@ -413,11 +411,34 @@ def handle_device_actions(context: CliContext, hooks: DeviceActionHooks) -> None
     elif args.setlat or args.setlon or args.setalt:
         outcome.close_now = True
         outcome.wait_for_ack_nak = True
-        alt = int(args.setalt) if args.setalt else 0
-        lat = _parse_coordinate(args.setlat, "latitude", hooks.cli_print)
-        lon = _parse_coordinate(args.setlon, "longitude", hooks.cli_print)
         if args.setalt:
+            try:
+                alt = int(args.setalt)
+            except (TypeError, ValueError):
+                hooks.cli_exit(f"ERROR: Invalid altitude value: {args.setalt}", 1)
+            if not POSITION_ALTITUDE_MIN <= alt <= POSITION_ALTITUDE_MAX:
+                hooks.cli_exit(
+                    "ERROR: altitude must fit the signed 32-bit position field, "
+                    f"got: {alt}",
+                    1,
+                )
             hooks.cli_print(f"Fixing altitude at {alt} meters")
+        else:
+            alt = 0
+        lat = _parse_coordinate(args.setlat, "latitude", hooks)
+        lon = _parse_coordinate(args.setlon, "longitude", hooks)
+        if not -90.0 <= lat <= 90.0:
+            hooks.cli_exit(
+                f"ERROR: latitude must be between -90 and 90, got: {lat}", 1
+            )
+        if not -180.0 <= lon <= 180.0:
+            hooks.cli_exit(
+                f"ERROR: longitude must be between -180 and 180, got: {lon}", 1
+            )
+        if args.setlat is not None:
+            hooks.cli_print(f"Fixing latitude at {lat} degrees")
+        if args.setlon is not None:
+            hooks.cli_print(f"Fixing longitude at {lon} degrees")
         hooks.cli_print("Setting device position and enabling fixed position setting")
         interface.getNode(args.dest, False, **get_node_kwargs).setFixedPosition(
             lat, lon, alt
@@ -487,16 +508,31 @@ def handle_device_actions(context: CliContext, hooks: DeviceActionHooks) -> None
 def _parse_coordinate(
     raw_value: Any,
     coordinate_name: str,
-    cli_print: Callable[[str], None],
+    hooks: DeviceActionHooks,
 ) -> float:
+    """Parse one CLI coordinate as degrees for the fixed-position command.
+
+    Parameters
+    ----------
+    raw_value : Any
+        Raw argparse value, or ``None`` when the coordinate was omitted.
+    coordinate_name : str
+        Human-readable coordinate name for diagnostics.
+    hooks : DeviceActionHooks
+        CLI reporting/exit hooks.
+
+    Returns
+    -------
+    float
+        Parsed coordinate, or ``0.0`` for an omitted value.
+    """
     if raw_value is None:
         return 0.0
     try:
-        value: float = int(raw_value)
-    except ValueError:
-        value = float(raw_value)
-    cli_print(f"Fixing {coordinate_name} at {value} degrees")
-    return value
+        return float(raw_value)
+    except (TypeError, ValueError):
+        hooks.cli_exit(f"ERROR: Invalid {coordinate_name} value: {raw_value}", 1)
+        raise AssertionError("cli_exit returned unexpectedly") from None
 
 
 def _handle_content_updates(context: CliContext, hooks: DeviceActionHooks) -> None:
@@ -543,9 +579,12 @@ def _handle_position_fields(context: CliContext, hooks: DeviceActionHooks) -> No
             for field in args.pos_fields:
                 all_fields |= position_config.PositionFlags.Value(field)
         except ValueError:
-            print("ERROR: supported position fields are:")
-            print(position_config.PositionFlags.keys())
-            print("If no fields are specified, will read and display current value.")
+            supported = ", ".join(position_config.PositionFlags.keys())
+            hooks.cli_exit(
+                "ERROR: Unsupported position field. Supported position fields are: "
+                f"{supported}. If no fields are specified, the current value is displayed.",
+                1,
+            )
         else:
             hooks.cli_print(f"Setting position fields to {all_fields}")
             hooks.set_pref(position_config, "position_flags", f"{all_fields:d}")
@@ -559,7 +598,7 @@ def _handle_position_fields(context: CliContext, hooks: DeviceActionHooks) -> No
             for bit in position_config.PositionFlags.values()
             if position_config.position_flags & bit
         ]
-        print(" ".join(field_names))
+        hooks.cli_print(" ".join(field_names))
 
 
 def _handle_reboot_and_reset_actions(
@@ -650,7 +689,7 @@ def _handle_node_database_actions(context: CliContext) -> None:
         interface.getNode(args.dest, False, **kwargs).resetNodeDb()
 
 
-def handle_lockdown_action(context: CliContext, hooks: DeviceActionHooks) -> None:
+def _handle_lockdown_action(context: CliContext, hooks: DeviceActionHooks) -> None:
     """Execute the mutually exclusive firmware-lockdown action, if requested.
 
     Parameters
@@ -715,15 +754,15 @@ def handle_lockdown_action(context: CliContext, hooks: DeviceActionHooks) -> Non
         hooks.cli_exit(f"Lockdown command failed: {exc}", 1)
 
     if status is None:
-        print("Lockdown command accepted; device may already be rebooting.")
+        hooks.cli_print("Lockdown command accepted; device may already be rebooting.")
         return
     try:
         state_name = mesh_pb2.LockdownStatus.State.Name(status.state)
     except ValueError:
         state_name = f"STATE_{status.state}"
-    print(f"Lockdown status: {state_name}")
+    hooks.cli_print(f"Lockdown status: {state_name}")
     if status.backoff_seconds:
-        print(f"Retry backoff: {status.backoff_seconds}s")
+        hooks.cli_print(f"Retry backoff: {status.backoff_seconds}s")
     if status.state == mesh_pb2.LockdownStatus.UNLOCK_FAILED:
         hooks.cli_exit("Lockdown authentication failed.", 1)
 

--- a/meshtastic/cli/device_actions.py
+++ b/meshtastic/cli/device_actions.py
@@ -118,11 +118,11 @@ def _send_local_factory_reset_and_wait(  # pylint: disable=inconsistent-return-s
         raise ValueError("factory reset acceptance timeout must be positive")
 
     disconnect_observed = threading.Event()
-    request_queued = threading.Event()
+    request_started = threading.Event()
 
     def _on_connection_lost(interface: MeshInterface) -> None:
-        """Record transport loss only after the destructive request is queued."""
-        if request_queued.is_set() and interface is reset_interface:
+        """Record transport loss once destructive request dispatch has started."""
+        if request_started.is_set() and interface is reset_interface:
             disconnect_observed.set()
 
     acknowledgment = getattr(reset_interface, "_acknowledgment", None)
@@ -134,6 +134,9 @@ def _send_local_factory_reset_and_wait(  # pylint: disable=inconsistent-return-s
     request: mesh_pb2.MeshPacket | None = None
     request_id: int | None = None
     try:
+        # Arm the observer before the synchronous send. A local device may reboot
+        # and publish connection loss before ``factoryReset`` returns its packet.
+        request_started.set()
         request = reset_node.factoryReset(full=full)
         if request is None:
             return None
@@ -141,7 +144,6 @@ def _send_local_factory_reset_and_wait(  # pylint: disable=inconsistent-return-s
         raw_request_id = getattr(request, "id", None)
         if isinstance(raw_request_id, int) and not isinstance(raw_request_id, bool):
             request_id = raw_request_id if raw_request_id > 0 else None
-        request_queued.set()
 
         missing_transport = object()
         socket_after_send = getattr(reset_interface, "socket", missing_transport)
@@ -674,7 +676,8 @@ def _handle_position_fields(context: CliContext, hooks: DeviceActionHooks) -> No
     )
     if args.pos_fields:
         outcome.close_now = True
-        position_config = interface.getNode(args.dest, **kwargs).localConfig.position
+        node = interface.getNode(args.dest, **kwargs)
+        position_config = node.localConfig.position
         all_fields = 0
         try:
             for field in args.pos_fields:
@@ -698,7 +701,7 @@ def _handle_position_fields(context: CliContext, hooks: DeviceActionHooks) -> No
                     1,
                 )
             hooks.cli_print("Writing modified preferences to device")
-            interface.getNode(args.dest, **kwargs).writeConfig("position")
+            node.writeConfig("position")
     elif args.pos_fields is not None:
         outcome.close_now = True
         position_config = interface.getNode(args.dest, **kwargs).localConfig.position

--- a/meshtastic/cli/device_actions.py
+++ b/meshtastic/cli/device_actions.py
@@ -680,7 +680,14 @@ def _handle_position_fields(context: CliContext, hooks: DeviceActionHooks) -> No
             )
         else:
             hooks.cli_print(f"Setting position fields to {all_fields}")
-            hooks.set_pref(position_config, "position_flags", f"{all_fields:d}")
+            if not hooks.set_pref(
+                position_config, "position_flags", f"{all_fields:d}"
+            ):
+                _terminate_cli(
+                    hooks.cli_exit,
+                    "ERROR: Failed to set position_flags preference.",
+                    1,
+                )
             hooks.cli_print("Writing modified preferences to device")
             interface.getNode(args.dest, **kwargs).writeConfig("position")
     elif args.pos_fields is not None:

--- a/meshtastic/cli/device_actions.py
+++ b/meshtastic/cli/device_actions.py
@@ -24,7 +24,7 @@ import meshtastic.serial_interface
 import meshtastic.tcp_interface
 import meshtastic.util
 from meshtastic._core_constants import LOCAL_ADDR
-from meshtastic.cli.context import CliContext, CliExit
+from meshtastic.cli.context import CliContext, CliExit, _terminate_cli
 from meshtastic.mesh_interface import MeshInterface
 from meshtastic.protobuf import admin_pb2, mesh_pb2
 
@@ -147,7 +147,9 @@ def send_local_factory_reset_and_wait(  # pylint: disable=inconsistent-return-st
         socket_after_send = getattr(reset_interface, "socket", missing_transport)
         stream_after_send = getattr(reset_interface, "stream", missing_transport)
         wait_for_request_ack = getattr(reset_interface, "_wait_for_request_ack", None)
-        raise_wait_error = getattr(reset_interface, "_raise_wait_error_if_present", None)
+        raise_wait_error = getattr(
+            reset_interface, "_raise_wait_error_if_present", None
+        )
         scoped_wait_available = (
             request_id is not None
             and callable(wait_for_request_ack)
@@ -169,7 +171,9 @@ def send_local_factory_reset_and_wait(  # pylint: disable=inconsistent-return-st
                 completed = wait_for_request_ack(
                     "receivedNak",
                     request_id,
-                    timeout_seconds=min(FACTORY_RESET_ACCEPTANCE_POLL_SECONDS, remaining),
+                    timeout_seconds=min(
+                        FACTORY_RESET_ACCEPTANCE_POLL_SECONDS, remaining
+                    ),
                 )
                 if completed:
                     raise_wait_error("receivedNak", request_id=request_id)
@@ -281,7 +285,10 @@ def post_factory_reset_ready_probe(interface: MeshInterface) -> None:
     interface : MeshInterface
         Connected interface; non-serial transports are ignored.
     """
-    if not isinstance(interface, meshtastic.serial_interface.SerialInterface):
+    serial_interface_cls = getattr(meshtastic.serial_interface, "SerialInterface", None)
+    if not isinstance(serial_interface_cls, type) or not isinstance(
+        interface, serial_interface_cls
+    ):
         return
 
     logger.debug("Factory reset: closing serial interface to release port.")
@@ -347,12 +354,14 @@ def handle_ota_update(
         Destination classifier.
     """
     if not isinstance(interface, meshtastic.tcp_interface.TCPInterface):
-        cli_exit(
+        _terminate_cli(
+            cli_exit,
             "Error: OTA update currently requires a TCP connection to the node (use --host).",
             1,
         )
     if not is_local_destination(interface, args.dest):
-        cli_exit(
+        _terminate_cli(
+            cli_exit,
             "Error: OTA update only supports the directly connected local node; "
             "omit --dest or use --dest ^local.",
             1,
@@ -361,8 +370,7 @@ def handle_ota_update(
     try:
         ota = meshtastic.ota.ESP32WiFiOTA(args.ota_update, interface.hostname)
     except meshtastic.ota.OTAError as exc:
-        cli_exit(f"OTA update failed: {exc}", 1)
-        raise AssertionError("cli_exit returned unexpectedly") from None
+        _terminate_cli(cli_exit, f"OTA update failed: {exc}", 1)
 
     cli_print(f"Triggering OTA update on {interface.hostname}...")
     interface.getNode(LOCAL_ADDR, requestChannels=False, **get_node_kwargs).startOTA(
@@ -379,12 +387,10 @@ def handle_ota_update(
         except meshtastic.ota.OTATransportError as exc:
             retries -= 1
             if retries == 0:
-                cli_exit(f"OTA update failed: {exc}", 1)
-                raise AssertionError("cli_exit returned unexpectedly") from None
+                _terminate_cli(cli_exit, f"OTA update failed: {exc}", 1)
             time.sleep(OTA_RETRY_DELAY_SECONDS)
         except meshtastic.ota.OTAError as exc:
-            cli_exit(f"OTA update failed: {exc}", 1)
-            raise AssertionError("cli_exit returned unexpectedly") from None
+            _terminate_cli(cli_exit, f"OTA update failed: {exc}", 1)
 
     cli_print("\nOTA update completed successfully!")
 
@@ -412,35 +418,30 @@ def _handle_device_actions(context: CliContext, hooks: DeviceActionHooks) -> Non
         outcome.wait_for_ack_nak = True
         hooks.cli_print("Removing fixed position and disabling fixed position setting")
         interface.getNode(args.dest, False, **get_node_kwargs).removeFixedPosition()
-    elif args.setlat or args.setlon or args.setalt:
+    elif any(value is not None for value in (args.setlat, args.setlon, args.setalt)):
         outcome.close_now = True
         outcome.wait_for_ack_nak = True
-        if args.setalt:
+        if args.setalt is not None:
             try:
                 alt = int(args.setalt)
             except (TypeError, ValueError):
-                hooks.cli_exit(f"ERROR: Invalid altitude value: {args.setalt}", 1)
-                raise AssertionError("cli_exit returned unexpectedly") from None
+                _terminate_cli(
+                    hooks.cli_exit, f"ERROR: Invalid altitude value: {args.setalt}", 1
+                )
             if not POSITION_ALTITUDE_MIN <= alt <= POSITION_ALTITUDE_MAX:
-                hooks.cli_exit(
+                _terminate_cli(
+                    hooks.cli_exit,
                     "ERROR: altitude must fit the signed 32-bit position field, "
                     f"got: {alt}",
                     1,
                 )
-                raise AssertionError("cli_exit returned unexpectedly") from None
             hooks.cli_print(f"Fixing altitude at {alt} meters")
         else:
             alt = 0
         lat = _parse_coordinate(args.setlat, "latitude", hooks)
         lon = _parse_coordinate(args.setlon, "longitude", hooks)
-        if not -90.0 <= lat <= 90.0:
-            hooks.cli_exit(
-                f"ERROR: latitude must be between -90 and 90, got: {lat}", 1
-            )
-        if not -180.0 <= lon <= 180.0:
-            hooks.cli_exit(
-                f"ERROR: longitude must be between -180 and 180, got: {lon}", 1
-            )
+        _validate_coordinate_range(lat, "latitude", 90, hooks)
+        _validate_coordinate_range(lon, "longitude", 180, hooks)
         if args.setlat is not None:
             hooks.cli_print(f"Fixing latitude at {lat} degrees")
         if args.setlon is not None:
@@ -456,12 +457,14 @@ def _handle_device_actions(context: CliContext, hooks: DeviceActionHooks) -> Non
         long_name = args.set_owner.strip() if args.set_owner else None
         short_name = args.set_owner_short.strip() if args.set_owner_short else None
         if long_name is not None and not long_name:
-            hooks.cli_exit(
+            _terminate_cli(
+                hooks.cli_exit,
                 "ERROR: Long Name cannot be empty or contain only whitespace characters",
                 1,
             )
         if short_name is not None and not short_name:
-            hooks.cli_exit(
+            _terminate_cli(
+                hooks.cli_exit,
                 "ERROR: Short Name cannot be empty or contain only whitespace characters",
                 1,
             )
@@ -494,16 +497,16 @@ def _handle_device_actions(context: CliContext, hooks: DeviceActionHooks) -> Non
     if args.set_ham:
         ham_id = args.set_ham.strip()
         if not ham_id:
-            hooks.cli_exit(
+            _terminate_cli(
+                hooks.cli_exit,
                 "ERROR: Ham radio callsign cannot be empty or contain only whitespace characters",
                 1,
             )
         outcome.close_now = True
         hooks.cli_print(f"Setting Ham ID to {ham_id} and turning off encryption")
-        interface.getNode(args.dest, **get_node_kwargs).setOwner(
-            ham_id, is_licensed=True
-        )
-        interface.getNode(args.dest, **get_node_kwargs).turnOffEncryptionOnPrimaryChannel()
+        ham_node = interface.getNode(args.dest, **get_node_kwargs)
+        ham_node.setOwner(ham_id, is_licensed=True)
+        ham_node.turnOffEncryptionOnPrimaryChannel()
 
     _handle_reboot_and_reset_actions(context, hooks)
     if outcome.stop_processing:
@@ -515,13 +518,15 @@ def _parse_coordinate(
     raw_value: Any,
     coordinate_name: str,
     hooks: DeviceActionHooks,
-) -> float:
-    """Parse one CLI coordinate as degrees for the fixed-position command.
+) -> int | float:
+    """Parse one CLI coordinate using the historical dual representation.
 
     Parameters
     ----------
     raw_value : Any
-        Raw argparse value, or ``None`` when the coordinate was omitted.
+        Raw argparse value, or ``None`` when the coordinate was omitted. Integer
+        values represent protobuf coordinates premultiplied by ``1e7``; decimal
+        values represent degrees.
     coordinate_name : str
         Human-readable coordinate name for diagnostics.
     hooks : DeviceActionHooks
@@ -529,16 +534,71 @@ def _parse_coordinate(
 
     Returns
     -------
-    float
-        Parsed coordinate, or ``0.0`` for an omitted value.
+    int | float
+        Parsed scaled integer or decimal-degree coordinate. Omitted coordinates
+        retain the historical ``0.0`` default.
     """
     if raw_value is None:
         return 0.0
+    if isinstance(raw_value, bool):
+        _terminate_cli(
+            hooks.cli_exit,
+            f"ERROR: Invalid {coordinate_name} value: {raw_value}",
+            1,
+        )
+    if isinstance(raw_value, (int, float)):
+        return raw_value
     try:
-        return float(raw_value)
+        return int(raw_value)
     except (TypeError, ValueError):
-        hooks.cli_exit(f"ERROR: Invalid {coordinate_name} value: {raw_value}", 1)
-        raise AssertionError("cli_exit returned unexpectedly") from None
+        try:
+            return float(raw_value)
+        except (TypeError, ValueError):
+            _terminate_cli(
+                hooks.cli_exit,
+                f"ERROR: Invalid {coordinate_name} value: {raw_value}",
+                1,
+            )
+
+
+def _validate_coordinate_range(
+    value: int | float,
+    coordinate_name: str,
+    degree_limit: int,
+    hooks: DeviceActionHooks,
+) -> None:
+    """Validate a coordinate according to its CLI representation.
+
+    Parameters
+    ----------
+    value : int | float
+        Parsed coordinate. Integers are already scaled by ``1e7``; floats are
+        decimal degrees.
+    coordinate_name : str
+        Human-readable coordinate name for diagnostics.
+    degree_limit : int
+        Absolute geographic degree limit (90 for latitude, 180 for longitude).
+    hooks : DeviceActionHooks
+        CLI exit hook used for invalid values.
+    """
+    if isinstance(value, int):
+        scaled_limit = degree_limit * 10_000_000
+        if not -scaled_limit <= value <= scaled_limit:
+            _terminate_cli(
+                hooks.cli_exit,
+                f"ERROR: {coordinate_name} premultiplied integer must be between "
+                f"{-scaled_limit} and {scaled_limit}, got: {value}",
+                1,
+            )
+        return
+
+    if not -degree_limit <= value <= degree_limit:
+        _terminate_cli(
+            hooks.cli_exit,
+            f"ERROR: {coordinate_name} must be between {-degree_limit} and "
+            f"{degree_limit}, got: {value}",
+            1,
+        )
 
 
 def _handle_content_updates(context: CliContext, hooks: DeviceActionHooks) -> None:
@@ -563,10 +623,14 @@ def _handle_content_updates(context: CliContext, hooks: DeviceActionHooks) -> No
         outcome.wait_for_ack_nak = True
         node = interface.getNode(args.dest, False, **kwargs)
         if node.module_available(mesh_pb2.CANNEDMSG_CONFIG):
-            hooks.cli_print(f"Setting canned plugin message to {args.set_canned_message}")
+            hooks.cli_print(
+                f"Setting canned plugin message to {args.set_canned_message}"
+            )
             node.set_canned_message(args.set_canned_message)
         else:
-            logger.warning("Canned Message module is excluded by firmware; skipping set.")
+            logger.warning(
+                "Canned Message module is excluded by firmware; skipping set."
+            )
     if args.set_ringtone:
         outcome.close_now = True
         outcome.wait_for_ack_nak = True
@@ -606,12 +670,12 @@ def _handle_position_fields(context: CliContext, hooks: DeviceActionHooks) -> No
                 all_fields |= position_config.PositionFlags.Value(field)
         except ValueError:
             supported = ", ".join(position_config.PositionFlags.keys())
-            hooks.cli_exit(
+            _terminate_cli(
+                hooks.cli_exit,
                 "ERROR: Unsupported position field. Supported position fields are: "
                 f"{supported}. If no fields are specified, the current value is displayed.",
                 1,
             )
-            raise AssertionError("cli_exit returned unexpectedly") from None
         else:
             hooks.cli_print(f"Setting position fields to {all_fields}")
             hooks.set_pref(position_config, "position_flags", f"{all_fields:d}")
@@ -690,15 +754,7 @@ def _handle_reboot_and_reset_actions(
             hooks.send_local_factory_reset_and_wait(reset_node, full=full)
         else:
             reset_node.factoryReset(full=full)
-        serial_interface_cls = getattr(
-            meshtastic.serial_interface, "SerialInterface", None
-        )
-        if (
-            full
-            and is_local_reset
-            and isinstance(serial_interface_cls, type)
-            and isinstance(interface, serial_interface_cls)
-        ):
+        if full and is_local_reset:
             hooks.post_factory_reset_ready_probe(interface)
 
 
@@ -764,17 +820,22 @@ def _handle_lockdown_action(context: CliContext, hooks: DeviceActionHooks) -> No
 
     context.outcome.close_now = True
     if not hooks.is_local_destination(context.interface, args.dest):
-        hooks.cli_exit(
-            "Lockdown commands apply only to the directly connected local node.", 1
+        _terminate_cli(
+            hooks.cli_exit,
+            "Lockdown commands apply only to the directly connected local node.",
+            1,
         )
-    if lockdown_action in {"provision", "lock-now", "disable"} and not args.lockdown_yes:
+    if (
+        lockdown_action in {"provision", "lock-now", "disable"}
+        and not args.lockdown_yes
+    ):
         confirmation = (
             input(f"Type 'yes' to confirm lockdown {lockdown_action}: ")
             .strip()
             .casefold()
         )
         if confirmation != "yes":
-            hooks.cli_exit("Aborted.", 1)
+            _terminate_cli(hooks.cli_exit, "Aborted.", 1)
 
     try:
         passphrase = _read_lockdown_passphrase(args, lockdown_action, hooks)
@@ -787,8 +848,7 @@ def _handle_lockdown_action(context: CliContext, hooks: DeviceActionHooks) -> No
             disable=lockdown_action == "disable",
         )
     except (OSError, ValueError) as exc:
-        hooks.cli_exit(f"Invalid lockdown options: {exc}", 1)
-        raise AssertionError("cli_exit returned unexpectedly") from None
+        _terminate_cli(hooks.cli_exit, f"Invalid lockdown options: {exc}", 1)
 
     try:
         status = hooks.send_lockdown_auth(
@@ -798,8 +858,7 @@ def _handle_lockdown_action(context: CliContext, hooks: DeviceActionHooks) -> No
             allow_reboot_without_status=lockdown_action == "lock-now",
         )
     except (TimeoutError, ValueError, RuntimeError) as exc:
-        hooks.cli_exit(f"Lockdown command failed: {exc}", 1)
-        raise AssertionError("cli_exit returned unexpectedly") from None
+        _terminate_cli(hooks.cli_exit, f"Lockdown command failed: {exc}", 1)
 
     if status is None:
         hooks.cli_print("Lockdown command accepted; device may already be rebooting.")
@@ -812,7 +871,7 @@ def _handle_lockdown_action(context: CliContext, hooks: DeviceActionHooks) -> No
     if status.backoff_seconds:
         hooks.cli_print(f"Retry backoff: {status.backoff_seconds}s")
     if status.state == mesh_pb2.LockdownStatus.UNLOCK_FAILED:
-        hooks.cli_exit("Lockdown authentication failed.", 1)
+        _terminate_cli(hooks.cli_exit, "Lockdown authentication failed.", 1)
 
 
 def _read_lockdown_passphrase(
@@ -840,13 +899,13 @@ def _read_lockdown_passphrase(
         return hooks.read_lockdown_passphrase_file(args.lockdown_passphrase_file)
     if args.lockdown_passphrase is not None:
         if not args.insecure_lockdown_passphrase_on_command_line:
-            hooks.cli_exit(
+            _terminate_cli(
+                hooks.cli_exit,
                 "--lockdown-passphrase requires "
                 "--insecure-lockdown-passphrase-on-command-line; "
                 "prefer an operator-only file or interactive entry.",
                 1,
             )
-            raise AssertionError("cli_exit returned unexpectedly") from None
         return hooks.validate_lockdown_passphrase(
             args.lockdown_passphrase.encode("utf-8")
         )
@@ -855,6 +914,5 @@ def _read_lockdown_passphrase(
     if lockdown_action == "provision":
         confirmed = getpass.getpass("Lockdown passphrase (confirm): ")
         if entered != confirmed:
-            hooks.cli_exit("Lockdown passphrases do not match.", 1)
-            raise AssertionError("cli_exit returned unexpectedly") from None
+            _terminate_cli(hooks.cli_exit, "Lockdown passphrases do not match.", 1)
     return hooks.validate_lockdown_passphrase(entered.encode("utf-8"))

--- a/meshtastic/cli/device_actions.py
+++ b/meshtastic/cli/device_actions.py
@@ -15,7 +15,7 @@ import threading
 import time
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 from pubsub import pub
 
@@ -291,9 +291,11 @@ def post_factory_reset_ready_probe(interface: MeshInterface) -> None:
     ):
         return
 
+    serial_interface = cast(meshtastic.serial_interface.SerialInterface, interface)
+
     logger.debug("Factory reset: closing serial interface to release port.")
     try:
-        interface.close()
+        serial_interface.close()
     except Exception:
         logger.debug("Factory reset: initial serial close failed.", exc_info=True)
 
@@ -307,9 +309,9 @@ def post_factory_reset_ready_probe(interface: MeshInterface) -> None:
         "_suppress_connect_failure_logging": True,
     }
     probe_start = time.monotonic()
-    with temporary_instance_attributes(interface, probe_overrides):
+    with temporary_instance_attributes(serial_interface, probe_overrides):
         try:
-            interface.connect()
+            serial_interface.connect()
             logger.debug(
                 "Factory reset: reconnect probe succeeded in %.2fs.",
                 time.monotonic() - probe_start,
@@ -322,7 +324,7 @@ def post_factory_reset_ready_probe(interface: MeshInterface) -> None:
                 exc,
             )
     try:
-        interface.close()
+        serial_interface.close()
     except Exception:
         logger.debug("Factory reset: final serial close failed.", exc_info=True)
 
@@ -451,7 +453,7 @@ def _handle_device_actions(context: CliContext, hooks: DeviceActionHooks) -> Non
             lat, lon, alt
         )
 
-    if args.set_owner or args.set_owner_short or args.set_is_unmessageable:
+    if args.set_owner or args.set_owner_short or args.set_is_unmessageable is not None:
         outcome.close_now = True
         outcome.wait_for_ack_nak = True
         long_name = args.set_owner.strip() if args.set_owner else None

--- a/meshtastic/cli/device_actions.py
+++ b/meshtastic/cli/device_actions.py
@@ -121,6 +121,7 @@ def send_local_factory_reset_and_wait(  # pylint: disable=inconsistent-return-st
     request_queued = threading.Event()
 
     def _on_connection_lost(interface: MeshInterface) -> None:
+        """Record transport loss only after the destructive request is queued."""
         if request_queued.is_set() and interface is reset_interface:
             disconnect_observed.set()
 
@@ -361,6 +362,7 @@ def handle_ota_update(
         ota = meshtastic.ota.ESP32WiFiOTA(args.ota_update, interface.hostname)
     except meshtastic.ota.OTAError as exc:
         cli_exit(f"OTA update failed: {exc}", 1)
+        raise AssertionError("cli_exit returned unexpectedly") from None
 
     cli_print(f"Triggering OTA update on {interface.hostname}...")
     interface.getNode(LOCAL_ADDR, requestChannels=False, **get_node_kwargs).startOTA(
@@ -378,9 +380,11 @@ def handle_ota_update(
             retries -= 1
             if retries == 0:
                 cli_exit(f"OTA update failed: {exc}", 1)
+                raise AssertionError("cli_exit returned unexpectedly") from None
             time.sleep(OTA_RETRY_DELAY_SECONDS)
         except meshtastic.ota.OTAError as exc:
             cli_exit(f"OTA update failed: {exc}", 1)
+            raise AssertionError("cli_exit returned unexpectedly") from None
 
     cli_print("\nOTA update completed successfully!")
 
@@ -416,12 +420,14 @@ def _handle_device_actions(context: CliContext, hooks: DeviceActionHooks) -> Non
                 alt = int(args.setalt)
             except (TypeError, ValueError):
                 hooks.cli_exit(f"ERROR: Invalid altitude value: {args.setalt}", 1)
+                raise AssertionError("cli_exit returned unexpectedly") from None
             if not POSITION_ALTITUDE_MIN <= alt <= POSITION_ALTITUDE_MAX:
                 hooks.cli_exit(
                     "ERROR: altitude must fit the signed 32-bit position field, "
                     f"got: {alt}",
                     1,
                 )
+                raise AssertionError("cli_exit returned unexpectedly") from None
             hooks.cli_print(f"Fixing altitude at {alt} meters")
         else:
             alt = 0
@@ -536,6 +542,16 @@ def _parse_coordinate(
 
 
 def _handle_content_updates(context: CliContext, hooks: DeviceActionHooks) -> None:
+    """Apply canned-message and ringtone updates in historical CLI order.
+
+    Parameters
+    ----------
+    context : CliContext
+        Connected invocation state. ``close_now`` and ``wait_for_ack_nak`` are
+        enabled for requested one-shot content writes.
+    hooks : DeviceActionHooks
+        Reporting and compatibility seams used by the updates.
+    """
     interface, args, kwargs, outcome = (
         context.interface,
         context.args,
@@ -565,6 +581,16 @@ def _handle_content_updates(context: CliContext, hooks: DeviceActionHooks) -> No
 
 
 def _handle_position_fields(context: CliContext, hooks: DeviceActionHooks) -> None:
+    """Read or write the position-field bitmask requested by the CLI.
+
+    Parameters
+    ----------
+    context : CliContext
+        Connected invocation state. ``close_now`` is enabled when position
+        fields are read or modified.
+    hooks : DeviceActionHooks
+        Preference assignment, reporting, and exit seams.
+    """
     interface, args, kwargs, outcome = (
         context.interface,
         context.args,
@@ -585,6 +611,7 @@ def _handle_position_fields(context: CliContext, hooks: DeviceActionHooks) -> No
                 f"{supported}. If no fields are specified, the current value is displayed.",
                 1,
             )
+            raise AssertionError("cli_exit returned unexpectedly") from None
         else:
             hooks.cli_print(f"Setting position fields to {all_fields}")
             hooks.set_pref(position_config, "position_flags", f"{all_fields:d}")
@@ -604,6 +631,17 @@ def _handle_position_fields(context: CliContext, hooks: DeviceActionHooks) -> No
 def _handle_reboot_and_reset_actions(
     context: CliContext, hooks: DeviceActionHooks
 ) -> None:
+    """Execute reboot, shutdown, transaction, metadata, and reset actions.
+
+    Parameters
+    ----------
+    context : CliContext
+        Connected invocation state. The handler updates ``close_now``,
+        ``wait_for_ack_nak``, ``skip_ack_wait``, and ``stop_processing`` to
+        preserve each action's historical lifecycle behavior.
+    hooks : DeviceActionHooks
+        Reset, reporting, and destination-classification seams.
+    """
     interface, args, kwargs, outcome = (
         context.interface,
         context.args,
@@ -665,6 +703,14 @@ def _handle_reboot_and_reset_actions(
 
 
 def _handle_node_database_actions(context: CliContext) -> None:
+    """Apply node-database favorite, ignored, removal, and reset actions.
+
+    Parameters
+    ----------
+    context : CliContext
+        Connected invocation state. Requested writes enable ``close_now`` and
+        ``wait_for_ack_nak`` for shared finalization.
+    """
     interface, args, kwargs, outcome = (
         context.interface,
         context.args,
@@ -742,6 +788,7 @@ def _handle_lockdown_action(context: CliContext, hooks: DeviceActionHooks) -> No
         )
     except (OSError, ValueError) as exc:
         hooks.cli_exit(f"Invalid lockdown options: {exc}", 1)
+        raise AssertionError("cli_exit returned unexpectedly") from None
 
     try:
         status = hooks.send_lockdown_auth(
@@ -752,6 +799,7 @@ def _handle_lockdown_action(context: CliContext, hooks: DeviceActionHooks) -> No
         )
     except (TimeoutError, ValueError, RuntimeError) as exc:
         hooks.cli_exit(f"Lockdown command failed: {exc}", 1)
+        raise AssertionError("cli_exit returned unexpectedly") from None
 
     if status is None:
         hooks.cli_print("Lockdown command accepted; device may already be rebooting.")
@@ -770,6 +818,22 @@ def _handle_lockdown_action(context: CliContext, hooks: DeviceActionHooks) -> No
 def _read_lockdown_passphrase(
     args: Any, lockdown_action: str, hooks: DeviceActionHooks
 ) -> bytes:
+    """Read and validate the passphrase required by one lockdown action.
+
+    Parameters
+    ----------
+    args : Any
+        Parsed lockdown CLI arguments.
+    lockdown_action : str
+        Selected action name (for example ``"provision"`` or ``"lock-now"``).
+    hooks : DeviceActionHooks
+        Passphrase file, validation, and exit seams.
+
+    Returns
+    -------
+    bytes
+        Validated passphrase bytes, or ``b""`` for ``lock-now``.
+    """
     if lockdown_action == "lock-now":
         return b""
     if args.lockdown_passphrase_file:
@@ -782,6 +846,7 @@ def _read_lockdown_passphrase(
                 "prefer an operator-only file or interactive entry.",
                 1,
             )
+            raise AssertionError("cli_exit returned unexpectedly") from None
         return hooks.validate_lockdown_passphrase(
             args.lockdown_passphrase.encode("utf-8")
         )
@@ -791,4 +856,5 @@ def _read_lockdown_passphrase(
         confirmed = getpass.getpass("Lockdown passphrase (confirm): ")
         if entered != confirmed:
             hooks.cli_exit("Lockdown passphrases do not match.", 1)
+            raise AssertionError("cli_exit returned unexpectedly") from None
     return hooks.validate_lockdown_passphrase(entered.encode("utf-8"))

--- a/meshtastic/cli/device_actions.py
+++ b/meshtastic/cli/device_actions.py
@@ -118,11 +118,11 @@ def _send_local_factory_reset_and_wait(  # pylint: disable=inconsistent-return-s
         raise ValueError("factory reset acceptance timeout must be positive")
 
     disconnect_observed = threading.Event()
-    request_started = threading.Event()
+    request_queued = threading.Event()
 
     def _on_connection_lost(interface: MeshInterface) -> None:
-        """Record transport loss once destructive request dispatch has started."""
-        if request_started.is_set() and interface is reset_interface:
+        """Record transport loss only after the reset request is queued."""
+        if request_queued.is_set() and interface is reset_interface:
             disconnect_observed.set()
 
     acknowledgment = getattr(reset_interface, "_acknowledgment", None)
@@ -134,12 +134,14 @@ def _send_local_factory_reset_and_wait(  # pylint: disable=inconsistent-return-s
     request: mesh_pb2.MeshPacket | None = None
     request_id: int | None = None
     try:
-        # Arm the observer before the synchronous send. A local device may reboot
-        # and publish connection loss before ``factoryReset`` returns its packet.
-        request_started.set()
         request = reset_node.factoryReset(full=full)
         if request is None:
             return None
+        # A connection-loss event observed before the send returns is not tied to
+        # this request and cannot prove that firmware accepted a destructive reset.
+        # Genuine reset transport loss remains visible through the connection and
+        # transport snapshots below even if publication raced with this boundary.
+        request_queued.set()
 
         raw_request_id = getattr(request, "id", None)
         if isinstance(raw_request_id, int) and not isinstance(raw_request_id, bool):

--- a/meshtastic/cli/device_actions.py
+++ b/meshtastic/cli/device_actions.py
@@ -244,7 +244,7 @@ def send_local_factory_reset_and_wait(  # pylint: disable=inconsistent-return-st
 
 
 @contextlib.contextmanager
-def temporary_instance_attributes(
+def _temporary_instance_attributes(
     instance: Any, overrides: dict[str, Any]
 ) -> Iterator[None]:
     """Temporarily override instance attributes and restore exact prior state.
@@ -309,7 +309,7 @@ def post_factory_reset_ready_probe(interface: MeshInterface) -> None:
         "_suppress_connect_failure_logging": True,
     }
     probe_start = time.monotonic()
-    with temporary_instance_attributes(serial_interface, probe_overrides):
+    with _temporary_instance_attributes(serial_interface, probe_overrides):
         try:
             serial_interface.connect()
             logger.debug(
@@ -838,13 +838,7 @@ def _handle_lockdown_action(context: CliContext, hooks: DeviceActionHooks) -> No
         lockdown_action in {"provision", "lock-now", "disable"}
         and not args.lockdown_yes
     ):
-        confirmation = (
-            input(f"Type 'yes' to confirm lockdown {lockdown_action}: ")
-            .strip()
-            .casefold()
-        )
-        if confirmation != "yes":
-            _terminate_cli(hooks.cli_exit, "Aborted.", 1)
+        _confirm_lockdown_action(lockdown_action, hooks)
 
     try:
         passphrase = _read_lockdown_passphrase(args, lockdown_action, hooks)
@@ -883,6 +877,59 @@ def _handle_lockdown_action(context: CliContext, hooks: DeviceActionHooks) -> No
         _terminate_cli(hooks.cli_exit, "Lockdown authentication failed.", 1)
 
 
+def _confirm_lockdown_action(lockdown_action: str, hooks: DeviceActionHooks) -> None:
+    """Require explicit interactive confirmation for a destructive lockdown action.
+
+    Parameters
+    ----------
+    lockdown_action : str
+        Destructive lockdown action being confirmed.
+    hooks : DeviceActionHooks
+        CLI-exit seam used to report aborted or non-interactive confirmation.
+    """
+    try:
+        confirmation = (
+            input(f"Type 'yes' to confirm lockdown {lockdown_action}: ")
+            .strip()
+            .casefold()
+        )
+    except EOFError:
+        _terminate_cli(
+            hooks.cli_exit,
+            "Lockdown confirmation requires an interactive terminal; "
+            "pass --lockdown-yes for non-interactive use.",
+            1,
+        )
+    if confirmation != "yes":
+        _terminate_cli(hooks.cli_exit, "Aborted.", 1)
+
+
+def _prompt_lockdown_passphrase(prompt: str, hooks: DeviceActionHooks) -> str:
+    """Read a lockdown passphrase without exposing a traceback on closed stdin.
+
+    Parameters
+    ----------
+    prompt : str
+        Prompt shown by :func:`getpass.getpass`.
+    hooks : DeviceActionHooks
+        CLI-exit seam used to report non-interactive input.
+
+    Returns
+    -------
+    str
+        Passphrase supplied by the operator.
+    """
+    try:
+        return getpass.getpass(prompt)
+    except EOFError:
+        _terminate_cli(
+            hooks.cli_exit,
+            "Lockdown passphrase input requires an interactive terminal; "
+            "use --lockdown-passphrase-file for non-interactive use.",
+            1,
+        )
+
+
 def _read_lockdown_passphrase(
     args: Any, lockdown_action: str, hooks: DeviceActionHooks
 ) -> bytes:
@@ -919,9 +966,11 @@ def _read_lockdown_passphrase(
             args.lockdown_passphrase.encode("utf-8")
         )
 
-    entered = getpass.getpass("Lockdown passphrase: ")
+    entered = _prompt_lockdown_passphrase("Lockdown passphrase: ", hooks)
     if lockdown_action == "provision":
-        confirmed = getpass.getpass("Lockdown passphrase (confirm): ")
+        confirmed = _prompt_lockdown_passphrase(
+            "Lockdown passphrase (confirm): ", hooks
+        )
         if entered != confirmed:
             _terminate_cli(hooks.cli_exit, "Lockdown passphrases do not match.", 1)
     return hooks.validate_lockdown_passphrase(entered.encode("utf-8"))

--- a/meshtastic/cli/dispatch.py
+++ b/meshtastic/cli/dispatch.py
@@ -8,13 +8,13 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from meshtastic._core_constants import BROADCAST_ADDR
 from meshtastic.cli import (
     channel_contact_actions,
     configure_actions,
     device_actions,
     messaging_service_actions,
 )
-from meshtastic._core_constants import BROADCAST_ADDR
 from meshtastic.cli.context import CliContext
 
 logger = logging.getLogger(__name__)
@@ -103,6 +103,8 @@ def dispatch_connected(context: CliContext, hooks: DispatchHooks) -> None:
     try:
         _print_connection(context, hooks)
 
+        # Action modules are internal implementation packages; these intentionally
+        # private entrypoints avoid expanding the backwards-compatible public API.
         device_actions._handle_device_actions(context, hooks.device)
 
         if not outcome.stop_processing:

--- a/meshtastic/cli/dispatch.py
+++ b/meshtastic/cli/dispatch.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 import logging
 import os
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable
 
-import meshtastic.cli.channel_contact_actions as channel_contact_actions
-import meshtastic.cli.configure_actions as configure_actions
-import meshtastic.cli.device_actions as device_actions
-import meshtastic.cli.messaging_service_actions as messaging_service_actions
+from meshtastic.cli import (
+    channel_contact_actions,
+    configure_actions,
+    device_actions,
+    messaging_service_actions,
+)
 from meshtastic._core_constants import BROADCAST_ADDR
 from meshtastic.cli.context import CliContext
 
@@ -99,31 +101,34 @@ def dispatch_connected(context: CliContext, hooks: DispatchHooks) -> None:
     try:
         _print_connection(context, hooks)
 
-        device_actions.handle_device_actions(context, hooks.device)
-        if outcome.stop_processing:
-            return
+        device_actions._handle_device_actions(context, hooks.device)
 
-        channel_contact_actions.handle_contact_import(context)
-        messaging_service_actions.handle_messaging_actions(context, hooks.services)
+        if not outcome.stop_processing:
+            channel_contact_actions._handle_contact_import(context)
+            messaging_service_actions._handle_messaging_actions(context, hooks.services)
+            configure_actions._handle_configure_actions(context, hooks.configure)
 
-        configure_actions.handle_configure_actions(context, hooks.configure)
-        if outcome.stop_processing:
-            return
+        if not outcome.stop_processing:
+            channel_contact_actions._handle_channel_mutations(
+                context, hooks.channel_contact
+            )
+            messaging_service_actions._handle_content_reads(context)
+            channel_contact_actions._handle_region_preset_display(
+                context, hooks.channel_contact
+            )
+            device_actions._handle_lockdown_action(context, hooks.device)
+            messaging_service_actions._handle_information_actions(
+                context, hooks.services
+            )
 
-        channel_contact_actions.handle_channel_mutations(context, hooks.channel_contact)
-        messaging_service_actions.handle_content_reads(context)
-        channel_contact_actions.handle_region_preset_display(
-            context, hooks.channel_contact
-        )
-        device_actions.handle_lockdown_action(context, hooks.device)
-        messaging_service_actions.handle_information_actions(context, hooks.services)
-        if outcome.stop_processing:
-            return
+        if not outcome.stop_processing:
+            channel_contact_actions._handle_channel_contact_display(
+                context, hooks.channel_contact
+            )
+            messaging_service_actions._handle_long_running_services(
+                context, hooks.services
+            )
 
-        channel_contact_actions.handle_channel_contact_display(
-            context, hooks.channel_contact
-        )
-        messaging_service_actions.handle_long_running_services(context, hooks.services)
         _finalize_connected_actions(context, hooks)
     except BaseException as exc:
         action_error = exc

--- a/meshtastic/cli/dispatch.py
+++ b/meshtastic/cli/dispatch.py
@@ -94,6 +94,12 @@ def _cleanup_failed_resources(context: CliContext) -> BaseException | None:
     :class:`SystemExit` take precedence over ordinary cleanup exceptions so a
     later rollback callback cannot accidentally suppress an operator interrupt.
     Within the same priority class, the first failure in rollback order wins.
+
+    Returns
+    -------
+    BaseException | None
+        Highest-priority rollback failure, or ``None`` when every callback
+        completes.
     """
     errors: list[BaseException] = []
     for cleanup in reversed(context.outcome.failure_cleanup_callbacks):

--- a/meshtastic/cli/dispatch.py
+++ b/meshtastic/cli/dispatch.py
@@ -88,20 +88,34 @@ def _close_interface_if_requested(context: CliContext) -> None:
 
 
 def _cleanup_failed_resources(context: CliContext) -> BaseException | None:
-    """Roll back retained service resources and return the first cleanup failure."""
-    first_error: BaseException | None = None
+    """Roll back retained services and return the highest-priority failure.
+
+    Control-flow exceptions such as :class:`KeyboardInterrupt` and
+    :class:`SystemExit` take precedence over ordinary cleanup exceptions so a
+    later rollback callback cannot accidentally suppress an operator interrupt.
+    Within the same priority class, the first failure in rollback order wins.
+    """
+    errors: list[BaseException] = []
     for cleanup in reversed(context.outcome.failure_cleanup_callbacks):
         try:
             cleanup()
         except BaseException as exc:  # noqa: BLE001 - preserve primary action failure
-            if first_error is None:
-                first_error = exc
-            else:
-                logger.warning(
-                    "Additional connected-action cleanup failed", exc_info=True
-                )
+            errors.append(exc)
     context.outcome.failure_cleanup_callbacks.clear()
-    return first_error
+    if not errors:
+        return None
+
+    selected_error = next(
+        (error for error in errors if not isinstance(error, Exception)), errors[0]
+    )
+    for error in errors:
+        if error is selected_error:
+            continue
+        logger.warning(
+            "Additional connected-action cleanup failed",
+            exc_info=(type(error), error, error.__traceback__),
+        )
+    return selected_error
 
 
 def _disarm_failure_cleanups(context: CliContext) -> None:

--- a/meshtastic/cli/dispatch.py
+++ b/meshtastic/cli/dispatch.py
@@ -123,7 +123,7 @@ def _disarm_failure_cleanups(context: CliContext) -> None:
     context.outcome.failure_cleanup_callbacks.clear()
 
 
-def dispatch_connected(context: CliContext, hooks: DispatchHooks) -> None:
+def _dispatch_connected(context: CliContext, hooks: DispatchHooks) -> None:
     """Execute all connected CLI action groups in their historical order."""
     outcome = context.outcome
     action_error: BaseException | None = None

--- a/meshtastic/cli/dispatch.py
+++ b/meshtastic/cli/dispatch.py
@@ -1,0 +1,143 @@
+"""Connected CLI action dispatcher and lifecycle finalization."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+import meshtastic.cli.channel_contact_actions as channel_contact_actions
+import meshtastic.cli.configure_actions as configure_actions
+import meshtastic.cli.device_actions as device_actions
+import meshtastic.cli.messaging_service_actions as messaging_service_actions
+from meshtastic._core_constants import BROADCAST_ADDR
+from meshtastic.cli.context import CliContext
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class DispatchHooks:
+    """Action hooks and compatibility seams used by connected dispatch."""
+
+    cli_print: Callable[[str], None]
+    device: device_actions.DeviceActionHooks
+    channel_contact: channel_contact_actions.ChannelContactHooks
+    configure: configure_actions.ConfigureActionHooks
+    services: messaging_service_actions.MessagingServiceHooks
+    sleep: Callable[[float], None] = time.sleep
+
+
+def _print_connection(context: CliContext, hooks: DispatchHooks) -> None:
+    """Print the historical connection banner unless config export is active."""
+    if context.args.export_config:
+        return
+
+    dev_path = getattr(context.interface, "devPath", "")
+    if not dev_path:
+        hooks.cli_print("Connected to radio")
+        return
+
+    tty_name = os.path.basename(dev_path)
+    stable_path = getattr(context.interface, "_stable_path", None)
+    if stable_path and stable_path != dev_path:
+        hooks.cli_print(f"Connected to radio on {tty_name} (stable: {stable_path})")
+    else:
+        hooks.cli_print(f"Connected to radio on {tty_name}")
+
+
+def _finalize_connected_actions(context: CliContext, hooks: DispatchHooks) -> None:
+    """Perform final ACK wait, delayed disconnect, and interface-close decisions."""
+    args = context.args
+    outcome = context.outcome
+    interface = context.interface
+
+    if not outcome.skip_ack_wait and (
+        args.ack or (args.dest != BROADCAST_ADDR and outcome.wait_for_ack_nak)
+    ):
+        hooks.cli_print(
+            "Waiting for an acknowledgment from remote node (this could take a while)"
+        )
+        interface.getNode(
+            args.dest, False, **context.get_node_kwargs
+        ).iface.waitForAckNak()
+
+    if args.wait_to_disconnect:
+        hooks.cli_print(
+            f"Waiting {args.wait_to_disconnect} seconds before disconnecting"
+        )
+        hooks.sleep(int(args.wait_to_disconnect))
+
+    if not args.seriallog and outcome.close_now:
+        try:
+            interface.close()
+        except Exception:
+            logger.debug("Error during interface close", exc_info=True)
+
+
+def _cleanup_connected_resources(context: CliContext) -> BaseException | None:
+    """Release retained action resources and return the first cleanup failure."""
+    first_error: BaseException | None = None
+    for cleanup in reversed(context.outcome.cleanup_callbacks):
+        try:
+            cleanup()
+        except BaseException as exc:  # noqa: BLE001 - preserve primary action failure
+            if first_error is None:
+                first_error = exc
+            else:
+                logger.warning("Additional connected-action cleanup failed", exc_info=True)
+    context.outcome.cleanup_callbacks.clear()
+    return first_error
+
+
+def dispatch_connected(context: CliContext, hooks: DispatchHooks) -> None:
+    """Execute all connected CLI action groups in their historical order."""
+    outcome = context.outcome
+    action_error: BaseException | None = None
+    try:
+        _print_connection(context, hooks)
+
+        device_actions.handle_device_actions(context, hooks.device)
+        if outcome.stop_processing:
+            return
+
+        channel_contact_actions.handle_contact_import(context)
+        messaging_service_actions.handle_messaging_actions(context, hooks.services)
+
+        configure_actions.handle_configure_actions(context, hooks.configure)
+        if outcome.stop_processing:
+            return
+
+        channel_contact_actions.handle_channel_mutations(context, hooks.channel_contact)
+        messaging_service_actions.handle_content_reads(context)
+        channel_contact_actions.handle_region_preset_display(
+            context, hooks.channel_contact
+        )
+        device_actions.handle_lockdown_action(context, hooks.device)
+        messaging_service_actions.handle_information_actions(context, hooks.services)
+        if outcome.stop_processing:
+            return
+
+        channel_contact_actions.handle_channel_contact_display(
+            context, hooks.channel_contact
+        )
+        messaging_service_actions.handle_long_running_services(context, hooks.services)
+        _finalize_connected_actions(context, hooks)
+    except BaseException as exc:
+        action_error = exc
+        raise
+    finally:
+        cleanup_error = _cleanup_connected_resources(context)
+        if cleanup_error is not None:
+            if action_error is None or not isinstance(cleanup_error, Exception):
+                raise cleanup_error
+            logger.warning(
+                "Connected-action cleanup failed while unwinding another error",
+                exc_info=(
+                    type(cleanup_error),
+                    cleanup_error,
+                    cleanup_error.__traceback__,
+                ),
+            )

--- a/meshtastic/cli/dispatch.py
+++ b/meshtastic/cli/dispatch.py
@@ -89,7 +89,9 @@ def _cleanup_connected_resources(context: CliContext) -> BaseException | None:
             if first_error is None:
                 first_error = exc
             else:
-                logger.warning("Additional connected-action cleanup failed", exc_info=True)
+                logger.warning(
+                    "Additional connected-action cleanup failed", exc_info=True
+                )
     context.outcome.cleanup_callbacks.clear()
     return first_error
 
@@ -136,6 +138,9 @@ def dispatch_connected(context: CliContext, hooks: DispatchHooks) -> None:
     finally:
         cleanup_error = _cleanup_connected_resources(context)
         if cleanup_error is not None:
+            # Control-flow BaseExceptions (for example KeyboardInterrupt/SystemExit)
+            # raised by cleanup must remain observable, even while another error is
+            # unwinding. The original action failure remains on ``__context__``.
             if action_error is None or not isinstance(cleanup_error, Exception):
                 raise cleanup_error
             logger.warning(

--- a/meshtastic/cli/dispatch.py
+++ b/meshtastic/cli/dispatch.py
@@ -51,7 +51,7 @@ def _print_connection(context: CliContext, hooks: DispatchHooks) -> None:
 
 
 def _finalize_connected_actions(context: CliContext, hooks: DispatchHooks) -> None:
-    """Perform final ACK wait, delayed disconnect, and interface-close decisions."""
+    """Perform final ACK handling and any requested disconnect delay."""
     args = context.args
     outcome = context.outcome
     interface = context.interface
@@ -72,17 +72,25 @@ def _finalize_connected_actions(context: CliContext, hooks: DispatchHooks) -> No
         )
         hooks.sleep(int(args.wait_to_disconnect))
 
-    if not args.seriallog and outcome.close_now:
-        try:
-            interface.close()
-        except Exception:
-            logger.debug("Error during interface close", exc_info=True)
+
+def _close_interface_if_requested(context: CliContext) -> None:
+    """Close a one-shot interface at most once despite earlier lifecycle failures."""
+    args = context.args
+    outcome = context.outcome
+    if args.seriallog or not outcome.close_now or outcome.interface_close_attempted:
+        return
+
+    outcome.interface_close_attempted = True
+    try:
+        context.interface.close()
+    except Exception:
+        logger.debug("Error during interface close", exc_info=True)
 
 
-def _cleanup_connected_resources(context: CliContext) -> BaseException | None:
-    """Release retained action resources and return the first cleanup failure."""
+def _cleanup_failed_resources(context: CliContext) -> BaseException | None:
+    """Roll back retained service resources and return the first cleanup failure."""
     first_error: BaseException | None = None
-    for cleanup in reversed(context.outcome.cleanup_callbacks):
+    for cleanup in reversed(context.outcome.failure_cleanup_callbacks):
         try:
             cleanup()
         except BaseException as exc:  # noqa: BLE001 - preserve primary action failure
@@ -92,8 +100,13 @@ def _cleanup_connected_resources(context: CliContext) -> BaseException | None:
                 logger.warning(
                     "Additional connected-action cleanup failed", exc_info=True
                 )
-    context.outcome.cleanup_callbacks.clear()
+    context.outcome.failure_cleanup_callbacks.clear()
     return first_error
+
+
+def _disarm_failure_cleanups(context: CliContext) -> None:
+    """Discard rollback callbacks without stopping successfully started services."""
+    context.outcome.failure_cleanup_callbacks.clear()
 
 
 def dispatch_connected(context: CliContext, hooks: DispatchHooks) -> None:
@@ -138,12 +151,19 @@ def dispatch_connected(context: CliContext, hooks: DispatchHooks) -> None:
         action_error = exc
         raise
     finally:
-        cleanup_error = _cleanup_connected_resources(context)
+        cleanup_error: BaseException | None = None
+        if action_error is None:
+            _disarm_failure_cleanups(context)
+        else:
+            cleanup_error = _cleanup_failed_resources(context)
+
+        _close_interface_if_requested(context)
+
         if cleanup_error is not None:
             # Control-flow BaseExceptions (for example KeyboardInterrupt/SystemExit)
             # raised by cleanup must remain observable, even while another error is
             # unwinding. The original action failure remains on ``__context__``.
-            if action_error is None or not isinstance(cleanup_error, Exception):
+            if not isinstance(cleanup_error, Exception):
                 raise cleanup_error
             logger.warning(
                 "Connected-action cleanup failed while unwinding another error",

--- a/meshtastic/cli/messaging_service_actions.py
+++ b/meshtastic/cli/messaging_service_actions.py
@@ -59,6 +59,7 @@ class MessagingServiceHooks:
     power_stress_factory: Callable[[Any], Any] | None
     get_meter: Callable[[], Any]
     platform_system: Callable[[], str] = platform.system
+    sleep: Callable[[float], None] = time.sleep
 
 
 def _selected_channel(hooks: MessagingServiceHooks) -> int:
@@ -272,7 +273,7 @@ def _handle_messaging_actions(
             interface.gotResponse = False
             client.readGPIOs(args.dest, bitmask, None)
             for _ in range(GPIO_READ_MAX_POLLS):
-                time.sleep(GPIO_READ_POLL_INTERVAL_SECONDS)
+                hooks.sleep(GPIO_READ_POLL_INTERVAL_SECONDS)
                 if interface.gotResponse:
                     break
             else:
@@ -287,7 +288,7 @@ def _handle_messaging_actions(
             )
             while True:
                 client.watchGPIOs(args.dest, bitmask)
-                time.sleep(GPIO_WATCH_INTERVAL_SECONDS)
+                hooks.sleep(GPIO_WATCH_INTERVAL_SECONDS)
 
 
 def _handle_content_reads(context: CliContext) -> None:

--- a/meshtastic/cli/messaging_service_actions.py
+++ b/meshtastic/cli/messaging_service_actions.py
@@ -404,6 +404,7 @@ def _handle_long_running_services(
     args = context.args
     interface = context.interface
 
+    log_set_close: Callable[[], None] | None = None
     if args.slog or args.power_stress:
         if not hooks.powermon_available():
             _terminate_cli(
@@ -426,7 +427,8 @@ def _handle_long_running_services(
                 args.slog if args.slog != "default" else None,
                 hooks.get_meter(),
             )
-            context.outcome.failure_cleanup_callbacks.append(log_set.close)
+            log_set_close = log_set.close
+            context.outcome.failure_cleanup_callbacks.append(log_set_close)
             context.outcome.close_now = False
 
         if args.power_stress:
@@ -438,6 +440,9 @@ def _handle_long_running_services(
                     "The powermon module loaded incompletely.",
                 )
             power_stress_factory(interface).run()
+            if log_set_close is not None:
+                log_set_close()
+                context.outcome.failure_cleanup_callbacks.remove(log_set_close)
             context.outcome.close_now = True
 
     if args.listen:

--- a/meshtastic/cli/messaging_service_actions.py
+++ b/meshtastic/cli/messaging_service_actions.py
@@ -20,6 +20,9 @@ GPIO_READ_POLL_INTERVAL_SECONDS = 1.0
 GPIO_READ_MAX_POLLS = 10
 GPIO_MASK_BITS = 64
 GPIO_MASK_MAX = (1 << GPIO_MASK_BITS) - 1
+INVALID_CHANNEL_MESSAGE = (
+    "Warning: {index} is not a valid channel. Channel must not be DISABLED."
+)
 TELEMETRY_TYPE_ALIASES = {
     "device": "device_metrics",
     "environment": "environment_metrics",
@@ -66,6 +69,29 @@ def _selected_channel(hooks: MessagingServiceHooks) -> int:
         Selected channel index, or ``0`` when no explicit channel is selected.
     """
     return hooks.get_channel_index() or 0
+
+
+def _require_channel(interface: Any, hooks: MessagingServiceHooks) -> int:
+    """Return the selected channel index after validating that it is enabled.
+
+    Parameters
+    ----------
+    interface : Any
+        Connected interface used for channel validation.
+    hooks : MessagingServiceHooks
+        Channel-selection, validation, and CLI-exit seams.
+
+    Returns
+    -------
+    int
+        Validated channel index.
+    """
+    channel_index = _selected_channel(hooks)
+    if not hooks.check_channel(interface, channel_index):
+        _terminate_cli(
+            hooks.cli_exit, INVALID_CHANNEL_MESSAGE.format(index=channel_index)
+        )
+    return channel_index
 
 
 def _escape_terminal_controls(value: Any) -> str:
@@ -135,13 +161,7 @@ def _handle_messaging_actions(
 
     if args.sendtext:
         context.outcome.close_now = True
-        channel_index = _selected_channel(hooks)
-        if not hooks.check_channel(interface, channel_index):
-            _terminate_cli(
-                hooks.cli_exit,
-                f"Warning: {channel_index} is not a valid channel. "
-                "Channel must not be DISABLED.",
-            )
+        channel_index = _require_channel(interface, hooks)
         hooks.cli_print(
             f"Sending text message {args.sendtext} to {args.dest} "
             f"on channelIndex:{channel_index}"
@@ -161,49 +181,46 @@ def _handle_messaging_actions(
         )
 
     if args.traceroute:
-        channel_index = _selected_channel(hooks)
-        if hooks.check_channel(interface, channel_index):
-            hop_limit = interface.localNode.localConfig.lora.hop_limit
-            destination = str(args.traceroute)
-            hooks.cli_print(
-                f"Sending traceroute request to {destination} on "
-                f"channelIndex:{channel_index} (this could take a while)"
-            )
-            interface.sendTraceRoute(destination, hop_limit, channelIndex=channel_index)
+        channel_index = _require_channel(interface, hooks)
+        hop_limit = interface.localNode.localConfig.lora.hop_limit
+        destination = str(args.traceroute)
+        hooks.cli_print(
+            f"Sending traceroute request to {destination} on "
+            f"channelIndex:{channel_index} (this could take a while)"
+        )
+        interface.sendTraceRoute(destination, hop_limit, channelIndex=channel_index)
 
     if args.request_telemetry:
         if args.dest == BROADCAST_ADDR:
             _terminate_cli(hooks.cli_exit, "Warning: Must use a destination node ID.")
-        channel_index = _selected_channel(hooks)
-        if hooks.check_channel(interface, channel_index):
-            telemetry_type = TELEMETRY_TYPE_ALIASES.get(
-                args.request_telemetry, "device_metrics"
-            )
-            hooks.cli_print(
-                f"Sending {telemetry_type} telemetry request to {args.dest} on "
-                f"channelIndex:{channel_index} (this could take a while)"
-            )
-            interface.sendTelemetry(
-                destinationId=args.dest,
-                wantResponse=True,
-                channelIndex=channel_index,
-                telemetryType=telemetry_type,
-            )
+        channel_index = _require_channel(interface, hooks)
+        telemetry_type = TELEMETRY_TYPE_ALIASES.get(
+            args.request_telemetry, "device_metrics"
+        )
+        hooks.cli_print(
+            f"Sending {telemetry_type} telemetry request to {args.dest} on "
+            f"channelIndex:{channel_index} (this could take a while)"
+        )
+        interface.sendTelemetry(
+            destinationId=args.dest,
+            wantResponse=True,
+            channelIndex=channel_index,
+            telemetryType=telemetry_type,
+        )
 
     if args.request_position:
         if args.dest == BROADCAST_ADDR:
             _terminate_cli(hooks.cli_exit, "Warning: Must use a destination node ID.")
-        channel_index = _selected_channel(hooks)
-        if hooks.check_channel(interface, channel_index):
-            hooks.cli_print(
-                f"Sending position request to {args.dest} on "
-                f"channelIndex:{channel_index} (this could take a while)"
-            )
-            interface.sendPosition(
-                destinationId=args.dest,
-                wantResponse=True,
-                channelIndex=channel_index,
-            )
+        channel_index = _require_channel(interface, hooks)
+        hooks.cli_print(
+            f"Sending position request to {args.dest} on "
+            f"channelIndex:{channel_index} (this could take a while)"
+        )
+        interface.sendPosition(
+            destinationId=args.dest,
+            wantResponse=True,
+            channelIndex=channel_index,
+        )
 
     if args.gpio_wrb or args.gpio_rd or args.gpio_watch:
         if args.dest == BROADCAST_ADDR:
@@ -368,9 +385,10 @@ def _start_tunnel(context: CliContext, hooks: MessagingServiceHooks) -> None:
     from meshtastic import tunnel  # pylint: disable=import-outside-toplevel
 
     if args.tunnel_net:
-        tunnel.Tunnel(context.interface, subnet=args.tunnel_net)
+        tunnel_instance = tunnel.Tunnel(context.interface, subnet=args.tunnel_net)
     else:
-        tunnel.Tunnel(context.interface)
+        tunnel_instance = tunnel.Tunnel(context.interface)
+    context.outcome.failure_cleanup_callbacks.append(tunnel_instance.close)
 
 
 def _handle_long_running_services(
@@ -402,7 +420,7 @@ def _handle_long_running_services(
                 args.slog if args.slog != "default" else None,
                 hooks.get_meter(),
             )
-            context.outcome.cleanup_callbacks.append(log_set.close)
+            context.outcome.failure_cleanup_callbacks.append(log_set.close)
             context.outcome.close_now = False
 
         if args.power_stress:

--- a/meshtastic/cli/messaging_service_actions.py
+++ b/meshtastic/cli/messaging_service_actions.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from meshtastic._core_constants import BROADCAST_ADDR
-from meshtastic.cli.context import CliContext, CliExit
+from meshtastic.cli.context import CliContext, CliExit, _terminate_cli
 from meshtastic.protobuf import portnums_pb2
 
 logger = logging.getLogger(__name__)
@@ -20,6 +20,15 @@ GPIO_READ_POLL_INTERVAL_SECONDS = 1.0
 GPIO_READ_MAX_POLLS = 10
 GPIO_MASK_BITS = 64
 GPIO_MASK_MAX = (1 << GPIO_MASK_BITS) - 1
+TELEMETRY_TYPE_ALIASES = {
+    "device": "device_metrics",
+    "environment": "environment_metrics",
+    "air_quality": "air_quality_metrics",
+    "airquality": "air_quality_metrics",
+    "power": "power_metrics",
+    "localstats": "local_stats",
+    "local_stats": "local_stats",
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -105,12 +114,13 @@ def _parse_gpio_mask(raw_value: Any, hooks: MessagingServiceHooks) -> int:
     """
     try:
         mask = int(raw_value, 16)
-    except (TypeError, ValueError) as exc:
-        hooks.cli_exit(f"Warning: Invalid GPIO mask: {raw_value}", 1)
-        raise AssertionError("cli_exit returned unexpectedly") from exc
+    except (TypeError, ValueError):
+        _terminate_cli(hooks.cli_exit, f"Warning: Invalid GPIO mask: {raw_value}", 1)
     if not 0 <= mask <= GPIO_MASK_MAX:
-        hooks.cli_exit(
-            f"Warning: GPIO mask must fit in {GPIO_MASK_BITS} bits: {raw_value}", 1
+        _terminate_cli(
+            hooks.cli_exit,
+            f"Warning: GPIO mask must fit in {GPIO_MASK_BITS} bits: {raw_value}",
+            1,
         )
     return mask
 
@@ -127,9 +137,10 @@ def _handle_messaging_actions(
         context.outcome.close_now = True
         channel_index = _selected_channel(hooks)
         if not hooks.check_channel(interface, channel_index):
-            hooks.cli_exit(
+            _terminate_cli(
+                hooks.cli_exit,
                 f"Warning: {channel_index} is not a valid channel. "
-                "Channel must not be DISABLED."
+                "Channel must not be DISABLED.",
             )
         hooks.cli_print(
             f"Sending text message {args.sendtext} to {args.dest} "
@@ -158,25 +169,14 @@ def _handle_messaging_actions(
                 f"Sending traceroute request to {destination} on "
                 f"channelIndex:{channel_index} (this could take a while)"
             )
-            interface.sendTraceRoute(
-                destination, hop_limit, channelIndex=channel_index
-            )
+            interface.sendTraceRoute(destination, hop_limit, channelIndex=channel_index)
 
     if args.request_telemetry:
         if args.dest == BROADCAST_ADDR:
-            hooks.cli_exit("Warning: Must use a destination node ID.")
+            _terminate_cli(hooks.cli_exit, "Warning: Must use a destination node ID.")
         channel_index = _selected_channel(hooks)
         if hooks.check_channel(interface, channel_index):
-            telemetry_map = {
-                "device": "device_metrics",
-                "environment": "environment_metrics",
-                "air_quality": "air_quality_metrics",
-                "airquality": "air_quality_metrics",
-                "power": "power_metrics",
-                "localstats": "local_stats",
-                "local_stats": "local_stats",
-            }
-            telemetry_type = telemetry_map.get(
+            telemetry_type = TELEMETRY_TYPE_ALIASES.get(
                 args.request_telemetry, "device_metrics"
             )
             hooks.cli_print(
@@ -192,7 +192,7 @@ def _handle_messaging_actions(
 
     if args.request_position:
         if args.dest == BROADCAST_ADDR:
-            hooks.cli_exit("Warning: Must use a destination node ID.")
+            _terminate_cli(hooks.cli_exit, "Warning: Must use a destination node ID.")
         channel_index = _selected_channel(hooks)
         if hooks.check_channel(interface, channel_index):
             hooks.cli_print(
@@ -207,26 +207,27 @@ def _handle_messaging_actions(
 
     if args.gpio_wrb or args.gpio_rd or args.gpio_watch:
         if args.dest == BROADCAST_ADDR:
-            hooks.cli_exit("Warning: Must use a destination node ID.")
+            _terminate_cli(hooks.cli_exit, "Warning: Must use a destination node ID.")
         client = hooks.remote_hardware_client(interface)
 
         if args.gpio_wrb:
             bitmask = 0
             bitval = 0
-            for bit, value in args.gpio_wrb or []:
+            for bit, value in args.gpio_wrb:
                 try:
                     bit_index = int(bit)
                     bit_value = int(value)
                 except (TypeError, ValueError):
-                    hooks.cli_exit(
-                        f"Warning: Invalid GPIO bit/value pair: {bit!r}={value!r}", 1
+                    _terminate_cli(
+                        hooks.cli_exit,
+                        f"Warning: Invalid GPIO bit/value pair: {bit!r}={value!r}",
+                        1,
                     )
-                if (
-                    not 0 <= bit_index < GPIO_MASK_BITS
-                    or bit_value not in {0, 1}
-                ):
-                    hooks.cli_exit(
-                        f"Warning: Invalid GPIO bit/value pair: {bit!r}={value!r}", 1
+                if not 0 <= bit_index < GPIO_MASK_BITS or bit_value not in {0, 1}:
+                    _terminate_cli(
+                        hooks.cli_exit,
+                        f"Warning: Invalid GPIO bit/value pair: {bit!r}={value!r}",
+                        1,
                     )
                 bitmask |= 1 << bit_index
                 bitval |= bit_value << bit_index
@@ -349,7 +350,9 @@ def _start_tunnel(context: CliContext, hooks: MessagingServiceHooks) -> None:
     if hooks.platform_system() != "Linux" or not args.tunnel:
         return
     if args.dest != BROADCAST_ADDR:
-        hooks.cli_exit("A tunnel can only be created using the local node.", 1)
+        _terminate_cli(
+            hooks.cli_exit, "A tunnel can only be created using the local node.", 1
+        )
 
     if context.interface.noProto:
         logger.warning("Not starting Tunnel - disabled by noProto")
@@ -374,32 +377,38 @@ def _handle_long_running_services(
 
     if args.slog or args.power_stress:
         if not hooks.powermon_available():
-            hooks.cli_exit(
+            _terminate_cli(
+                hooks.cli_exit,
                 "The powermon module could not be loaded. "
                 "You may need to run `poetry install --with powermon`. "
-                f"Import Error was: {hooks.powermon_error()}"
+                f"Import Error was: {hooks.powermon_error()}",
             )
 
         if args.slog:
-            if hooks.log_set_factory is None:
-                hooks.cli_exit(
+            log_set_factory = hooks.log_set_factory
+            if log_set_factory is None:
+                _terminate_cli(
+                    hooks.cli_exit,
                     "LogSet is required for --slog but not available. "
-                    "The powermon module loaded incompletely."
+                    "The powermon module loaded incompletely.",
                 )
-            log_set = hooks.log_set_factory(
+            log_set = log_set_factory(
                 interface,
                 args.slog if args.slog != "default" else None,
                 hooks.get_meter(),
             )
             context.outcome.cleanup_callbacks.append(log_set.close)
+            context.outcome.close_now = False
 
         if args.power_stress:
-            if hooks.power_stress_factory is None:
-                hooks.cli_exit(
+            power_stress_factory = hooks.power_stress_factory
+            if power_stress_factory is None:
+                _terminate_cli(
+                    hooks.cli_exit,
                     "PowerStress is required for --power-stress but not available. "
-                    "The powermon module loaded incompletely."
+                    "The powermon module loaded incompletely.",
                 )
-            hooks.power_stress_factory(interface).run()
+            power_stress_factory(interface).run()
             context.outcome.close_now = True
 
     if args.listen:

--- a/meshtastic/cli/messaging_service_actions.py
+++ b/meshtastic/cli/messaging_service_actions.py
@@ -25,10 +25,14 @@ INVALID_CHANNEL_MESSAGE = (
 )
 TELEMETRY_TYPE_ALIASES = {
     "device": "device_metrics",
+    "device_metrics": "device_metrics",
     "environment": "environment_metrics",
+    "environment_metrics": "environment_metrics",
     "air_quality": "air_quality_metrics",
     "airquality": "air_quality_metrics",
+    "air_quality_metrics": "air_quality_metrics",
     "power": "power_metrics",
+    "power_metrics": "power_metrics",
     "localstats": "local_stats",
     "local_stats": "local_stats",
 }

--- a/meshtastic/cli/messaging_service_actions.py
+++ b/meshtastic/cli/messaging_service_actions.py
@@ -100,6 +100,13 @@ def _require_channel(interface: Any, hooks: MessagingServiceHooks) -> int:
     return channel_index
 
 
+_CONTROL_ESCAPES = {
+    "\n": r"\n",
+    "\r": r"\r",
+    "\t": r"\t",
+}
+
+
 def _escape_terminal_controls(value: Any) -> str:
     """Render terminal control characters as inert escape text.
 
@@ -118,12 +125,7 @@ def _escape_terminal_controls(value: Any) -> str:
     for character in text:
         codepoint = ord(character)
         if codepoint < 0x20 or 0x7F <= codepoint <= 0x9F:
-            escapes = {
-                "\n": r"\n",
-                "\r": r"\r",
-                "\t": r"\t",
-            }
-            escaped.append(escapes.get(character, f"\\x{codepoint:02x}"))
+            escaped.append(_CONTROL_ESCAPES.get(character, f"\\x{codepoint:02x}"))
         else:
             escaped.append(character)
     return "".join(escaped)
@@ -386,14 +388,13 @@ def _start_tunnel(context: CliContext, hooks: MessagingServiceHooks) -> None:
         logger.warning("Not starting Tunnel - disabled by noProto")
         return
 
-    context.outcome.close_now = False
-
     from meshtastic import tunnel  # pylint: disable=import-outside-toplevel
 
     if args.tunnel_net:
         tunnel_instance = tunnel.Tunnel(context.interface, subnet=args.tunnel_net)
     else:
         tunnel_instance = tunnel.Tunnel(context.interface)
+    context.outcome.close_now = False
     context.outcome.failure_cleanup_callbacks.append(tunnel_instance.close)
 
 

--- a/meshtastic/cli/messaging_service_actions.py
+++ b/meshtastic/cli/messaging_service_actions.py
@@ -1,0 +1,311 @@
+"""Connected CLI actions for messaging, reads, and long-running services."""
+
+from __future__ import annotations
+
+import logging
+import platform
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, NoReturn
+
+from meshtastic._core_constants import BROADCAST_ADDR
+from meshtastic.cli.context import CliContext
+from meshtastic.protobuf import portnums_pb2
+
+logger = logging.getLogger(__name__)
+
+GPIO_WATCH_INTERVAL_SECONDS = 1.0
+GPIO_READ_POLL_INTERVAL_SECONDS = 1.0
+GPIO_READ_MAX_POLLS = 10
+
+
+@dataclass(frozen=True, slots=True)
+class MessagingServiceHooks:
+    """Compatibility and optional-subsystem seams for service actions."""
+
+    cli_exit: Callable[..., NoReturn]
+    cli_print: Callable[[str], None]
+    get_channel_index: Callable[[], int | None]
+    check_channel: Callable[[Any, int], bool]
+    remote_hardware_client: Callable[[Any], Any]
+    get_pref: Callable[[Any, str], bool]
+    validate_cli_show_fields: Callable[[Any, list[str]], None]
+    newer_version: Callable[[], str | None]
+    install_upgrade_hint: str
+    powermon_available: Callable[[], bool]
+    powermon_error: Callable[[], BaseException | None]
+    log_set_factory: Callable[[Any, str | None, Any], Any] | None
+    power_stress_factory: Callable[[Any], Any] | None
+    get_meter: Callable[[], Any]
+    platform_system: Callable[[], str] = platform.system
+
+
+def _selected_channel(hooks: MessagingServiceHooks) -> int:
+    return hooks.get_channel_index() or 0
+
+
+def handle_messaging_actions(
+    context: CliContext, hooks: MessagingServiceHooks
+) -> None:
+    """Send messages, requests, and remote-hardware operations in CLI order."""
+    args = context.args
+    interface = context.interface
+    get_node_kwargs = context.get_node_kwargs
+
+    if args.sendtext:
+        context.outcome.close_now = True
+        channel_index = _selected_channel(hooks)
+        if not hooks.check_channel(interface, channel_index):
+            hooks.cli_exit(
+                f"Warning: {channel_index} is not a valid channel. "
+                "Channel must not be DISABLED."
+            )
+        hooks.cli_print(
+            f"Sending text message {args.sendtext} to {args.dest} "
+            f"on channelIndex:{channel_index}"
+            f" {'using PRIVATE_APP port' if args.private else ''}"
+        )
+        interface.sendText(
+            args.sendtext,
+            args.dest,
+            wantAck=True,
+            channelIndex=channel_index,
+            onResponse=interface.getNode(args.dest, False, **get_node_kwargs).onAckNak,
+            portNum=(
+                portnums_pb2.PortNum.PRIVATE_APP
+                if args.private
+                else portnums_pb2.PortNum.TEXT_MESSAGE_APP
+            ),
+        )
+
+    if args.traceroute:
+        channel_index = _selected_channel(hooks)
+        if hooks.check_channel(interface, channel_index):
+            hop_limit = interface.localNode.localConfig.lora.hop_limit
+            destination = str(args.traceroute)
+            hooks.cli_print(
+                f"Sending traceroute request to {destination} on "
+                f"channelIndex:{channel_index} (this could take a while)"
+            )
+            interface.sendTraceRoute(
+                destination, hop_limit, channelIndex=channel_index
+            )
+
+    if args.request_telemetry:
+        if args.dest == BROADCAST_ADDR:
+            hooks.cli_exit("Warning: Must use a destination node ID.")
+        channel_index = _selected_channel(hooks)
+        if hooks.check_channel(interface, channel_index):
+            telemetry_map = {
+                "device": "device_metrics",
+                "environment": "environment_metrics",
+                "air_quality": "air_quality_metrics",
+                "airquality": "air_quality_metrics",
+                "power": "power_metrics",
+                "localstats": "local_stats",
+                "local_stats": "local_stats",
+            }
+            telemetry_type = telemetry_map.get(
+                args.request_telemetry, "device_metrics"
+            )
+            hooks.cli_print(
+                f"Sending {telemetry_type} telemetry request to {args.dest} on "
+                f"channelIndex:{channel_index} (this could take a while)"
+            )
+            interface.sendTelemetry(
+                destinationId=args.dest,
+                wantResponse=True,
+                channelIndex=channel_index,
+                telemetryType=telemetry_type,
+            )
+
+    if args.request_position:
+        if args.dest == BROADCAST_ADDR:
+            hooks.cli_exit("Warning: Must use a destination node ID.")
+        channel_index = _selected_channel(hooks)
+        if hooks.check_channel(interface, channel_index):
+            hooks.cli_print(
+                f"Sending position request to {args.dest} on "
+                f"channelIndex:{channel_index} (this could take a while)"
+            )
+            interface.sendPosition(
+                destinationId=args.dest,
+                wantResponse=True,
+                channelIndex=channel_index,
+            )
+
+    if args.gpio_wrb or args.gpio_rd or args.gpio_watch:
+        if args.dest == BROADCAST_ADDR:
+            hooks.cli_exit("Warning: Must use a destination node ID.")
+        client = hooks.remote_hardware_client(interface)
+
+        if args.gpio_wrb:
+            bitmask = 0
+            bitval = 0
+            for bit, value in args.gpio_wrb or []:
+                bitmask |= 1 << int(bit)
+                bitval |= int(value) << int(bit)
+            hooks.cli_print(
+                f"Writing GPIO mask 0x{bitmask:x} with value 0x{bitval:x} "
+                f"to {args.dest}"
+            )
+            client.writeGPIOs(args.dest, bitmask, bitval)
+            context.outcome.close_now = True
+
+        if args.gpio_rd:
+            bitmask = int(args.gpio_rd, 16)
+            hooks.cli_print(f"Reading GPIO mask 0x{bitmask:x} from {args.dest}")
+            interface.mask = bitmask
+            client.readGPIOs(args.dest, bitmask, None)
+            for _ in range(GPIO_READ_MAX_POLLS):
+                time.sleep(GPIO_READ_POLL_INTERVAL_SECONDS)
+                if interface.gotResponse:
+                    break
+            logger.debug("end of gpio_rd")
+
+        if args.gpio_watch:
+            bitmask = int(args.gpio_watch, 16)
+            hooks.cli_print(
+                f"Watching GPIO mask 0x{bitmask:x} from {args.dest}. "
+                "Press ctrl-c to exit"
+            )
+            while True:
+                client.watchGPIOs(args.dest, bitmask)
+                time.sleep(GPIO_WATCH_INTERVAL_SECONDS)
+
+
+def handle_content_reads(context: CliContext) -> None:
+    """Read canned-message and ringtone content in their historical position."""
+    args = context.args
+    interface = context.interface
+
+    if args.get_canned_message:
+        context.outcome.close_now = True
+        print("")
+        messages = interface.getNode(
+            args.dest, **context.get_node_kwargs
+        ).get_canned_message()
+        print(f"canned_plugin_message:{messages}")
+
+    if args.get_ringtone:
+        context.outcome.close_now = True
+        print("")
+        ringtone = interface.getNode(
+            args.dest, **context.get_node_kwargs
+        ).get_ringtone()
+        print(f"ringtone:{ringtone}")
+
+
+def handle_information_actions(
+    context: CliContext, hooks: MessagingServiceHooks
+) -> None:
+    """Handle info, preference reads, node listing, and show-field validation."""
+    args = context.args
+    interface = context.interface
+
+    if args.info:
+        print("")
+        if args.dest == BROADCAST_ADDR:
+            interface.showInfo()
+            print("")
+            interface.getNode(args.dest, **context.get_node_kwargs).showInfo()
+            context.outcome.close_now = True
+            print("")
+            pypi_version = hooks.newer_version()
+            if pypi_version:
+                print(
+                    f"*** A newer version v{pypi_version} is available!"
+                    f' Consider running "{hooks.install_upgrade_hint}" ***\n'
+                )
+        else:
+            print("Showing info of remote node is not supported.")
+            print(
+                "Use the '--get' command for a specific configuration "
+                "(e.g. 'lora') instead."
+            )
+
+    if args.get:
+        context.outcome.close_now = True
+        node = interface.getNode(args.dest, False, **context.get_node_kwargs)
+        found = False
+        for pref in args.get:
+            found = hooks.get_pref(node, pref[0])
+        if found:
+            hooks.cli_print("Completed getting preferences")
+
+    if args.nodes:
+        context.outcome.close_now = True
+        if args.dest != BROADCAST_ADDR:
+            print("Showing node list of a remote node is not supported.")
+            context.outcome.stop_processing = True
+            return
+        if args.show_fields:
+            hooks.validate_cli_show_fields(interface, args.show_fields)
+        interface.showNodes(True, args.show_fields)
+
+    if args.show_fields and not args.nodes:
+        print("--show-fields can only be used with --nodes")
+        context.outcome.stop_processing = True
+
+
+def _start_tunnel(context: CliContext, hooks: MessagingServiceHooks) -> None:
+    args = context.args
+    if hooks.platform_system() != "Linux" or not args.tunnel:
+        return
+    if args.dest != BROADCAST_ADDR:
+        hooks.cli_exit("A tunnel can only be created using the local node.", 1)
+
+    context.outcome.close_now = False
+    if context.interface.noProto:
+        logger.warning("Not starting Tunnel - disabled by noProto")
+        return
+
+    from meshtastic import tunnel  # pylint: disable=import-outside-toplevel
+
+    if args.tunnel_net:
+        tunnel.Tunnel(context.interface, subnet=args.tunnel_net)
+    else:
+        tunnel.Tunnel(context.interface)
+
+
+def handle_long_running_services(
+    context: CliContext, hooks: MessagingServiceHooks
+) -> None:
+    """Start structured logging, power stress, listening, and tunnel services."""
+    args = context.args
+    interface = context.interface
+
+    if args.slog or args.power_stress:
+        if not hooks.powermon_available():
+            hooks.cli_exit(
+                "The powermon module could not be loaded. "
+                "You may need to run `poetry install --with powermon`. "
+                f"Import Error was: {hooks.powermon_error()}"
+            )
+
+        if args.slog:
+            if hooks.log_set_factory is None:
+                hooks.cli_exit(
+                    "LogSet is required for --slog but not available. "
+                    "The powermon module loaded incompletely."
+                )
+            log_set = hooks.log_set_factory(
+                interface,
+                args.slog if args.slog != "default" else None,
+                hooks.get_meter(),
+            )
+            context.outcome.cleanup_callbacks.append(log_set.close)
+
+        if args.power_stress:
+            if hooks.power_stress_factory is None:
+                hooks.cli_exit(
+                    "PowerStress is required for --power-stress but not available. "
+                    "The powermon module loaded incompletely."
+                )
+            hooks.power_stress_factory(interface).run()
+            context.outcome.close_now = True
+
+    if args.listen:
+        context.outcome.close_now = False
+
+    _start_tunnel(context, hooks)

--- a/meshtastic/cli/messaging_service_actions.py
+++ b/meshtastic/cli/messaging_service_actions.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import logging
 import platform
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Callable, NoReturn
+from typing import Any
 
 from meshtastic._core_constants import BROADCAST_ADDR
-from meshtastic.cli.context import CliContext
+from meshtastic.cli.context import CliContext, CliExit
 from meshtastic.protobuf import portnums_pb2
 
 logger = logging.getLogger(__name__)
@@ -17,13 +18,15 @@ logger = logging.getLogger(__name__)
 GPIO_WATCH_INTERVAL_SECONDS = 1.0
 GPIO_READ_POLL_INTERVAL_SECONDS = 1.0
 GPIO_READ_MAX_POLLS = 10
+GPIO_MASK_BITS = 64
+GPIO_MASK_MAX = (1 << GPIO_MASK_BITS) - 1
 
 
 @dataclass(frozen=True, slots=True)
 class MessagingServiceHooks:
     """Compatibility and optional-subsystem seams for service actions."""
 
-    cli_exit: Callable[..., NoReturn]
+    cli_exit: CliExit
     cli_print: Callable[[str], None]
     get_channel_index: Callable[[], int | None]
     check_channel: Callable[[Any, int], bool]
@@ -44,7 +47,63 @@ def _selected_channel(hooks: MessagingServiceHooks) -> int:
     return hooks.get_channel_index() or 0
 
 
-def handle_messaging_actions(
+def _escape_terminal_controls(value: Any) -> str:
+    """Render terminal control characters as inert escape text.
+
+    Parameters
+    ----------
+    value : Any
+        Remote/user-provided value destined for terminal output.
+
+    Returns
+    -------
+    str
+        Printable text with C0/C1 controls escaped and visible Unicode retained.
+    """
+    text = str(value)
+    escaped: list[str] = []
+    for character in text:
+        codepoint = ord(character)
+        if codepoint < 0x20 or 0x7F <= codepoint <= 0x9F:
+            escapes = {
+                "\n": r"\n",
+                "\r": r"\r",
+                "\t": r"\t",
+            }
+            escaped.append(escapes.get(character, f"\\x{codepoint:02x}"))
+        else:
+            escaped.append(character)
+    return "".join(escaped)
+
+
+def _parse_gpio_mask(raw_value: Any, hooks: MessagingServiceHooks) -> int:
+    """Parse one hexadecimal GPIO mask or terminate with a CLI diagnostic.
+
+    Parameters
+    ----------
+    raw_value : Any
+        Raw mask value supplied by argparse.
+    hooks : MessagingServiceHooks
+        CLI exit hook used for invalid input.
+
+    Returns
+    -------
+    int
+        Parsed hexadecimal bit mask.
+    """
+    try:
+        mask = int(raw_value, 16)
+    except (TypeError, ValueError) as exc:
+        hooks.cli_exit(f"Warning: Invalid GPIO mask: {raw_value}", 1)
+        raise AssertionError("cli_exit returned unexpectedly") from exc
+    if not 0 <= mask <= GPIO_MASK_MAX:
+        hooks.cli_exit(
+            f"Warning: GPIO mask must fit in {GPIO_MASK_BITS} bits: {raw_value}", 1
+        )
+    return mask
+
+
+def _handle_messaging_actions(
     context: CliContext, hooks: MessagingServiceHooks
 ) -> None:
     """Send messages, requests, and remote-hardware operations in CLI order."""
@@ -143,8 +202,22 @@ def handle_messaging_actions(
             bitmask = 0
             bitval = 0
             for bit, value in args.gpio_wrb or []:
-                bitmask |= 1 << int(bit)
-                bitval |= int(value) << int(bit)
+                try:
+                    bit_index = int(bit)
+                    bit_value = int(value)
+                except (TypeError, ValueError):
+                    hooks.cli_exit(
+                        f"Warning: Invalid GPIO bit/value pair: {bit!r}={value!r}", 1
+                    )
+                if (
+                    not 0 <= bit_index < GPIO_MASK_BITS
+                    or bit_value not in {0, 1}
+                ):
+                    hooks.cli_exit(
+                        f"Warning: Invalid GPIO bit/value pair: {bit!r}={value!r}", 1
+                    )
+                bitmask |= 1 << bit_index
+                bitval |= bit_value << bit_index
             hooks.cli_print(
                 f"Writing GPIO mask 0x{bitmask:x} with value 0x{bitval:x} "
                 f"to {args.dest}"
@@ -153,7 +226,7 @@ def handle_messaging_actions(
             context.outcome.close_now = True
 
         if args.gpio_rd:
-            bitmask = int(args.gpio_rd, 16)
+            bitmask = _parse_gpio_mask(args.gpio_rd, hooks)
             hooks.cli_print(f"Reading GPIO mask 0x{bitmask:x} from {args.dest}")
             interface.mask = bitmask
             client.readGPIOs(args.dest, bitmask, None)
@@ -164,7 +237,7 @@ def handle_messaging_actions(
             logger.debug("end of gpio_rd")
 
         if args.gpio_watch:
-            bitmask = int(args.gpio_watch, 16)
+            bitmask = _parse_gpio_mask(args.gpio_watch, hooks)
             hooks.cli_print(
                 f"Watching GPIO mask 0x{bitmask:x} from {args.dest}. "
                 "Press ctrl-c to exit"
@@ -174,7 +247,7 @@ def handle_messaging_actions(
                 time.sleep(GPIO_WATCH_INTERVAL_SECONDS)
 
 
-def handle_content_reads(context: CliContext) -> None:
+def _handle_content_reads(context: CliContext) -> None:
     """Read canned-message and ringtone content in their historical position."""
     args = context.args
     interface = context.interface
@@ -185,7 +258,7 @@ def handle_content_reads(context: CliContext) -> None:
         messages = interface.getNode(
             args.dest, **context.get_node_kwargs
         ).get_canned_message()
-        print(f"canned_plugin_message:{messages}")
+        print(f"canned_plugin_message:{_escape_terminal_controls(messages)}")
 
     if args.get_ringtone:
         context.outcome.close_now = True
@@ -193,10 +266,10 @@ def handle_content_reads(context: CliContext) -> None:
         ringtone = interface.getNode(
             args.dest, **context.get_node_kwargs
         ).get_ringtone()
-        print(f"ringtone:{ringtone}")
+        print(f"ringtone:{_escape_terminal_controls(ringtone)}")
 
 
-def handle_information_actions(
+def _handle_information_actions(
     context: CliContext, hooks: MessagingServiceHooks
 ) -> None:
     """Handle info, preference reads, node listing, and show-field validation."""
@@ -229,14 +302,14 @@ def handle_information_actions(
         node = interface.getNode(args.dest, False, **context.get_node_kwargs)
         found = False
         for pref in args.get:
-            found = hooks.get_pref(node, pref[0])
+            found = hooks.get_pref(node, pref[0]) or found
         if found:
             hooks.cli_print("Completed getting preferences")
 
     if args.nodes:
         context.outcome.close_now = True
         if args.dest != BROADCAST_ADDR:
-            print("Showing node list of a remote node is not supported.")
+            hooks.cli_print("Showing node list of a remote node is not supported.")
             context.outcome.stop_processing = True
             return
         if args.show_fields:
@@ -244,7 +317,8 @@ def handle_information_actions(
         interface.showNodes(True, args.show_fields)
 
     if args.show_fields and not args.nodes:
-        print("--show-fields can only be used with --nodes")
+        context.outcome.close_now = True
+        hooks.cli_print("--show-fields can only be used with --nodes")
         context.outcome.stop_processing = True
 
 
@@ -268,7 +342,7 @@ def _start_tunnel(context: CliContext, hooks: MessagingServiceHooks) -> None:
         tunnel.Tunnel(context.interface)
 
 
-def handle_long_running_services(
+def _handle_long_running_services(
     context: CliContext, hooks: MessagingServiceHooks
 ) -> None:
     """Start structured logging, power stress, listening, and tunnel services."""

--- a/meshtastic/cli/messaging_service_actions.py
+++ b/meshtastic/cli/messaging_service_actions.py
@@ -334,8 +334,8 @@ def _handle_information_actions(
                     f' Consider running "{hooks.install_upgrade_hint}" ***\n'
                 )
         else:
-            print("Showing info of remote node is not supported.")
-            print(
+            hooks.cli_print("Showing info of remote node is not supported.")
+            hooks.cli_print(
                 "Use the '--get' command for a specific configuration "
                 "(e.g. 'lora') instead."
             )

--- a/meshtastic/cli/messaging_service_actions.py
+++ b/meshtastic/cli/messaging_service_actions.py
@@ -44,6 +44,18 @@ class MessagingServiceHooks:
 
 
 def _selected_channel(hooks: MessagingServiceHooks) -> int:
+    """Return the selected channel index, defaulting to the primary channel.
+
+    Parameters
+    ----------
+    hooks : MessagingServiceHooks
+        Entrypoint-owned channel-selection seam.
+
+    Returns
+    -------
+    int
+        Selected channel index, or ``0`` when no explicit channel is selected.
+    """
     return hooks.get_channel_index() or 0
 
 
@@ -323,16 +335,27 @@ def _handle_information_actions(
 
 
 def _start_tunnel(context: CliContext, hooks: MessagingServiceHooks) -> None:
+    """Start the local tunnel service when platform and CLI state permit it.
+
+    Parameters
+    ----------
+    context : CliContext
+        Connected invocation and lifecycle state. ``close_now`` is cleared only
+        when a tunnel is actually eligible to start.
+    hooks : MessagingServiceHooks
+        Platform, reporting, and exit seams.
+    """
     args = context.args
     if hooks.platform_system() != "Linux" or not args.tunnel:
         return
     if args.dest != BROADCAST_ADDR:
         hooks.cli_exit("A tunnel can only be created using the local node.", 1)
 
-    context.outcome.close_now = False
     if context.interface.noProto:
         logger.warning("Not starting Tunnel - disabled by noProto")
         return
+
+    context.outcome.close_now = False
 
     from meshtastic import tunnel  # pylint: disable=import-outside-toplevel
 

--- a/meshtastic/cli/messaging_service_actions.py
+++ b/meshtastic/cli/messaging_service_actions.py
@@ -23,6 +23,8 @@ GPIO_MASK_MAX = (1 << GPIO_MASK_BITS) - 1
 INVALID_CHANNEL_MESSAGE = (
     "Warning: {index} is not a valid channel. Channel must not be DISABLED."
 )
+REQUIRE_DESTINATION_MESSAGE = "Warning: Must use a destination node ID."
+INVALID_GPIO_PAIR_MESSAGE = "Warning: Invalid GPIO bit/value pair: {bit!r}={value!r}"
 TELEMETRY_TYPE_ALIASES = {
     "device": "device_metrics",
     "device_metrics": "device_metrics",
@@ -196,7 +198,7 @@ def _handle_messaging_actions(
 
     if args.request_telemetry:
         if args.dest == BROADCAST_ADDR:
-            _terminate_cli(hooks.cli_exit, "Warning: Must use a destination node ID.")
+            _terminate_cli(hooks.cli_exit, REQUIRE_DESTINATION_MESSAGE)
         channel_index = _require_channel(interface, hooks)
         telemetry_type = TELEMETRY_TYPE_ALIASES.get(
             args.request_telemetry, "device_metrics"
@@ -214,7 +216,7 @@ def _handle_messaging_actions(
 
     if args.request_position:
         if args.dest == BROADCAST_ADDR:
-            _terminate_cli(hooks.cli_exit, "Warning: Must use a destination node ID.")
+            _terminate_cli(hooks.cli_exit, REQUIRE_DESTINATION_MESSAGE)
         channel_index = _require_channel(interface, hooks)
         hooks.cli_print(
             f"Sending position request to {args.dest} on "
@@ -228,7 +230,7 @@ def _handle_messaging_actions(
 
     if args.gpio_wrb or args.gpio_rd or args.gpio_watch:
         if args.dest == BROADCAST_ADDR:
-            _terminate_cli(hooks.cli_exit, "Warning: Must use a destination node ID.")
+            _terminate_cli(hooks.cli_exit, REQUIRE_DESTINATION_MESSAGE)
         client = hooks.remote_hardware_client(interface)
 
         if args.gpio_wrb:
@@ -241,13 +243,13 @@ def _handle_messaging_actions(
                 except (TypeError, ValueError):
                     _terminate_cli(
                         hooks.cli_exit,
-                        f"Warning: Invalid GPIO bit/value pair: {bit!r}={value!r}",
+                        INVALID_GPIO_PAIR_MESSAGE.format(bit=bit, value=value),
                         1,
                     )
                 if not 0 <= bit_index < GPIO_MASK_BITS or bit_value not in {0, 1}:
                     _terminate_cli(
                         hooks.cli_exit,
-                        f"Warning: Invalid GPIO bit/value pair: {bit!r}={value!r}",
+                        INVALID_GPIO_PAIR_MESSAGE.format(bit=bit, value=value),
                         1,
                     )
                 bitmask |= 1 << bit_index

--- a/meshtastic/cli/messaging_service_actions.py
+++ b/meshtastic/cli/messaging_service_actions.py
@@ -242,11 +242,16 @@ def _handle_messaging_actions(
             bitmask = _parse_gpio_mask(args.gpio_rd, hooks)
             hooks.cli_print(f"Reading GPIO mask 0x{bitmask:x} from {args.dest}")
             interface.mask = bitmask
+            # Reset per-request state so a prior GPIO response cannot make this read
+            # appear complete before its own callback arrives.
+            interface.gotResponse = False
             client.readGPIOs(args.dest, bitmask, None)
             for _ in range(GPIO_READ_MAX_POLLS):
                 time.sleep(GPIO_READ_POLL_INTERVAL_SECONDS)
                 if interface.gotResponse:
                     break
+            else:
+                hooks.cli_print("Warning: no GPIO response received.")
             logger.debug("end of gpio_rd")
 
         if args.gpio_watch:

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -511,6 +511,12 @@ class Node:  # pylint: disable=too-many-instance-attributes
         """
         self._channel_request_runtime.requestChannels(starting_index=startingIndex)
 
+    def _invalidate_channel_cache(self) -> None:
+        """Clear cached channel state under the channel-state owner lock."""
+        with self._channels_lock:
+            self.channels = None
+            self.partialChannels = []
+
     def onResponseRequestSettings(self, p: dict[str, Any]) -> None:
         """Process an admin response for a settings request and update the node's config objects.
 

--- a/meshtastic/tests/simradio_helpers.py
+++ b/meshtastic/tests/simradio_helpers.py
@@ -214,12 +214,12 @@ def _classify_cli_operation(arguments: Sequence[str]) -> str:
     forms, then read-only allowlist, then idempotent-mutation allowlist.
     Unknown operations default to ``non_idempotent``.
     """
-    # Phase 1: explicit destructive flags
+    # direct writes: explicit destructive flags
     for argument in arguments:
         if argument in _DESTRUCTIVE_ARGUMENTS:
             return "non_idempotent"
 
-    # Phase 2: semantic --set with destructive field values
+    # Semantic --set operations with destructive field values are non-idempotent.
     for i, argument in enumerate(arguments):
         if argument == "--set" and i + 1 < len(arguments):
             field = arguments[i + 1].split(".")[0]
@@ -231,12 +231,12 @@ def _classify_cli_operation(arguments: Sequence[str]) -> str:
         if argument in _READ_ONLY_ARGUMENTS:
             return "read_only"
 
-    # Phase 4: explicit idempotent-mutation flags
+    # Explicit idempotent-mutation flags take precedence.
     for argument in arguments:
         if argument in _IDEMPOTENT_ARGUMENTS:
             return "idempotent_mutation"
 
-    # Phase 5: default conservative — assume non-idempotent
+    # Conservative fallback: assume unclassified mutations are non-idempotent.
     return "non_idempotent"
 
 

--- a/meshtastic/tests/simradio_helpers.py
+++ b/meshtastic/tests/simradio_helpers.py
@@ -226,7 +226,7 @@ def _classify_cli_operation(arguments: Sequence[str]) -> str:
             if field in _DESTRUCTIVE_SET_VALUES:
                 return "non_idempotent"
 
-    # Phase 3: explicit read-only flags
+    # Explicit read-only flags
     for argument in arguments:
         if argument in _READ_ONLY_ARGUMENTS:
             return "read_only"

--- a/meshtastic/tests/test_cli_channel_contact_edge_cases.py
+++ b/meshtastic/tests/test_cli_channel_contact_edge_cases.py
@@ -4,24 +4,27 @@ from __future__ import annotations
 
 import argparse
 from contextlib import nullcontext
-from typing import Any, cast
-from unittest.mock import MagicMock
+from typing import Any, NoReturn, cast
+from unittest.mock import MagicMock, create_autospec
 
 import pytest
 
 from meshtastic.cli import channel_contact_actions as actions
 from meshtastic.cli.channel_contact_actions import ChannelContactHooks
-from meshtastic.cli.context import ActionOutcome, CliContext, CliExit
+from meshtastic.cli.context import ActionOutcome, CliContext
 from meshtastic.mesh_interface import MeshInterface
+from meshtastic.node import Node
 
 
-def _cli_exit(_message: str, return_value: int = 1) -> None:
+def _cli_exit(_message: str, return_value: int = 1) -> NoReturn:
+    """Raise ``SystemExit`` with the status supplied by the action under test."""
     raise SystemExit(return_value)
 
 
 def _hooks(**overrides: Any) -> ChannelContactHooks:
+    """Build channel/contact hooks with deterministic defaults."""
     values: dict[str, Any] = {
-        "cli_exit": cast(CliExit, _cli_exit),
+        "cli_exit": _cli_exit,
         "cli_print": MagicMock(),
         "get_channel_index": MagicMock(return_value=1),
         "set_channel_index": MagicMock(),
@@ -39,6 +42,7 @@ def _hooks(**overrides: Any) -> ChannelContactHooks:
 
 
 def _args(**overrides: Any) -> argparse.Namespace:
+    """Build parser-faithful defaults for channel/contact action tests."""
     values: dict[str, Any] = {
         "dest": "^all",
         "add_contact": None,
@@ -62,6 +66,7 @@ def _args(**overrides: Any) -> argparse.Namespace:
 
 
 def _context(interface: Any, **overrides: Any) -> CliContext:
+    """Build a connected action context around a test interface double."""
     return CliContext(
         interface=cast(MeshInterface, interface),
         args=_args(**overrides),
@@ -70,12 +75,30 @@ def _context(interface: Any, **overrides: Any) -> CliContext:
     )
 
 
+def _interface_double() -> MagicMock:
+    """Return an autospecced connected-interface double."""
+    return create_autospec(MeshInterface, instance=True)
+
+
+def _node_double() -> MagicMock:
+    """Return an autospecced node double for configured node behavior."""
+    return create_autospec(Node, instance=True)
+
+
+def _interface_with_node() -> tuple[MagicMock, MagicMock]:
+    """Return a specced interface whose ``getNode`` returns a specced node."""
+    interface = _interface_double()
+    node = _node_double()
+    interface.getNode.return_value = node
+    return interface, node
+
+
 @pytest.mark.unit
 def test_invalid_numeric_modem_preset_is_rejected() -> None:
     """Unknown numeric presets should fail instead of leaking invalid protobuf values."""
     with pytest.raises(SystemExit):
         actions._resolve_requested_modem_preset(
-            _context(MagicMock(), ch_preset=999999), _hooks()
+            _context(_interface_double(), ch_preset=999999), _hooks()
         )
 
 
@@ -83,8 +106,7 @@ def test_invalid_numeric_modem_preset_is_rejected() -> None:
 @pytest.mark.parametrize("case", ["missing", "negative", "out_of_range"])
 def test_channel_update_rejects_unavailable_or_invalid_channel(case: str) -> None:
     """Channel mutation must fail before dereferencing unavailable channel state."""
-    interface = MagicMock()
-    node = interface.getNode.return_value
+    interface, node = _interface_with_node()
     hooks = _hooks()
     if case == "missing":
         node.channels = None
@@ -103,9 +125,9 @@ def test_channel_update_rejects_unavailable_or_invalid_channel(case: str) -> Non
 @pytest.mark.unit
 def test_channel_update_rejects_failed_preference_write() -> None:
     """A resolved setting whose value cannot be applied must not write the channel."""
-    interface = MagicMock()
+    interface, node = _interface_with_node()
     channel = MagicMock()
-    interface.getNode.return_value.channels = [MagicMock(), channel]
+    node.channels = [MagicMock(), channel]
     hooks = _hooks(set_pref=MagicMock(return_value=False))
 
     with pytest.raises(SystemExit):
@@ -118,7 +140,7 @@ def test_channel_update_rejects_failed_preference_write() -> None:
 @pytest.mark.unit
 def test_add_channel_url_uses_add_only_mode(monkeypatch: pytest.MonkeyPatch) -> None:
     """--ch-add-url should preserve existing channels by selecting addOnly mode."""
-    interface = MagicMock()
+    interface, node = _interface_with_node()
     context = _context(interface, ch_add_url="https://example.invalid/#abc")
     monkeypatch.setattr(actions, "_handle_channel_add", MagicMock())
     monkeypatch.setattr(actions, "_handle_channel_delete", MagicMock())
@@ -129,7 +151,7 @@ def test_add_channel_url_uses_add_only_mode(monkeypatch: pytest.MonkeyPatch) -> 
 
     actions._handle_channel_mutations(context, _hooks())
 
-    interface.getNode.return_value.setURL.assert_called_once_with(
+    node.setURL.assert_called_once_with(
         "https://example.invalid/#abc", addOnly=True
     )
     assert context.outcome.close_now is True
@@ -148,7 +170,7 @@ def test_enum_name_or_fallback_handles_known_and_unknown_values() -> None:
 @pytest.mark.unit
 def test_region_display_uses_numeric_fallbacks_for_future_firmware_values() -> None:
     """Unknown region and preset values should still produce readable metadata output."""
-    interface = MagicMock()
+    interface = _interface_double()
     interface.regionPresets = {
         999: argparse.Namespace(presets=[998], default_preset=997, licensed_only=True)
     }
@@ -185,7 +207,7 @@ def test_invalid_named_modem_preset_is_rejected() -> None:
     """Unknown preset names should fail through the same diagnostic path as bad integers."""
     with pytest.raises(SystemExit):
         actions._resolve_requested_modem_preset(
-            _context(MagicMock(), ch_preset="NOT_A_PRESET"), _hooks()
+            _context(_interface_double(), ch_preset="NOT_A_PRESET"), _hooks()
         )
 
 
@@ -194,8 +216,8 @@ def test_modem_preset_only_action_requests_interface_close() -> None:
     """A preset-only write is a one-shot mutation and must close after persistence."""
     from meshtastic.protobuf import config_pb2
 
-    interface = MagicMock()
-    node = interface.getNode.return_value
+    interface, node = _interface_with_node()
+    node.localConfig = MagicMock()
     node.localConfig.ListFields.return_value = [object()]
     context = _context(interface, ch_preset="LONG_FAST")
     hooks = _hooks(get_channel_index=MagicMock(return_value=0))
@@ -211,9 +233,25 @@ def test_modem_preset_only_action_requests_interface_close() -> None:
 
 
 @pytest.mark.unit
+def test_modem_preset_rejects_negative_channel_index() -> None:
+    """A negative channel index must not fall through to a primary preset write."""
+    interface, node = _interface_with_node()
+    context = _context(interface, ch_preset="LONG_FAST")
+    hooks = _hooks(get_channel_index=MagicMock(return_value=-1))
+
+    with pytest.raises(SystemExit):
+        actions._handle_channel_mutations(context, hooks)
+
+    interface.getNode.assert_not_called()
+    node.writeConfig.assert_not_called()
+    assert context.outcome.close_now is False
+
+
+@pytest.mark.unit
 def test_contact_qr_uses_parser_argument_name() -> None:
     """Contact QR display must consume argparse's contact_qr destination."""
-    interface = MagicMock()
+    interface = _interface_double()
+    interface.localNode = _node_double()
     interface.localNode.getContactURL.return_value = "https://example.invalid/contact"
     context = _context(
         interface,

--- a/meshtastic/tests/test_cli_channel_contact_edge_cases.py
+++ b/meshtastic/tests/test_cli_channel_contact_edge_cases.py
@@ -1,0 +1,187 @@
+"""Edge-case tests for internal channel/contact CLI action contracts."""
+
+from __future__ import annotations
+
+import argparse
+from contextlib import nullcontext
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from meshtastic.cli import channel_contact_actions as actions
+from meshtastic.cli.channel_contact_actions import ChannelContactHooks
+from meshtastic.cli.context import ActionOutcome, CliContext, CliExit
+from meshtastic.mesh_interface import MeshInterface
+
+
+def _cli_exit(_message: str, return_value: int = 1) -> None:
+    raise SystemExit(return_value)
+
+
+def _hooks(**overrides: Any) -> ChannelContactHooks:
+    values: dict[str, Any] = {
+        "cli_exit": cast(CliExit, _cli_exit),
+        "cli_print": MagicMock(),
+        "get_channel_index": MagicMock(return_value=1),
+        "set_channel_index": MagicMock(),
+        "resolve_pref": MagicMock(return_value=True),
+        "set_pref": MagicMock(return_value=True),
+        "fatal_preference_value_errors": lambda: nullcontext(),
+        "preference_value_error": ValueError,
+        "print_channel_field_choices": MagicMock(),
+        "is_local_destination": MagicMock(return_value=True),
+        "modem_preset_shorthands": (),
+        "qr_create": None,
+    }
+    values.update(overrides)
+    return ChannelContactHooks(**values)
+
+
+def _args(**overrides: Any) -> argparse.Namespace:
+    values: dict[str, Any] = {
+        "dest": "^all",
+        "add_contact": None,
+        "ch_add": None,
+        "ch_del": False,
+        "ch_set": None,
+        "ch_enable": False,
+        "ch_disable": False,
+        "ch_set_url": None,
+        "ch_add_url": None,
+        "ch_preset": None,
+        "show_region_presets": False,
+        "qr": False,
+        "qr_all": False,
+        "qr_contact": None,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def _context(interface: Any, **overrides: Any) -> CliContext:
+    return CliContext(
+        interface=cast(MeshInterface, interface),
+        args=_args(**overrides),
+        get_node_kwargs={},
+        outcome=ActionOutcome(),
+    )
+
+
+@pytest.mark.unit
+def test_invalid_numeric_modem_preset_is_rejected() -> None:
+    """Unknown numeric presets should fail instead of leaking invalid protobuf values."""
+    with pytest.raises(SystemExit):
+        actions._resolve_requested_modem_preset(
+            _context(MagicMock(), ch_preset=999999), _hooks()
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("case", ["missing", "negative", "out_of_range"])
+def test_channel_update_rejects_unavailable_or_invalid_channel(case: str) -> None:
+    """Channel mutation must fail before dereferencing unavailable channel state."""
+    interface = MagicMock()
+    node = interface.getNode.return_value
+    hooks = _hooks()
+    if case == "missing":
+        node.channels = None
+    elif case == "negative":
+        node.channels = [MagicMock()]
+        hooks = _hooks(get_channel_index=MagicMock(return_value=-1))
+    else:
+        node.channels = [MagicMock()]
+        hooks = _hooks(get_channel_index=MagicMock(return_value=4))
+
+    with pytest.raises(SystemExit):
+        actions._handle_channel_update(_context(interface, ch_enable=True), hooks)
+    node.writeChannel.assert_not_called()
+
+
+@pytest.mark.unit
+def test_channel_update_rejects_failed_preference_write() -> None:
+    """A resolved setting whose value cannot be applied must not write the channel."""
+    interface = MagicMock()
+    channel = MagicMock()
+    interface.getNode.return_value.channels = [MagicMock(), channel]
+    hooks = _hooks(set_pref=MagicMock(return_value=False))
+
+    with pytest.raises(SystemExit):
+        actions._handle_channel_update(
+            _context(interface, ch_set=[["name", "mesh"]]), hooks
+        )
+    interface.getNode.return_value.writeChannel.assert_not_called()
+
+
+@pytest.mark.unit
+def test_add_channel_url_uses_add_only_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--ch-add-url should preserve existing channels by selecting addOnly mode."""
+    interface = MagicMock()
+    context = _context(interface, ch_add_url="https://example.invalid/#abc")
+    monkeypatch.setattr(actions, "_handle_channel_add", MagicMock())
+    monkeypatch.setattr(actions, "_handle_channel_delete", MagicMock())
+    monkeypatch.setattr(
+        actions, "_resolve_requested_modem_preset", MagicMock(return_value=None)
+    )
+    monkeypatch.setattr(actions, "_handle_channel_update", MagicMock())
+
+    actions._handle_channel_mutations(context, _hooks())
+
+    interface.getNode.return_value.setURL.assert_called_once_with(
+        "https://example.invalid/#abc", addOnly=True
+    )
+    assert context.outcome.close_now is True
+
+
+@pytest.mark.unit
+def test_enum_name_or_fallback_handles_known_and_unknown_values() -> None:
+    """Region/preset display should remain stable across future enum values."""
+    enum_wrapper = MagicMock()
+    enum_wrapper.Name.side_effect = ["KNOWN", ValueError("unknown")]
+
+    assert actions._enum_name_or_fallback(enum_wrapper, 1, "VALUE_") == "KNOWN"
+    assert actions._enum_name_or_fallback(enum_wrapper, 99, "VALUE_") == "VALUE_99"
+
+
+@pytest.mark.unit
+def test_region_display_uses_numeric_fallbacks_for_future_firmware_values() -> None:
+    """Unknown region and preset values should still produce readable metadata output."""
+    interface = MagicMock()
+    interface.regionPresets = {
+        999: argparse.Namespace(presets=[998], default_preset=997, licensed_only=True)
+    }
+    cli_print = MagicMock()
+
+    actions._handle_region_preset_display(
+        _context(interface, show_region_presets=True), _hooks(cli_print=cli_print)
+    )
+
+    rendered = str(cli_print.call_args)
+    assert "REGION_999" in rendered
+    assert "PRESET_998" in rendered
+    assert "PRESET_997" in rendered
+    assert "licensed-only" in rendered
+
+
+@pytest.mark.unit
+def test_qr_without_optional_dependency_prints_install_guidance() -> None:
+    """Missing pyqrcode should still emit the URL and an actionable installation hint."""
+    cli_print = MagicMock()
+    actions._print_qr(
+        "https://example.invalid/#abc",
+        description="Primary channel URL",
+        qr_create=None,
+        cli_print=cli_print,
+    )
+
+    assert cli_print.call_count == 2
+    cli_print.assert_any_call("Install pyqrcode to view a QR code printed to terminal.")
+
+
+@pytest.mark.unit
+def test_invalid_named_modem_preset_is_rejected() -> None:
+    """Unknown preset names should fail through the same diagnostic path as bad integers."""
+    with pytest.raises(SystemExit):
+        actions._resolve_requested_modem_preset(
+            _context(MagicMock(), ch_preset="NOT_A_PRESET"), _hooks()
+        )

--- a/meshtastic/tests/test_cli_channel_contact_edge_cases.py
+++ b/meshtastic/tests/test_cli_channel_contact_edge_cases.py
@@ -103,6 +103,21 @@ def test_invalid_numeric_modem_preset_is_rejected() -> None:
 
 
 @pytest.mark.unit
+def test_channel_add_rejects_name_over_protocol_limit() -> None:
+    """Channel names longer than the firmware field limit must fail before lookup."""
+    interface = _interface_double()
+    hooks = _hooks(get_channel_index=MagicMock(return_value=None))
+    context = _context(
+        interface, ch_add="x" * (actions.MAX_CHANNEL_NAME_LENGTH + 1)
+    )
+
+    with pytest.raises(SystemExit):
+        actions._handle_channel_add(context, hooks)
+
+    interface.getNode.assert_not_called()
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize("case", ["missing", "negative", "out_of_range"])
 def test_channel_update_rejects_unavailable_or_invalid_channel(case: str) -> None:
     """Channel mutation must fail before dereferencing unavailable channel state."""

--- a/meshtastic/tests/test_cli_channel_contact_edge_cases.py
+++ b/meshtastic/tests/test_cli_channel_contact_edge_cases.py
@@ -14,6 +14,7 @@ from meshtastic.cli.channel_contact_actions import ChannelContactHooks
 from meshtastic.cli.context import ActionOutcome, CliContext
 from meshtastic.mesh_interface import MeshInterface
 from meshtastic.node import Node
+from meshtastic.protobuf import channel_pb2
 
 
 def _cli_exit(_message: str, return_value: int = 1) -> NoReturn:
@@ -150,6 +151,35 @@ def test_channel_update_rejects_failed_preference_write() -> None:
             _context(interface, ch_set=[["name", "mesh"]]), hooks
         )
     interface.getNode.return_value.writeChannel.assert_not_called()
+
+
+@pytest.mark.unit
+def test_channel_disable_remains_authoritative_when_settings_change() -> None:
+    """A settings update must not re-enable an explicitly disabled channel."""
+    interface, node = _interface_with_node()
+    primary = channel_pb2.Channel(index=0, role=channel_pb2.Channel.Role.PRIMARY)
+    channel = channel_pb2.Channel(index=1, role=channel_pb2.Channel.Role.SECONDARY)
+    channel.settings.name = "old"
+    node.channels = [primary, channel]
+
+    def set_pref(target: Any, name: str, value: Any) -> bool:
+        setattr(target, name, value)
+        return True
+
+    hooks = _hooks(set_pref=MagicMock(side_effect=set_pref))
+
+    actions._handle_channel_update(
+        _context(
+            interface,
+            ch_disable=True,
+            ch_set=[["name", "mesh"]],
+        ),
+        hooks,
+    )
+
+    assert channel.settings.name == "mesh"
+    assert channel.role == channel_pb2.Channel.Role.DISABLED
+    node.writeChannel.assert_called_once_with(1)
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_cli_channel_contact_edge_cases.py
+++ b/meshtastic/tests/test_cli_channel_contact_edge_cases.py
@@ -53,7 +53,9 @@ def _args(**overrides: Any) -> argparse.Namespace:
         "show_region_presets": False,
         "qr": False,
         "qr_all": False,
-        "qr_contact": None,
+        "contact_qr": None,
+        "contact_ignore": False,
+        "contact_verified": False,
     }
     values.update(overrides)
     return argparse.Namespace(**values)
@@ -185,3 +187,45 @@ def test_invalid_named_modem_preset_is_rejected() -> None:
         actions._resolve_requested_modem_preset(
             _context(MagicMock(), ch_preset="NOT_A_PRESET"), _hooks()
         )
+
+
+@pytest.mark.unit
+def test_modem_preset_only_action_requests_interface_close() -> None:
+    """A preset-only write is a one-shot mutation and must close after persistence."""
+    from meshtastic.protobuf import config_pb2
+
+    interface = MagicMock()
+    node = interface.getNode.return_value
+    node.localConfig.ListFields.return_value = [object()]
+    context = _context(interface, ch_preset="LONG_FAST")
+    hooks = _hooks(get_channel_index=MagicMock(return_value=0))
+
+    actions._handle_channel_mutations(context, hooks)
+
+    assert context.outcome.close_now is True
+    assert (
+        node.localConfig.lora.modem_preset
+        == config_pb2.Config.LoRaConfig.ModemPreset.Value("LONG_FAST")
+    )
+    node.writeConfig.assert_called_once_with("lora")
+
+
+@pytest.mark.unit
+def test_contact_qr_uses_parser_argument_name() -> None:
+    """Contact QR display must consume argparse's contact_qr destination."""
+    interface = MagicMock()
+    interface.localNode.getContactURL.return_value = "https://example.invalid/contact"
+    context = _context(
+        interface,
+        contact_qr="!12345678",
+        contact_ignore=True,
+        contact_verified=True,
+    )
+    cli_print = MagicMock()
+
+    actions._handle_channel_contact_display(context, _hooks(cli_print=cli_print))
+
+    interface.localNode.getContactURL.assert_called_once_with(
+        "!12345678", should_ignore=True, manually_verified=True
+    )
+    assert context.outcome.close_now is True

--- a/meshtastic/tests/test_cli_channel_ux.py
+++ b/meshtastic/tests/test_cli_channel_ux.py
@@ -1,11 +1,17 @@
 """Focused CLI validation tests for channel and node-list options."""
 
+import argparse
 import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from meshtastic.__main__ import main
+from meshtastic.cli.channel_contact_actions import (
+    ChannelContactHooks,
+    _handle_channel_delete,
+)
+from meshtastic.cli.context import ActionOutcome, CliContext
 from meshtastic.tcp_interface import TCPInterface
 
 
@@ -176,3 +182,23 @@ def test_nodes_show_fields_accepts_schema_field_without_node_database(
     interface.showNodes.assert_called_once_with(
         True, ["environmentMetrics.temperature"]
     )
+
+
+@pytest.mark.unit
+def test_channel_delete_fails_closed_if_exit_seam_returns() -> None:
+    """A missing channel index must never fall through to deletion after exit."""
+    interface = MagicMock()
+    context = CliContext(
+        interface=interface,  # type: ignore[arg-type]
+        args=argparse.Namespace(ch_del=True, dest="^local"),
+        get_node_kwargs={},
+        outcome=ActionOutcome(),
+    )
+    hooks = MagicMock(spec=ChannelContactHooks)
+    hooks.get_channel_index.return_value = None
+    hooks.cli_exit = MagicMock()
+
+    with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
+        _handle_channel_delete(context, hooks)
+
+    interface.getNode.assert_not_called()

--- a/meshtastic/tests/test_cli_channel_ux.py
+++ b/meshtastic/tests/test_cli_channel_ux.py
@@ -195,11 +195,25 @@ def test_channel_delete_fails_closed_if_exit_seam_returns() -> None:
         get_node_kwargs={},
         outcome=ActionOutcome(),
     )
-    hooks = MagicMock(spec=ChannelContactHooks)
-    hooks.get_channel_index.return_value = None
-    hooks.cli_exit = MagicMock()
+    cli_exit = MagicMock()
+    hooks = ChannelContactHooks(
+        cli_exit=cli_exit,
+        cli_print=MagicMock(),
+        get_channel_index=MagicMock(return_value=None),
+        set_channel_index=MagicMock(),
+        resolve_pref=MagicMock(),
+        set_pref=MagicMock(),
+        fatal_preference_value_errors=MagicMock(),
+        preference_value_error=ValueError,
+        print_channel_field_choices=MagicMock(),
+        is_local_destination=MagicMock(),
+        modem_preset_shorthands=(),
+    )
 
     with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
         _handle_channel_delete(context, hooks)
 
+    cli_exit.assert_called_once_with(
+        "Warning: Need to specify '--ch-index' for '--ch-del'.", 1
+    )
     interface.getNode.assert_not_called()

--- a/meshtastic/tests/test_cli_channel_ux.py
+++ b/meshtastic/tests/test_cli_channel_ux.py
@@ -2,7 +2,7 @@
 
 import argparse
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 
@@ -12,6 +12,7 @@ from meshtastic.cli.channel_contact_actions import (
     _handle_channel_delete,
 )
 from meshtastic.cli.context import ActionOutcome, CliContext
+from meshtastic.mesh_interface import MeshInterface
 from meshtastic.tcp_interface import TCPInterface
 
 
@@ -187,9 +188,9 @@ def test_nodes_show_fields_accepts_schema_field_without_node_database(
 @pytest.mark.unit
 def test_channel_delete_fails_closed_if_exit_seam_returns() -> None:
     """A missing channel index must never fall through to deletion after exit."""
-    interface = MagicMock()
+    interface = create_autospec(MeshInterface, instance=True)
     context = CliContext(
-        interface=interface,  # type: ignore[arg-type]
+        interface=interface,
         args=argparse.Namespace(ch_del=True, dest="^local"),
         get_node_kwargs={},
         outcome=ActionOutcome(),

--- a/meshtastic/tests/test_cli_configure_edge_cases.py
+++ b/meshtastic/tests/test_cli_configure_edge_cases.py
@@ -21,6 +21,10 @@ from meshtastic.cli.configure_actions import (
 from meshtastic.cli.context import ActionOutcome, CliContext, CliExit
 from meshtastic.mesh_interface import MeshInterface
 
+_PREFLIGHT_MODE: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "configure_edge_preflight", default=False
+)
+
 
 def _cli_exit(_message: str, return_value: int = 1) -> None:
     raise SystemExit(return_value)
@@ -31,9 +35,7 @@ def _hooks(**overrides: Any) -> ConfigureHooks:
         "cli_exit": cast(CliExit, _cli_exit),
         "cli_print": MagicMock(),
         "traverse_config": MagicMock(return_value=True),
-        "preflight_mode": contextvars.ContextVar(
-            "configure_edge_preflight", default=False
-        ),
+        "preflight_mode": _PREFLIGHT_MODE,
         "is_local_destination": MagicMock(return_value=True),
         "post_seturl_stability_check": MagicMock(return_value=True),
         "post_configure_reconnect_and_verify": MagicMock(

--- a/meshtastic/tests/test_cli_configure_edge_cases.py
+++ b/meshtastic/tests/test_cli_configure_edge_cases.py
@@ -7,6 +7,7 @@ import contextvars
 import os
 import stat
 import threading
+from collections.abc import Callable
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, NoReturn, cast
@@ -92,6 +93,24 @@ def _interface(connected: bool = True) -> MagicMock:
     return iface
 
 
+def _install_clock(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    monotonic: Callable[[], float] | None = None,
+    sleep: Callable[[float], None] | None = None,
+) -> None:
+    """Install a configure-runtime clock without changing shared time functions."""
+    current_time = configure_actions.time
+    monkeypatch.setattr(
+        configure_actions,
+        "time",
+        SimpleNamespace(
+            monotonic=current_time.monotonic if monotonic is None else monotonic,
+            sleep=current_time.sleep if sleep is None else sleep,
+        ),
+    )
+
+
 @pytest.mark.unit
 def test_reconnect_verify_reports_refresh_failure(
     monkeypatch: pytest.MonkeyPatch,
@@ -100,10 +119,11 @@ def test_reconnect_verify_reports_refresh_failure(
     iface = _interface()
     iface.getNode.return_value = MagicMock()
     ticks = iter(float(value) for value in range(20))
-    monkeypatch.setattr(
-        configure_actions.time, "monotonic", lambda: next(ticks, 20.0)
+    _install_clock(
+        monkeypatch,
+        monotonic=lambda: next(ticks, 20.0),
+        sleep=lambda _seconds: None,
     )
-    monkeypatch.setattr(configure_actions.time, "sleep", lambda _seconds: None)
     monkeypatch.setattr(
         configure_actions,
         "_refresh_no_disconnect_verify_state",
@@ -128,10 +148,11 @@ def test_reconnect_verify_reports_unexpected_verifier_failure(
     iface = _interface()
     iface.getNode.return_value = MagicMock()
     ticks = iter(float(value) for value in range(20))
-    monkeypatch.setattr(
-        configure_actions.time, "monotonic", lambda: next(ticks, 20.0)
+    _install_clock(
+        monkeypatch,
+        monotonic=lambda: next(ticks, 20.0),
+        sleep=lambda _seconds: None,
     )
-    monkeypatch.setattr(configure_actions.time, "sleep", lambda _seconds: None)
     monkeypatch.setattr(
         configure_actions, "_refresh_no_disconnect_verify_state", MagicMock()
     )
@@ -199,8 +220,11 @@ def test_seturl_stability_reconnect_hook_success(
     iface._attempt_reconnect = MagicMock(return_value=True)
     iface.waitForConfig = MagicMock()
     ticks = iter(float(value) for value in range(20))
-    monkeypatch.setattr(configure_actions.time, "monotonic", lambda: next(ticks, 20.0))
-    monkeypatch.setattr(configure_actions.time, "sleep", lambda _seconds: None)
+    _install_clock(
+        monkeypatch,
+        monotonic=lambda: next(ticks, 20.0),
+        sleep=lambda _seconds: None,
+    )
 
     assert configure_actions._post_seturl_stability_check(iface, timeout=10.0)
     iface._attempt_reconnect.assert_called_once_with()
@@ -216,8 +240,11 @@ def test_seturl_stability_reconnect_and_connect_fail(
     iface.isConnected = _ConnectionEvent([False] * 20)
     iface._attempt_reconnect = MagicMock(side_effect=RuntimeError("reconnect"))
     iface.connect = MagicMock(side_effect=RuntimeError("connect"))
-    monkeypatch.setattr(configure_actions.time, "monotonic", lambda: 0.0)
-    monkeypatch.setattr(configure_actions.time, "sleep", lambda _seconds: None)
+    _install_clock(
+        monkeypatch,
+        monotonic=lambda: 0.0,
+        sleep=lambda _seconds: None,
+    )
 
     assert configure_actions._post_seturl_stability_check(iface, timeout=1.0) is False
     assert (
@@ -235,7 +262,7 @@ def test_seturl_stability_respects_expired_deadline(
     iface = MagicMock()
     iface.isConnected = _ConnectionEvent([False])
     ticks = iter([0.0, 2.0])
-    monkeypatch.setattr(configure_actions.time, "monotonic", lambda: next(ticks, 2.0))
+    _install_clock(monkeypatch, monotonic=lambda: next(ticks, 2.0))
 
     assert configure_actions._post_seturl_stability_check(iface, timeout=1.0) is False
 
@@ -243,16 +270,28 @@ def test_seturl_stability_respects_expired_deadline(
 @pytest.mark.unit
 def test_seturl_stability_detects_drop_during_window(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A transport drop inside the stability window should retry then fail boundedly."""
     iface = MagicMock()
-    # Per attempt: connected gate, first window check false. Repeat three times.
-    iface.isConnected = _ConnectionEvent([True, False, True, False, True, False])
+    # Per attempt: initial gate, pre-window gate, first window check.
+    iface.isConnected = _ConnectionEvent(
+        [True, True, False] * configure_actions.SETURL_STABILITY_MAX_ATTEMPTS
+    )
     ticks = iter(float(value) for value in range(20))
-    monkeypatch.setattr(configure_actions.time, "monotonic", lambda: next(ticks, 20.0))
-    monkeypatch.setattr(configure_actions.time, "sleep", lambda _seconds: None)
+    _install_clock(
+        monkeypatch,
+        monotonic=lambda: next(ticks, 20.0),
+        sleep=lambda _seconds: None,
+    )
 
-    assert configure_actions._post_seturl_stability_check(iface, timeout=1.0) is False
+    assert (
+        configure_actions._post_seturl_stability_check(iface, timeout=100.0) is False
+    )
+    iface.waitForConfig.assert_not_called()
+    assert caplog.text.count("Transport dropped during stability window") == (
+        configure_actions.SETURL_STABILITY_MAX_ATTEMPTS
+    )
 
 
 @pytest.mark.unit
@@ -264,8 +303,11 @@ def test_seturl_stability_retries_config_reload_failure(
     iface.isConnected = _ConnectionEvent([True] * 30)
     iface.waitForConfig.side_effect = RuntimeError("reload")
     ticks = iter(float(value) for value in range(40))
-    monkeypatch.setattr(configure_actions.time, "monotonic", lambda: next(ticks, 40.0))
-    monkeypatch.setattr(configure_actions.time, "sleep", lambda _seconds: None)
+    _install_clock(
+        monkeypatch,
+        monotonic=lambda: next(ticks, 40.0),
+        sleep=lambda _seconds: None,
+    )
 
     assert configure_actions._post_seturl_stability_check(iface, timeout=100.0) is False
     assert (
@@ -540,7 +582,7 @@ def test_apply_direct_configuration_prints_explicit_altitude_and_applies_all_val
         config_sections={},
         module_config_sections={},
     )
-    monkeypatch.setattr(configure_actions.time, "sleep", lambda _seconds: None)
+    _install_clock(monkeypatch, sleep=lambda _seconds: None)
 
     result = configure_actions._apply_direct_configuration(hooks, node, prepared)
 
@@ -639,21 +681,6 @@ def test_configure_actions_remote_export_and_write_failure(tmp_path: Path) -> No
 
 
 @pytest.mark.unit
-def test_seturl_stability_marks_midwindow_drop_unstable(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A connection that drops after entering the stability window must retry."""
-    iface = MagicMock()
-    iface.isConnected = _ConnectionEvent([True, True, False])
-    ticks = iter(float(value) for value in range(20))
-    monkeypatch.setattr(configure_actions.time, "monotonic", lambda: next(ticks, 20.0))
-    monkeypatch.setattr(configure_actions.time, "sleep", lambda _seconds: None)
-
-    assert configure_actions._post_seturl_stability_check(iface, timeout=100.0) is False
-    iface.waitForConfig.assert_not_called()
-
-
-@pytest.mark.unit
 def test_post_reconnect_local_config_mismatch_is_incomplete(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -693,7 +720,7 @@ def test_settings_transaction_logs_unknown_fields_without_rejecting_section(
 ) -> None:
     """Unknown nested fields may be skipped while known fields still persist."""
     node = MagicMock()
-    monkeypatch.setattr(configure_actions.time, "sleep", lambda _seconds: None)
+    _install_clock(monkeypatch, sleep=lambda _seconds: None)
 
     def _traverse(
         _section: str, _values: dict[str, Any], _root: Any, *, failed_fields: list[str]

--- a/meshtastic/tests/test_cli_configure_edge_cases.py
+++ b/meshtastic/tests/test_cli_configure_edge_cases.py
@@ -1,0 +1,708 @@
+"""Focused edge-case tests for the extracted configure action runtime."""
+
+from __future__ import annotations
+
+import argparse
+import contextvars
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from meshtastic.cli import configure_actions
+from meshtastic.cli.configure_actions import (
+    ConfigureActionHooks,
+    ConfigureHooks,
+    ConfigureReconnectResult,
+)
+from meshtastic.cli.context import ActionOutcome, CliContext, CliExit
+from meshtastic.mesh_interface import MeshInterface
+
+
+def _cli_exit(_message: str, return_value: int = 1) -> None:
+    raise SystemExit(return_value)
+
+
+def _hooks(**overrides: Any) -> ConfigureHooks:
+    values: dict[str, Any] = {
+        "cli_exit": cast(CliExit, _cli_exit),
+        "cli_print": MagicMock(),
+        "traverse_config": MagicMock(return_value=True),
+        "preflight_mode": contextvars.ContextVar(
+            "configure_edge_preflight", default=False
+        ),
+        "is_local_destination": MagicMock(return_value=True),
+        "post_seturl_stability_check": MagicMock(return_value=True),
+        "post_configure_reconnect_and_verify": MagicMock(
+            return_value=ConfigureReconnectResult.VERIFIED
+        ),
+        "channel_url_matches_current_device_state": MagicMock(return_value=False),
+        "pace_configure_write": MagicMock(),
+    }
+    values.update(overrides)
+    return ConfigureHooks(**values)
+
+
+def _interface(connected: bool = True) -> MagicMock:
+    iface = MagicMock(spec=MeshInterface)
+    iface.isConnected = threading.Event()
+    if connected:
+        iface.isConnected.set()
+    iface.waitForConfig = MagicMock()
+    return iface
+
+
+@pytest.mark.unit
+def test_reconnect_verify_reports_refresh_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No-disconnect refresh failures should become a config-reload result."""
+    iface = _interface()
+    iface.getNode.return_value = MagicMock()
+    monkeypatch.setattr(
+        configure_actions,
+        "_refresh_no_disconnect_verify_state",
+        MagicMock(side_effect=RuntimeError("refresh failed")),
+    )
+
+    result = configure_actions._post_configure_reconnect_and_verify(
+        iface,
+        timeout=1.0,
+        node_dest="^local",
+        verify_config_fields={"power": {"ls_secs": 1}},
+    )
+
+    assert result is ConfigureReconnectResult.CONFIG_RELOAD_FAILED
+
+
+@pytest.mark.unit
+def test_reconnect_verify_reports_unexpected_verifier_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unexpected verifier exceptions should remain an incomplete verification."""
+    iface = _interface()
+    iface.getNode.return_value = MagicMock()
+    monkeypatch.setattr(
+        configure_actions, "_refresh_no_disconnect_verify_state", MagicMock()
+    )
+    monkeypatch.setattr(
+        configure_actions,
+        "_verify_post_reconnect_config",
+        MagicMock(side_effect=RuntimeError("verify failed")),
+    )
+
+    result = configure_actions._post_configure_reconnect_and_verify(
+        iface,
+        timeout=1.0,
+        node_dest="^local",
+        verify_config_fields={"power": {"ls_secs": 1}},
+    )
+
+    assert result is ConfigureReconnectResult.VERIFICATION_INCOMPLETE
+
+
+class _ConnectionEvent:
+    """Mutable connection-event double for deterministic stability tests."""
+
+    def __init__(self, states: list[bool], *, wait_result: bool = False) -> None:
+        self._states = iter(states)
+        self._last = False
+        self.wait_result = wait_result
+
+    def is_set(self) -> bool:
+        try:
+            self._last = next(self._states)
+        except StopIteration:
+            pass
+        return self._last
+
+    def wait(self, _timeout: float) -> bool:
+        return self.wait_result
+
+
+@pytest.mark.unit
+def test_seturl_stability_reconnect_hook_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A reconnect hook that restores connectivity should reach config reload."""
+    iface = MagicMock()
+    iface.isConnected = _ConnectionEvent([False, True, True, True, True])
+    iface._attempt_reconnect = MagicMock(return_value=True)
+    iface.waitForConfig = MagicMock()
+    ticks = iter(float(value) for value in range(20))
+    monkeypatch.setattr(configure_actions.time, "monotonic", lambda: next(ticks, 20.0))
+    monkeypatch.setattr(configure_actions.time, "sleep", lambda _seconds: None)
+
+    assert configure_actions._post_seturl_stability_check(iface, timeout=10.0)
+    iface._attempt_reconnect.assert_called_once_with()
+    iface.waitForConfig.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_seturl_stability_reconnect_and_connect_fail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reconnect trigger failures should fall through to a bounded false result."""
+    iface = MagicMock()
+    iface.isConnected = _ConnectionEvent([False] * 20)
+    iface._attempt_reconnect = MagicMock(side_effect=RuntimeError("reconnect"))
+    iface.connect = MagicMock(side_effect=RuntimeError("connect"))
+    monkeypatch.setattr(configure_actions.time, "monotonic", lambda: 0.0)
+    monkeypatch.setattr(configure_actions.time, "sleep", lambda _seconds: None)
+
+    assert configure_actions._post_seturl_stability_check(iface, timeout=1.0) is False
+    assert (
+        iface._attempt_reconnect.call_count
+        == configure_actions.SETURL_STABILITY_MAX_ATTEMPTS
+    )
+    assert iface.connect.call_count == configure_actions.SETURL_STABILITY_MAX_ATTEMPTS
+
+
+@pytest.mark.unit
+def test_seturl_stability_respects_expired_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An exhausted budget must terminate before another reconnect attempt."""
+    iface = MagicMock()
+    iface.isConnected = _ConnectionEvent([False])
+    ticks = iter([0.0, 2.0])
+    monkeypatch.setattr(configure_actions.time, "monotonic", lambda: next(ticks, 2.0))
+
+    assert configure_actions._post_seturl_stability_check(iface, timeout=1.0) is False
+
+
+@pytest.mark.unit
+def test_seturl_stability_detects_drop_during_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transport drop inside the stability window should retry then fail boundedly."""
+    iface = MagicMock()
+    # Per attempt: connected gate, first window check false. Repeat three times.
+    iface.isConnected = _ConnectionEvent([True, False, True, False, True, False])
+    ticks = iter(float(value) for value in range(20))
+    monkeypatch.setattr(configure_actions.time, "monotonic", lambda: next(ticks, 20.0))
+    monkeypatch.setattr(configure_actions.time, "sleep", lambda _seconds: None)
+
+    assert configure_actions._post_seturl_stability_check(iface, timeout=1.0) is False
+
+
+@pytest.mark.unit
+def test_seturl_stability_retries_config_reload_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Config reload failure after a stable transport should consume all attempts."""
+    iface = MagicMock()
+    iface.isConnected = _ConnectionEvent([True] * 30)
+    iface.waitForConfig.side_effect = RuntimeError("reload")
+    ticks = iter(float(value) for value in range(40))
+    monkeypatch.setattr(configure_actions.time, "monotonic", lambda: next(ticks, 40.0))
+    monkeypatch.setattr(configure_actions.time, "sleep", lambda _seconds: None)
+
+    assert configure_actions._post_seturl_stability_check(iface, timeout=100.0) is False
+    assert (
+        iface.waitForConfig.call_count
+        == configure_actions.SETURL_STABILITY_MAX_ATTEMPTS
+    )
+
+
+@pytest.mark.unit
+def test_refresh_verify_state_skips_unknown_sections() -> None:
+    """Unknown config and module-config sections should be skipped without mutation."""
+    node = MagicMock()
+    node.localConfig.DESCRIPTOR.fields_by_name = {}
+    node.moduleConfig.DESCRIPTOR.fields_by_name = {}
+
+    configure_actions._refresh_no_disconnect_verify_state(
+        node,
+        verify_channel_url=None,
+        verify_config_fields={"futureConfig": {"x": 1}},
+        verify_module_config_fields={"futureModule": {"x": 1}},
+    )
+
+    node.localConfig.ClearField.assert_not_called()
+    node.moduleConfig.ClearField.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("local_config", "expected"),
+    [
+        (None, None),
+        (SimpleNamespace(HasField=None), None),
+        (SimpleNamespace(HasField=lambda _name: False), None),
+    ],
+)
+def test_device_lora_config_handles_absent_state(
+    local_config: Any, expected: Any
+) -> None:
+    """LoRa state probing should tolerate every unloaded-state representation."""
+    node = SimpleNamespace(localConfig=local_config)
+    assert configure_actions._device_lora_config(node) is expected
+
+
+@pytest.mark.unit
+def test_device_lora_config_returns_loaded_message() -> None:
+    """Loaded LoRa state should be returned once and reused by verifiers."""
+    lora = object()
+    node = SimpleNamespace(
+        localConfig=SimpleNamespace(HasField=lambda name: name == "lora", lora=lora)
+    )
+    assert configure_actions._device_lora_config(node) is lora
+
+
+@pytest.mark.unit
+def test_post_reconnect_verification_rejects_disconnected_transport() -> None:
+    """Verification must not read stale node state while disconnected."""
+    iface = _interface(connected=False)
+    result = configure_actions._verify_post_reconnect_config(iface, "^local")
+    assert result is ConfigureReconnectResult.VERIFICATION_INCOMPLETE
+    iface.getNode.assert_not_called()
+
+
+@pytest.mark.unit
+def test_post_reconnect_verification_tracks_channel_url_success() -> None:
+    """A matching URL with loaded LoRa state should complete verification."""
+    iface = _interface()
+    node = MagicMock()
+    node.localConfig.HasField.return_value = True
+    iface.getNode.return_value = node
+    verify_url = MagicMock(return_value=True)
+
+    result = configure_actions._verify_post_reconnect_config(
+        iface,
+        "^local",
+        verify_channel_url="https://example.invalid/#ok",
+        verify_channel_url_against_state=verify_url,
+    )
+
+    assert result is ConfigureReconnectResult.VERIFIED
+    assert verify_url.call_args.kwargs["device_lora_config"] is node.localConfig.lora
+
+
+@pytest.mark.unit
+def test_post_reconnect_module_verification_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A module-config mismatch should return incomplete verification."""
+    iface = _interface()
+    iface.getNode.return_value = MagicMock()
+    monkeypatch.setattr(
+        configure_actions, "_verify_config_sections", MagicMock(return_value=False)
+    )
+
+    result = configure_actions._verify_post_reconnect_config(
+        iface,
+        "^local",
+        verify_module_config_fields={"telemetry": {"enabled": True}},
+    )
+
+    assert result is ConfigureReconnectResult.VERIFICATION_INCOMPLETE
+
+
+@pytest.mark.unit
+def test_post_reconnect_detects_disconnect_after_comparison(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A disconnect after values match must prevent a false verified result."""
+    iface = _interface()
+    iface.isConnected = MagicMock()
+    iface.isConnected.is_set.side_effect = [True, False]
+    iface.getNode.return_value = MagicMock()
+    monkeypatch.setattr(
+        configure_actions, "_verify_config_sections", MagicMock(return_value=True)
+    )
+
+    result = configure_actions._verify_post_reconnect_config(
+        iface,
+        "^local",
+        verify_config_fields={"power": {"ls_secs": 1}},
+    )
+
+    assert result is ConfigureReconnectResult.VERIFICATION_INCOMPLETE
+
+
+@pytest.mark.unit
+def test_close_failed_settings_transaction_does_not_retry_failed_commit() -> None:
+    """A failed normal commit must not be retried when device state is unknown."""
+    node = MagicMock()
+    cli_print = MagicMock()
+    configure_actions._close_failed_settings_transaction(
+        _hooks(cli_print=cli_print), node, commit_attempted=True
+    )
+    node.commitSettingsTransaction.assert_not_called()
+    assert "state is unknown" in str(cli_print.call_args)
+
+
+@pytest.mark.unit
+def test_close_failed_settings_transaction_reports_close_failure() -> None:
+    """Failure of the only available transaction-close operation must be visible."""
+    node = MagicMock()
+    node.commitSettingsTransaction.side_effect = RuntimeError("commit")
+    cli_print = MagicMock()
+    configure_actions._close_failed_settings_transaction(
+        _hooks(cli_print=cli_print), node, commit_attempted=False
+    )
+    assert node.commitSettingsTransaction.call_count == 1
+    assert "open transaction" in str(cli_print.call_args)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "configuration",
+    [
+        {"owner": None},
+        {"owner_short": "   "},
+        {"location": []},
+        {"location": {"lat": 1, "lon": 2, "bogus": 3}},
+        {"location": {"lat": 1}},
+        {"location": {"lat": True, "lon": 0}},
+        {"location": {"lat": "bad", "lon": 0}},
+        {"location": {"lat": 0, "lon": False}},
+        {"location": {"lat": 0, "lon": "bad"}},
+        {"location": {"lat": 91, "lon": 0}},
+        {"location": {"lat": 0, "lon": 181}},
+        {"location": {"lat": 0, "lon": 0, "alt": True}},
+        {"location": {"lat": 0, "lon": 0, "alt": "bad"}},
+        {"location": {"lat": 0, "lon": 0, "alt": 1 << 31}},
+        {"canned_messages": 123},
+        {"ringtone": object()},
+        {"channel_url": 123},
+        {"channel_url": "   "},
+    ],
+)
+def test_phase1_validation_rejects_all_invalid_direct_write_shapes(
+    configuration: dict[str, Any],
+) -> None:
+    """Every deterministic Phase-1 validation failure must occur before mutation."""
+    with pytest.raises(SystemExit):
+        configure_actions._validate_phase1_configuration(_hooks(), configuration)
+
+
+@pytest.mark.unit
+def test_phase1_validation_preserves_alias_and_altitude_metadata() -> None:
+    """Normalized Phase-1 values should carry all apply-time shape decisions."""
+    values = configure_actions._validate_phase1_configuration(
+        _hooks(),
+        {
+            "owner": " Owner ",
+            "ownerShort": " OS ",
+            "location": {"lat": 90, "lon": 180, "alt": -(1 << 31)},
+            "channelUrl": " https://example.invalid/#abc ",
+            "canned_messages": "hello",
+            "ringtone": "tone",
+        },
+    )
+    assert values.owner == "Owner"
+    assert values.owner_short == "OS"
+    assert values.location == (90.0, 180.0, -(1 << 31))
+    assert values.altitude_specified is True
+    assert values.channel_url_key == "channelUrl"
+    assert values.channel_url == "https://example.invalid/#abc"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("text", "expected_fragment"),
+    [
+        ("", "empty"),
+        ("[]", "mapping/dictionary"),
+        ("{}", "nothing to configure"),
+        ("unknown: true", "Unknown top-level key(s)"),
+        ("owner_short: A\nownerShort: B", "both 'owner_short' and 'ownerShort'"),
+        ("channel_url: x\nchannelUrl: y", "both 'channel_url' and 'channelUrl'"),
+        ("config: []", "'config' must be a non-empty mapping"),
+        ("module_config: []", "'module_config' must be a non-empty mapping"),
+    ],
+)
+def test_configure_document_rejects_invalid_top_level_shapes(
+    tmp_path: Path, text: str, expected_fragment: str
+) -> None:
+    """Document structural failures should terminate with actionable diagnostics."""
+    path = tmp_path / "bad.yaml"
+    path.write_text(text, encoding="utf-8")
+    cli_exit = MagicMock(side_effect=SystemExit(1))
+    with pytest.raises(SystemExit):
+        configure_actions._load_and_validate_configure_document(
+            _hooks(cli_exit=cast(CliExit, cli_exit)), str(path)
+        )
+    assert expected_fragment in str(cli_exit.call_args)
+
+
+@pytest.mark.unit
+def test_configure_document_reports_read_and_parse_failures(tmp_path: Path) -> None:
+    """Filesystem and YAML parse failures should not leak raw tracebacks."""
+    for path in [tmp_path / "missing.yaml", tmp_path / "invalid.yaml"]:
+        if path.name == "invalid.yaml":
+            path.write_text("[unterminated", encoding="utf-8")
+        with pytest.raises(SystemExit):
+            configure_actions._load_and_validate_configure_document(_hooks(), str(path))
+
+
+@pytest.mark.unit
+def test_apply_phase1_prints_explicit_altitude_and_applies_all_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prepared direct writes should apply without rereading raw YAML shape."""
+    node = MagicMock()
+    cli_print = MagicMock()
+    hooks = _hooks(cli_print=cli_print)
+    prepared = configure_actions._PreparedConfigureDocument(
+        phase1=configure_actions._Phase1ConfigureValues(
+            owner="Owner",
+            owner_short="OS",
+            location=(1.0, 2.0, 3),
+            altitude_specified=True,
+            canned_messages="hello",
+            ringtone="tone",
+            channel_url="https://example.invalid/#abc",
+            channel_url_key="channelUrl",
+        ),
+        config_sections={},
+        module_config_sections={},
+    )
+    monkeypatch.setattr(configure_actions.time, "sleep", lambda _seconds: None)
+
+    result = configure_actions._apply_phase1_configuration(hooks, node, prepared)
+
+    assert result is True
+    node.setFixedPosition.assert_called_once_with(1.0, 2.0, 3)
+    node.setURL.assert_called_once_with("https://example.invalid/#abc")
+    assert "Fixing altitude at 3 meters" in [
+        c.args[0] for c in cli_print.call_args_list
+    ]
+
+
+@pytest.mark.unit
+def test_apply_settings_transaction_reports_write_failure() -> None:
+    """A failed section write should close the opened transaction and re-raise."""
+    node = MagicMock()
+    node.writeConfig.side_effect = RuntimeError("write failed")
+    hooks = _hooks(traverse_config=MagicMock(return_value=True))
+
+    with pytest.raises(RuntimeError, match="write failed"):
+        configure_actions._apply_settings_transaction(
+            hooks,
+            node,
+            config_sections={"power": {"ls_secs": 1}},
+            module_config_sections={},
+        )
+
+    node.beginSettingsTransaction.assert_called_once_with()
+    node.commitSettingsTransaction.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_apply_settings_transaction_fails_when_traversal_rejects_section() -> None:
+    """A traversal rejection should fail closed and close the transaction."""
+    node = MagicMock()
+    hooks = _hooks(traverse_config=MagicMock(return_value=False))
+
+    with pytest.raises(SystemExit):
+        configure_actions._apply_settings_transaction(
+            hooks,
+            node,
+            config_sections={"power": {"ls_secs": 1}},
+            module_config_sections={},
+        )
+    node.commitSettingsTransaction.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_configure_actions_remote_export_and_write_failure(tmp_path: Path) -> None:
+    """Export dispatch should stop on remote targets and report local write failures."""
+    interface = cast(MeshInterface, MagicMock())
+    remote_context = CliContext(
+        interface=interface,
+        args=argparse.Namespace(
+            set=None,
+            configure=None,
+            export_config=str(tmp_path / "unused"),
+            dest="!remote",
+        ),
+        get_node_kwargs={},
+        outcome=ActionOutcome(),
+    )
+    export_config = MagicMock(return_value="yaml")
+    action_hooks = ConfigureActionHooks(
+        handle_set_command=MagicMock(),
+        handle_configure_command=MagicMock(return_value=(False, False)),
+        export_config=export_config,
+        cli_exit=cast(CliExit, _cli_exit),
+        cli_print=MagicMock(),
+        is_local_destination=MagicMock(return_value=False),
+    )
+    configure_actions._handle_configure_actions(remote_context, action_hooks)
+    assert remote_context.outcome.stop_processing is True
+    export_config.assert_not_called()
+
+    local_context = CliContext(
+        interface=interface,
+        args=argparse.Namespace(
+            set=None,
+            configure=None,
+            export_config=str(tmp_path / "missing" / "config.yaml"),
+            dest="^all",
+        ),
+        get_node_kwargs={},
+        outcome=ActionOutcome(),
+    )
+    local_hooks = ConfigureActionHooks(
+        handle_set_command=action_hooks.handle_set_command,
+        handle_configure_command=action_hooks.handle_configure_command,
+        export_config=action_hooks.export_config,
+        cli_exit=action_hooks.cli_exit,
+        cli_print=action_hooks.cli_print,
+        is_local_destination=MagicMock(return_value=True),
+    )
+    with pytest.raises(SystemExit):
+        configure_actions._handle_configure_actions(local_context, local_hooks)
+
+
+@pytest.mark.unit
+def test_seturl_stability_marks_midwindow_drop_unstable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A connection that drops after entering the stability window must retry."""
+    iface = MagicMock()
+    iface.isConnected = _ConnectionEvent([True, True, False])
+    ticks = iter(float(value) for value in range(20))
+    monkeypatch.setattr(configure_actions.time, "monotonic", lambda: next(ticks, 20.0))
+    monkeypatch.setattr(configure_actions.time, "sleep", lambda _seconds: None)
+
+    assert configure_actions._post_seturl_stability_check(iface, timeout=100.0) is False
+    iface.waitForConfig.assert_not_called()
+
+
+@pytest.mark.unit
+def test_post_reconnect_local_config_mismatch_is_incomplete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A local-config mismatch should terminate verification before module checks."""
+    iface = _interface()
+    iface.getNode.return_value = MagicMock()
+    verifier = MagicMock(return_value=False)
+    monkeypatch.setattr(configure_actions, "_verify_config_sections", verifier)
+
+    result = configure_actions._verify_post_reconnect_config(
+        iface,
+        "^local",
+        verify_config_fields={"power": {"ls_secs": 1}},
+    )
+
+    assert result is ConfigureReconnectResult.VERIFICATION_INCOMPLETE
+    verifier.assert_called_once()
+
+
+@pytest.mark.unit
+def test_apply_phase1_rejects_internally_inconsistent_normalized_url() -> None:
+    """Prepared configure values must never carry a URL without its source alias."""
+    prepared = configure_actions._PreparedConfigureDocument(
+        phase1=configure_actions._Phase1ConfigureValues(
+            channel_url="https://example.invalid/#abc", channel_url_key=None
+        ),
+        config_sections={},
+        module_config_sections={},
+    )
+    with pytest.raises(AssertionError, match="source key"):
+        configure_actions._apply_phase1_configuration(_hooks(), MagicMock(), prepared)
+
+
+@pytest.mark.unit
+def test_settings_transaction_logs_unknown_fields_without_rejecting_section() -> None:
+    """Unknown nested fields may be skipped while known fields still persist."""
+    node = MagicMock()
+
+    def _traverse(
+        _section: str, _values: dict[str, Any], _root: Any, *, failed_fields: list[str]
+    ) -> bool:
+        failed_fields.append("future_field")
+        return True
+
+    configure_actions._apply_settings_transaction(
+        _hooks(traverse_config=_traverse),
+        node,
+        config_sections={"power": {"future_field": 1}},
+        module_config_sections={},
+    )
+
+    node.writeConfig.assert_called_once_with("power")
+    node.commitSettingsTransaction.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_configure_actions_no_export_and_stdout_export(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Configure dispatch should cover the no-export fast path and stdout payload path."""
+    interface = cast(MeshInterface, MagicMock())
+    export_config = MagicMock(return_value="config: true\n")
+    hooks = ConfigureActionHooks(
+        handle_set_command=MagicMock(),
+        handle_configure_command=MagicMock(return_value=(False, False)),
+        export_config=export_config,
+        cli_exit=cast(CliExit, _cli_exit),
+        cli_print=MagicMock(),
+        is_local_destination=MagicMock(return_value=True),
+    )
+    no_export = CliContext(
+        interface=interface,
+        args=argparse.Namespace(
+            set=None, configure=None, export_config=None, dest="^all"
+        ),
+        get_node_kwargs={},
+        outcome=ActionOutcome(),
+    )
+    configure_actions._handle_configure_actions(no_export, hooks)
+    export_config.assert_not_called()
+
+    stdout_export = CliContext(
+        interface=interface,
+        args=argparse.Namespace(
+            set=None, configure=None, export_config="-", dest="^all"
+        ),
+        get_node_kwargs={},
+        outcome=ActionOutcome(),
+    )
+    configure_actions._handle_configure_actions(stdout_export, hooks)
+    assert "config: true" in capsys.readouterr().out
+
+
+@pytest.mark.unit
+def test_channel_url_match_requires_loaded_lora_state() -> None:
+    """Channel URL short-circuit comparison should reject unloaded LoRa state."""
+    node = SimpleNamespace(localConfig=None)
+    comparator = MagicMock(return_value=True)
+
+    assert not configure_actions._channel_url_matches_current_device_state(
+        node,
+        "https://example.invalid/#abc",
+        verify_channel_url_against_state=comparator,
+    )
+    comparator.assert_not_called()
+
+
+@pytest.mark.unit
+def test_channel_url_match_delegates_with_normalized_loaded_state() -> None:
+    """Loaded channel and LoRa state should be forwarded to the URL comparator."""
+    lora = object()
+    channels = [object()]
+    node = SimpleNamespace(
+        localConfig=SimpleNamespace(HasField=lambda name: name == "lora", lora=lora),
+        channels=channels,
+    )
+    comparator = MagicMock(return_value=True)
+
+    assert configure_actions._channel_url_matches_current_device_state(
+        node,
+        "https://example.invalid/#abc",
+        verify_channel_url_against_state=comparator,
+    )
+    comparator.assert_called_once_with(
+        "https://example.invalid/#abc",
+        device_channels=channels,
+        device_lora_config=lora,
+        emit_warnings=False,
+    )

--- a/meshtastic/tests/test_cli_configure_edge_cases.py
+++ b/meshtastic/tests/test_cli_configure_edge_cases.py
@@ -594,7 +594,7 @@ def test_configure_actions_remote_export_and_write_failure(tmp_path: Path) -> No
         handle_set_command=MagicMock(),
         handle_configure_command=MagicMock(return_value=(False, False)),
         export_config=export_config,
-        cli_exit=_cli_exit,
+        cli_exit=cast(CliExit, _cli_exit),
         cli_print=MagicMock(),
         is_local_destination=MagicMock(return_value=False),
     )
@@ -710,7 +710,7 @@ def test_configure_actions_no_export_and_stdout_export(
         handle_set_command=MagicMock(),
         handle_configure_command=MagicMock(return_value=(False, False)),
         export_config=export_config,
-        cli_exit=_cli_exit,
+        cli_exit=cast(CliExit, _cli_exit),
         cli_print=MagicMock(),
         is_local_destination=MagicMock(return_value=True),
     )
@@ -847,7 +847,7 @@ def test_configure_noop_does_not_arm_shared_ack_wait() -> None:
         handle_set_command=MagicMock(),
         handle_configure_command=MagicMock(return_value=result),
         export_config=MagicMock(),
-        cli_exit=_cli_exit,
+        cli_exit=cast(CliExit, _cli_exit),
         cli_print=MagicMock(),
         is_local_destination=MagicMock(return_value=True),
     )
@@ -879,7 +879,7 @@ def test_set_ack_wait_survives_later_configure_noop() -> None:
         handle_set_command=set_command,
         handle_configure_command=MagicMock(return_value=result),
         export_config=MagicMock(),
-        cli_exit=_cli_exit,
+        cli_exit=cast(CliExit, _cli_exit),
         cli_print=MagicMock(),
         is_local_destination=MagicMock(return_value=True),
     )
@@ -910,7 +910,7 @@ def test_configure_plain_tuple_hook_retains_legacy_ack_behavior() -> None:
         handle_set_command=MagicMock(),
         handle_configure_command=MagicMock(return_value=(False, False)),
         export_config=MagicMock(),
-        cli_exit=_cli_exit,
+        cli_exit=cast(CliExit, _cli_exit),
         cli_print=MagicMock(),
         is_local_destination=MagicMock(return_value=True),
     )

--- a/meshtastic/tests/test_cli_configure_edge_cases.py
+++ b/meshtastic/tests/test_cli_configure_edge_cases.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, create_autospec
 
 import pytest
 
-from meshtastic.cli import configure_actions
+from meshtastic.cli import configure_actions, configure_values
 from meshtastic.cli.configure_actions import (
     ConfigureActionHooks,
     ConfigureHooks,
@@ -430,6 +430,8 @@ def test_close_failed_settings_transaction_reports_close_failure() -> None:
         {"location": {"lat": 0, "lon": 181}},
         {"location": {"lat": 0, "lon": 0, "alt": True}},
         {"location": {"lat": 0, "lon": 0, "alt": "bad"}},
+        {"location": {"lat": 0, "lon": 0, "alt": 1.5}},
+        {"location": {"lat": 0, "lon": 0, "alt": float("inf")}},
         {"location": {"lat": 0, "lon": 0, "alt": 1 << 31}},
         {"canned_messages": 123},
         {"ringtone": object()},
@@ -442,13 +444,13 @@ def test_direct_write_validation_rejects_all_invalid_direct_write_shapes(
 ) -> None:
     """Ensure deterministic direct-write validation fails before device mutation."""
     with pytest.raises(SystemExit):
-        configure_actions._validate_direct_configuration(_hooks(), configuration)
+        configure_values._validate_direct_configuration(_hooks(), configuration)
 
 
 @pytest.mark.unit
 def test_direct_write_validation_preserves_alias_and_altitude_metadata() -> None:
     """Normalized direct-write values should carry all apply-time shape decisions."""
-    values = configure_actions._validate_direct_configuration(
+    values = configure_values._validate_direct_configuration(
         _hooks(),
         {
             "owner": " Owner ",
@@ -477,6 +479,15 @@ def test_direct_write_validation_preserves_alias_and_altitude_metadata() -> None
         ("unknown: true", "Unknown top-level key(s)"),
         ("owner_short: A\nownerShort: B", "both 'owner_short' and 'ownerShort'"),
         ("channel_url: x\nchannelUrl: y", "both 'channel_url' and 'channelUrl'"),
+        ("1: value", "configuration keys must be strings"),
+        (
+            "location:\n  lat: 0\n  lon: 0\n  1: value",
+            "configuration.location keys must be strings",
+        ),
+        (
+            "config:\n  1:\n    enabled: true",
+            "configuration.config keys must be strings",
+        ),
         ("config: []", "'config' must be a non-empty mapping"),
         ("module_config: []", "'module_config' must be a non-empty mapping"),
     ],
@@ -514,7 +525,7 @@ def test_apply_direct_configuration_prints_explicit_altitude_and_applies_all_val
     cli_print = MagicMock()
     hooks = _hooks(cli_print=cli_print)
     prepared = configure_actions._PreparedConfigureDocument(
-        direct_values=configure_actions._DirectConfigureValues(
+        direct_values=configure_values._DirectConfigureValues(
             owner="Owner",
             owner_short="OS",
             location=(1.0, 2.0, 3),
@@ -664,7 +675,7 @@ def test_post_reconnect_local_config_mismatch_is_incomplete(
 def test_apply_direct_configuration_rejects_inconsistent_normalized_url() -> None:
     """Prepared configure values must never carry a URL without its source alias."""
     prepared = configure_actions._PreparedConfigureDocument(
-        direct_values=configure_actions._DirectConfigureValues(
+        direct_values=configure_values._DirectConfigureValues(
             channel_url="https://example.invalid/#abc", channel_url_key=None
         ),
         config_sections={},
@@ -952,3 +963,25 @@ def test_matching_channel_url_reports_no_request_sent(
     assert result.settings_transaction_started is False
     assert result.local_channel_url_applied is False
     node.setURL.assert_not_called()
+
+
+@pytest.mark.unit
+def test_configure_command_rejects_multiple_documents_before_device_access() -> None:
+    """Repeated --configure options must not silently ignore later documents."""
+    interface = MagicMock()
+    cli_exit = MagicMock(side_effect=SystemExit(1))
+    args = argparse.Namespace(
+        configure=["first.yaml", "second.yaml"],
+        dest="^local",
+    )
+
+    with pytest.raises(SystemExit):
+        configure_actions._handle_configure_command(
+            _hooks(cli_exit=cast(CliExit, cli_exit)),
+            interface,
+            args,
+            {},
+        )
+
+    assert "only once" in str(cli_exit.call_args)
+    interface.getNode.assert_not_called()

--- a/meshtastic/tests/test_cli_configure_edge_cases.py
+++ b/meshtastic/tests/test_cli_configure_edge_cases.py
@@ -464,6 +464,7 @@ def test_close_failed_settings_transaction_reports_close_failure() -> None:
         {"owner": None},
         {"owner_short": "   "},
         {"location": []},
+        {"location": {"lat": 1, "lon": 2, 3: "non-string key"}},
         {"location": {"lat": 1, "lon": 2, "bogus": 3}},
         {"location": {"lat": 1}},
         {"location": {"lat": True, "lon": 0}},

--- a/meshtastic/tests/test_cli_configure_edge_cases.py
+++ b/meshtastic/tests/test_cli_configure_edge_cases.py
@@ -97,6 +97,10 @@ def test_reconnect_verify_reports_refresh_failure(
     """No-disconnect refresh failures should become a config-reload result."""
     iface = _interface()
     iface.getNode.return_value = MagicMock()
+    ticks = iter(float(value) for value in range(20))
+    monkeypatch.setattr(
+        configure_actions.time, "monotonic", lambda: next(ticks, 20.0)
+    )
     monkeypatch.setattr(configure_actions.time, "sleep", lambda _seconds: None)
     monkeypatch.setattr(
         configure_actions,
@@ -121,6 +125,10 @@ def test_reconnect_verify_reports_unexpected_verifier_failure(
     """Unexpected verifier exceptions should remain an incomplete verification."""
     iface = _interface()
     iface.getNode.return_value = MagicMock()
+    ticks = iter(float(value) for value in range(20))
+    monkeypatch.setattr(
+        configure_actions.time, "monotonic", lambda: next(ticks, 20.0)
+    )
     monkeypatch.setattr(configure_actions.time, "sleep", lambda _seconds: None)
     monkeypatch.setattr(
         configure_actions, "_refresh_no_disconnect_verify_state", MagicMock()
@@ -856,6 +864,41 @@ def test_configure_noop_does_not_arm_shared_ack_wait() -> None:
 
     assert context.outcome.close_now is True
     assert context.outcome.wait_for_ack_nak is False
+    assert context.outcome.skip_ack_wait is False
+
+
+@pytest.mark.unit
+def test_set_ack_wait_survives_later_configure_noop() -> None:
+    """A configure no-op must not disarm an ACK wait requested by ``--set``."""
+    interface = _interface()
+    result = configure_actions._ConfigureCommandResult(
+        False, False, request_sent=False
+    )
+    set_command = MagicMock()
+    hooks = ConfigureActionHooks(
+        handle_set_command=set_command,
+        handle_configure_command=MagicMock(return_value=result),
+        export_config=MagicMock(),
+        cli_exit=_cli_exit,
+        cli_print=MagicMock(),
+        is_local_destination=MagicMock(return_value=True),
+    )
+    context = CliContext(
+        interface=interface,
+        args=argparse.Namespace(
+            set=[["lora.hop_limit", "3"]],
+            configure=["config.yaml"],
+            export_config=None,
+            dest="^local",
+        ),
+        get_node_kwargs={},
+        outcome=ActionOutcome(),
+    )
+
+    configure_actions._handle_configure_actions(context, hooks)
+
+    set_command.assert_called_once_with(interface, context.args, {})
+    assert context.outcome.wait_for_ack_nak is True
     assert context.outcome.skip_ack_wait is False
 
 

--- a/meshtastic/tests/test_cli_configure_edge_cases.py
+++ b/meshtastic/tests/test_cli_configure_edge_cases.py
@@ -62,6 +62,7 @@ def test_reconnect_verify_reports_refresh_failure(
     """No-disconnect refresh failures should become a config-reload result."""
     iface = _interface()
     iface.getNode.return_value = MagicMock()
+    monkeypatch.setattr(configure_actions.time, "sleep", lambda _seconds: None)
     monkeypatch.setattr(
         configure_actions,
         "_refresh_no_disconnect_verify_state",
@@ -85,6 +86,7 @@ def test_reconnect_verify_reports_unexpected_verifier_failure(
     """Unexpected verifier exceptions should remain an incomplete verification."""
     iface = _interface()
     iface.getNode.return_value = MagicMock()
+    monkeypatch.setattr(configure_actions.time, "sleep", lambda _seconds: None)
     monkeypatch.setattr(
         configure_actions, "_refresh_no_disconnect_verify_state", MagicMock()
     )
@@ -373,18 +375,18 @@ def test_close_failed_settings_transaction_reports_close_failure() -> None:
         {"channel_url": "   "},
     ],
 )
-def test_phase1_validation_rejects_all_invalid_direct_write_shapes(
+def test_direct_write_validation_rejects_all_invalid_direct_write_shapes(
     configuration: dict[str, Any],
 ) -> None:
-    """Every deterministic Phase-1 validation failure must occur before mutation."""
+    """Ensure deterministic direct-write validation fails before device mutation."""
     with pytest.raises(SystemExit):
-        configure_actions._validate_phase1_configuration(_hooks(), configuration)
+        configure_actions._validate_direct_configuration(_hooks(), configuration)
 
 
 @pytest.mark.unit
-def test_phase1_validation_preserves_alias_and_altitude_metadata() -> None:
-    """Normalized Phase-1 values should carry all apply-time shape decisions."""
-    values = configure_actions._validate_phase1_configuration(
+def test_direct_write_validation_preserves_alias_and_altitude_metadata() -> None:
+    """Normalized direct-write values should carry all apply-time shape decisions."""
+    values = configure_actions._validate_direct_configuration(
         _hooks(),
         {
             "owner": " Owner ",
@@ -442,7 +444,7 @@ def test_configure_document_reports_read_and_parse_failures(tmp_path: Path) -> N
 
 
 @pytest.mark.unit
-def test_apply_phase1_prints_explicit_altitude_and_applies_all_values(
+def test_apply_direct_configuration_prints_explicit_altitude_and_applies_all_values(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Prepared direct writes should apply without rereading raw YAML shape."""
@@ -450,7 +452,7 @@ def test_apply_phase1_prints_explicit_altitude_and_applies_all_values(
     cli_print = MagicMock()
     hooks = _hooks(cli_print=cli_print)
     prepared = configure_actions._PreparedConfigureDocument(
-        phase1=configure_actions._Phase1ConfigureValues(
+        direct_values=configure_actions._DirectConfigureValues(
             owner="Owner",
             owner_short="OS",
             location=(1.0, 2.0, 3),
@@ -465,7 +467,7 @@ def test_apply_phase1_prints_explicit_altitude_and_applies_all_values(
     )
     monkeypatch.setattr(configure_actions.time, "sleep", lambda _seconds: None)
 
-    result = configure_actions._apply_phase1_configuration(hooks, node, prepared)
+    result = configure_actions._apply_direct_configuration(hooks, node, prepared)
 
     assert result is True
     node.setFixedPosition.assert_called_once_with(1.0, 2.0, 3)
@@ -597,23 +599,26 @@ def test_post_reconnect_local_config_mismatch_is_incomplete(
 
 
 @pytest.mark.unit
-def test_apply_phase1_rejects_internally_inconsistent_normalized_url() -> None:
+def test_apply_direct_configuration_rejects_inconsistent_normalized_url() -> None:
     """Prepared configure values must never carry a URL without its source alias."""
     prepared = configure_actions._PreparedConfigureDocument(
-        phase1=configure_actions._Phase1ConfigureValues(
+        direct_values=configure_actions._DirectConfigureValues(
             channel_url="https://example.invalid/#abc", channel_url_key=None
         ),
         config_sections={},
         module_config_sections={},
     )
     with pytest.raises(AssertionError, match="source key"):
-        configure_actions._apply_phase1_configuration(_hooks(), MagicMock(), prepared)
+        configure_actions._apply_direct_configuration(_hooks(), MagicMock(), prepared)
 
 
 @pytest.mark.unit
-def test_settings_transaction_logs_unknown_fields_without_rejecting_section() -> None:
+def test_settings_transaction_logs_unknown_fields_without_rejecting_section(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Unknown nested fields may be skipped while known fields still persist."""
     node = MagicMock()
+    monkeypatch.setattr(configure_actions.time, "sleep", lambda _seconds: None)
 
     def _traverse(
         _section: str, _values: dict[str, Any], _root: Any, *, failed_fields: list[str]
@@ -706,3 +711,22 @@ def test_channel_url_match_delegates_with_normalized_loaded_state() -> None:
         device_lora_config=lora,
         emit_warnings=False,
     )
+
+
+@pytest.mark.unit
+def test_channel_refresh_tolerates_legacy_node_without_cache_invalidator() -> None:
+    """Channel verification refresh should support node doubles and older node seams."""
+    node = SimpleNamespace(
+        requestChannels=MagicMock(),
+        localConfig=MagicMock(),
+        moduleConfig=MagicMock(),
+    )
+
+    configure_actions._refresh_no_disconnect_verify_state(
+        node,
+        verify_channel_url="https://example.invalid/#abc",
+        verify_config_fields=None,
+        verify_module_config_fields=None,
+    )
+
+    node.requestChannels.assert_called_once_with(0)

--- a/meshtastic/tests/test_cli_configure_edge_cases.py
+++ b/meshtastic/tests/test_cli_configure_edge_cases.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import argparse
 import contextvars
+import os
+import stat
 import threading
 from pathlib import Path
 from types import SimpleNamespace
@@ -746,6 +748,44 @@ def test_configure_actions_no_export_and_stdout_export(
     )
     configure_actions._handle_configure_actions(stdout_export, hooks)
     assert "config: true" in capsys.readouterr().out
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(not hasattr(os, "fchmod"), reason="requires POSIX file modes")
+def test_configure_export_restricts_existing_file_permissions(tmp_path: Path) -> None:
+    """Secret-bearing exports must replace permissive modes with owner-only access."""
+    export_path = tmp_path / "config.yaml"
+    export_path.write_text("stale: true\n", encoding="utf-8")
+    export_path.chmod(0o644)
+    interface = cast(MeshInterface, MagicMock())
+    hooks = ConfigureActionHooks(
+        handle_set_command=MagicMock(),
+        handle_configure_command=MagicMock(return_value=(False, False)),
+        export_config=MagicMock(return_value="config:\n  security:\n    privateKey: secret\n"),
+        cli_exit=cast(CliExit, _cli_exit),
+        cli_print=MagicMock(),
+        is_local_destination=MagicMock(return_value=True),
+    )
+    context = CliContext(
+        interface=interface,
+        args=argparse.Namespace(
+            set=None,
+            configure=None,
+            export_config=str(export_path),
+            dest="^local",
+        ),
+        get_node_kwargs={},
+        outcome=ActionOutcome(),
+    )
+
+    configure_actions._handle_configure_actions(context, hooks)
+
+    assert export_path.read_text(encoding="utf-8") == (
+        "config:\n  security:\n    privateKey: secret\n"
+    )
+    assert stat.S_IMODE(export_path.stat().st_mode) == (
+        configure_actions.PRIVATE_CONFIG_FILE_MODE
+    )
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_cli_configure_edge_cases.py
+++ b/meshtastic/tests/test_cli_configure_edge_cases.py
@@ -7,8 +7,8 @@ import contextvars
 import threading
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, cast
-from unittest.mock import MagicMock
+from typing import Any, NoReturn, cast
+from unittest.mock import MagicMock, create_autospec
 
 import pytest
 
@@ -26,13 +26,34 @@ _PREFLIGHT_MODE: contextvars.ContextVar[bool] = contextvars.ContextVar(
 )
 
 
-def _cli_exit(_message: str, return_value: int = 1) -> None:
+def _cli_exit(_message: str, return_value: int = 1) -> NoReturn:
+    """Raise ``SystemExit`` in place of the production CLI-exit hook.
+
+    Parameters
+    ----------
+    _message : str
+        Ignored user-facing message.
+    return_value : int
+        Exit status carried by the raised exception.
+    """
     raise SystemExit(return_value)
 
 
 def _hooks(**overrides: Any) -> ConfigureHooks:
+    """Build configure hooks with deterministic defaults.
+
+    Parameters
+    ----------
+    **overrides : Any
+        Hook values that should replace the focused-test defaults.
+
+    Returns
+    -------
+    ConfigureHooks
+        Fully populated configure-runtime dependency seams.
+    """
     values: dict[str, Any] = {
-        "cli_exit": cast(CliExit, _cli_exit),
+        "cli_exit": _cli_exit,
         "cli_print": MagicMock(),
         "traverse_config": MagicMock(return_value=True),
         "preflight_mode": _PREFLIGHT_MODE,
@@ -49,7 +70,19 @@ def _hooks(**overrides: Any) -> ConfigureHooks:
 
 
 def _interface(connected: bool = True) -> MagicMock:
-    iface = MagicMock(spec=MeshInterface)
+    """Build a specced interface with controllable connection state.
+
+    Parameters
+    ----------
+    connected : bool
+        Whether the returned interface starts in the connected state.
+
+    Returns
+    -------
+    MagicMock
+        Autospecced ``MeshInterface`` double with a real ``threading.Event``.
+    """
+    iface = create_autospec(MeshInterface, instance=True)
     iface.isConnected = threading.Event()
     if connected:
         iface.isConnected.set()
@@ -117,6 +150,13 @@ class _ConnectionEvent:
         self.wait_result = wait_result
 
     def is_set(self) -> bool:
+        """Return the next scripted connection state.
+
+        Returns
+        -------
+        bool
+            Next scripted state, or the final state after the script is exhausted.
+        """
         try:
             self._last = next(self._states)
         except StopIteration:
@@ -124,6 +164,18 @@ class _ConnectionEvent:
         return self._last
 
     def wait(self, _timeout: float) -> bool:
+        """Return the scripted wait result without blocking.
+
+        Parameters
+        ----------
+        _timeout : float
+            Ignored wait budget supplied by the runtime.
+
+        Returns
+        -------
+        bool
+            Configured event-wait result.
+        """
         return self.wait_result
 
 
@@ -534,7 +586,7 @@ def test_configure_actions_remote_export_and_write_failure(tmp_path: Path) -> No
         handle_set_command=MagicMock(),
         handle_configure_command=MagicMock(return_value=(False, False)),
         export_config=export_config,
-        cli_exit=cast(CliExit, _cli_exit),
+        cli_exit=_cli_exit,
         cli_print=MagicMock(),
         is_local_destination=MagicMock(return_value=False),
     )
@@ -650,7 +702,7 @@ def test_configure_actions_no_export_and_stdout_export(
         handle_set_command=MagicMock(),
         handle_configure_command=MagicMock(return_value=(False, False)),
         export_config=export_config,
-        cli_exit=cast(CliExit, _cli_exit),
+        cli_exit=_cli_exit,
         cli_print=MagicMock(),
         is_local_destination=MagicMock(return_value=True),
     )
@@ -732,3 +784,128 @@ def test_channel_refresh_tolerates_legacy_node_without_cache_invalidator() -> No
     )
 
     node.requestChannels.assert_called_once_with(0)
+
+
+@pytest.mark.unit
+def test_configure_result_reporting_handles_future_verification_result() -> None:
+    """Reporting must not fail after commit when a verification seam returns a new result."""
+    cli_print = MagicMock()
+    hooks = _hooks(
+        cli_print=cli_print,
+        post_configure_reconnect_and_verify=MagicMock(return_value="future-result"),
+    )
+
+    configure_actions._report_configure_result(
+        hooks,
+        _interface(),
+        destination="^local",
+        is_local_target=True,
+        settings_transaction_started=True,
+        seturl_executed=False,
+        channel_url=None,
+        config_sections={},
+        module_config_sections={},
+    )
+
+    cli_print.assert_called_once()
+    message = cli_print.call_args.args[0]
+    assert "unrecognized verification result" in message
+    assert "future-result" in message
+
+
+@pytest.mark.unit
+def test_configure_command_result_preserves_two_item_tuple_contract() -> None:
+    """Internal ACK metadata must not change the historical two-item result shape."""
+    result = configure_actions._ConfigureCommandResult(
+        False, False, request_sent=False
+    )
+
+    assert isinstance(result, tuple)
+    assert result == (False, False)
+    assert len(result) == 2
+    assert result.settings_transaction_started is False
+    assert result.local_channel_url_applied is False
+    assert result.request_sent is False
+
+
+@pytest.mark.unit
+def test_configure_noop_does_not_arm_shared_ack_wait() -> None:
+    """A confirmed configure no-op must not wait for an acknowledgment never sent."""
+    interface = _interface()
+    result = configure_actions._ConfigureCommandResult(
+        False, False, request_sent=False
+    )
+    hooks = ConfigureActionHooks(
+        handle_set_command=MagicMock(),
+        handle_configure_command=MagicMock(return_value=result),
+        export_config=MagicMock(),
+        cli_exit=_cli_exit,
+        cli_print=MagicMock(),
+        is_local_destination=MagicMock(return_value=True),
+    )
+    context = CliContext(
+        interface=interface,
+        args=argparse.Namespace(
+            set=None, configure=["config.yaml"], export_config=None, dest="^local"
+        ),
+        get_node_kwargs={},
+        outcome=ActionOutcome(),
+    )
+
+    configure_actions._handle_configure_actions(context, hooks)
+
+    assert context.outcome.close_now is True
+    assert context.outcome.wait_for_ack_nak is False
+    assert context.outcome.skip_ack_wait is False
+
+
+@pytest.mark.unit
+def test_configure_plain_tuple_hook_retains_legacy_ack_behavior() -> None:
+    """Downstream hook doubles returning plain tuples keep legacy ACK semantics."""
+    interface = _interface()
+    hooks = ConfigureActionHooks(
+        handle_set_command=MagicMock(),
+        handle_configure_command=MagicMock(return_value=(False, False)),
+        export_config=MagicMock(),
+        cli_exit=_cli_exit,
+        cli_print=MagicMock(),
+        is_local_destination=MagicMock(return_value=True),
+    )
+    context = CliContext(
+        interface=interface,
+        args=argparse.Namespace(
+            set=None, configure=["config.yaml"], export_config=None, dest="^local"
+        ),
+        get_node_kwargs={},
+        outcome=ActionOutcome(),
+    )
+
+    configure_actions._handle_configure_actions(context, hooks)
+
+    assert context.outcome.wait_for_ack_nak is True
+
+
+@pytest.mark.unit
+def test_matching_channel_url_reports_no_request_sent(
+    tmp_path: Path,
+) -> None:
+    """A redundant channel URL must preserve the two-item result without arming ACK."""
+    path = tmp_path / "matching-url.yaml"
+    path.write_text(
+        "channel_url: https://meshtastic.org/e/#matching\n", encoding="utf-8"
+    )
+    interface = _interface()
+    node = MagicMock()
+    interface.getNode.return_value = node
+    hooks = _hooks(
+        channel_url_matches_current_device_state=MagicMock(return_value=True)
+    )
+    args = argparse.Namespace(configure=[str(path)], dest="^local")
+
+    result = configure_actions._handle_configure_command(hooks, interface, args, {})
+
+    assert result == (False, False)
+    assert result.request_sent is False
+    assert result.settings_transaction_started is False
+    assert result.local_channel_url_applied is False
+    node.setURL.assert_not_called()

--- a/meshtastic/tests/test_cli_context.py
+++ b/meshtastic/tests/test_cli_context.py
@@ -1,0 +1,50 @@
+"""Tests for the internal connected CLI execution context."""
+
+from argparse import Namespace
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from meshtastic.cli.context import ActionOutcome, CliContext
+from meshtastic.mesh_interface import MeshInterface
+
+
+@pytest.mark.unit
+def test_action_outcome_defaults_are_explicit() -> None:
+    """Action outcomes should expose conservative lifecycle defaults."""
+    outcome = ActionOutcome()
+
+    assert outcome.close_now is False
+    assert outcome.wait_for_ack_nak is True
+    assert outcome.skip_ack_wait is False
+
+
+@pytest.mark.unit
+def test_cli_context_exposes_destination_and_shared_outcome() -> None:
+    """Handlers should share one explicit lifecycle outcome through the context."""
+    interface = cast(MeshInterface, SimpleNamespace())
+    args = Namespace(dest="!12345678")
+    outcome = ActionOutcome(close_now=True, wait_for_ack_nak=False)
+    context = CliContext(
+        interface=interface,
+        args=args,
+        get_node_kwargs={"timeout": 10.0},
+        outcome=outcome,
+    )
+
+    assert context.destination == "!12345678"
+    assert context.outcome is outcome
+    assert context.get_node_kwargs == {"timeout": 10.0}
+
+
+@pytest.mark.unit
+def test_cli_context_destination_normalizes_compatibility_doubles() -> None:
+    """Destination access should tolerate non-string compatibility test doubles."""
+    context = CliContext(
+        interface=cast(MeshInterface, SimpleNamespace()),
+        args=Namespace(dest=1234),
+        get_node_kwargs={},
+    )
+
+    assert context.destination == "1234"

--- a/meshtastic/tests/test_cli_context.py
+++ b/meshtastic/tests/test_cli_context.py
@@ -2,7 +2,7 @@
 
 from argparse import Namespace
 from typing import cast
-from unittest.mock import MagicMock
+from unittest.mock import create_autospec
 
 import pytest
 
@@ -30,7 +30,7 @@ def test_action_outcome_defaults_are_explicit() -> None:
 @pytest.mark.unit
 def test_cli_context_exposes_destination_and_shared_outcome() -> None:
     """Handlers should share one explicit lifecycle outcome through the context."""
-    interface = cast(MeshInterface, MagicMock(autospec=MeshInterface))
+    interface = cast(MeshInterface, create_autospec(MeshInterface, instance=True))
     args = Namespace(dest="!12345678")
     outcome = ActionOutcome(close_now=True, wait_for_ack_nak=False)
     context = CliContext(
@@ -49,7 +49,10 @@ def test_cli_context_exposes_destination_and_shared_outcome() -> None:
 def test_cli_context_destination_normalizes_compatibility_doubles() -> None:
     """Destination access should tolerate non-string compatibility test doubles."""
     context = CliContext(
-        interface=cast(MeshInterface, MagicMock(autospec=MeshInterface)),
+        interface=cast(
+            MeshInterface,
+            create_autospec(MeshInterface, instance=True),
+        ),
         args=Namespace(dest=1234),
         get_node_kwargs={},
     )

--- a/meshtastic/tests/test_cli_context.py
+++ b/meshtastic/tests/test_cli_context.py
@@ -16,8 +16,11 @@ def test_action_outcome_defaults_are_explicit() -> None:
     outcome = ActionOutcome()
 
     assert outcome.close_now is False
-    assert outcome.wait_for_ack_nak is True
+    assert outcome.wait_for_ack_nak is False
     assert outcome.skip_ack_wait is False
+    assert outcome.stop_processing is False
+    assert outcome.cleanup_callbacks == []
+    assert ActionOutcome().cleanup_callbacks is not outcome.cleanup_callbacks
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_cli_context.py
+++ b/meshtastic/tests/test_cli_context.py
@@ -6,7 +6,7 @@ from typing import cast
 
 import pytest
 
-from meshtastic.cli.context import ActionOutcome, CliContext
+from meshtastic.cli.context import ActionOutcome, CliContext, _terminate_cli
 from meshtastic.mesh_interface import MeshInterface
 
 
@@ -51,3 +51,16 @@ def test_cli_context_destination_normalizes_compatibility_doubles() -> None:
     )
 
     assert context.destination == "1234"
+
+
+@pytest.mark.unit
+def test_terminate_cli_fails_closed_for_returning_compatibility_seam() -> None:
+    """A non-conforming injected exit callable must never allow fallthrough."""
+
+    def _returning_exit(_message: str, _return_value: int = 1) -> None:
+        return None
+
+    with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
+        _terminate_cli(  # type: ignore[arg-type]
+            _returning_exit, "fatal"
+        )

--- a/meshtastic/tests/test_cli_context.py
+++ b/meshtastic/tests/test_cli_context.py
@@ -6,7 +6,7 @@ from typing import cast
 
 import pytest
 
-from meshtastic.cli.context import ActionOutcome, CliContext, _terminate_cli
+from meshtastic.cli.context import ActionOutcome, CliContext, CliExit, _terminate_cli
 from meshtastic.mesh_interface import MeshInterface
 
 
@@ -61,6 +61,4 @@ def test_terminate_cli_fails_closed_for_returning_compatibility_seam() -> None:
         return None
 
     with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
-        _terminate_cli(  # type: ignore[arg-type]
-            _returning_exit, "fatal"
-        )
+        _terminate_cli(cast(CliExit, _returning_exit), "fatal")

--- a/meshtastic/tests/test_cli_context.py
+++ b/meshtastic/tests/test_cli_context.py
@@ -1,8 +1,8 @@
 """Tests for the internal connected CLI execution context."""
 
 from argparse import Namespace
-from types import SimpleNamespace
 from typing import cast
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -19,14 +19,18 @@ def test_action_outcome_defaults_are_explicit() -> None:
     assert outcome.wait_for_ack_nak is False
     assert outcome.skip_ack_wait is False
     assert outcome.stop_processing is False
-    assert outcome.cleanup_callbacks == []
-    assert ActionOutcome().cleanup_callbacks is not outcome.cleanup_callbacks
+    assert outcome.failure_cleanup_callbacks == []
+    assert (
+        ActionOutcome().failure_cleanup_callbacks
+        is not outcome.failure_cleanup_callbacks
+    )
+    assert outcome.interface_close_attempted is False
 
 
 @pytest.mark.unit
 def test_cli_context_exposes_destination_and_shared_outcome() -> None:
     """Handlers should share one explicit lifecycle outcome through the context."""
-    interface = cast(MeshInterface, SimpleNamespace())
+    interface = cast(MeshInterface, MagicMock(autospec=MeshInterface))
     args = Namespace(dest="!12345678")
     outcome = ActionOutcome(close_now=True, wait_for_ack_nak=False)
     context = CliContext(
@@ -45,7 +49,7 @@ def test_cli_context_exposes_destination_and_shared_outcome() -> None:
 def test_cli_context_destination_normalizes_compatibility_doubles() -> None:
     """Destination access should tolerate non-string compatibility test doubles."""
     context = CliContext(
-        interface=cast(MeshInterface, SimpleNamespace()),
+        interface=cast(MeshInterface, MagicMock(autospec=MeshInterface)),
         args=Namespace(dest=1234),
         get_node_kwargs={},
     )

--- a/meshtastic/tests/test_cli_device_actions.py
+++ b/meshtastic/tests/test_cli_device_actions.py
@@ -239,6 +239,60 @@ def test_lockdown_confirmation_mismatch_guard_rejects_returning_cli_exit(
 
 
 @pytest.mark.unit
+def test_lockdown_confirmation_reports_closed_stdin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Destructive lockdown confirmation should explain non-interactive usage."""
+    context = _lockdown_context()
+    context.args.lockdown_unlock = False
+    context.args.lockdown_provision = True
+    context.args.lockdown_passphrase_file = "secret.txt"
+    exit_mock = MagicMock()
+    send_lockdown_auth = MagicMock(return_value=None)
+    monkeypatch.setattr(
+        "builtins.input", MagicMock(side_effect=EOFError("closed stdin"))
+    )
+
+    with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
+        device_actions._handle_lockdown_action(
+            context,
+            _hooks(cli_exit=exit_mock, send_lockdown_auth=send_lockdown_auth),
+        )
+
+    assert "--lockdown-yes" in str(exit_mock.call_args)
+    send_lockdown_auth.assert_not_called()
+
+
+@pytest.mark.unit
+def test_lockdown_passphrase_reports_closed_stdin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Interactive passphrase EOF should recommend the file-based input path."""
+    args = SimpleNamespace(
+        lockdown_passphrase_file=None,
+        lockdown_passphrase=None,
+        insecure_lockdown_passphrase_on_command_line=False,
+    )
+    exit_mock = MagicMock()
+    validate = MagicMock(return_value=b"secret")
+    monkeypatch.setattr(
+        device_actions.getpass,
+        "getpass",
+        MagicMock(side_effect=EOFError("closed stdin")),
+    )
+
+    with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
+        device_actions._read_lockdown_passphrase(
+            args,
+            "unlock",
+            _hooks(cli_exit=exit_mock, validate_lockdown_passphrase=validate),
+        )
+
+    assert "--lockdown-passphrase-file" in str(exit_mock.call_args)
+    validate.assert_not_called()
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     ("failure_kind", "expected_fragment"),
     [
@@ -563,6 +617,7 @@ def test_factory_reset_transport_change_checks_scoped_error(
     node.factoryReset.return_value = SimpleNamespace(id=0)
     monkeypatch.setattr(device_actions.pub, "subscribe", MagicMock())
     monkeypatch.setattr(device_actions.pub, "unsubscribe", MagicMock())
+    monkeypatch.setattr(device_actions.time, "sleep", lambda _seconds: None)
 
     result = device_actions.send_local_factory_reset_and_wait(
         node, full=False, cli_print=MagicMock(), timeout=1.0

--- a/meshtastic/tests/test_cli_device_actions.py
+++ b/meshtastic/tests/test_cli_device_actions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock
@@ -60,6 +61,24 @@ def _context(interface: object, **args: object) -> CliContext:
     )
 
 
+def _install_clock(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    monotonic: Callable[[], float] | None = None,
+    sleep: Callable[[float], None] | None = None,
+) -> None:
+    """Install a device-runtime clock without changing the shared ``time`` module."""
+    current_time = device_actions.time
+    monkeypatch.setattr(
+        device_actions,
+        "time",
+        SimpleNamespace(
+            monotonic=current_time.monotonic if monotonic is None else monotonic,
+            sleep=current_time.sleep if sleep is None else sleep,
+        ),
+    )
+
+
 @pytest.fixture
 def isolated_device_handlers(monkeypatch: pytest.MonkeyPatch) -> None:
     """Stub nested device handlers so focused tests isolate top-level behavior."""
@@ -100,7 +119,7 @@ def _prepare_ota(
         device_actions.meshtastic.tcp_interface, "TCPInterface", _DummyTCPInterface
     )
     monkeypatch.setattr(device_actions.meshtastic.ota, "ESP32WiFiOTA", ota_factory)
-    monkeypatch.setattr(device_actions.time, "sleep", lambda _seconds: None)
+    _install_clock(monkeypatch, sleep=lambda _seconds: None)
     return _DummyTCPInterface()
 
 
@@ -500,7 +519,9 @@ def test_position_fields_write_and_read_paths() -> None:
 
     set_pref.assert_called_once_with(position, "position_flags", "5")
     node.writeConfig.assert_called_once_with("position")
+    interface.getNode.assert_called_once_with("^local")
 
+    interface.getNode.reset_mock()
     position.PositionFlags.values.return_value = [1, 2, 4]
     position.position_flags = 5
     position.PositionFlags.Name.side_effect = lambda value: {1: "ALTITUDE", 4: "TIME"}[
@@ -510,6 +531,7 @@ def test_position_fields_write_and_read_paths() -> None:
     read_print = MagicMock()
     device_actions._handle_position_fields(read_context, _hooks(cli_print=read_print))
     read_print.assert_called_once_with("ALTITUDE TIME")
+    interface.getNode.assert_called_once_with("^local")
 
 
 @pytest.mark.unit
@@ -568,9 +590,7 @@ def test_factory_reset_probe_logs_close_failures(
         device_actions.meshtastic.serial_interface, "SerialInterface", SerialDouble
     )
     ticks = iter([0.0, 0.1])
-    monkeypatch.setattr(
-        device_actions.time, "monotonic", lambda: next(ticks, 0.1)
-    )
+    _install_clock(monkeypatch, monotonic=lambda: next(ticks, 0.1))
 
     device_actions._post_factory_reset_ready_probe(cast(MeshInterface, serial))
 
@@ -620,7 +640,7 @@ def test_factory_reset_transport_change_checks_scoped_error(
     node.factoryReset.return_value = SimpleNamespace(id=0)
     monkeypatch.setattr(device_actions.pub, "subscribe", MagicMock())
     monkeypatch.setattr(device_actions.pub, "unsubscribe", MagicMock())
-    monkeypatch.setattr(device_actions.time, "sleep", lambda _seconds: None)
+    _install_clock(monkeypatch, sleep=lambda _seconds: None)
 
     result = device_actions._send_local_factory_reset_and_wait(
         node, full=False, cli_print=MagicMock(), timeout=1.0
@@ -628,6 +648,50 @@ def test_factory_reset_transport_change_checks_scoped_error(
 
     assert result is node.factoryReset.return_value
     raise_wait_error.assert_called_with("receivedNak", request_id=None)
+
+
+@pytest.mark.unit
+def test_factory_reset_observes_disconnect_during_synchronous_send(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A reboot published before the send returns must count as reset acceptance."""
+    iface = MagicMock()
+    iface.MeshInterfaceError = device_actions.MeshInterface.MeshInterfaceError
+    iface._wait_for_request_ack = None
+    iface._raise_wait_error_if_present = None
+    iface._acknowledgment.receivedAck = False
+    iface._acknowledgment.receivedImplAck = False
+    iface._acknowledgment.receivedNak = False
+    iface.isConnected.is_set.return_value = True
+    request = SimpleNamespace(id=0)
+    subscribers: list[Callable[[MeshInterface], None]] = []
+
+    def _subscribe(
+        callback: Callable[[MeshInterface], None], _topic: str
+    ) -> None:
+        subscribers.append(callback)
+
+    def _factory_reset(*, full: bool) -> SimpleNamespace:
+        assert full is False
+        subscribers[0](iface)
+        return request
+
+    node = MagicMock(iface=iface)
+    node.factoryReset.side_effect = _factory_reset
+    monkeypatch.setattr(device_actions.pub, "subscribe", _subscribe)
+    monkeypatch.setattr(device_actions.pub, "unsubscribe", MagicMock())
+    ticks = iter([0.0, 0.0, 2.0])
+    _install_clock(
+        monkeypatch,
+        monotonic=lambda: next(ticks, 2.0),
+        sleep=lambda _seconds: None,
+    )
+
+    result = device_actions._send_local_factory_reset_and_wait(
+        node, full=False, cli_print=MagicMock(), timeout=1.0
+    )
+
+    assert result is request
 
 
 @pytest.mark.unit
@@ -690,7 +754,7 @@ def test_factory_reset_timeout_checks_scoped_error_and_tolerates_unsubscribe_fai
     node = MagicMock(iface=iface)
     node.factoryReset.return_value = SimpleNamespace(id=0)
     ticks = iter([0.0, 2.0])
-    monkeypatch.setattr(device_actions.time, "monotonic", lambda: next(ticks, 2.0))
+    _install_clock(monkeypatch, monotonic=lambda: next(ticks, 2.0))
     monkeypatch.setattr(device_actions.pub, "subscribe", MagicMock())
     monkeypatch.setattr(
         device_actions.pub,

--- a/meshtastic/tests/test_cli_device_actions.py
+++ b/meshtastic/tests/test_cli_device_actions.py
@@ -60,6 +60,18 @@ def _context(interface: object, **args: object) -> CliContext:
     )
 
 
+@pytest.fixture
+def isolated_device_handlers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub nested device handlers so focused tests isolate top-level behavior."""
+    for name in (
+        "_handle_content_updates",
+        "_handle_position_fields",
+        "_handle_reboot_and_reset_actions",
+        "_handle_node_database_actions",
+    ):
+        monkeypatch.setattr(device_actions, name, lambda *_args: None)
+
+
 def _lockdown_context() -> CliContext:
     """Build a local unlock request that avoids interactive confirmation."""
     return _context(
@@ -261,6 +273,7 @@ def test_ota_preconditions_reject_returning_cli_exit(
 
 
 @pytest.mark.unit
+@pytest.mark.usefixtures("isolated_device_handlers")
 @pytest.mark.parametrize(
     ("args", "expected_fragment"),
     [
@@ -272,7 +285,6 @@ def test_ota_preconditions_reject_returning_cli_exit(
     ],
 )
 def test_device_validation_guards_reject_returning_cli_exit(
-    monkeypatch: pytest.MonkeyPatch,
     args: dict[str, object],
     expected_fragment: str,
 ) -> None:
@@ -294,14 +306,6 @@ def test_device_validation_guards_reject_returning_cli_exit(
     context = _context(interface, **defaults)
     exit_mock = MagicMock()
     hooks = _hooks(cli_exit=exit_mock)
-    monkeypatch.setattr(device_actions, "_handle_content_updates", lambda *_a: None)
-    monkeypatch.setattr(device_actions, "_handle_position_fields", lambda *_a: None)
-    monkeypatch.setattr(
-        device_actions, "_handle_reboot_and_reset_actions", lambda *_a: None
-    )
-    monkeypatch.setattr(
-        device_actions, "_handle_node_database_actions", lambda *_a: None
-    )
 
     with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
         device_actions._handle_device_actions(context, hooks)
@@ -342,9 +346,8 @@ def test_lockdown_preconditions_reject_returning_cli_exit(
 
 
 @pytest.mark.unit
-def test_numeric_zero_fixed_position_is_not_treated_as_omitted(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+@pytest.mark.usefixtures("isolated_device_handlers")
+def test_numeric_zero_fixed_position_is_not_treated_as_omitted() -> None:
     """Programmatic zero coordinates must still enter the fixed-position action."""
     interface = MagicMock()
     context = _context(
@@ -360,14 +363,6 @@ def test_numeric_zero_fixed_position_is_not_treated_as_omitted(
         set_ham=None,
         dest="^local",
     )
-    monkeypatch.setattr(device_actions, "_handle_content_updates", lambda *_a: None)
-    monkeypatch.setattr(device_actions, "_handle_position_fields", lambda *_a: None)
-    monkeypatch.setattr(
-        device_actions, "_handle_reboot_and_reset_actions", lambda *_a: None
-    )
-    monkeypatch.setattr(
-        device_actions, "_handle_node_database_actions", lambda *_a: None
-    )
 
     device_actions._handle_device_actions(context, _hooks())
 
@@ -375,9 +370,8 @@ def test_numeric_zero_fixed_position_is_not_treated_as_omitted(
 
 
 @pytest.mark.unit
-def test_false_unmessageable_value_is_applied(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+@pytest.mark.usefixtures("isolated_device_handlers")
+def test_false_unmessageable_value_is_applied() -> None:
     """A programmatic False unmessageable value must not be dropped by truthiness."""
     interface = MagicMock()
     context = _context(
@@ -393,14 +387,6 @@ def test_false_unmessageable_value_is_applied(
         set_ham=None,
         dest="^local",
     )
-    monkeypatch.setattr(device_actions, "_handle_content_updates", lambda *_a: None)
-    monkeypatch.setattr(device_actions, "_handle_position_fields", lambda *_a: None)
-    monkeypatch.setattr(
-        device_actions, "_handle_reboot_and_reset_actions", lambda *_a: None
-    )
-    monkeypatch.setattr(
-        device_actions, "_handle_node_database_actions", lambda *_a: None
-    )
 
     device_actions._handle_device_actions(context, _hooks())
 
@@ -410,9 +396,8 @@ def test_false_unmessageable_value_is_applied(
 
 
 @pytest.mark.unit
-def test_owner_long_and_short_names_share_one_write(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+@pytest.mark.usefixtures("isolated_device_handlers")
+def test_owner_long_and_short_names_share_one_write() -> None:
     """Combined owner names should be logged and written together exactly once."""
     interface = MagicMock()
     cli_print = MagicMock()
@@ -428,14 +413,6 @@ def test_owner_long_and_short_names_share_one_write(
         set_is_unmessageable=None,
         set_ham=None,
         dest="^local",
-    )
-    monkeypatch.setattr(device_actions, "_handle_content_updates", lambda *_a: None)
-    monkeypatch.setattr(device_actions, "_handle_position_fields", lambda *_a: None)
-    monkeypatch.setattr(
-        device_actions, "_handle_reboot_and_reset_actions", lambda *_a: None
-    )
-    monkeypatch.setattr(
-        device_actions, "_handle_node_database_actions", lambda *_a: None
     )
 
     device_actions._handle_device_actions(context, _hooks(cli_print=cli_print))
@@ -627,3 +604,21 @@ def test_factory_reset_timeout_checks_scoped_error_and_tolerates_unsubscribe_fai
         )
 
     raise_wait_error.assert_called_with("receivedNak", request_id=None)
+
+
+@pytest.mark.unit
+def test_position_fields_does_not_write_when_preference_assignment_fails() -> None:
+    """Failed position preference assignment must stop before writeConfig."""
+    interface = MagicMock()
+    node = interface.getNode.return_value
+    position = node.localConfig.position
+    position.PositionFlags.Value.return_value = 1
+    context = _context(interface, pos_fields=["ALTITUDE"], dest="^local")
+    set_pref = MagicMock(return_value=False)
+
+    with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
+        device_actions._handle_position_fields(
+            context, _hooks(set_pref=set_pref, cli_print=MagicMock())
+        )
+
+    node.writeConfig.assert_not_called()

--- a/meshtastic/tests/test_cli_device_actions.py
+++ b/meshtastic/tests/test_cli_device_actions.py
@@ -555,6 +555,8 @@ def test_factory_reset_probe_logs_close_failures(
     """Serial readiness probing should tolerate both initial and final close failures."""
 
     class SerialDouble:
+        """Serial-interface double whose close calls fail on both attempts."""
+
         def __init__(self) -> None:
             self.close = MagicMock(
                 side_effect=[RuntimeError("initial"), RuntimeError("final")]

--- a/meshtastic/tests/test_cli_device_actions.py
+++ b/meshtastic/tests/test_cli_device_actions.py
@@ -651,50 +651,6 @@ def test_factory_reset_transport_change_checks_scoped_error(
 
 
 @pytest.mark.unit
-def test_factory_reset_observes_disconnect_during_synchronous_send(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A reboot published before the send returns must count as reset acceptance."""
-    iface = MagicMock()
-    iface.MeshInterfaceError = device_actions.MeshInterface.MeshInterfaceError
-    iface._wait_for_request_ack = None
-    iface._raise_wait_error_if_present = None
-    iface._acknowledgment.receivedAck = False
-    iface._acknowledgment.receivedImplAck = False
-    iface._acknowledgment.receivedNak = False
-    iface.isConnected.is_set.return_value = True
-    request = SimpleNamespace(id=0)
-    subscribers: list[Callable[[MeshInterface], None]] = []
-
-    def _subscribe(
-        callback: Callable[[MeshInterface], None], _topic: str
-    ) -> None:
-        subscribers.append(callback)
-
-    def _factory_reset(*, full: bool) -> SimpleNamespace:
-        assert full is False
-        subscribers[0](iface)
-        return request
-
-    node = MagicMock(iface=iface)
-    node.factoryReset.side_effect = _factory_reset
-    monkeypatch.setattr(device_actions.pub, "subscribe", _subscribe)
-    monkeypatch.setattr(device_actions.pub, "unsubscribe", MagicMock())
-    ticks = iter([0.0, 0.0, 2.0])
-    _install_clock(
-        monkeypatch,
-        monotonic=lambda: next(ticks, 2.0),
-        sleep=lambda _seconds: None,
-    )
-
-    result = device_actions._send_local_factory_reset_and_wait(
-        node, full=False, cli_print=MagicMock(), timeout=1.0
-    )
-
-    assert result is request
-
-
-@pytest.mark.unit
 def test_factory_reset_scoped_wait_checks_error_before_return_and_retires_request(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/meshtastic/tests/test_cli_device_actions.py
+++ b/meshtastic/tests/test_cli_device_actions.py
@@ -106,7 +106,7 @@ def _prepare_ota(
 
 def _run_ota(interface: _DummyTCPInterface) -> None:
     """Invoke the OTA helper with the returning-exit test seam."""
-    device_actions.handle_ota_update(
+    device_actions._handle_ota_update(
         cast(MeshInterface, interface),
         SimpleNamespace(ota_update="firmware.bin", dest="^local"),
         {},
@@ -314,7 +314,7 @@ def test_ota_preconditions_reject_returning_cli_exit(
     exit_mock = MagicMock()
 
     with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
-        device_actions.handle_ota_update(
+        device_actions._handle_ota_update(
             cast(MeshInterface, interface),
             argparse.Namespace(ota_update="firmware.bin", dest="!remote"),
             {},
@@ -565,11 +565,12 @@ def test_factory_reset_probe_logs_close_failures(
     monkeypatch.setattr(
         device_actions.meshtastic.serial_interface, "SerialInterface", SerialDouble
     )
+    ticks = iter([0.0, 0.1])
     monkeypatch.setattr(
-        device_actions.time, "monotonic", MagicMock(side_effect=[0.0, 0.1])
+        device_actions.time, "monotonic", lambda: next(ticks, 0.1)
     )
 
-    device_actions.post_factory_reset_ready_probe(cast(MeshInterface, serial))
+    device_actions._post_factory_reset_ready_probe(cast(MeshInterface, serial))
 
     assert serial.close.call_count == 2
     serial.connect.assert_called_once_with()
@@ -595,7 +596,7 @@ def test_factory_reset_legacy_acknowledgment_rejects_nak(
     with pytest.raises(
         device_actions.MeshInterface.MeshInterfaceError, match="rejected"
     ):
-        device_actions.send_local_factory_reset_and_wait(
+        device_actions._send_local_factory_reset_and_wait(
             node, full=False, cli_print=MagicMock(), timeout=1.0
         )
 
@@ -619,12 +620,53 @@ def test_factory_reset_transport_change_checks_scoped_error(
     monkeypatch.setattr(device_actions.pub, "unsubscribe", MagicMock())
     monkeypatch.setattr(device_actions.time, "sleep", lambda _seconds: None)
 
-    result = device_actions.send_local_factory_reset_and_wait(
+    result = device_actions._send_local_factory_reset_and_wait(
         node, full=False, cli_print=MagicMock(), timeout=1.0
     )
 
     assert result is node.factoryReset.return_value
     raise_wait_error.assert_called_with("receivedNak", request_id=None)
+
+
+@pytest.mark.unit
+def test_factory_reset_scoped_wait_checks_error_before_return_and_retires_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A request-scoped ACK completion must surface NAK state before cleanup."""
+    events: list[str] = []
+    iface = MagicMock()
+    wait_for_request_ack = MagicMock(
+        side_effect=lambda *_args, **_kwargs: events.append("wait") or True
+    )
+    raise_wait_error = MagicMock(
+        side_effect=lambda *_args, **_kwargs: events.append("raise")
+    )
+    retire_wait = MagicMock(
+        side_effect=lambda *_args, **_kwargs: events.append("retire")
+    )
+    iface._wait_for_request_ack = wait_for_request_ack
+    iface._raise_wait_error_if_present = raise_wait_error
+    iface._retire_wait_request = retire_wait
+    node = MagicMock(iface=iface)
+    request = SimpleNamespace(id=73)
+    node.factoryReset.return_value = request
+    monkeypatch.setattr(device_actions.pub, "subscribe", MagicMock())
+    monkeypatch.setattr(device_actions.pub, "unsubscribe", MagicMock())
+
+    result = device_actions._send_local_factory_reset_and_wait(
+        node, full=False, cli_print=MagicMock(), timeout=1.0
+    )
+
+    assert result is request
+    assert events == ["wait", "raise", "retire"]
+    wait_for_request_ack.assert_called_once()
+    wait_args = wait_for_request_ack.call_args
+    assert wait_args.args[:2] == ("receivedNak", 73)
+    assert 0 < wait_args.kwargs["timeout_seconds"] <= (
+        device_actions.FACTORY_RESET_ACCEPTANCE_POLL_SECONDS
+    )
+    raise_wait_error.assert_called_once_with("receivedNak", request_id=73)
+    retire_wait.assert_called_once_with("receivedNak", request_id=73)
 
 
 @pytest.mark.unit
@@ -654,11 +696,63 @@ def test_factory_reset_timeout_checks_scoped_error_and_tolerates_unsubscribe_fai
     with pytest.raises(
         device_actions.MeshInterface.MeshInterfaceError, match="Timed out"
     ):
-        device_actions.send_local_factory_reset_and_wait(
+        device_actions._send_local_factory_reset_and_wait(
             node, full=False, cli_print=MagicMock(), timeout=1.0
         )
 
     raise_wait_error.assert_called_with("receivedNak", request_id=None)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("argument_name", "value", "setter_name"),
+    [
+        ("set_canned_message", "hello", "set_canned_message"),
+        ("set_ringtone", "ring", "set_ringtone"),
+    ],
+)
+def test_content_update_waits_for_ack_only_when_write_is_sent(
+    argument_name: str, value: str, setter_name: str
+) -> None:
+    """Supported content updates should close after the shared ACK/NAK wait."""
+    interface = MagicMock()
+    node = interface.getNode.return_value
+    node.module_available.return_value = True
+    args = {"set_canned_message": None, "set_ringtone": None, "dest": "^local"}
+    args[argument_name] = value
+    context = _context(interface, **args)
+
+    device_actions._handle_content_updates(context, _hooks())
+
+    assert context.outcome.close_now is True
+    assert context.outcome.wait_for_ack_nak is True
+    getattr(node, setter_name).assert_called_once_with(value)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("argument_name", "value", "setter_name"),
+    [
+        ("set_canned_message", "hello", "set_canned_message"),
+        ("set_ringtone", "ring", "set_ringtone"),
+    ],
+)
+def test_content_update_skips_ack_wait_when_module_is_unavailable(
+    argument_name: str, value: str, setter_name: str
+) -> None:
+    """Excluded firmware modules must not arm an acknowledgment that cannot arrive."""
+    interface = MagicMock()
+    node = interface.getNode.return_value
+    node.module_available.return_value = False
+    args = {"set_canned_message": None, "set_ringtone": None, "dest": "^local"}
+    args[argument_name] = value
+    context = _context(interface, **args)
+
+    device_actions._handle_content_updates(context, _hooks())
+
+    assert context.outcome.close_now is True
+    assert context.outcome.wait_for_ack_nak is False
+    getattr(node, setter_name).assert_not_called()
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_cli_device_actions.py
+++ b/meshtastic/tests/test_cli_device_actions.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import argparse
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
 
 from meshtastic.cli import device_actions
-from meshtastic.cli.context import ActionOutcome, CliContext
+from meshtastic.cli.context import ActionOutcome, CliContext, CliExit
+from meshtastic.mesh_interface import MeshInterface
 
 
 class _DummyTCPInterface:
@@ -30,9 +31,9 @@ def _returning_cli_exit(*_args: object, **_kwargs: object) -> None:
     """Model an injected exit seam that incorrectly returns to its caller."""
 
 
-def _hooks(**overrides: object) -> device_actions.DeviceActionHooks:
+def _hooks(**overrides: Any) -> device_actions.DeviceActionHooks:
     """Build device-action hooks with a deliberately returning exit seam."""
-    values: dict[str, object] = {
+    values: dict[str, Any] = {
         "cli_exit": _returning_cli_exit,
         "cli_print": MagicMock(),
         "set_pref": MagicMock(return_value=True),
@@ -46,13 +47,13 @@ def _hooks(**overrides: object) -> device_actions.DeviceActionHooks:
         "validate_lockdown_passphrase": MagicMock(return_value=b"secret"),
     }
     values.update(overrides)
-    return device_actions.DeviceActionHooks(**values)  # type: ignore[arg-type]
+    return device_actions.DeviceActionHooks(**values)
 
 
 def _context(interface: object, **args: object) -> CliContext:
     """Build the minimal connected CLI context needed by a focused handler test."""
     return CliContext(
-        interface=interface,  # type: ignore[arg-type]
+        interface=cast(MeshInterface, interface),
         args=argparse.Namespace(**args),
         get_node_kwargs={},
         outcome=ActionOutcome(),
@@ -94,10 +95,10 @@ def _prepare_ota(
 def _run_ota(interface: _DummyTCPInterface) -> None:
     """Invoke the OTA helper with the returning-exit test seam."""
     device_actions.handle_ota_update(
-        interface,  # type: ignore[arg-type]
+        cast(MeshInterface, interface),
         SimpleNamespace(ota_update="firmware.bin", dest="^local"),
         {},
-        cli_exit=_returning_cli_exit,  # type: ignore[arg-type]
+        cli_exit=cast(CliExit, _returning_cli_exit),
         cli_print=MagicMock(),
         is_local_destination=lambda *_args: True,
     )
@@ -226,27 +227,37 @@ def test_lockdown_confirmation_mismatch_guard_rejects_returning_cli_exit(
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("failure_kind", ["transport", "destination"])
+@pytest.mark.parametrize(
+    ("failure_kind", "expected_fragment"),
+    [
+        ("transport", "requires a TCP connection"),
+        ("destination", "directly connected local node"),
+    ],
+)
 def test_ota_preconditions_reject_returning_cli_exit(
-    monkeypatch: pytest.MonkeyPatch, failure_kind: str
+    monkeypatch: pytest.MonkeyPatch, failure_kind: str, expected_fragment: str
 ) -> None:
-    """Rejected OTA transport/destination preconditions must never continue."""
+    """Rejected OTA preconditions must fail closed with the correct diagnostic."""
+    interface: object
     if failure_kind == "transport":
         interface = MagicMock()
         local_destination = MagicMock(return_value=True)
     else:
         interface = _prepare_ota(monkeypatch, MagicMock())
         local_destination = MagicMock(return_value=False)
+    exit_mock = MagicMock()
 
     with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
         device_actions.handle_ota_update(
-            interface,  # type: ignore[arg-type]
+            cast(MeshInterface, interface),
             argparse.Namespace(ota_update="firmware.bin", dest="!remote"),
             {},
-            cli_exit=_returning_cli_exit,  # type: ignore[arg-type]
+            cli_exit=cast(CliExit, exit_mock),
             cli_print=MagicMock(),
             is_local_destination=local_destination,
         )
+
+    assert expected_fragment in str(exit_mock.call_args)
 
 
 @pytest.mark.unit
@@ -307,19 +318,27 @@ def test_lockdown_preconditions_reject_returning_cli_exit(
     """Lockdown must fail closed on non-local targets and rejected confirmation."""
     remote = _lockdown_context()
     remote.args.dest = "!remote"
-    hooks = _hooks(is_local_destination=MagicMock(return_value=False))
+    remote_send = MagicMock(return_value=None)
+    hooks = _hooks(
+        is_local_destination=MagicMock(return_value=False),
+        send_lockdown_auth=remote_send,
+    )
     with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
         device_actions._handle_lockdown_action(remote, hooks)
-    hooks.send_lockdown_auth.assert_not_called()
+    remote_send.assert_not_called()
 
     confirm = _lockdown_context()
     confirm.args.lockdown_unlock = False
     confirm.args.lockdown_provision = True
     monkeypatch.setattr("builtins.input", lambda _prompt: "no")
-    hooks = _hooks(is_local_destination=MagicMock(return_value=True))
+    confirm_send = MagicMock(return_value=None)
+    hooks = _hooks(
+        is_local_destination=MagicMock(return_value=True),
+        send_lockdown_auth=confirm_send,
+    )
     with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
         device_actions._handle_lockdown_action(confirm, hooks)
-    hooks.send_lockdown_auth.assert_not_called()
+    confirm_send.assert_not_called()
 
 
 @pytest.mark.unit
@@ -353,3 +372,258 @@ def test_numeric_zero_fixed_position_is_not_treated_as_omitted(
     device_actions._handle_device_actions(context, _hooks())
 
     interface.getNode.return_value.setFixedPosition.assert_called_once_with(0.0, 0.0, 0)
+
+
+@pytest.mark.unit
+def test_false_unmessageable_value_is_applied(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A programmatic False unmessageable value must not be dropped by truthiness."""
+    interface = MagicMock()
+    context = _context(
+        interface,
+        set_time=None,
+        remove_position=False,
+        setlat=None,
+        setlon=None,
+        setalt=None,
+        set_owner=None,
+        set_owner_short=None,
+        set_is_unmessageable=False,
+        set_ham=None,
+        dest="^local",
+    )
+    monkeypatch.setattr(device_actions, "_handle_content_updates", lambda *_a: None)
+    monkeypatch.setattr(device_actions, "_handle_position_fields", lambda *_a: None)
+    monkeypatch.setattr(
+        device_actions, "_handle_reboot_and_reset_actions", lambda *_a: None
+    )
+    monkeypatch.setattr(
+        device_actions, "_handle_node_database_actions", lambda *_a: None
+    )
+
+    device_actions._handle_device_actions(context, _hooks())
+
+    interface.getNode.return_value.setOwner.assert_called_once_with(
+        long_name=None, short_name=None, is_unmessagable=False
+    )
+
+
+@pytest.mark.unit
+def test_owner_long_and_short_names_share_one_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Combined owner names should be logged and written together exactly once."""
+    interface = MagicMock()
+    cli_print = MagicMock()
+    context = _context(
+        interface,
+        set_time=None,
+        remove_position=False,
+        setlat=None,
+        setlon=None,
+        setalt=None,
+        set_owner="Long Name",
+        set_owner_short="LN",
+        set_is_unmessageable=None,
+        set_ham=None,
+        dest="^local",
+    )
+    monkeypatch.setattr(device_actions, "_handle_content_updates", lambda *_a: None)
+    monkeypatch.setattr(device_actions, "_handle_position_fields", lambda *_a: None)
+    monkeypatch.setattr(
+        device_actions, "_handle_reboot_and_reset_actions", lambda *_a: None
+    )
+    monkeypatch.setattr(
+        device_actions, "_handle_node_database_actions", lambda *_a: None
+    )
+
+    device_actions._handle_device_actions(context, _hooks(cli_print=cli_print))
+
+    cli_print.assert_any_call("Setting device owner to Long Name and short name to LN")
+    interface.getNode.return_value.setOwner.assert_called_once_with(
+        long_name="Long Name", short_name="LN", is_unmessagable=None
+    )
+
+
+@pytest.mark.unit
+def test_coordinate_parser_rejects_boolean_and_unparseable_values() -> None:
+    """Boolean and nonnumeric coordinate values should terminate through the CLI seam."""
+    for raw in (True, object()):
+        with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
+            device_actions._parse_coordinate(raw, "latitude", _hooks())
+
+
+@pytest.mark.unit
+def test_position_fields_write_and_read_paths() -> None:
+    """Position-field actions should cover both mutation and display contracts."""
+    interface = MagicMock()
+    node = interface.getNode.return_value
+    position = node.localConfig.position
+    position.PositionFlags.Value.side_effect = [1, 4]
+    write_context = _context(interface, pos_fields=["ALTITUDE", "TIME"], dest="^local")
+    set_pref = MagicMock(return_value=True)
+    hooks = _hooks(set_pref=set_pref, cli_print=MagicMock())
+
+    device_actions._handle_position_fields(write_context, hooks)
+
+    set_pref.assert_called_once_with(position, "position_flags", "5")
+    node.writeConfig.assert_called_once_with("position")
+
+    position.PositionFlags.values.return_value = [1, 2, 4]
+    position.position_flags = 5
+    position.PositionFlags.Name.side_effect = lambda value: {1: "ALTITUDE", 4: "TIME"}[
+        value
+    ]
+    read_context = _context(interface, pos_fields=[], dest="^local")
+    read_print = MagicMock()
+    device_actions._handle_position_fields(read_context, _hooks(cli_print=read_print))
+    read_print.assert_called_once_with("ALTITUDE TIME")
+
+
+@pytest.mark.unit
+def test_remote_factory_reset_uses_direct_factory_reset() -> None:
+    """Remote reset must use Node.factoryReset without the local acceptance probe."""
+    interface = MagicMock()
+    reset_node = interface.getNode.return_value
+    args = argparse.Namespace(
+        reboot=False,
+        reboot_ota=False,
+        enter_dfu=False,
+        shutdown=False,
+        ota_update=None,
+        device_metadata=False,
+        begin_edit=False,
+        commit_edit=False,
+        factory_reset=True,
+        factory_reset_device=False,
+        dest="!remote",
+    )
+    context = CliContext(
+        interface=cast(MeshInterface, interface),
+        args=args,
+        get_node_kwargs={},
+        outcome=ActionOutcome(),
+    )
+    local_wait = MagicMock()
+    hooks = _hooks(
+        is_local_destination=MagicMock(return_value=False),
+        send_local_factory_reset_and_wait=local_wait,
+    )
+
+    device_actions._handle_reboot_and_reset_actions(context, hooks)
+
+    reset_node.factoryReset.assert_called_once_with(full=False)
+    local_wait.assert_not_called()
+
+
+@pytest.mark.unit
+def test_factory_reset_probe_logs_close_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Serial readiness probing should tolerate both initial and final close failures."""
+
+    class SerialDouble:
+        def __init__(self) -> None:
+            self.close = MagicMock(
+                side_effect=[RuntimeError("initial"), RuntimeError("final")]
+            )
+            self.connect = MagicMock()
+
+    serial = SerialDouble()
+    monkeypatch.setattr(
+        device_actions.meshtastic.serial_interface, "SerialInterface", SerialDouble
+    )
+    monkeypatch.setattr(
+        device_actions.time, "monotonic", MagicMock(side_effect=[0.0, 0.1])
+    )
+
+    device_actions.post_factory_reset_ready_probe(cast(MeshInterface, serial))
+
+    assert serial.close.call_count == 2
+    serial.connect.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_factory_reset_legacy_acknowledgment_rejects_nak(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy acknowledgment state should turn a received NAK into a reset error."""
+    iface = MagicMock()
+    iface.MeshInterfaceError = device_actions.MeshInterface.MeshInterfaceError
+    iface._wait_for_request_ack = None
+    iface._raise_wait_error_if_present = None
+    iface._acknowledgment.receivedAck = False
+    iface._acknowledgment.receivedImplAck = False
+    iface._acknowledgment.receivedNak = True
+    node = MagicMock(iface=iface)
+    node.factoryReset.return_value = SimpleNamespace(id=1)
+    monkeypatch.setattr(device_actions.pub, "subscribe", MagicMock())
+    monkeypatch.setattr(device_actions.pub, "unsubscribe", MagicMock())
+
+    with pytest.raises(
+        device_actions.MeshInterface.MeshInterfaceError, match="rejected"
+    ):
+        device_actions.send_local_factory_reset_and_wait(
+            node, full=False, cli_print=MagicMock(), timeout=1.0
+        )
+
+
+@pytest.mark.unit
+def test_factory_reset_transport_change_checks_scoped_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A reboot disconnect should still surface any scoped ACK/NAK error first."""
+    iface = MagicMock()
+    iface._wait_for_request_ack = None
+    raise_wait_error = MagicMock()
+    iface._raise_wait_error_if_present = raise_wait_error
+    iface._acknowledgment.receivedAck = False
+    iface._acknowledgment.receivedImplAck = False
+    iface._acknowledgment.receivedNak = False
+    iface.isConnected.is_set.return_value = False
+    node = MagicMock(iface=iface)
+    node.factoryReset.return_value = SimpleNamespace(id=0)
+    monkeypatch.setattr(device_actions.pub, "subscribe", MagicMock())
+    monkeypatch.setattr(device_actions.pub, "unsubscribe", MagicMock())
+
+    result = device_actions.send_local_factory_reset_and_wait(
+        node, full=False, cli_print=MagicMock(), timeout=1.0
+    )
+
+    assert result is node.factoryReset.return_value
+    raise_wait_error.assert_called_with("receivedNak", request_id=None)
+
+
+@pytest.mark.unit
+def test_factory_reset_timeout_checks_scoped_error_and_tolerates_unsubscribe_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Timeout cleanup should probe scoped error state and never mask unsubscribe failure."""
+    iface = MagicMock()
+    iface.MeshInterfaceError = device_actions.MeshInterface.MeshInterfaceError
+    iface._wait_for_request_ack = None
+    raise_wait_error = MagicMock()
+    iface._raise_wait_error_if_present = raise_wait_error
+    iface._acknowledgment.receivedAck = False
+    iface._acknowledgment.receivedImplAck = False
+    iface._acknowledgment.receivedNak = False
+    node = MagicMock(iface=iface)
+    node.factoryReset.return_value = SimpleNamespace(id=0)
+    ticks = iter([0.0, 2.0])
+    monkeypatch.setattr(device_actions.time, "monotonic", lambda: next(ticks, 2.0))
+    monkeypatch.setattr(device_actions.pub, "subscribe", MagicMock())
+    monkeypatch.setattr(
+        device_actions.pub,
+        "unsubscribe",
+        MagicMock(side_effect=RuntimeError("unsubscribe")),
+    )
+
+    with pytest.raises(
+        device_actions.MeshInterface.MeshInterfaceError, match="Timed out"
+    ):
+        device_actions.send_local_factory_reset_and_wait(
+            node, full=False, cli_print=MagicMock(), timeout=1.0
+        )
+
+    raise_wait_error.assert_called_with("receivedNak", request_id=None)

--- a/meshtastic/tests/test_cli_device_actions.py
+++ b/meshtastic/tests/test_cli_device_actions.py
@@ -1,0 +1,224 @@
+"""Focused unit tests for extracted device-action failure boundaries."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from meshtastic.cli import device_actions
+from meshtastic.cli.context import ActionOutcome, CliContext
+
+
+class _DummyTCPInterface:
+    """Minimal TCP-interface stand-in for OTA failure-path tests."""
+
+    hostname = "mesh.local"
+
+    def __init__(self) -> None:
+        self.node = MagicMock()
+
+    def getNode(self, *_args: object, **_kwargs: object) -> MagicMock:  # noqa: N802
+        """Return the local-node test double expected by the OTA helper."""
+        return self.node
+
+
+def _returning_cli_exit(*_args: object, **_kwargs: object) -> None:
+    """Model an injected exit seam that incorrectly returns to its caller."""
+
+
+def _hooks(**overrides: object) -> device_actions.DeviceActionHooks:
+    """Build device-action hooks with a deliberately returning exit seam."""
+    values: dict[str, object] = {
+        "cli_exit": _returning_cli_exit,
+        "cli_print": MagicMock(),
+        "set_pref": MagicMock(return_value=True),
+        "is_local_destination": MagicMock(return_value=True),
+        "send_local_factory_reset_and_wait": MagicMock(),
+        "post_factory_reset_ready_probe": MagicMock(),
+        "handle_ota_update": MagicMock(),
+        "build_lockdown_auth": MagicMock(return_value=object()),
+        "read_lockdown_passphrase_file": MagicMock(return_value=b"secret"),
+        "send_lockdown_auth": MagicMock(return_value=None),
+        "validate_lockdown_passphrase": MagicMock(return_value=b"secret"),
+    }
+    values.update(overrides)
+    return device_actions.DeviceActionHooks(**values)  # type: ignore[arg-type]
+
+
+def _context(interface: object, **args: object) -> CliContext:
+    """Build the minimal connected CLI context needed by a focused handler test."""
+    return CliContext(
+        interface=interface,  # type: ignore[arg-type]
+        args=SimpleNamespace(**args),
+        get_node_kwargs={},
+        outcome=ActionOutcome(),
+    )
+
+
+def _lockdown_context() -> CliContext:
+    """Build a local unlock request that avoids interactive confirmation."""
+    return _context(
+        MagicMock(),
+        lockdown_provision=False,
+        lockdown_unlock=True,
+        lockdown_lock_now=False,
+        lockdown_disable=False,
+        lockdown_yes=False,
+        lockdown_passphrase_file="secret.txt",
+        lockdown_passphrase=None,
+        insecure_lockdown_passphrase_on_command_line=False,
+        lockdown_boots=None,
+        lockdown_valid_until=None,
+        lockdown_max_session_seconds=None,
+        lockdown_wait=1.0,
+        dest="^local",
+    )
+
+
+def _prepare_ota(
+    monkeypatch: pytest.MonkeyPatch, ota_factory: Any
+) -> _DummyTCPInterface:
+    """Install OTA seams and return a compatible TCP-interface test double."""
+    monkeypatch.setattr(
+        device_actions.meshtastic.tcp_interface, "TCPInterface", _DummyTCPInterface
+    )
+    monkeypatch.setattr(device_actions.meshtastic.ota, "ESP32WiFiOTA", ota_factory)
+    monkeypatch.setattr(device_actions.time, "sleep", lambda _seconds: None)
+    return _DummyTCPInterface()
+
+
+def _run_ota(interface: _DummyTCPInterface) -> None:
+    """Invoke the OTA helper with the returning-exit test seam."""
+    device_actions.handle_ota_update(
+        interface,  # type: ignore[arg-type]
+        SimpleNamespace(ota_update="firmware.bin", dest="^local"),
+        {},
+        cli_exit=_returning_cli_exit,  # type: ignore[arg-type]
+        cli_print=MagicMock(),
+        is_local_destination=lambda *_args: True,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("raw_altitude", ["not-an-altitude", str(1 << 31)])
+def test_altitude_guards_reject_returning_cli_exit(raw_altitude: str) -> None:
+    """Invalid altitude input must not continue into position assignment."""
+    context = _context(
+        MagicMock(),
+        set_time=None,
+        remove_position=False,
+        setlat=None,
+        setlon=None,
+        setalt=raw_altitude,
+        dest="^local",
+    )
+
+    with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
+        device_actions._handle_device_actions(context, _hooks())
+
+
+@pytest.mark.unit
+def test_invalid_position_fields_guard_rejects_returning_cli_exit() -> None:
+    """Unknown position fields must not fall through after the exit seam returns."""
+    interface = MagicMock()
+    position = interface.getNode.return_value.localConfig.position
+    position.PositionFlags.Value.side_effect = ValueError("unknown field")
+    context = _context(interface, pos_fields=["bogus"], dest="^local")
+
+    with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
+        device_actions._handle_position_fields(context, _hooks())
+
+
+@pytest.mark.unit
+def test_ota_constructor_guard_rejects_returning_cli_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OTA setup failure must not continue with an unbound OTA client."""
+
+    def _raise_ota_error(*_args: object, **_kwargs: object) -> None:
+        raise device_actions.meshtastic.ota.OTAError("invalid image")
+
+    interface = _prepare_ota(monkeypatch, _raise_ota_error)
+
+    with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
+        _run_ota(interface)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "failure",
+    [
+        device_actions.meshtastic.ota.OTAError("invalid"),
+        device_actions.meshtastic.ota.OTATransportError("lost"),
+    ],
+)
+def test_ota_update_guards_reject_returning_cli_exit(
+    monkeypatch: pytest.MonkeyPatch, failure: Exception
+) -> None:
+    """OTA update failures must not fall through to the success path."""
+    ota = MagicMock()
+    ota.hash_bytes.return_value = b"hash"
+    ota.update.side_effect = failure
+    interface = _prepare_ota(monkeypatch, MagicMock(return_value=ota))
+
+    with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
+        _run_ota(interface)
+
+    expected_calls = (
+        device_actions.OTA_MAX_RETRIES
+        if isinstance(failure, device_actions.meshtastic.ota.OTATransportError)
+        else 1
+    )
+    assert ota.update.call_count == expected_calls
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("hook_name", "failure"),
+    [
+        ("build_lockdown_auth", ValueError("invalid")),
+        ("send_lockdown_auth", RuntimeError("lost")),
+    ],
+)
+def test_lockdown_action_guards_reject_returning_cli_exit(
+    hook_name: str, failure: Exception
+) -> None:
+    """Lockdown failures must not continue with unbound auth or status values."""
+    hooks = _hooks(**{hook_name: MagicMock(side_effect=failure)})
+
+    with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
+        device_actions._handle_lockdown_action(_lockdown_context(), hooks)
+
+
+@pytest.mark.unit
+def test_lockdown_cli_secret_guard_rejects_returning_cli_exit() -> None:
+    """A refused command-line secret must not be validated after the exit call."""
+    args = SimpleNamespace(
+        lockdown_passphrase_file=None,
+        lockdown_passphrase="secret",
+        insecure_lockdown_passphrase_on_command_line=False,
+    )
+
+    with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
+        device_actions._read_lockdown_passphrase(args, "unlock", _hooks())
+
+
+@pytest.mark.unit
+def test_lockdown_confirmation_mismatch_guard_rejects_returning_cli_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mismatched provisioning secrets must not continue into validation."""
+    monkeypatch.setattr(
+        device_actions.getpass, "getpass", MagicMock(side_effect=["a", "b"])
+    )
+    args = SimpleNamespace(
+        lockdown_passphrase_file=None,
+        lockdown_passphrase=None,
+        insecure_lockdown_passphrase_on_command_line=False,
+    )
+
+    with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
+        device_actions._read_lockdown_passphrase(args, "provision", _hooks())

--- a/meshtastic/tests/test_cli_device_actions.py
+++ b/meshtastic/tests/test_cli_device_actions.py
@@ -637,9 +637,12 @@ def test_factory_reset_scoped_wait_checks_error_before_return_and_retires_reques
     """A request-scoped ACK completion must surface NAK state before cleanup."""
     events: list[str] = []
     iface = MagicMock()
-    wait_for_request_ack = MagicMock(
-        side_effect=lambda *_args, **_kwargs: events.append("wait") or True
-    )
+
+    def _record_wait(*_args: object, **_kwargs: object) -> bool:
+        events.append("wait")
+        return True
+
+    wait_for_request_ack = MagicMock(side_effect=_record_wait)
     raise_wait_error = MagicMock(
         side_effect=lambda *_args, **_kwargs: events.append("raise")
     )

--- a/meshtastic/tests/test_cli_device_actions.py
+++ b/meshtastic/tests/test_cli_device_actions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
@@ -52,7 +53,7 @@ def _context(interface: object, **args: object) -> CliContext:
     """Build the minimal connected CLI context needed by a focused handler test."""
     return CliContext(
         interface=interface,  # type: ignore[arg-type]
-        args=SimpleNamespace(**args),
+        args=argparse.Namespace(**args),
         get_node_kwargs={},
         outcome=ActionOutcome(),
     )
@@ -222,3 +223,133 @@ def test_lockdown_confirmation_mismatch_guard_rejects_returning_cli_exit(
 
     with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
         device_actions._read_lockdown_passphrase(args, "provision", _hooks())
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("failure_kind", ["transport", "destination"])
+def test_ota_preconditions_reject_returning_cli_exit(
+    monkeypatch: pytest.MonkeyPatch, failure_kind: str
+) -> None:
+    """Rejected OTA transport/destination preconditions must never continue."""
+    if failure_kind == "transport":
+        interface = MagicMock()
+        local_destination = MagicMock(return_value=True)
+    else:
+        interface = _prepare_ota(monkeypatch, MagicMock())
+        local_destination = MagicMock(return_value=False)
+
+    with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
+        device_actions.handle_ota_update(
+            interface,  # type: ignore[arg-type]
+            argparse.Namespace(ota_update="firmware.bin", dest="!remote"),
+            {},
+            cli_exit=_returning_cli_exit,  # type: ignore[arg-type]
+            cli_print=MagicMock(),
+            is_local_destination=local_destination,
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("args", "expected_fragment"),
+    [
+        ({"setlat": "91.0", "setlon": None, "setalt": None}, "latitude"),
+        ({"setlat": None, "setlon": "181.0", "setalt": None}, "longitude"),
+        ({"set_owner": "   "}, "Long Name"),
+        ({"set_owner_short": "   "}, "Short Name"),
+        ({"set_ham": "   "}, "Ham radio callsign"),
+    ],
+)
+def test_device_validation_guards_reject_returning_cli_exit(
+    monkeypatch: pytest.MonkeyPatch,
+    args: dict[str, object],
+    expected_fragment: str,
+) -> None:
+    """Fatal device validation must not reach a mutating operation after exit."""
+    interface = MagicMock()
+    defaults: dict[str, object] = {
+        "set_time": None,
+        "remove_position": False,
+        "setlat": None,
+        "setlon": None,
+        "setalt": None,
+        "set_owner": None,
+        "set_owner_short": None,
+        "set_is_unmessageable": None,
+        "set_ham": None,
+        "dest": "^local",
+    }
+    defaults.update(args)
+    context = _context(interface, **defaults)
+    exit_mock = MagicMock()
+    hooks = _hooks(cli_exit=exit_mock)
+    monkeypatch.setattr(device_actions, "_handle_content_updates", lambda *_a: None)
+    monkeypatch.setattr(device_actions, "_handle_position_fields", lambda *_a: None)
+    monkeypatch.setattr(
+        device_actions, "_handle_reboot_and_reset_actions", lambda *_a: None
+    )
+    monkeypatch.setattr(
+        device_actions, "_handle_node_database_actions", lambda *_a: None
+    )
+
+    with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
+        device_actions._handle_device_actions(context, hooks)
+
+    assert expected_fragment in str(exit_mock.call_args)
+    interface.getNode.return_value.setFixedPosition.assert_not_called()
+    interface.getNode.return_value.setOwner.assert_not_called()
+
+
+@pytest.mark.unit
+def test_lockdown_preconditions_reject_returning_cli_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lockdown must fail closed on non-local targets and rejected confirmation."""
+    remote = _lockdown_context()
+    remote.args.dest = "!remote"
+    hooks = _hooks(is_local_destination=MagicMock(return_value=False))
+    with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
+        device_actions._handle_lockdown_action(remote, hooks)
+    hooks.send_lockdown_auth.assert_not_called()
+
+    confirm = _lockdown_context()
+    confirm.args.lockdown_unlock = False
+    confirm.args.lockdown_provision = True
+    monkeypatch.setattr("builtins.input", lambda _prompt: "no")
+    hooks = _hooks(is_local_destination=MagicMock(return_value=True))
+    with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
+        device_actions._handle_lockdown_action(confirm, hooks)
+    hooks.send_lockdown_auth.assert_not_called()
+
+
+@pytest.mark.unit
+def test_numeric_zero_fixed_position_is_not_treated_as_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Programmatic zero coordinates must still enter the fixed-position action."""
+    interface = MagicMock()
+    context = _context(
+        interface,
+        set_time=None,
+        remove_position=False,
+        setlat=0.0,
+        setlon=None,
+        setalt=None,
+        set_owner=None,
+        set_owner_short=None,
+        set_is_unmessageable=None,
+        set_ham=None,
+        dest="^local",
+    )
+    monkeypatch.setattr(device_actions, "_handle_content_updates", lambda *_a: None)
+    monkeypatch.setattr(device_actions, "_handle_position_fields", lambda *_a: None)
+    monkeypatch.setattr(
+        device_actions, "_handle_reboot_and_reset_actions", lambda *_a: None
+    )
+    monkeypatch.setattr(
+        device_actions, "_handle_node_database_actions", lambda *_a: None
+    )
+
+    device_actions._handle_device_actions(context, _hooks())
+
+    interface.getNode.return_value.setFixedPosition.assert_called_once_with(0.0, 0.0, 0)

--- a/meshtastic/tests/test_cli_dispatch.py
+++ b/meshtastic/tests/test_cli_dispatch.py
@@ -30,6 +30,7 @@ def _context() -> CliContext:
     )
 
 
+@pytest.mark.unit
 def test_cleanup_connected_resources_runs_in_reverse_order() -> None:
     """Retained resources should unwind in reverse registration order exactly once."""
     context = _context()
@@ -45,6 +46,7 @@ def test_cleanup_connected_resources_runs_in_reverse_order() -> None:
     assert context.outcome.cleanup_callbacks == []
 
 
+@pytest.mark.unit
 def test_cleanup_connected_resources_returns_first_failure(caplog: pytest.LogCaptureFixture) -> None:
     """Cleanup should continue after failures while retaining the first exception."""
     context = _context()
@@ -65,6 +67,7 @@ def test_cleanup_connected_resources_returns_first_failure(caplog: pytest.LogCap
     assert context.outcome.cleanup_callbacks == []
 
 
+@pytest.mark.unit
 def test_dispatch_does_not_suppress_cleanup_base_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -83,6 +86,7 @@ def test_dispatch_does_not_suppress_cleanup_base_exception(
     assert context.outcome.cleanup_callbacks == []
 
 
+@pytest.mark.unit
 def test_dispatch_preserves_primary_failure_when_cleanup_also_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -102,3 +106,34 @@ def test_dispatch_preserves_primary_failure_when_cleanup_also_fails(
         dispatch.dispatch_connected(context, hooks)
 
     assert context.outcome.cleanup_callbacks == []
+
+
+@pytest.mark.unit
+def test_stop_processing_still_runs_final_disconnect_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Early action termination should skip later actions but still finalize/close."""
+    context = _context()
+    context.interface = MagicMock()  # type: ignore[assignment]
+    context.args.wait_to_disconnect = 2
+    context.outcome.close_now = True
+
+    def _stop(_context: CliContext, _hooks: object) -> None:
+        _context.outcome.stop_processing = True
+
+    monkeypatch.setattr(dispatch.device_actions, "_handle_device_actions", _stop)
+    later_action = MagicMock()
+    monkeypatch.setattr(
+        dispatch.messaging_service_actions,
+        "_handle_messaging_actions",
+        later_action,
+    )
+    sleep = MagicMock()
+    hooks = MagicMock()
+    hooks.sleep = sleep
+
+    dispatch.dispatch_connected(context, hooks)
+
+    later_action.assert_not_called()
+    sleep.assert_called_once_with(2)
+    context.interface.close.assert_called_once_with()

--- a/meshtastic/tests/test_cli_dispatch.py
+++ b/meshtastic/tests/test_cli_dispatch.py
@@ -91,6 +91,72 @@ def test_failure_cleanup_returns_first_failure(
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("control_flow_error", [KeyboardInterrupt(), SystemExit(2)])
+def test_failure_cleanup_prioritizes_control_flow_errors(
+    control_flow_error: BaseException,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Operator control-flow exceptions must outrank earlier rollback failures."""
+    context = _context()
+    ordinary_error = RuntimeError("ordinary cleanup failure")
+
+    def _raise(exc: BaseException) -> None:
+        raise exc
+
+    # Rollback order is reversed, so the ordinary exception is observed first.
+    context.outcome.failure_cleanup_callbacks.extend(
+        [lambda: _raise(control_flow_error), lambda: _raise(ordinary_error)]
+    )
+
+    error = dispatch._cleanup_failed_resources(context)  # noqa: SLF001
+
+    assert error is control_flow_error
+    assert "Additional connected-action cleanup failed" in caplog.text
+    assert context.outcome.failure_cleanup_callbacks == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("dev_path", "stable_path", "expected"),
+    [
+        ("", None, "Connected to radio"),
+        ("/dev/ttyUSB0", None, "Connected to radio on ttyUSB0"),
+        (
+            "/dev/ttyUSB0",
+            "/dev/serial/by-id/mesh-radio",
+            "Connected to radio on ttyUSB0 (stable: /dev/serial/by-id/mesh-radio)",
+        ),
+    ],
+)
+def test_print_connection_banner_variants(
+    dev_path: str, stable_path: str | None, expected: str
+) -> None:
+    """Connection banners should describe generic, device, and stable paths."""
+    context = _context()
+    interface = MagicMock(autospec=MeshInterface)
+    interface.devPath = dev_path
+    interface._stable_path = stable_path
+    context.interface = cast(MeshInterface, interface)
+    hooks = MagicMock()
+
+    dispatch._print_connection(context, hooks)  # noqa: SLF001
+
+    hooks.cli_print.assert_called_once_with(expected)
+
+
+@pytest.mark.unit
+def test_print_connection_suppresses_banner_during_export() -> None:
+    """Configuration export must keep stdout free of the connection banner."""
+    context = _context()
+    context.args.export_config = True
+    hooks = MagicMock()
+
+    dispatch._print_connection(context, hooks)  # noqa: SLF001
+
+    hooks.cli_print.assert_not_called()
+
+
+@pytest.mark.unit
 def test_dispatch_does_not_suppress_cleanup_base_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/meshtastic/tests/test_cli_dispatch.py
+++ b/meshtastic/tests/test_cli_dispatch.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-from types import SimpleNamespace
 from typing import cast
 from unittest.mock import MagicMock
 
@@ -23,7 +22,7 @@ def _context() -> CliContext:
         seriallog=False,
         wait_to_disconnect=None,
     )
-    interface = SimpleNamespace()
+    interface = MagicMock(autospec=MeshInterface)
     return CliContext(
         interface=cast(MeshInterface, interface),
         args=args,
@@ -32,27 +31,47 @@ def _context() -> CliContext:
     )
 
 
+@pytest.fixture
+def isolated_dispatch_actions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub connected action entrypoints so lifecycle tests isolate dispatch itself."""
+    targets = (
+        (dispatch.device_actions, "_handle_device_actions"),
+        (dispatch.channel_contact_actions, "_handle_contact_import"),
+        (dispatch.messaging_service_actions, "_handle_messaging_actions"),
+        (dispatch.configure_actions, "_handle_configure_actions"),
+        (dispatch.channel_contact_actions, "_handle_channel_mutations"),
+        (dispatch.messaging_service_actions, "_handle_content_reads"),
+        (dispatch.channel_contact_actions, "_handle_region_preset_display"),
+        (dispatch.device_actions, "_handle_lockdown_action"),
+        (dispatch.messaging_service_actions, "_handle_information_actions"),
+        (dispatch.channel_contact_actions, "_handle_channel_contact_display"),
+        (dispatch.messaging_service_actions, "_handle_long_running_services"),
+    )
+    for module, name in targets:
+        monkeypatch.setattr(module, name, lambda *_args: None)
+
+
 @pytest.mark.unit
-def test_cleanup_connected_resources_runs_in_reverse_order() -> None:
-    """Retained resources should unwind in reverse registration order exactly once."""
+def test_failure_cleanup_runs_in_reverse_order() -> None:
+    """Unwind failure rollback resources once in reverse registration order."""
     context = _context()
     calls: list[str] = []
-    context.outcome.cleanup_callbacks.extend(
+    context.outcome.failure_cleanup_callbacks.extend(
         [lambda: calls.append("first"), lambda: calls.append("second")]
     )
 
-    error = dispatch._cleanup_connected_resources(context)  # noqa: SLF001
+    error = dispatch._cleanup_failed_resources(context)  # noqa: SLF001
 
     assert error is None
     assert calls == ["second", "first"]
-    assert context.outcome.cleanup_callbacks == []
+    assert context.outcome.failure_cleanup_callbacks == []
 
 
 @pytest.mark.unit
-def test_cleanup_connected_resources_returns_first_failure(
+def test_failure_cleanup_returns_first_failure(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Cleanup should continue after failures while retaining the first exception."""
+    """Continue failure rollback while retaining the first exception."""
     context = _context()
     first = RuntimeError("first")
     second = ValueError("second")
@@ -60,15 +79,15 @@ def test_cleanup_connected_resources_returns_first_failure(
     def _raise(exc: BaseException) -> None:
         raise exc
 
-    context.outcome.cleanup_callbacks.extend(
+    context.outcome.failure_cleanup_callbacks.extend(
         [lambda: _raise(second), lambda: _raise(first)]
     )
 
-    error = dispatch._cleanup_connected_resources(context)  # noqa: SLF001
+    error = dispatch._cleanup_failed_resources(context)  # noqa: SLF001
 
     assert error is first
     assert "Additional connected-action cleanup failed" in caplog.text
-    assert context.outcome.cleanup_callbacks == []
+    assert context.outcome.failure_cleanup_callbacks == []
 
 
 @pytest.mark.unit
@@ -77,7 +96,9 @@ def test_dispatch_does_not_suppress_cleanup_base_exception(
 ) -> None:
     """A control-flow BaseException raised during cleanup must remain observable."""
     context = _context()
-    context.outcome.cleanup_callbacks.append(MagicMock(side_effect=KeyboardInterrupt))
+    context.outcome.failure_cleanup_callbacks.append(
+        MagicMock(side_effect=KeyboardInterrupt)
+    )
     monkeypatch.setattr(
         dispatch,
         "_print_connection",
@@ -89,7 +110,7 @@ def test_dispatch_does_not_suppress_cleanup_base_exception(
 
     assert isinstance(exc_info.value.__context__, ValueError)
     assert str(exc_info.value.__context__) == "primary"
-    assert context.outcome.cleanup_callbacks == []
+    assert context.outcome.failure_cleanup_callbacks == []
 
 
 @pytest.mark.unit
@@ -98,7 +119,7 @@ def test_dispatch_preserves_primary_failure_when_cleanup_also_fails(
 ) -> None:
     """A cleanup failure must not replace the action failure being unwound."""
     context = _context()
-    context.outcome.cleanup_callbacks.append(
+    context.outcome.failure_cleanup_callbacks.append(
         MagicMock(side_effect=RuntimeError("cleanup"))
     )
     monkeypatch.setattr(
@@ -111,7 +132,7 @@ def test_dispatch_preserves_primary_failure_when_cleanup_also_fails(
     with pytest.raises(ValueError, match="primary"):
         dispatch.dispatch_connected(context, hooks)
 
-    assert context.outcome.cleanup_callbacks == []
+    assert context.outcome.failure_cleanup_callbacks == []
 
 
 @pytest.mark.unit
@@ -120,7 +141,7 @@ def test_stop_processing_still_runs_final_disconnect_lifecycle(
 ) -> None:
     """Early action termination should skip later actions but still finalize/close."""
     context = _context()
-    interface = MagicMock()
+    interface = MagicMock(autospec=MeshInterface)
     context.interface = cast(MeshInterface, interface)
     context.args.wait_to_disconnect = 2
     context.outcome.close_now = True
@@ -150,7 +171,7 @@ def test_stop_processing_still_runs_final_disconnect_lifecycle(
 def test_finalize_waits_for_ack_when_requested() -> None:
     """An explicit --ack request must trigger the shared final ACK/NAK wait."""
     context = _context()
-    interface = MagicMock()
+    interface = MagicMock(autospec=MeshInterface)
     node = interface.getNode.return_value
     context.interface = cast(MeshInterface, interface)
     context.args.ack = True
@@ -166,7 +187,7 @@ def test_finalize_waits_for_ack_when_requested() -> None:
 def test_finalize_skip_ack_wait_takes_precedence() -> None:
     """Actions that own completion must suppress the shared ACK/NAK wait."""
     context = _context()
-    interface = MagicMock()
+    interface = MagicMock(autospec=MeshInterface)
     context.interface = cast(MeshInterface, interface)
     context.args.ack = True
     context.outcome.skip_ack_wait = True
@@ -177,20 +198,108 @@ def test_finalize_skip_ack_wait_takes_precedence() -> None:
 
 
 @pytest.mark.unit
-def test_finalize_swallows_interface_close_failure(
+def test_interface_close_failure_is_diagnostic_and_not_retried(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Transport-close failures during finalization should remain diagnostic-only."""
+    """Keep transport-close failures diagnostic-only and consume the close request."""
     import logging
 
     caplog.set_level(logging.DEBUG, logger=dispatch.__name__)
     context = _context()
-    interface = MagicMock()
+    interface = MagicMock(autospec=MeshInterface)
     interface.close.side_effect = RuntimeError("close failed")
     context.interface = cast(MeshInterface, interface)
     context.outcome.close_now = True
 
-    dispatch._finalize_connected_actions(context, MagicMock())  # noqa: SLF001
+    dispatch._close_interface_if_requested(context)  # noqa: SLF001
+    dispatch._close_interface_if_requested(context)  # noqa: SLF001
 
     interface.close.assert_called_once_with()
     assert "Error during interface close" in caplog.text
+
+
+@pytest.mark.unit
+def test_finalize_waits_for_requested_unicast_ack() -> None:
+    """A unicast operation that delegates completion must wait for ACK/NAK."""
+    context = _context()
+    interface = MagicMock(autospec=MeshInterface)
+    node = interface.getNode.return_value
+    context.interface = cast(MeshInterface, interface)
+    context.args.dest = "!12345678"
+    context.outcome.wait_for_ack_nak = True
+
+    dispatch._finalize_connected_actions(context, MagicMock())  # noqa: SLF001
+
+    node.iface.waitForAckNak.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_finalize_skips_delegated_ack_wait_for_broadcast() -> None:
+    """Broadcast operations must not enter the shared ACK/NAK wait."""
+    context = _context()
+    interface = MagicMock(autospec=MeshInterface)
+    context.interface = cast(MeshInterface, interface)
+    context.outcome.wait_for_ack_nak = True
+
+    dispatch._finalize_connected_actions(context, MagicMock())  # noqa: SLF001
+
+    interface.getNode.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("isolated_dispatch_actions")
+def test_ack_wait_failure_still_closes_one_shot_interface() -> None:
+    """A failed final ACK wait must not bypass a requested interface close."""
+    context = _context()
+    interface = MagicMock(autospec=MeshInterface)
+    interface.getNode.return_value.iface.waitForAckNak.side_effect = RuntimeError(
+        "ack failed"
+    )
+    context.interface = cast(MeshInterface, interface)
+    context.args.ack = True
+    context.outcome.close_now = True
+    with pytest.raises(RuntimeError, match="ack failed"):
+        dispatch.dispatch_connected(context, MagicMock())
+
+    interface.close.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_action_failure_after_close_request_still_closes_interface(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An action failure after requesting closure must still close the interface."""
+    context = _context()
+    interface = MagicMock(autospec=MeshInterface)
+    context.interface = cast(MeshInterface, interface)
+
+    def _fail(action_context: CliContext, _hooks: object) -> None:
+        action_context.outcome.close_now = True
+        raise RuntimeError("action failed")
+
+    monkeypatch.setattr(dispatch.device_actions, "_handle_device_actions", _fail)
+
+    with pytest.raises(RuntimeError, match="action failed"):
+        dispatch.dispatch_connected(context, MagicMock())
+
+    interface.close.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_successful_dispatch_retains_started_service_resources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Failure rollback callbacks must not stop services after successful dispatch."""
+    context = _context()
+    rollback = MagicMock()
+
+    def _register(action_context: CliContext, _hooks: object) -> None:
+        action_context.outcome.failure_cleanup_callbacks.append(rollback)
+        action_context.outcome.stop_processing = True
+
+    monkeypatch.setattr(dispatch.device_actions, "_handle_device_actions", _register)
+
+    dispatch.dispatch_connected(context, MagicMock())
+
+    rollback.assert_not_called()
+    assert context.outcome.failure_cleanup_callbacks == []

--- a/meshtastic/tests/test_cli_dispatch.py
+++ b/meshtastic/tests/test_cli_dispatch.py
@@ -1,0 +1,104 @@
+"""Focused tests for connected CLI dispatch lifecycle ownership."""
+
+from __future__ import annotations
+
+import argparse
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from meshtastic.cli import dispatch
+from meshtastic.cli.context import ActionOutcome, CliContext
+
+
+def _context() -> CliContext:
+    """Build a minimal connected CLI context for lifecycle helper tests."""
+    args = argparse.Namespace(
+        ack=False,
+        dest="^all",
+        export_config=False,
+        seriallog=False,
+        wait_to_disconnect=None,
+    )
+    interface = SimpleNamespace()
+    return CliContext(
+        interface=interface,  # type: ignore[arg-type]
+        args=args,
+        get_node_kwargs={},
+        outcome=ActionOutcome(),
+    )
+
+
+def test_cleanup_connected_resources_runs_in_reverse_order() -> None:
+    """Retained resources should unwind in reverse registration order exactly once."""
+    context = _context()
+    calls: list[str] = []
+    context.outcome.cleanup_callbacks.extend(
+        [lambda: calls.append("first"), lambda: calls.append("second")]
+    )
+
+    error = dispatch._cleanup_connected_resources(context)  # noqa: SLF001
+
+    assert error is None
+    assert calls == ["second", "first"]
+    assert context.outcome.cleanup_callbacks == []
+
+
+def test_cleanup_connected_resources_returns_first_failure(caplog: pytest.LogCaptureFixture) -> None:
+    """Cleanup should continue after failures while retaining the first exception."""
+    context = _context()
+    first = RuntimeError("first")
+    second = ValueError("second")
+
+    def _raise(exc: BaseException) -> None:
+        raise exc
+
+    context.outcome.cleanup_callbacks.extend(
+        [lambda: _raise(second), lambda: _raise(first)]
+    )
+
+    error = dispatch._cleanup_connected_resources(context)  # noqa: SLF001
+
+    assert error is first
+    assert "Additional connected-action cleanup failed" in caplog.text
+    assert context.outcome.cleanup_callbacks == []
+
+
+def test_dispatch_does_not_suppress_cleanup_base_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A control-flow BaseException raised during cleanup must remain observable."""
+    context = _context()
+    context.outcome.cleanup_callbacks.append(MagicMock(side_effect=KeyboardInterrupt))
+    monkeypatch.setattr(
+        dispatch,
+        "_print_connection",
+        MagicMock(side_effect=ValueError("primary")),
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        dispatch.dispatch_connected(context, MagicMock())
+
+    assert context.outcome.cleanup_callbacks == []
+
+
+def test_dispatch_preserves_primary_failure_when_cleanup_also_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cleanup failure must not replace the action failure being unwound."""
+    context = _context()
+    context.outcome.cleanup_callbacks.append(
+        MagicMock(side_effect=RuntimeError("cleanup"))
+    )
+    monkeypatch.setattr(
+        dispatch,
+        "_print_connection",
+        MagicMock(side_effect=ValueError("primary")),
+    )
+    hooks = MagicMock()
+
+    with pytest.raises(ValueError, match="primary"):
+        dispatch.dispatch_connected(context, hooks)
+
+    assert context.outcome.cleanup_callbacks == []

--- a/meshtastic/tests/test_cli_dispatch.py
+++ b/meshtastic/tests/test_cli_dispatch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 from typing import cast
 from unittest.mock import MagicMock
 
@@ -270,8 +271,6 @@ def test_interface_close_failure_is_diagnostic_and_not_retried(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Keep transport-close failures diagnostic-only and consume the close request."""
-    import logging
-
     caplog.set_level(logging.DEBUG, logger=dispatch.__name__)
     context = _context()
     interface = MagicMock(autospec=MeshInterface)
@@ -284,6 +283,20 @@ def test_interface_close_failure_is_diagnostic_and_not_retried(
 
     interface.close.assert_called_once_with()
     assert "Error during interface close" in caplog.text
+
+
+@pytest.mark.unit
+def test_seriallog_active_skips_interface_close() -> None:
+    """An active seriallog owns the transport; one-shot close must be skipped."""
+    context = _context()
+    interface = MagicMock(autospec=MeshInterface)
+    context.interface = cast(MeshInterface, interface)
+    context.args.seriallog = "out.log"
+    context.outcome.close_now = True
+
+    dispatch._close_interface_if_requested(context)  # noqa: SLF001
+
+    interface.close.assert_not_called()
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_cli_dispatch.py
+++ b/meshtastic/tests/test_cli_dispatch.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import logging
 from typing import cast
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, create_autospec
 
 import pytest
 
@@ -23,7 +23,7 @@ def _context() -> CliContext:
         seriallog=False,
         wait_to_disconnect=None,
     )
-    interface = MagicMock(autospec=MeshInterface)
+    interface = create_autospec(MeshInterface, instance=True)
     interface.devPath = ""
     return CliContext(
         interface=cast(MeshInterface, interface),
@@ -135,7 +135,7 @@ def test_print_connection_banner_variants(
 ) -> None:
     """Connection banners should describe generic, device, and stable paths."""
     context = _context()
-    interface = MagicMock(autospec=MeshInterface)
+    interface = create_autospec(MeshInterface, instance=True)
     interface.devPath = dev_path
     interface._stable_path = stable_path
     context.interface = cast(MeshInterface, interface)
@@ -209,7 +209,7 @@ def test_stop_processing_still_runs_final_disconnect_lifecycle(
 ) -> None:
     """Early action termination should skip later actions but still finalize/close."""
     context = _context()
-    interface = MagicMock(autospec=MeshInterface)
+    interface = create_autospec(MeshInterface, instance=True)
     interface.devPath = ""
     context.interface = cast(MeshInterface, interface)
     context.args.wait_to_disconnect = 2
@@ -240,7 +240,7 @@ def test_stop_processing_still_runs_final_disconnect_lifecycle(
 def test_finalize_waits_for_ack_when_requested() -> None:
     """An explicit --ack request must trigger the shared final ACK/NAK wait."""
     context = _context()
-    interface = MagicMock(autospec=MeshInterface)
+    interface = create_autospec(MeshInterface, instance=True)
     node = interface.getNode.return_value
     context.interface = cast(MeshInterface, interface)
     context.args.ack = True
@@ -256,7 +256,7 @@ def test_finalize_waits_for_ack_when_requested() -> None:
 def test_finalize_skip_ack_wait_takes_precedence() -> None:
     """Actions that own completion must suppress the shared ACK/NAK wait."""
     context = _context()
-    interface = MagicMock(autospec=MeshInterface)
+    interface = create_autospec(MeshInterface, instance=True)
     context.interface = cast(MeshInterface, interface)
     context.args.ack = True
     context.outcome.skip_ack_wait = True
@@ -273,7 +273,7 @@ def test_interface_close_failure_is_diagnostic_and_not_retried(
     """Keep transport-close failures diagnostic-only and consume the close request."""
     caplog.set_level(logging.DEBUG, logger=dispatch.__name__)
     context = _context()
-    interface = MagicMock(autospec=MeshInterface)
+    interface = create_autospec(MeshInterface, instance=True)
     interface.close.side_effect = RuntimeError("close failed")
     context.interface = cast(MeshInterface, interface)
     context.outcome.close_now = True
@@ -289,7 +289,7 @@ def test_interface_close_failure_is_diagnostic_and_not_retried(
 def test_seriallog_active_skips_interface_close() -> None:
     """An active seriallog owns the transport; one-shot close must be skipped."""
     context = _context()
-    interface = MagicMock(autospec=MeshInterface)
+    interface = create_autospec(MeshInterface, instance=True)
     context.interface = cast(MeshInterface, interface)
     context.args.seriallog = "out.log"
     context.outcome.close_now = True
@@ -303,7 +303,7 @@ def test_seriallog_active_skips_interface_close() -> None:
 def test_finalize_waits_for_requested_unicast_ack() -> None:
     """A unicast operation that delegates completion must wait for ACK/NAK."""
     context = _context()
-    interface = MagicMock(autospec=MeshInterface)
+    interface = create_autospec(MeshInterface, instance=True)
     node = interface.getNode.return_value
     context.interface = cast(MeshInterface, interface)
     context.args.dest = "!12345678"
@@ -318,7 +318,7 @@ def test_finalize_waits_for_requested_unicast_ack() -> None:
 def test_finalize_skips_delegated_ack_wait_for_broadcast() -> None:
     """Broadcast operations must not enter the shared ACK/NAK wait."""
     context = _context()
-    interface = MagicMock(autospec=MeshInterface)
+    interface = create_autospec(MeshInterface, instance=True)
     context.interface = cast(MeshInterface, interface)
     context.outcome.wait_for_ack_nak = True
 
@@ -332,7 +332,7 @@ def test_finalize_skips_delegated_ack_wait_for_broadcast() -> None:
 def test_ack_wait_failure_still_closes_one_shot_interface() -> None:
     """A failed final ACK wait must not bypass a requested interface close."""
     context = _context()
-    interface = MagicMock(autospec=MeshInterface)
+    interface = create_autospec(MeshInterface, instance=True)
     interface.devPath = ""
     interface.getNode.return_value.iface.waitForAckNak.side_effect = RuntimeError(
         "ack failed"
@@ -352,7 +352,7 @@ def test_action_failure_after_close_request_still_closes_interface(
 ) -> None:
     """An action failure after requesting closure must still close the interface."""
     context = _context()
-    interface = MagicMock(autospec=MeshInterface)
+    interface = create_autospec(MeshInterface, instance=True)
     interface.devPath = ""
     context.interface = cast(MeshInterface, interface)
 

--- a/meshtastic/tests/test_cli_dispatch.py
+++ b/meshtastic/tests/test_cli_dispatch.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import argparse
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
 
 from meshtastic.cli import dispatch
 from meshtastic.cli.context import ActionOutcome, CliContext
+from meshtastic.mesh_interface import MeshInterface
 
 
 def _context() -> CliContext:
@@ -23,7 +25,7 @@ def _context() -> CliContext:
     )
     interface = SimpleNamespace()
     return CliContext(
-        interface=interface,  # type: ignore[arg-type]
+        interface=cast(MeshInterface, interface),
         args=args,
         get_node_kwargs={},
         outcome=ActionOutcome(),
@@ -118,7 +120,8 @@ def test_stop_processing_still_runs_final_disconnect_lifecycle(
 ) -> None:
     """Early action termination should skip later actions but still finalize/close."""
     context = _context()
-    context.interface = MagicMock()  # type: ignore[assignment]
+    interface = MagicMock()
+    context.interface = cast(MeshInterface, interface)
     context.args.wait_to_disconnect = 2
     context.outcome.close_now = True
 
@@ -140,31 +143,54 @@ def test_stop_processing_still_runs_final_disconnect_lifecycle(
 
     later_action.assert_not_called()
     sleep.assert_called_once_with(2)
-    context.interface.close.assert_called_once_with()
+    interface.close.assert_called_once_with()
 
 
 @pytest.mark.unit
 def test_finalize_waits_for_ack_when_requested() -> None:
     """An explicit --ack request must trigger the shared final ACK/NAK wait."""
     context = _context()
-    context.interface = MagicMock()  # type: ignore[assignment]
+    interface = MagicMock()
+    node = interface.getNode.return_value
+    context.interface = cast(MeshInterface, interface)
     context.args.ack = True
     hooks = MagicMock()
 
     dispatch._finalize_connected_actions(context, hooks)  # noqa: SLF001
 
-    context.interface.getNode.assert_called_once_with("^all", False)
-    context.interface.getNode.return_value.iface.waitForAckNak.assert_called_once_with()
+    interface.getNode.assert_called_once_with("^all", False)
+    node.iface.waitForAckNak.assert_called_once_with()
 
 
 @pytest.mark.unit
 def test_finalize_skip_ack_wait_takes_precedence() -> None:
     """Actions that own completion must suppress the shared ACK/NAK wait."""
     context = _context()
-    context.interface = MagicMock()  # type: ignore[assignment]
+    interface = MagicMock()
+    context.interface = cast(MeshInterface, interface)
     context.args.ack = True
     context.outcome.skip_ack_wait = True
 
     dispatch._finalize_connected_actions(context, MagicMock())  # noqa: SLF001
 
-    context.interface.getNode.assert_not_called()
+    interface.getNode.assert_not_called()
+
+
+@pytest.mark.unit
+def test_finalize_swallows_interface_close_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Transport-close failures during finalization should remain diagnostic-only."""
+    import logging
+
+    caplog.set_level(logging.DEBUG, logger=dispatch.__name__)
+    context = _context()
+    interface = MagicMock()
+    interface.close.side_effect = RuntimeError("close failed")
+    context.interface = cast(MeshInterface, interface)
+    context.outcome.close_now = True
+
+    dispatch._finalize_connected_actions(context, MagicMock())  # noqa: SLF001
+
+    interface.close.assert_called_once_with()
+    assert "Error during interface close" in caplog.text

--- a/meshtastic/tests/test_cli_dispatch.py
+++ b/meshtastic/tests/test_cli_dispatch.py
@@ -172,7 +172,7 @@ def test_dispatch_does_not_suppress_cleanup_base_exception(
     )
 
     with pytest.raises(KeyboardInterrupt) as exc_info:
-        dispatch.dispatch_connected(context, MagicMock())
+        dispatch._dispatch_connected(context, MagicMock())
 
     assert isinstance(exc_info.value.__context__, ValueError)
     assert str(exc_info.value.__context__) == "primary"
@@ -196,7 +196,7 @@ def test_dispatch_preserves_primary_failure_when_cleanup_also_fails(
     hooks = MagicMock()
 
     with pytest.raises(ValueError, match="primary"):
-        dispatch.dispatch_connected(context, hooks)
+        dispatch._dispatch_connected(context, hooks)
 
     assert context.outcome.failure_cleanup_callbacks == []
 
@@ -226,7 +226,7 @@ def test_stop_processing_still_runs_final_disconnect_lifecycle(
     hooks = MagicMock()
     hooks.sleep = sleep
 
-    dispatch.dispatch_connected(context, hooks)
+    dispatch._dispatch_connected(context, hooks)
 
     later_action.assert_not_called()
     sleep.assert_called_once_with(2)
@@ -325,7 +325,7 @@ def test_ack_wait_failure_still_closes_one_shot_interface() -> None:
     context.args.ack = True
     context.outcome.close_now = True
     with pytest.raises(RuntimeError, match="ack failed"):
-        dispatch.dispatch_connected(context, MagicMock())
+        dispatch._dispatch_connected(context, MagicMock())
 
     interface.close.assert_called_once_with()
 
@@ -346,7 +346,7 @@ def test_action_failure_after_close_request_still_closes_interface(
     monkeypatch.setattr(dispatch.device_actions, "_handle_device_actions", _fail)
 
     with pytest.raises(RuntimeError, match="action failed"):
-        dispatch.dispatch_connected(context, MagicMock())
+        dispatch._dispatch_connected(context, MagicMock())
 
     interface.close.assert_called_once_with()
 
@@ -365,7 +365,7 @@ def test_successful_dispatch_retains_started_service_resources(
 
     monkeypatch.setattr(dispatch.device_actions, "_handle_device_actions", _register)
 
-    dispatch.dispatch_connected(context, MagicMock())
+    dispatch._dispatch_connected(context, MagicMock())
 
     rollback.assert_not_called()
     assert context.outcome.failure_cleanup_callbacks == []

--- a/meshtastic/tests/test_cli_dispatch.py
+++ b/meshtastic/tests/test_cli_dispatch.py
@@ -23,6 +23,7 @@ def _context() -> CliContext:
         wait_to_disconnect=None,
     )
     interface = MagicMock(autospec=MeshInterface)
+    interface.devPath = ""
     return CliContext(
         interface=cast(MeshInterface, interface),
         args=args,
@@ -208,6 +209,7 @@ def test_stop_processing_still_runs_final_disconnect_lifecycle(
     """Early action termination should skip later actions but still finalize/close."""
     context = _context()
     interface = MagicMock(autospec=MeshInterface)
+    interface.devPath = ""
     context.interface = cast(MeshInterface, interface)
     context.args.wait_to_disconnect = 2
     context.outcome.close_now = True
@@ -318,6 +320,7 @@ def test_ack_wait_failure_still_closes_one_shot_interface() -> None:
     """A failed final ACK wait must not bypass a requested interface close."""
     context = _context()
     interface = MagicMock(autospec=MeshInterface)
+    interface.devPath = ""
     interface.getNode.return_value.iface.waitForAckNak.side_effect = RuntimeError(
         "ack failed"
     )
@@ -337,6 +340,7 @@ def test_action_failure_after_close_request_still_closes_interface(
     """An action failure after requesting closure must still close the interface."""
     context = _context()
     interface = MagicMock(autospec=MeshInterface)
+    interface.devPath = ""
     context.interface = cast(MeshInterface, interface)
 
     def _fail(action_context: CliContext, _hooks: object) -> None:

--- a/meshtastic/tests/test_cli_dispatch.py
+++ b/meshtastic/tests/test_cli_dispatch.py
@@ -47,7 +47,9 @@ def test_cleanup_connected_resources_runs_in_reverse_order() -> None:
 
 
 @pytest.mark.unit
-def test_cleanup_connected_resources_returns_first_failure(caplog: pytest.LogCaptureFixture) -> None:
+def test_cleanup_connected_resources_returns_first_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Cleanup should continue after failures while retaining the first exception."""
     context = _context()
     first = RuntimeError("first")
@@ -80,9 +82,11 @@ def test_dispatch_does_not_suppress_cleanup_base_exception(
         MagicMock(side_effect=ValueError("primary")),
     )
 
-    with pytest.raises(KeyboardInterrupt):
+    with pytest.raises(KeyboardInterrupt) as exc_info:
         dispatch.dispatch_connected(context, MagicMock())
 
+    assert isinstance(exc_info.value.__context__, ValueError)
+    assert str(exc_info.value.__context__) == "primary"
     assert context.outcome.cleanup_callbacks == []
 
 
@@ -137,3 +141,30 @@ def test_stop_processing_still_runs_final_disconnect_lifecycle(
     later_action.assert_not_called()
     sleep.assert_called_once_with(2)
     context.interface.close.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_finalize_waits_for_ack_when_requested() -> None:
+    """An explicit --ack request must trigger the shared final ACK/NAK wait."""
+    context = _context()
+    context.interface = MagicMock()  # type: ignore[assignment]
+    context.args.ack = True
+    hooks = MagicMock()
+
+    dispatch._finalize_connected_actions(context, hooks)  # noqa: SLF001
+
+    context.interface.getNode.assert_called_once_with("^all", False)
+    context.interface.getNode.return_value.iface.waitForAckNak.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_finalize_skip_ack_wait_takes_precedence() -> None:
+    """Actions that own completion must suppress the shared ACK/NAK wait."""
+    context = _context()
+    context.interface = MagicMock()  # type: ignore[assignment]
+    context.args.ack = True
+    context.outcome.skip_ack_wait = True
+
+    dispatch._finalize_connected_actions(context, MagicMock())  # noqa: SLF001
+
+    context.interface.getNode.assert_not_called()

--- a/meshtastic/tests/test_cli_messaging_service_actions.py
+++ b/meshtastic/tests/test_cli_messaging_service_actions.py
@@ -97,9 +97,7 @@ def test_messaging_actions_send_traceroute_with_selected_channel() -> None:
 
     _handle_messaging_actions(context, hooks)
 
-    interface.sendTraceRoute.assert_called_once_with(
-        "!00000003", 5, channelIndex=2
-    )
+    interface.sendTraceRoute.assert_called_once_with("!00000003", 5, channelIndex=2)
 
 
 @pytest.mark.unit
@@ -112,9 +110,7 @@ def test_messaging_actions_send_traceroute_with_selected_channel() -> None:
         ("unknown", "device_metrics"),
     ],
 )
-def test_messaging_actions_maps_telemetry_types(
-    requested: str, expected: str
-) -> None:
+def test_messaging_actions_maps_telemetry_types(requested: str, expected: str) -> None:
     """Telemetry request aliases should map to the historical metric names."""
     interface = _interface_double()
     context = _context(interface, request_telemetry=requested)
@@ -131,16 +127,25 @@ def test_messaging_actions_maps_telemetry_types(
 
 
 @pytest.mark.unit
-def test_messaging_actions_reject_broadcast_response_requests() -> None:
+@pytest.mark.parametrize(
+    ("overrides", "method_name"),
+    [
+        ({"request_telemetry": "device"}, "sendTelemetry"),
+        ({"request_position": True}, "sendPosition"),
+    ],
+)
+def test_messaging_actions_reject_broadcast_response_requests(
+    overrides: dict[str, Any], method_name: str
+) -> None:
     """Telemetry and position response requests require a concrete destination."""
     interface = _interface_double()
-    context = _context(interface, dest="^all", request_telemetry="device")
+    context = _context(interface, dest="^all", **overrides)
     hooks = _hooks()
 
     with pytest.raises(SystemExit):
         _handle_messaging_actions(context, hooks)
 
-    interface.sendTelemetry.assert_not_called()
+    getattr(interface, method_name).assert_not_called()
 
 
 @pytest.mark.unit
@@ -158,7 +163,7 @@ def test_messaging_actions_writes_gpio_bitmask() -> None:
 
 
 @pytest.mark.unit
-def test_information_actions_remote_nodes_stops_dispatch(capsys: pytest.CaptureFixture[str]) -> None:
+def test_information_actions_remote_nodes_stops_dispatch() -> None:
     """Remote node-list requests should retain the historical early-return behavior."""
     interface = _interface_double()
     context = _context(interface, nodes=True)
@@ -233,8 +238,8 @@ def test_rejected_no_proto_tunnel_preserves_prior_close_request() -> None:
 
 
 @pytest.mark.unit
-def test_sendtext_does_not_force_ack_wait_without_ack_flag() -> None:
-    """Text sends should leave ACK waiting under the explicit ``--ack`` option."""
+def test_sendtext_requests_protocol_ack_without_owning_final_wait() -> None:
+    """Text sends request an ACK while final blocking waits remain dispatch-owned."""
     interface = _interface_double()
     node = MagicMock()
     interface.getNode.return_value = node
@@ -243,8 +248,8 @@ def test_sendtext_does_not_force_ack_wait_without_ack_flag() -> None:
     _handle_messaging_actions(context, _hooks())
 
     assert context.outcome.close_now is True
-    assert context.outcome.wait_for_ack_nak is False
     interface.sendText.assert_called_once()
+    assert interface.sendText.call_args.kwargs["wantAck"] is True
 
 
 @pytest.mark.unit
@@ -327,3 +332,67 @@ def test_gpio_write_rejects_bit_index_outside_uint64() -> None:
         _handle_messaging_actions(context, hooks)
 
     client.writeGPIOs.assert_not_called()
+
+
+@pytest.mark.unit
+def test_slog_overrides_prior_one_shot_close_request() -> None:
+    """Starting structured logging must keep the connection alive until cleanup."""
+    interface = _interface_double()
+    log_set = MagicMock()
+    context = _context(interface, slog="default")
+    context.outcome.close_now = True
+    hooks = _hooks(log_set_factory=MagicMock(return_value=log_set))
+
+    _handle_long_running_services(context, hooks)
+
+    assert context.outcome.close_now is False
+    assert context.outcome.cleanup_callbacks == [log_set.close]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("service", ["slog", "power_stress"])
+def test_missing_optional_service_factory_fails_closed(service: str) -> None:
+    """Missing optional factories must never be called after a returning exit seam."""
+    interface = _interface_double()
+    returning_exit = MagicMock()
+    overrides: dict[str, Any] = {"cli_exit": returning_exit}
+    context_overrides: dict[str, Any] = {}
+    if service == "slog":
+        overrides["log_set_factory"] = None
+        context_overrides["slog"] = "default"
+    else:
+        overrides["power_stress_factory"] = None
+        context_overrides["power_stress"] = True
+    context = _context(interface, **context_overrides)
+
+    with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
+        _handle_long_running_services(context, _hooks(**overrides))
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("overrides", "expected_message"),
+    [
+        ({"gpio_rd": "10000000000000000"}, "GPIO mask"),
+        ({"gpio_wrb": [("not-a-bit", "1")]}, "GPIO bit/value"),
+        ({"gpio_wrb": [("64", "1")]}, "GPIO bit/value"),
+    ],
+)
+def test_gpio_validation_fails_closed_with_returning_exit(
+    overrides: dict[str, Any], expected_message: str
+) -> None:
+    """Invalid GPIO input must not reach remote hardware if the exit seam returns."""
+    interface = _interface_double()
+    client = MagicMock()
+    cli_exit = MagicMock()
+    hooks = _hooks(
+        cli_exit=cli_exit, remote_hardware_client=MagicMock(return_value=client)
+    )
+    context = _context(interface, **overrides)
+
+    with pytest.raises(AssertionError, match="cli_exit returned unexpectedly"):
+        _handle_messaging_actions(context, hooks)
+
+    assert expected_message in str(cli_exit.call_args)
+    client.writeGPIOs.assert_not_called()
+    client.readGPIOs.assert_not_called()

--- a/meshtastic/tests/test_cli_messaging_service_actions.py
+++ b/meshtastic/tests/test_cli_messaging_service_actions.py
@@ -1,0 +1,207 @@
+"""Focused behavioral tests for connected messaging/service CLI actions."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from meshtastic.cli.context import ActionOutcome, CliContext
+from meshtastic.cli.messaging_service_actions import (
+    MessagingServiceHooks,
+    handle_information_actions,
+    handle_long_running_services,
+    handle_messaging_actions,
+)
+
+
+def _args(**overrides: Any) -> argparse.Namespace:
+    values: dict[str, Any] = {
+        "sendtext": None,
+        "private": False,
+        "dest": "!00000002",
+        "traceroute": None,
+        "request_telemetry": None,
+        "request_position": False,
+        "gpio_wrb": None,
+        "gpio_rd": None,
+        "gpio_watch": None,
+        "info": False,
+        "get": None,
+        "nodes": False,
+        "show_fields": None,
+        "slog": None,
+        "power_stress": False,
+        "listen": False,
+        "tunnel": False,
+        "tunnel_net": None,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def _context(interface: Any, **arg_overrides: Any) -> CliContext:
+    return CliContext(
+        interface=interface,
+        args=_args(**arg_overrides),
+        get_node_kwargs={"timeout": 5.0},
+        outcome=ActionOutcome(wait_for_ack_nak=False),
+        channel_index=2,
+    )
+
+
+def _cli_exit(_message: str, return_value: int = 1) -> None:
+    raise SystemExit(return_value)
+
+
+def _hooks(**overrides: Any) -> MessagingServiceHooks:
+    values: dict[str, Any] = {
+        "cli_exit": _cli_exit,
+        "cli_print": MagicMock(),
+        "get_channel_index": lambda: 2,
+        "check_channel": MagicMock(return_value=True),
+        "remote_hardware_client": MagicMock(),
+        "get_pref": MagicMock(return_value=True),
+        "validate_cli_show_fields": MagicMock(),
+        "newer_version": MagicMock(return_value=None),
+        "install_upgrade_hint": "pipx upgrade mtjk",
+        "powermon_available": MagicMock(return_value=True),
+        "powermon_error": MagicMock(return_value=None),
+        "log_set_factory": MagicMock(),
+        "power_stress_factory": MagicMock(),
+        "get_meter": MagicMock(return_value=object()),
+        "platform_system": MagicMock(return_value="Linux"),
+    }
+    values.update(overrides)
+    return MessagingServiceHooks(**values)
+
+
+@pytest.mark.unit
+def test_messaging_actions_send_traceroute_with_selected_channel() -> None:
+    """Traceroute should use the selected channel and local hop limit."""
+    interface = MagicMock()
+    interface.localNode.localConfig.lora.hop_limit = 5
+    context = _context(interface, traceroute="!00000003")
+    hooks = _hooks()
+
+    handle_messaging_actions(context, hooks)
+
+    interface.sendTraceRoute.assert_called_once_with(
+        "!00000003", 5, channelIndex=2
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("requested", "expected"),
+    [
+        ("environment", "environment_metrics"),
+        ("air_quality", "air_quality_metrics"),
+        ("local_stats", "local_stats"),
+        ("unknown", "device_metrics"),
+    ],
+)
+def test_messaging_actions_maps_telemetry_types(
+    requested: str, expected: str
+) -> None:
+    """Telemetry request aliases should map to the historical metric names."""
+    interface = MagicMock()
+    context = _context(interface, request_telemetry=requested)
+    hooks = _hooks()
+
+    handle_messaging_actions(context, hooks)
+
+    interface.sendTelemetry.assert_called_once_with(
+        destinationId="!00000002",
+        wantResponse=True,
+        channelIndex=2,
+        telemetryType=expected,
+    )
+
+
+@pytest.mark.unit
+def test_messaging_actions_reject_broadcast_response_requests() -> None:
+    """Telemetry and position response requests require a concrete destination."""
+    interface = MagicMock()
+    context = _context(interface, dest="^all", request_telemetry="device")
+    hooks = _hooks()
+
+    with pytest.raises(SystemExit):
+        handle_messaging_actions(context, hooks)
+
+    interface.sendTelemetry.assert_not_called()
+
+
+@pytest.mark.unit
+def test_messaging_actions_writes_gpio_bitmask() -> None:
+    """GPIO writes should combine bit/value pairs before sending one request."""
+    interface = MagicMock()
+    client = MagicMock()
+    context = _context(interface, gpio_wrb=[("4", "1"), ("7", "1")])
+    hooks = _hooks(remote_hardware_client=MagicMock(return_value=client))
+
+    handle_messaging_actions(context, hooks)
+
+    client.writeGPIOs.assert_called_once_with("!00000002", 0x90, 0x90)
+    assert context.outcome.close_now is True
+
+
+@pytest.mark.unit
+def test_information_actions_remote_nodes_stops_dispatch(capsys: pytest.CaptureFixture[str]) -> None:
+    """Remote node-list requests should retain the historical early-return behavior."""
+    interface = MagicMock()
+    context = _context(interface, nodes=True)
+    hooks = _hooks()
+
+    handle_information_actions(context, hooks)
+
+    assert context.outcome.stop_processing is True
+    interface.showNodes.assert_not_called()
+    assert "remote node is not supported" in capsys.readouterr().out
+
+
+@pytest.mark.unit
+def test_information_actions_validates_selected_node_fields() -> None:
+    """Local node listing should validate requested fields before rendering."""
+    interface = MagicMock()
+    context = _context(interface, dest="^all", nodes=True, show_fields=["user.id"])
+    validate = MagicMock()
+    hooks = _hooks(validate_cli_show_fields=validate)
+
+    handle_information_actions(context, hooks)
+
+    validate.assert_called_once_with(interface, ["user.id"])
+    interface.showNodes.assert_called_once_with(True, ["user.id"])
+
+
+@pytest.mark.unit
+def test_long_running_services_registers_log_cleanup_and_runs_stress() -> None:
+    """Slog lifetime should be retained explicitly while power stress still closes."""
+    interface = MagicMock()
+    log_set = MagicMock()
+    stress = MagicMock()
+    context = _context(interface, slog="default", power_stress=True)
+    hooks = _hooks(
+        log_set_factory=MagicMock(return_value=log_set),
+        power_stress_factory=MagicMock(return_value=stress),
+    )
+
+    handle_long_running_services(context, hooks)
+
+    stress.run.assert_called_once_with()
+    assert context.outcome.close_now is True
+    assert context.outcome.cleanup_callbacks == [log_set.close]
+
+
+@pytest.mark.unit
+def test_long_running_services_listen_overrides_close_request() -> None:
+    """Listen mode should keep the interface open after earlier close requests."""
+    interface = MagicMock()
+    context = _context(interface, listen=True)
+    context.outcome.close_now = True
+
+    handle_long_running_services(context, _hooks())
+
+    assert context.outcome.close_now is False

--- a/meshtastic/tests/test_cli_messaging_service_actions.py
+++ b/meshtastic/tests/test_cli_messaging_service_actions.py
@@ -574,16 +574,15 @@ def test_information_actions_info_paths_and_upgrade_notice(
 
 
 @pytest.mark.unit
-def test_information_actions_remote_info_is_non_mutating(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """Remote --info should explain the supported --get alternative."""
+def test_information_actions_remote_info_is_non_mutating() -> None:
+    """Remote --info should explain the supported --get alternative via the quiet-aware hook."""
     interface = _interface_double()
     context = _context(interface, info=True)
+    cli_print = MagicMock()
 
-    _handle_information_actions(context, _hooks())
+    _handle_information_actions(context, _hooks(cli_print=cli_print))
 
-    assert "remote node is not supported" in capsys.readouterr().out
+    cli_print.assert_any_call("Showing info of remote node is not supported.")
     interface.showInfo.assert_not_called()
 
 

--- a/meshtastic/tests/test_cli_messaging_service_actions.py
+++ b/meshtastic/tests/test_cli_messaging_service_actions.py
@@ -485,9 +485,7 @@ def test_position_request_sends_on_selected_channel() -> None:
 
 
 @pytest.mark.unit
-def test_gpio_read_resets_state_and_stops_on_own_response(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_gpio_read_resets_state_and_stops_on_own_response() -> None:
     """Each GPIO read must reset stale response state and stop on its own callback."""
     interface = _interface_double()
     interface.gotResponse = True
@@ -499,11 +497,14 @@ def test_gpio_read_resets_state_and_stops_on_own_response(
 
     client.readGPIOs.side_effect = _respond
     sleep = MagicMock()
-    monkeypatch.setattr(actions.time, "sleep", sleep)
     context = _context(interface, gpio_rd="0x10")
 
     _handle_messaging_actions(
-        context, _hooks(remote_hardware_client=MagicMock(return_value=client))
+        context,
+        _hooks(
+            remote_hardware_client=MagicMock(return_value=client),
+            sleep=sleep,
+        ),
     )
 
     assert interface.mask == 0x10
@@ -512,15 +513,12 @@ def test_gpio_read_resets_state_and_stops_on_own_response(
 
 
 @pytest.mark.unit
-def test_gpio_read_timeout_is_diagnostic_not_attribute_error(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_gpio_read_timeout_is_diagnostic_not_attribute_error() -> None:
     """An unanswered GPIO read should exhaust its poll budget and warn cleanly."""
     interface = _interface_double()
     client = MagicMock()
     cli_print = MagicMock()
     sleep = MagicMock()
-    monkeypatch.setattr(actions.time, "sleep", sleep)
     context = _context(interface, gpio_rd="0x1")
 
     _handle_messaging_actions(
@@ -528,6 +526,7 @@ def test_gpio_read_timeout_is_diagnostic_not_attribute_error(
         _hooks(
             cli_print=cli_print,
             remote_hardware_client=MagicMock(return_value=client),
+            sleep=sleep,
         ),
     )
 
@@ -537,20 +536,21 @@ def test_gpio_read_timeout_is_diagnostic_not_attribute_error(
 
 
 @pytest.mark.unit
-def test_gpio_watch_sends_watch_before_propagating_interrupt(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_gpio_watch_sends_watch_before_propagating_interrupt() -> None:
     """Watch mode should issue the remote watch request before its long-running sleep."""
     interface = _interface_double()
     client = MagicMock()
     client.watchGPIOs.side_effect = [None, KeyboardInterrupt()]
     sleep = MagicMock()
-    monkeypatch.setattr(actions.time, "sleep", sleep)
     context = _context(interface, gpio_watch="0x4")
 
     with pytest.raises(KeyboardInterrupt):
         _handle_messaging_actions(
-            context, _hooks(remote_hardware_client=MagicMock(return_value=client))
+            context,
+            _hooks(
+                remote_hardware_client=MagicMock(return_value=client),
+                sleep=sleep,
+            ),
         )
 
     assert client.watchGPIOs.call_count == 2

--- a/meshtastic/tests/test_cli_messaging_service_actions.py
+++ b/meshtastic/tests/test_cli_messaging_service_actions.py
@@ -17,6 +17,7 @@ from meshtastic.cli.messaging_service_actions import (
     _handle_messaging_actions,
 )
 from meshtastic.mesh_interface import MeshInterface
+from meshtastic.protobuf import portnums_pb2
 
 
 def _args(**overrides: Any) -> argparse.Namespace:
@@ -104,8 +105,12 @@ def test_messaging_actions_send_traceroute_with_selected_channel() -> None:
 @pytest.mark.parametrize(
     ("requested", "expected"),
     [
+        ("device_metrics", "device_metrics"),
         ("environment", "environment_metrics"),
+        ("environment_metrics", "environment_metrics"),
         ("air_quality", "air_quality_metrics"),
+        ("air_quality_metrics", "air_quality_metrics"),
+        ("power_metrics", "power_metrics"),
         ("local_stats", "local_stats"),
         ("unknown", "device_metrics"),
     ],
@@ -124,6 +129,26 @@ def test_messaging_actions_maps_telemetry_types(requested: str, expected: str) -
         channelIndex=2,
         telemetryType=expected,
     )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("private", "expected_port"),
+    [
+        (False, portnums_pb2.PortNum.TEXT_MESSAGE_APP),
+        (True, portnums_pb2.PortNum.PRIVATE_APP),
+    ],
+)
+def test_sendtext_selects_port_for_private_flag(
+    private: bool, expected_port: int
+) -> None:
+    """Private text sends must use the private application port."""
+    interface = _interface_double()
+    context = _context(interface, sendtext="hello", private=private)
+
+    _handle_messaging_actions(context, _hooks())
+
+    assert interface.sendText.call_args.kwargs["portNum"] == expected_port
 
 
 @pytest.mark.unit
@@ -555,6 +580,24 @@ def test_tunnel_rejects_remote_destination() -> None:
 
     with pytest.raises(SystemExit):
         actions._start_tunnel(context, _hooks())
+
+
+@pytest.mark.unit
+def test_tunnel_is_skipped_on_non_linux_platforms() -> None:
+    """Unsupported platforms must not start a tunnel or alter lifecycle state."""
+    from meshtastic.cli import messaging_service_actions as actions
+
+    interface = _interface_double()
+    context = _context(interface, tunnel=True, dest="^all")
+    context.outcome.close_now = True
+
+    actions._start_tunnel(
+        context,
+        _hooks(platform_system=MagicMock(return_value="Windows")),
+    )
+
+    assert context.outcome.close_now is True
+    assert context.outcome.failure_cleanup_callbacks == []
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_cli_messaging_service_actions.py
+++ b/meshtastic/tests/test_cli_messaging_service_actions.py
@@ -9,7 +9,6 @@ from unittest.mock import MagicMock, create_autospec
 import pytest
 
 from meshtastic.cli.context import ActionOutcome, CliContext
-from meshtastic.mesh_interface import MeshInterface
 from meshtastic.cli.messaging_service_actions import (
     MessagingServiceHooks,
     _handle_content_reads,
@@ -17,6 +16,7 @@ from meshtastic.cli.messaging_service_actions import (
     _handle_long_running_services,
     _handle_messaging_actions,
 )
+from meshtastic.mesh_interface import MeshInterface
 
 
 def _args(**overrides: Any) -> argparse.Namespace:
@@ -396,3 +396,207 @@ def test_gpio_validation_fails_closed_with_returning_exit(
     assert expected_message in str(cli_exit.call_args)
     client.writeGPIOs.assert_not_called()
     client.readGPIOs.assert_not_called()
+
+
+@pytest.mark.unit
+def test_gpio_mask_accepts_full_uint64_range() -> None:
+    """The largest valid uint64 GPIO mask should parse without truncation."""
+    from meshtastic.cli import messaging_service_actions as actions
+
+    assert actions._parse_gpio_mask("ffffffffffffffff", _hooks()) == (1 << 64) - 1
+
+
+@pytest.mark.unit
+def test_position_request_sends_on_selected_channel() -> None:
+    """A valid position request should use the selected channel and await response."""
+    interface = _interface_double()
+    context = _context(interface, request_position=True)
+
+    _handle_messaging_actions(context, _hooks())
+
+    interface.sendPosition.assert_called_once_with(
+        destinationId="!00000002", wantResponse=True, channelIndex=2
+    )
+
+
+@pytest.mark.unit
+def test_gpio_read_resets_state_and_stops_on_own_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each GPIO read must reset stale response state and stop on its own callback."""
+    from meshtastic.cli import messaging_service_actions as actions
+
+    interface = _interface_double()
+    interface.gotResponse = True
+    client = MagicMock()
+
+    def _respond(*_args: Any) -> None:
+        assert interface.gotResponse is False
+        interface.gotResponse = True
+
+    client.readGPIOs.side_effect = _respond
+    sleep = MagicMock()
+    monkeypatch.setattr(actions.time, "sleep", sleep)
+    context = _context(interface, gpio_rd="0x10")
+
+    _handle_messaging_actions(
+        context, _hooks(remote_hardware_client=MagicMock(return_value=client))
+    )
+
+    assert interface.mask == 0x10
+    client.readGPIOs.assert_called_once_with("!00000002", 0x10, None)
+    sleep.assert_called_once_with(actions.GPIO_READ_POLL_INTERVAL_SECONDS)
+
+
+@pytest.mark.unit
+def test_gpio_read_timeout_is_diagnostic_not_attribute_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unanswered GPIO read should exhaust its poll budget and warn cleanly."""
+    from meshtastic.cli import messaging_service_actions as actions
+
+    interface = _interface_double()
+    client = MagicMock()
+    cli_print = MagicMock()
+    sleep = MagicMock()
+    monkeypatch.setattr(actions.time, "sleep", sleep)
+    context = _context(interface, gpio_rd="0x1")
+
+    _handle_messaging_actions(
+        context,
+        _hooks(
+            cli_print=cli_print,
+            remote_hardware_client=MagicMock(return_value=client),
+        ),
+    )
+
+    assert interface.gotResponse is False
+    assert sleep.call_count == actions.GPIO_READ_MAX_POLLS
+    cli_print.assert_any_call("Warning: no GPIO response received.")
+
+
+@pytest.mark.unit
+def test_gpio_watch_sends_watch_before_propagating_interrupt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Watch mode should issue the remote watch request before its long-running sleep."""
+    from meshtastic.cli import messaging_service_actions as actions
+
+    interface = _interface_double()
+    client = MagicMock()
+    client.watchGPIOs.side_effect = [None, KeyboardInterrupt()]
+    sleep = MagicMock()
+    monkeypatch.setattr(actions.time, "sleep", sleep)
+    context = _context(interface, gpio_watch="0x4")
+
+    with pytest.raises(KeyboardInterrupt):
+        _handle_messaging_actions(
+            context, _hooks(remote_hardware_client=MagicMock(return_value=client))
+        )
+
+    assert client.watchGPIOs.call_count == 2
+    client.watchGPIOs.assert_called_with("!00000002", 0x4)
+    sleep.assert_called_once_with(actions.GPIO_WATCH_INTERVAL_SECONDS)
+
+
+@pytest.mark.unit
+def test_information_actions_info_paths_and_upgrade_notice(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Local info should include node detail and a discovered upgrade notice."""
+    interface = _interface_double()
+    interface.getNode.return_value = MagicMock()
+    context = _context(interface, dest="^all", info=True)
+
+    _handle_information_actions(
+        context,
+        _hooks(newer_version=MagicMock(return_value="9.9.9")),
+    )
+
+    interface.showInfo.assert_called_once_with()
+    interface.getNode.return_value.showInfo.assert_called_once_with()
+    assert "newer version v9.9.9" in capsys.readouterr().out
+
+
+@pytest.mark.unit
+def test_information_actions_remote_info_is_non_mutating(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Remote --info should explain the supported --get alternative."""
+    interface = _interface_double()
+    context = _context(interface, info=True)
+
+    _handle_information_actions(context, _hooks())
+
+    assert "remote node is not supported" in capsys.readouterr().out
+    interface.showInfo.assert_not_called()
+
+
+@pytest.mark.unit
+def test_show_fields_without_nodes_stops_processing() -> None:
+    """--show-fields alone should stop before later connected actions execute."""
+    interface = _interface_double()
+    context = _context(interface, show_fields=["user.id"])
+    cli_print = MagicMock()
+
+    _handle_information_actions(context, _hooks(cli_print=cli_print))
+
+    assert context.outcome.stop_processing is True
+    cli_print.assert_called_once_with("--show-fields can only be used with --nodes")
+
+
+@pytest.mark.unit
+def test_tunnel_rejects_remote_destination() -> None:
+    """Tunnel mode must fail closed for any non-local destination."""
+    from meshtastic.cli import messaging_service_actions as actions
+
+    interface = _interface_double()
+    context = _context(interface, tunnel=True, dest="!remote")
+
+    with pytest.raises(SystemExit):
+        actions._start_tunnel(context, _hooks())
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("subnet", [None, "10.42.0.0/16"])
+def test_tunnel_starts_with_optional_subnet(
+    monkeypatch: pytest.MonkeyPatch, subnet: str | None
+) -> None:
+    """Eligible tunnel requests should keep the connection open and forward subnet."""
+    from meshtastic import tunnel
+    from meshtastic.cli import messaging_service_actions as actions
+
+    interface = _interface_double()
+    interface.noProto = False
+    context = _context(interface, tunnel=True, dest="^all", tunnel_net=subnet)
+    context.outcome.close_now = True
+    tunnel_factory = MagicMock()
+    monkeypatch.setattr(tunnel, "Tunnel", tunnel_factory)
+
+    actions._start_tunnel(context, _hooks())
+
+    assert context.outcome.close_now is False
+    if subnet is None:
+        tunnel_factory.assert_called_once_with(interface)
+    else:
+        tunnel_factory.assert_called_once_with(interface, subnet=subnet)
+
+
+@pytest.mark.unit
+def test_powermon_unavailable_reports_import_error() -> None:
+    """Optional power actions should fail with the captured import diagnostic."""
+    interface = _interface_double()
+    context = _context(interface, slog="default")
+    cli_exit = MagicMock(side_effect=SystemExit(1))
+
+    with pytest.raises(SystemExit):
+        _handle_long_running_services(
+            context,
+            _hooks(
+                cli_exit=cli_exit,
+                powermon_available=MagicMock(return_value=False),
+                powermon_error=MagicMock(return_value=ImportError("missing meter")),
+            ),
+        )
+
+    assert "missing meter" in str(cli_exit.call_args)

--- a/meshtastic/tests/test_cli_messaging_service_actions.py
+++ b/meshtastic/tests/test_cli_messaging_service_actions.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, create_autospec
 
 import pytest
 
+from meshtastic.cli import messaging_service_actions as actions
 from meshtastic.cli.context import ActionOutcome, CliContext
 from meshtastic.cli.messaging_service_actions import (
     MessagingServiceHooks,
@@ -247,7 +248,28 @@ def test_long_running_services_registers_log_cleanup_and_runs_stress() -> None:
     _handle_long_running_services(context, hooks)
 
     stress.run.assert_called_once_with()
+    log_set.close.assert_called_once_with()
     assert context.outcome.close_now is True
+    assert context.outcome.failure_cleanup_callbacks == []
+
+
+@pytest.mark.unit
+def test_power_stress_failure_retains_slog_failure_cleanup() -> None:
+    """A failed stress run must leave the log rollback armed for dispatch cleanup."""
+    interface = _interface_double()
+    log_set = MagicMock()
+    stress = MagicMock()
+    stress.run.side_effect = RuntimeError("stress failed")
+    context = _context(interface, slog="default", power_stress=True)
+    hooks = _hooks(
+        log_set_factory=MagicMock(return_value=log_set),
+        power_stress_factory=MagicMock(return_value=stress),
+    )
+
+    with pytest.raises(RuntimeError, match="stress failed"):
+        _handle_long_running_services(context, hooks)
+
+    log_set.close.assert_not_called()
     assert context.outcome.failure_cleanup_callbacks == [log_set.close]
 
 
@@ -296,14 +318,16 @@ def test_gpio_read_rejects_invalid_hex_mask() -> None:
     """Malformed GPIO masks should exit cleanly rather than raising ValueError."""
     interface = _interface_double()
     context = _context(interface, gpio_rd="zz")
-    client_factory = MagicMock()
+    client = MagicMock()
+    client_factory = MagicMock(return_value=client)
     hooks = _hooks(remote_hardware_client=client_factory)
 
     with pytest.raises(SystemExit) as exc_info:
         _handle_messaging_actions(context, hooks)
 
     assert exc_info.value.code == 1
-    client_factory.return_value.readGPIOs.assert_not_called()
+    client_factory.assert_called_once_with(interface)
+    client.readGPIOs.assert_not_called()
 
 
 @pytest.mark.unit
@@ -440,8 +464,6 @@ def test_gpio_validation_fails_closed_with_returning_exit(
 @pytest.mark.unit
 def test_gpio_mask_accepts_full_uint64_range() -> None:
     """The largest valid uint64 GPIO mask should parse without truncation."""
-    from meshtastic.cli import messaging_service_actions as actions
-
     assert actions._parse_gpio_mask("ffffffffffffffff", _hooks()) == (1 << 64) - 1
 
 
@@ -463,8 +485,6 @@ def test_gpio_read_resets_state_and_stops_on_own_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Each GPIO read must reset stale response state and stop on its own callback."""
-    from meshtastic.cli import messaging_service_actions as actions
-
     interface = _interface_double()
     interface.gotResponse = True
     client = MagicMock()
@@ -492,8 +512,6 @@ def test_gpio_read_timeout_is_diagnostic_not_attribute_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """An unanswered GPIO read should exhaust its poll budget and warn cleanly."""
-    from meshtastic.cli import messaging_service_actions as actions
-
     interface = _interface_double()
     client = MagicMock()
     cli_print = MagicMock()
@@ -519,8 +537,6 @@ def test_gpio_watch_sends_watch_before_propagating_interrupt(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Watch mode should issue the remote watch request before its long-running sleep."""
-    from meshtastic.cli import messaging_service_actions as actions
-
     interface = _interface_double()
     client = MagicMock()
     client.watchGPIOs.side_effect = [None, KeyboardInterrupt()]
@@ -587,8 +603,6 @@ def test_show_fields_without_nodes_stops_processing() -> None:
 @pytest.mark.unit
 def test_tunnel_rejects_remote_destination() -> None:
     """Tunnel mode must fail closed for any non-local destination."""
-    from meshtastic.cli import messaging_service_actions as actions
-
     interface = _interface_double()
     context = _context(interface, tunnel=True, dest="!remote")
 
@@ -599,8 +613,6 @@ def test_tunnel_rejects_remote_destination() -> None:
 @pytest.mark.unit
 def test_tunnel_is_skipped_on_non_linux_platforms() -> None:
     """Unsupported platforms must not start a tunnel or alter lifecycle state."""
-    from meshtastic.cli import messaging_service_actions as actions
-
     interface = _interface_double()
     context = _context(interface, tunnel=True, dest="^all")
     context.outcome.close_now = True
@@ -621,8 +633,6 @@ def test_tunnel_starts_with_optional_subnet(
 ) -> None:
     """Eligible tunnel requests should keep the connection open and forward subnet."""
     from meshtastic import tunnel
-    from meshtastic.cli import messaging_service_actions as actions
-
     interface = _interface_double()
     interface.noProto = False
     context = _context(interface, tunnel=True, dest="^all", tunnel_net=subnet)

--- a/meshtastic/tests/test_cli_messaging_service_actions.py
+++ b/meshtastic/tests/test_cli_messaging_service_actions.py
@@ -22,6 +22,7 @@ from meshtastic.protobuf import portnums_pb2
 
 
 def _args(**overrides: Any) -> argparse.Namespace:
+    """Build parser-faithful defaults for messaging/service action tests."""
     values: dict[str, Any] = {
         "sendtext": None,
         "private": False,
@@ -54,6 +55,7 @@ def _interface_double() -> MagicMock:
 
 
 def _context(interface: Any, **arg_overrides: Any) -> CliContext:
+    """Build a connected action context around a test interface double."""
     return CliContext(
         interface=interface,
         args=_args(**arg_overrides),
@@ -63,10 +65,12 @@ def _context(interface: Any, **arg_overrides: Any) -> CliContext:
 
 
 def _cli_exit(_message: str, return_value: int = 1) -> NoReturn:
+    """Raise ``SystemExit`` in place of the production CLI-exit hook."""
     raise SystemExit(return_value)
 
 
 def _hooks(**overrides: Any) -> MessagingServiceHooks:
+    """Build messaging-service hooks with deterministic defaults."""
     values: dict[str, Any] = {
         "cli_exit": _cli_exit,
         "cli_print": MagicMock(),

--- a/meshtastic/tests/test_cli_messaging_service_actions.py
+++ b/meshtastic/tests/test_cli_messaging_service_actions.py
@@ -174,6 +174,20 @@ def test_messaging_actions_reject_broadcast_response_requests(
 
 
 @pytest.mark.unit
+def test_gpio_actions_reject_broadcast_destination_before_client_creation() -> None:
+    """GPIO response operations require a concrete node before creating a client."""
+    interface = _interface_double()
+    context = _context(interface, dest="^all", gpio_rd="ff")
+    remote_hardware_client = MagicMock()
+    hooks = _hooks(remote_hardware_client=remote_hardware_client)
+
+    with pytest.raises(SystemExit):
+        _handle_messaging_actions(context, hooks)
+
+    remote_hardware_client.assert_not_called()
+
+
+@pytest.mark.unit
 def test_messaging_actions_writes_gpio_bitmask() -> None:
     """GPIO writes should combine bit/value pairs before sending one request."""
     interface = _interface_double()

--- a/meshtastic/tests/test_cli_messaging_service_actions.py
+++ b/meshtastic/tests/test_cli_messaging_service_actions.py
@@ -4,16 +4,18 @@ from __future__ import annotations
 
 import argparse
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, create_autospec
 
 import pytest
 
 from meshtastic.cli.context import ActionOutcome, CliContext
+from meshtastic.mesh_interface import MeshInterface
 from meshtastic.cli.messaging_service_actions import (
     MessagingServiceHooks,
-    handle_information_actions,
-    handle_long_running_services,
-    handle_messaging_actions,
+    _handle_content_reads,
+    _handle_information_actions,
+    _handle_long_running_services,
+    _handle_messaging_actions,
 )
 
 
@@ -42,13 +44,17 @@ def _args(**overrides: Any) -> argparse.Namespace:
     return argparse.Namespace(**values)
 
 
+def _interface_double() -> MagicMock:
+    """Return an interface double constrained to the MeshInterface method surface."""
+    return create_autospec(MeshInterface, instance=True)
+
+
 def _context(interface: Any, **arg_overrides: Any) -> CliContext:
     return CliContext(
         interface=interface,
         args=_args(**arg_overrides),
         get_node_kwargs={"timeout": 5.0},
-        outcome=ActionOutcome(wait_for_ack_nak=False),
-        channel_index=2,
+        outcome=ActionOutcome(),
     )
 
 
@@ -81,12 +87,13 @@ def _hooks(**overrides: Any) -> MessagingServiceHooks:
 @pytest.mark.unit
 def test_messaging_actions_send_traceroute_with_selected_channel() -> None:
     """Traceroute should use the selected channel and local hop limit."""
-    interface = MagicMock()
+    interface = _interface_double()
+    interface.localNode = MagicMock()
     interface.localNode.localConfig.lora.hop_limit = 5
     context = _context(interface, traceroute="!00000003")
     hooks = _hooks()
 
-    handle_messaging_actions(context, hooks)
+    _handle_messaging_actions(context, hooks)
 
     interface.sendTraceRoute.assert_called_once_with(
         "!00000003", 5, channelIndex=2
@@ -107,11 +114,11 @@ def test_messaging_actions_maps_telemetry_types(
     requested: str, expected: str
 ) -> None:
     """Telemetry request aliases should map to the historical metric names."""
-    interface = MagicMock()
+    interface = _interface_double()
     context = _context(interface, request_telemetry=requested)
     hooks = _hooks()
 
-    handle_messaging_actions(context, hooks)
+    _handle_messaging_actions(context, hooks)
 
     interface.sendTelemetry.assert_called_once_with(
         destinationId="!00000002",
@@ -124,12 +131,12 @@ def test_messaging_actions_maps_telemetry_types(
 @pytest.mark.unit
 def test_messaging_actions_reject_broadcast_response_requests() -> None:
     """Telemetry and position response requests require a concrete destination."""
-    interface = MagicMock()
+    interface = _interface_double()
     context = _context(interface, dest="^all", request_telemetry="device")
     hooks = _hooks()
 
     with pytest.raises(SystemExit):
-        handle_messaging_actions(context, hooks)
+        _handle_messaging_actions(context, hooks)
 
     interface.sendTelemetry.assert_not_called()
 
@@ -137,12 +144,12 @@ def test_messaging_actions_reject_broadcast_response_requests() -> None:
 @pytest.mark.unit
 def test_messaging_actions_writes_gpio_bitmask() -> None:
     """GPIO writes should combine bit/value pairs before sending one request."""
-    interface = MagicMock()
+    interface = _interface_double()
     client = MagicMock()
     context = _context(interface, gpio_wrb=[("4", "1"), ("7", "1")])
     hooks = _hooks(remote_hardware_client=MagicMock(return_value=client))
 
-    handle_messaging_actions(context, hooks)
+    _handle_messaging_actions(context, hooks)
 
     client.writeGPIOs.assert_called_once_with("!00000002", 0x90, 0x90)
     assert context.outcome.close_now is True
@@ -151,26 +158,29 @@ def test_messaging_actions_writes_gpio_bitmask() -> None:
 @pytest.mark.unit
 def test_information_actions_remote_nodes_stops_dispatch(capsys: pytest.CaptureFixture[str]) -> None:
     """Remote node-list requests should retain the historical early-return behavior."""
-    interface = MagicMock()
+    interface = _interface_double()
     context = _context(interface, nodes=True)
-    hooks = _hooks()
+    cli_print = MagicMock()
+    hooks = _hooks(cli_print=cli_print)
 
-    handle_information_actions(context, hooks)
+    _handle_information_actions(context, hooks)
 
     assert context.outcome.stop_processing is True
     interface.showNodes.assert_not_called()
-    assert "remote node is not supported" in capsys.readouterr().out
+    cli_print.assert_called_once_with(
+        "Showing node list of a remote node is not supported."
+    )
 
 
 @pytest.mark.unit
 def test_information_actions_validates_selected_node_fields() -> None:
     """Local node listing should validate requested fields before rendering."""
-    interface = MagicMock()
+    interface = _interface_double()
     context = _context(interface, dest="^all", nodes=True, show_fields=["user.id"])
     validate = MagicMock()
     hooks = _hooks(validate_cli_show_fields=validate)
 
-    handle_information_actions(context, hooks)
+    _handle_information_actions(context, hooks)
 
     validate.assert_called_once_with(interface, ["user.id"])
     interface.showNodes.assert_called_once_with(True, ["user.id"])
@@ -179,7 +189,7 @@ def test_information_actions_validates_selected_node_fields() -> None:
 @pytest.mark.unit
 def test_long_running_services_registers_log_cleanup_and_runs_stress() -> None:
     """Slog lifetime should be retained explicitly while power stress still closes."""
-    interface = MagicMock()
+    interface = _interface_double()
     log_set = MagicMock()
     stress = MagicMock()
     context = _context(interface, slog="default", power_stress=True)
@@ -188,7 +198,7 @@ def test_long_running_services_registers_log_cleanup_and_runs_stress() -> None:
         power_stress_factory=MagicMock(return_value=stress),
     )
 
-    handle_long_running_services(context, hooks)
+    _handle_long_running_services(context, hooks)
 
     stress.run.assert_called_once_with()
     assert context.outcome.close_now is True
@@ -198,10 +208,107 @@ def test_long_running_services_registers_log_cleanup_and_runs_stress() -> None:
 @pytest.mark.unit
 def test_long_running_services_listen_overrides_close_request() -> None:
     """Listen mode should keep the interface open after earlier close requests."""
-    interface = MagicMock()
+    interface = _interface_double()
     context = _context(interface, listen=True)
     context.outcome.close_now = True
 
-    handle_long_running_services(context, _hooks())
+    _handle_long_running_services(context, _hooks())
 
     assert context.outcome.close_now is False
+
+
+@pytest.mark.unit
+def test_sendtext_does_not_force_ack_wait_without_ack_flag() -> None:
+    """Text sends should leave ACK waiting under the explicit ``--ack`` option."""
+    interface = _interface_double()
+    node = MagicMock()
+    interface.getNode.return_value = node
+    context = _context(interface, sendtext="hello")
+
+    _handle_messaging_actions(context, _hooks())
+
+    assert context.outcome.close_now is True
+    assert context.outcome.wait_for_ack_nak is False
+    interface.sendText.assert_called_once()
+
+
+@pytest.mark.unit
+def test_gpio_read_rejects_invalid_hex_mask() -> None:
+    """Malformed GPIO masks should exit cleanly rather than raising ValueError."""
+    interface = _interface_double()
+    context = _context(interface, gpio_rd="zz")
+    client_factory = MagicMock()
+    hooks = _hooks(remote_hardware_client=client_factory)
+
+    with pytest.raises(SystemExit) as exc_info:
+        _handle_messaging_actions(context, hooks)
+
+    assert exc_info.value.code == 1
+    client_factory.return_value.readGPIOs.assert_not_called()
+
+
+@pytest.mark.unit
+def test_information_get_accumulates_success_across_preferences() -> None:
+    """Any successful preference lookup should retain the completion message."""
+    interface = _interface_double()
+    context = _context(interface, get=[["lora"], ["missing"]])
+    get_pref = MagicMock(side_effect=[True, False])
+    cli_print = MagicMock()
+
+    _handle_information_actions(
+        context,
+        _hooks(get_pref=get_pref, cli_print=cli_print),
+    )
+
+    cli_print.assert_any_call("Completed getting preferences")
+
+
+@pytest.mark.unit
+def test_content_reads_escape_terminal_control_sequences(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Remote text content must not inject terminal control sequences."""
+    interface = _interface_double()
+    node = MagicMock()
+    node.get_canned_message.return_value = "hello\x1b[31mred\x07"
+    node.get_ringtone.return_value = "tone\nnext"
+    interface.getNode.return_value = node
+    context = _context(interface, get_canned_message=True, get_ringtone=True)
+
+    _handle_content_reads(context)
+
+    output = capsys.readouterr().out
+    assert "\x1b" not in output
+    assert "\x07" not in output
+    assert r"\x1b[31m" in output
+    assert r"\x07" in output
+    assert r"tone\nnext" in output
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("raw_mask", ["-1", "10000000000000000"])
+def test_gpio_read_rejects_masks_outside_uint64(raw_mask: str) -> None:
+    """GPIO read masks must fit the uint64 protobuf field before transmission."""
+    interface = _interface_double()
+    client = MagicMock()
+    context = _context(interface, gpio_rd=raw_mask)
+    hooks = _hooks(remote_hardware_client=MagicMock(return_value=client))
+
+    with pytest.raises(SystemExit):
+        _handle_messaging_actions(context, hooks)
+
+    client.readGPIOs.assert_not_called()
+
+
+@pytest.mark.unit
+def test_gpio_write_rejects_bit_index_outside_uint64() -> None:
+    """GPIO write bit indices must not exceed the uint64 hardware mask."""
+    interface = _interface_double()
+    client = MagicMock()
+    context = _context(interface, gpio_wrb=[("64", "1")])
+    hooks = _hooks(remote_hardware_client=MagicMock(return_value=client))
+
+    with pytest.raises(SystemExit):
+        _handle_messaging_actions(context, hooks)
+
+    client.writeGPIOs.assert_not_called()

--- a/meshtastic/tests/test_cli_messaging_service_actions.py
+++ b/meshtastic/tests/test_cli_messaging_service_actions.py
@@ -195,7 +195,7 @@ def test_information_actions_validates_selected_node_fields() -> None:
 
 @pytest.mark.unit
 def test_long_running_services_registers_log_cleanup_and_runs_stress() -> None:
-    """Slog lifetime should be retained explicitly while power stress still closes."""
+    """Register slog failure rollback while power stress still requests closure."""
     interface = _interface_double()
     log_set = MagicMock()
     stress = MagicMock()
@@ -209,7 +209,7 @@ def test_long_running_services_registers_log_cleanup_and_runs_stress() -> None:
 
     stress.run.assert_called_once_with()
     assert context.outcome.close_now is True
-    assert context.outcome.cleanup_callbacks == [log_set.close]
+    assert context.outcome.failure_cleanup_callbacks == [log_set.close]
 
 
 @pytest.mark.unit
@@ -336,7 +336,7 @@ def test_gpio_write_rejects_bit_index_outside_uint64() -> None:
 
 @pytest.mark.unit
 def test_slog_overrides_prior_one_shot_close_request() -> None:
-    """Starting structured logging must keep the connection alive until cleanup."""
+    """Keep the connection alive after structured logging starts successfully."""
     interface = _interface_double()
     log_set = MagicMock()
     context = _context(interface, slog="default")
@@ -346,7 +346,7 @@ def test_slog_overrides_prior_one_shot_close_request() -> None:
     _handle_long_running_services(context, hooks)
 
     assert context.outcome.close_now is False
-    assert context.outcome.cleanup_callbacks == [log_set.close]
+    assert context.outcome.failure_cleanup_callbacks == [log_set.close]
 
 
 @pytest.mark.unit
@@ -570,12 +570,14 @@ def test_tunnel_starts_with_optional_subnet(
     interface.noProto = False
     context = _context(interface, tunnel=True, dest="^all", tunnel_net=subnet)
     context.outcome.close_now = True
-    tunnel_factory = MagicMock()
+    tunnel_instance = MagicMock()
+    tunnel_factory = MagicMock(return_value=tunnel_instance)
     monkeypatch.setattr(tunnel, "Tunnel", tunnel_factory)
 
     actions._start_tunnel(context, _hooks())
 
     assert context.outcome.close_now is False
+    assert context.outcome.failure_cleanup_callbacks == [tunnel_instance.close]
     if subnet is None:
         tunnel_factory.assert_called_once_with(interface)
     else:
@@ -600,3 +602,31 @@ def test_powermon_unavailable_reports_import_error() -> None:
         )
 
     assert "missing meter" in str(cli_exit.call_args)
+
+
+@pytest.mark.unit
+def test_invalid_channel_rejects_traceroute_without_sending() -> None:
+    """Invalid selected channels must fail visibly before traceroute transmission."""
+    interface = _interface_double()
+    interface.localNode = MagicMock()
+    context = _context(interface, traceroute="!00000003")
+    hooks = _hooks(check_channel=MagicMock(return_value=False))
+
+    with pytest.raises(SystemExit):
+        _handle_messaging_actions(context, hooks)
+
+    interface.sendTraceRoute.assert_not_called()
+
+
+@pytest.mark.unit
+def test_missing_channel_selection_defaults_to_primary_channel() -> None:
+    """An omitted channel index must send requests on the primary channel."""
+    interface = _interface_double()
+    interface.localNode = MagicMock()
+    interface.localNode.localConfig.lora.hop_limit = 5
+    context = _context(interface, traceroute="!00000003")
+    hooks = _hooks(get_channel_index=lambda: None)
+
+    _handle_messaging_actions(context, hooks)
+
+    interface.sendTraceRoute.assert_called_once_with("!00000003", 5, channelIndex=0)

--- a/meshtastic/tests/test_cli_messaging_service_actions.py
+++ b/meshtastic/tests/test_cli_messaging_service_actions.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import argparse
-from typing import Any
+from typing import Any, NoReturn
 from unittest.mock import MagicMock, create_autospec
 
 import pytest
@@ -62,7 +62,7 @@ def _context(interface: Any, **arg_overrides: Any) -> CliContext:
     )
 
 
-def _cli_exit(_message: str, return_value: int = 1) -> None:
+def _cli_exit(_message: str, return_value: int = 1) -> NoReturn:
     raise SystemExit(return_value)
 
 

--- a/meshtastic/tests/test_cli_messaging_service_actions.py
+++ b/meshtastic/tests/test_cli_messaging_service_actions.py
@@ -30,6 +30,8 @@ def _args(**overrides: Any) -> argparse.Namespace:
         "gpio_wrb": None,
         "gpio_rd": None,
         "gpio_watch": None,
+        "get_canned_message": False,
+        "get_ringtone": False,
         "info": False,
         "get": None,
         "nodes": False,
@@ -215,6 +217,19 @@ def test_long_running_services_listen_overrides_close_request() -> None:
     _handle_long_running_services(context, _hooks())
 
     assert context.outcome.close_now is False
+
+
+@pytest.mark.unit
+def test_rejected_no_proto_tunnel_preserves_prior_close_request() -> None:
+    """A tunnel that cannot start must not undo an earlier one-shot close request."""
+    interface = _interface_double()
+    interface.noProto = True
+    context = _context(interface, tunnel=True, dest="^all")
+    context.outcome.close_now = True
+
+    _handle_long_running_services(context, _hooks())
+
+    assert context.outcome.close_now is True
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_main_cli_compatibility.py
+++ b/meshtastic/tests/test_main_cli_compatibility.py
@@ -1,0 +1,154 @@
+"""Compatibility and failure-path tests for ``__main__`` CLI adapters."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+import meshtastic.__main__ as main_module
+from meshtastic.protobuf import localonly_pb2
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("wrapper_name", "runtime_name", "kwargs"),
+    [
+        (
+            "_preflight_configure_sections",
+            "_preflight_configure_sections",
+            {"config_sections": {"power": {}}, "module_config_sections": {}},
+        ),
+        (
+            "_refresh_no_disconnect_verify_state",
+            "_refresh_no_disconnect_verify_state",
+            {
+                "verify_channel_url": "url",
+                "verify_config_fields": {"power": {}},
+                "verify_module_config_fields": {},
+            },
+        ),
+    ],
+)
+def test_void_configure_compat_wrappers_delegate(
+    monkeypatch: pytest.MonkeyPatch,
+    wrapper_name: str,
+    runtime_name: str,
+    kwargs: dict[str, Any],
+) -> None:
+    """Retained ``__main__`` seams must delegate to the internal runtime."""
+    delegate = MagicMock()
+    hooks = object()
+    monkeypatch.setattr(main_module.cli_configure_actions, runtime_name, delegate)
+    monkeypatch.setattr(main_module, "_configure_hooks", MagicMock(return_value=hooks))
+    target = object()
+
+    getattr(main_module, wrapper_name)(target, **kwargs)
+
+    if wrapper_name == "_preflight_configure_sections":
+        delegate.assert_called_once_with(hooks, target, **kwargs)
+    else:
+        delegate.assert_called_once_with(target, **kwargs)
+
+
+@pytest.mark.unit
+def test_verify_config_sections_compat_wrapper_delegates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The verification wrapper should preserve verified-fields forwarding."""
+    delegate = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        main_module.cli_configure_actions, "_verify_config_sections", delegate
+    )
+    verified: list[str] = []
+    proto_config = object()
+
+    assert main_module._verify_config_sections(
+        {"power": {}}, proto_config, "Config", verified
+    )
+    delegate.assert_called_once_with(
+        {"power": {}}, proto_config, "Config", verified_fields=verified
+    )
+
+
+@pytest.mark.unit
+def test_verify_post_reconnect_compat_wrapper_injects_url_comparator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The reconnect wrapper should inject the historical URL-comparison seam."""
+    expected = main_module._ConfigureReconnectResult.VERIFIED
+    delegate = MagicMock(return_value=expected)
+    monkeypatch.setattr(
+        main_module.cli_configure_actions, "_verify_post_reconnect_config", delegate
+    )
+    interface = MagicMock()
+
+    result = main_module._verify_post_reconnect_config(
+        interface,
+        "^local",
+        verify_channel_url="url",
+        verify_config_fields={"power": {}},
+        verify_module_config_fields={"telemetry": {}},
+    )
+
+    assert result is expected
+    assert (
+        delegate.call_args.kwargs["verify_channel_url_against_state"]
+        is main_module._verify_channel_url_against_state
+    )
+
+
+@pytest.mark.unit
+def test_nonsecret_preflight_error_preserves_detail() -> None:
+    """Non-secret preference failures should retain useful exception detail."""
+    assert (
+        main_module._format_set_preflight_exception(
+            "lora.region", ValueError("bad region")
+        )
+        == "lora.region: bad region"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("apply_result", [ValueError("apply failed"), False])
+def test_set_apply_divergence_terminates_after_successful_preflight(
+    monkeypatch: pytest.MonkeyPatch, apply_result: Exception | bool
+) -> None:
+    """Post-preflight divergence must abort rather than writing inconsistent state."""
+    node = MagicMock()
+    node.localConfig = localonly_pb2.LocalConfig()
+    node.moduleConfig = localonly_pb2.LocalModuleConfig()
+    interface = MagicMock()
+    interface.getNode.return_value = node
+    field = SimpleNamespace(name="power")
+    config = object()
+    monkeypatch.setattr(
+        main_module,
+        "_normalize_set_entries",
+        MagicMock(return_value=[("power.ls_secs", "1")]),
+    )
+    monkeypatch.setattr(main_module, "_ensure_set_sections_loaded", MagicMock())
+    monkeypatch.setattr(
+        main_module, "_preflight_set_entries", MagicMock(return_value=True)
+    )
+    monkeypatch.setattr(
+        main_module, "_resolve_set_target", MagicMock(return_value=(config, field))
+    )
+    if isinstance(apply_result, Exception):
+        monkeypatch.setattr(main_module, "setPref", MagicMock(side_effect=apply_result))
+    else:
+        monkeypatch.setattr(
+            main_module, "setPref", MagicMock(return_value=apply_result)
+        )
+    cli_exit = MagicMock(side_effect=SystemExit(1))
+    monkeypatch.setattr(main_module, "_cli_exit", cli_exit)
+
+    with pytest.raises(SystemExit):
+        main_module._handle_set_command(
+            interface, SimpleNamespace(dest="^local", set=[["power.ls_secs", "1"]]), {}
+        )
+
+    assert "apply diverged" in str(cli_exit.call_args)
+    node.writeConfig.assert_not_called()

--- a/meshtastic/tests/test_main_cli_compatibility.py
+++ b/meshtastic/tests/test_main_cli_compatibility.py
@@ -14,16 +14,16 @@ from meshtastic.protobuf import localonly_pb2
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
-    ("wrapper_name", "runtime_name", "kwargs"),
+    ("wrapper_name", "forwards_hooks", "kwargs"),
     [
         (
             "_preflight_configure_sections",
-            "_preflight_configure_sections",
+            True,
             {"config_sections": {"power": {}}, "module_config_sections": {}},
         ),
         (
             "_refresh_no_disconnect_verify_state",
-            "_refresh_no_disconnect_verify_state",
+            False,
             {
                 "verify_channel_url": "url",
                 "verify_config_fields": {"power": {}},
@@ -35,19 +35,19 @@ from meshtastic.protobuf import localonly_pb2
 def test_void_configure_compat_wrappers_delegate(
     monkeypatch: pytest.MonkeyPatch,
     wrapper_name: str,
-    runtime_name: str,
+    forwards_hooks: bool,
     kwargs: dict[str, Any],
 ) -> None:
     """Retained ``__main__`` seams must delegate to the internal runtime."""
     delegate = MagicMock()
     hooks = object()
-    monkeypatch.setattr(main_module.cli_configure_actions, runtime_name, delegate)
+    monkeypatch.setattr(main_module.cli_configure_actions, wrapper_name, delegate)
     monkeypatch.setattr(main_module, "_configure_hooks", MagicMock(return_value=hooks))
     target = object()
 
     getattr(main_module, wrapper_name)(target, **kwargs)
 
-    if wrapper_name == "_preflight_configure_sections":
+    if forwards_hooks:
         delegate.assert_called_once_with(hooks, target, **kwargs)
     else:
         delegate.assert_called_once_with(target, **kwargs)

--- a/meshtastic/tests/test_main_cli_compatibility.py
+++ b/meshtastic/tests/test_main_cli_compatibility.py
@@ -152,3 +152,26 @@ def test_set_apply_divergence_terminates_after_successful_preflight(
 
     assert "apply diverged" in str(cli_exit.call_args)
     node.writeConfig.assert_not_called()
+
+
+@pytest.mark.unit
+def test_ota_compat_wrapper_delegates_to_private_device_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The retained ``__main__`` OTA seam must delegate with historical hooks."""
+    delegate = MagicMock()
+    monkeypatch.setattr(main_module.cli_device_actions, "_handle_ota_update", delegate)
+    interface = MagicMock()
+    args = SimpleNamespace(ota_update="firmware.bin", dest="^local")
+    get_node_kwargs = {"timeout": 10}
+
+    main_module._handle_ota_update(interface, args, get_node_kwargs)
+
+    delegate.assert_called_once_with(
+        interface,
+        args,
+        get_node_kwargs,
+        cli_exit=main_module._cli_exit,
+        cli_print=main_module._cli_print,
+        is_local_destination=main_module._is_local_destination,
+    )

--- a/meshtastic/tests/test_main_cli_core.py
+++ b/meshtastic/tests/test_main_cli_core.py
@@ -238,6 +238,42 @@ def test_main_list_fields_includes_all_descriptor_fields(
 
 
 @pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_main_rejects_repeated_configure_before_connecting(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Repeated configure documents must fail instead of silently ignoring one."""
+    first = tmp_path / "first.yaml"
+    second = tmp_path / "second.yaml"
+    first.write_text("owner: first\n", encoding="utf-8")
+    second.write_text("owner: second\n", encoding="utf-8")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshtastic",
+            "--configure",
+            str(first),
+            "--configure",
+            str(second),
+        ],
+    )
+    serial_factory = MagicMock()
+
+    with (
+        patch("meshtastic.serial_interface.SerialInterface", serial_factory),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        main()
+
+    assert exc_info.value.code == 2
+    assert "--configure may be specified only once" in capsys.readouterr().err
+    serial_factory.assert_not_called()
+
+
+@pytest.mark.unit
 def test_support_info_alias_delegates_to_supportInfo(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/meshtastic/tests/test_main_commands.py
+++ b/meshtastic/tests/test_main_commands.py
@@ -28,7 +28,6 @@ from ..node import Node
 from ..protobuf import localonly_pb2
 from ..protobuf.channel_pb2 import Channel  # pylint: disable=E0611
 from ..serial_interface import SerialInterface
-
 from ._main_legacy_support import (
     _build_configure_interface,
     _mock_send_text,
@@ -51,6 +50,18 @@ def _mock_newer_version_check(monkeypatch: pytest.MonkeyPatch) -> None:
         Pytest monkeypatching fixture.
     """
     monkeypatch.setattr("meshtastic.util.check_if_newer_version", lambda: None)
+
+
+@pytest.fixture
+def mocked_serial_node() -> tuple[Any, Any]:
+    """Return an autospecced serial interface and its selected-node double."""
+    mocked_node = create_autospec(Node, instance=True)
+    iface = create_autospec(SerialInterface, instance=True)
+    iface.devPath = "/dev/mock"
+    iface.__enter__.return_value = iface
+    iface.__exit__.return_value = None
+    iface.getNode.return_value = mocked_node
+    return iface, mocked_node
 
 
 @pytest.mark.unit
@@ -659,17 +670,13 @@ def test_main_set_fixed_position(
     expected_message: str,
     expected_call: tuple[float, float, int],
     capsys: pytest.CaptureFixture[str],
+    mocked_serial_node: tuple[Any, Any],
 ) -> None:
     """Each fixed-position flag should forward the normalized coordinates exactly."""
     sys.argv = ["", flag, value]
     mt_config.args = sys.argv  # type: ignore[assignment]
 
-    mocked_node = create_autospec(Node, instance=True)
-    iface = create_autospec(SerialInterface, instance=True)
-    iface.devPath = "/dev/mock"
-    iface.__enter__.return_value = iface
-    iface.__exit__.return_value = None
-    iface.getNode.return_value = mocked_node
+    iface, mocked_node = mocked_serial_node
 
     with patch("meshtastic.serial_interface.SerialInterface", return_value=iface) as mo:
         main()
@@ -1226,16 +1233,12 @@ def test_main_rejects_out_of_range_fixed_coordinates(
     value: str,
     expected: str,
     capsys: pytest.CaptureFixture[str],
+    mocked_serial_node: tuple[Any, Any],
 ) -> None:
     """Direct fixed-position flags should reject impossible coordinates cleanly."""
     sys.argv = ["", flag, value]
     mt_config.args = sys.argv  # type: ignore[assignment]
-    mocked_node = create_autospec(Node, instance=True)
-    iface = create_autospec(SerialInterface, instance=True)
-    iface.devPath = "/dev/mock"
-    iface.__enter__.return_value = iface
-    iface.__exit__.return_value = None
-    iface.getNode.return_value = mocked_node
+    iface, mocked_node = mocked_serial_node
 
     with (
         patch("meshtastic.serial_interface.SerialInterface", return_value=iface),
@@ -1250,16 +1253,13 @@ def test_main_rejects_out_of_range_fixed_coordinates(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-def test_main_integer_latitude_preserves_scaled_coordinate_compatibility() -> None:
+def test_main_integer_latitude_preserves_scaled_coordinate_compatibility(
+    mocked_serial_node: tuple[Any, Any],
+) -> None:
     """Integer CLI latitude values remain historical 1e7-scaled coordinates."""
     sys.argv = ["", "--setlat", "375000000"]
     mt_config.args = sys.argv  # type: ignore[assignment]
-    mocked_node = create_autospec(Node, instance=True)
-    iface = create_autospec(SerialInterface, instance=True)
-    iface.devPath = "/dev/mock"
-    iface.__enter__.return_value = iface
-    iface.__exit__.return_value = None
-    iface.getNode.return_value = mocked_node
+    iface, mocked_node = mocked_serial_node
 
     with patch("meshtastic.serial_interface.SerialInterface", return_value=iface):
         main()
@@ -1271,17 +1271,14 @@ def test_main_integer_latitude_preserves_scaled_coordinate_compatibility() -> No
 @pytest.mark.usefixtures("reset_mt_config")
 @pytest.mark.parametrize("raw_altitude", [str(1 << 31), str(-(1 << 31) - 1)])
 def test_main_rejects_altitude_outside_position_int32(
-    raw_altitude: str, capsys: pytest.CaptureFixture[str]
+    raw_altitude: str,
+    capsys: pytest.CaptureFixture[str],
+    mocked_serial_node: tuple[Any, Any],
 ) -> None:
     """CLI altitude should fail cleanly outside either protobuf int32 bound."""
     sys.argv = ["", "--setalt", raw_altitude]
     mt_config.args = sys.argv  # type: ignore[assignment]
-    mocked_node = create_autospec(Node, instance=True)
-    iface = create_autospec(SerialInterface, instance=True)
-    iface.devPath = "/dev/mock"
-    iface.__enter__.return_value = iface
-    iface.__exit__.return_value = None
-    iface.getNode.return_value = mocked_node
+    iface, mocked_node = mocked_serial_node
 
     with (
         patch("meshtastic.serial_interface.SerialInterface", return_value=iface),

--- a/meshtastic/tests/test_main_commands.py
+++ b/meshtastic/tests/test_main_commands.py
@@ -40,6 +40,7 @@ from ._main_legacy_support import (
 
 MAIN_LOCAL_ADDR: str = cast(str, main_module.__dict__["LOCAL_ADDR"])
 
+
 @pytest.fixture(autouse=True)
 def _mock_newer_version_check(monkeypatch: pytest.MonkeyPatch) -> None:
     """Prevent external network calls during unit tests in this module.
@@ -50,6 +51,7 @@ def _mock_newer_version_check(monkeypatch: pytest.MonkeyPatch) -> None:
         Pytest monkeypatching fixture.
     """
     monkeypatch.setattr("meshtastic.util.check_if_newer_version", lambda: None)
+
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
@@ -641,6 +643,13 @@ def test_main_removeposition(capsys: pytest.CaptureFixture[str]) -> None:
     [
         ("--setlat", "37.5", "Fixing latitude", (37.5, 0.0, 0)),
         ("--setlon", "-122.1", "Fixing longitude", (0.0, -122.1, 0)),
+        ("--setlat", "900000000", "Fixing latitude", (900000000, 0.0, 0)),
+        (
+            "--setlon",
+            "-1800000000",
+            "Fixing longitude",
+            (0.0, -1800000000, 0),
+        ),
         ("--setalt", "51", "Fixing altitude", (0.0, 0.0, 51)),
     ],
 )
@@ -1198,8 +1207,18 @@ def test_main_configure_skips_unknown_config_field(
 @pytest.mark.parametrize(
     ("flag", "value", "expected"),
     [
-        ("--setlat", "91", "latitude must be between -90 and 90"),
-        ("--setlon", "181", "longitude must be between -180 and 180"),
+        ("--setlat", "91.0", "latitude must be between -90 and 90"),
+        ("--setlon", "181.0", "longitude must be between -180 and 180"),
+        (
+            "--setlat",
+            "900000001",
+            "latitude premultiplied integer must be between",
+        ),
+        (
+            "--setlon",
+            "1800000001",
+            "longitude premultiplied integer must be between",
+        ),
     ],
 )
 def test_main_rejects_out_of_range_fixed_coordinates(
@@ -1231,9 +1250,9 @@ def test_main_rejects_out_of_range_fixed_coordinates(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-def test_main_integer_latitude_is_interpreted_as_degrees() -> None:
-    """An integer-looking CLI latitude must not become raw protobuf coordinate units."""
-    sys.argv = ["", "--setlat", "37"]
+def test_main_integer_latitude_preserves_scaled_coordinate_compatibility() -> None:
+    """Integer CLI latitude values remain historical 1e7-scaled coordinates."""
+    sys.argv = ["", "--setlat", "375000000"]
     mt_config.args = sys.argv  # type: ignore[assignment]
     mocked_node = create_autospec(Node, instance=True)
     iface = create_autospec(SerialInterface, instance=True)
@@ -1245,14 +1264,17 @@ def test_main_integer_latitude_is_interpreted_as_degrees() -> None:
     with patch("meshtastic.serial_interface.SerialInterface", return_value=iface):
         main()
 
-    mocked_node.setFixedPosition.assert_called_once_with(37.0, 0.0, 0)
+    mocked_node.setFixedPosition.assert_called_once_with(375000000, 0.0, 0)
 
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-def test_main_rejects_altitude_outside_position_int32(capsys: pytest.CaptureFixture[str]) -> None:
-    """CLI altitude should fail cleanly before overflowing the protobuf int32 field."""
-    sys.argv = ["", "--setalt", str(1 << 31)]
+@pytest.mark.parametrize("raw_altitude", [str(1 << 31), str(-(1 << 31) - 1)])
+def test_main_rejects_altitude_outside_position_int32(
+    raw_altitude: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """CLI altitude should fail cleanly outside either protobuf int32 bound."""
+    sys.argv = ["", "--setalt", raw_altitude]
     mt_config.args = sys.argv  # type: ignore[assignment]
     mocked_node = create_autospec(Node, instance=True)
     iface = create_autospec(SerialInterface, instance=True)

--- a/meshtastic/tests/test_main_commands.py
+++ b/meshtastic/tests/test_main_commands.py
@@ -1194,6 +1194,7 @@ def test_main_configure_skips_unknown_config_field(
 
 
 @pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
 @pytest.mark.parametrize(
     ("flag", "value", "expected"),
     [

--- a/meshtastic/tests/test_main_commands.py
+++ b/meshtastic/tests/test_main_commands.py
@@ -1191,3 +1191,80 @@ def test_main_configure_skips_unknown_config_field(
     assert "Skipping 1 unknown field(s) from bluetooth" in caplog.text
     target_node.writeConfig.assert_called_once_with("bluetooth")
     target_node.commitSettingsTransaction.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("flag", "value", "expected"),
+    [
+        ("--setlat", "91", "latitude must be between -90 and 90"),
+        ("--setlon", "181", "longitude must be between -180 and 180"),
+    ],
+)
+def test_main_rejects_out_of_range_fixed_coordinates(
+    flag: str,
+    value: str,
+    expected: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Direct fixed-position flags should reject impossible coordinates cleanly."""
+    sys.argv = ["", flag, value]
+    mt_config.args = sys.argv  # type: ignore[assignment]
+    mocked_node = create_autospec(Node, instance=True)
+    iface = create_autospec(SerialInterface, instance=True)
+    iface.devPath = "/dev/mock"
+    iface.__enter__.return_value = iface
+    iface.__exit__.return_value = None
+    iface.getNode.return_value = mocked_node
+
+    with (
+        patch("meshtastic.serial_interface.SerialInterface", return_value=iface),
+        pytest.raises(SystemExit),
+    ):
+        main()
+
+    captured = capsys.readouterr()
+    assert expected in captured.err
+    mocked_node.setFixedPosition.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_main_integer_latitude_is_interpreted_as_degrees() -> None:
+    """An integer-looking CLI latitude must not become raw protobuf coordinate units."""
+    sys.argv = ["", "--setlat", "37"]
+    mt_config.args = sys.argv  # type: ignore[assignment]
+    mocked_node = create_autospec(Node, instance=True)
+    iface = create_autospec(SerialInterface, instance=True)
+    iface.devPath = "/dev/mock"
+    iface.__enter__.return_value = iface
+    iface.__exit__.return_value = None
+    iface.getNode.return_value = mocked_node
+
+    with patch("meshtastic.serial_interface.SerialInterface", return_value=iface):
+        main()
+
+    mocked_node.setFixedPosition.assert_called_once_with(37.0, 0.0, 0)
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_main_rejects_altitude_outside_position_int32(capsys: pytest.CaptureFixture[str]) -> None:
+    """CLI altitude should fail cleanly before overflowing the protobuf int32 field."""
+    sys.argv = ["", "--setalt", str(1 << 31)]
+    mt_config.args = sys.argv  # type: ignore[assignment]
+    mocked_node = create_autospec(Node, instance=True)
+    iface = create_autospec(SerialInterface, instance=True)
+    iface.devPath = "/dev/mock"
+    iface.__enter__.return_value = iface
+    iface.__exit__.return_value = None
+    iface.getNode.return_value = mocked_node
+
+    with (
+        patch("meshtastic.serial_interface.SerialInterface", return_value=iface),
+        pytest.raises(SystemExit),
+    ):
+        main()
+
+    assert "signed 32-bit position field" in capsys.readouterr().err
+    mocked_node.setFixedPosition.assert_not_called()

--- a/meshtastic/tests/test_main_configure_channels.py
+++ b/meshtastic/tests/test_main_configure_channels.py
@@ -1948,6 +1948,18 @@ def test_configure_commit_failure_is_not_retried(
 
 
 @pytest.mark.unit
+def test_legacy_mapping_validation_wrapper_delegates_to_renamed_helper() -> None:
+    """The retained __main__ compatibility seam must call the renamed validator."""
+    sections = {"audio": {}}
+
+    result = main_module._validate_non_empty_mapping_sections(
+        top_level_key="module_config", section_mapping=sections
+    )
+
+    assert result == sections
+
+
+@pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_configure_reconnect_verifies_normalized_channel_url(
     tmp_path: Path,
@@ -1968,6 +1980,7 @@ def test_configure_reconnect_verifies_normalized_channel_url(
     iface, target_node = _build_configure_interface()
     args = SimpleNamespace(configure=[str(config_path)], dest=MAIN_LOCAL_ADDR)
     reconnect = MagicMock(return_value=main_module._ConfigureReconnectResult.VERIFIED)
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
     monkeypatch.setattr(main_module, "_post_seturl_stability_check", lambda *_a, **_k: True)
     monkeypatch.setattr(main_module, "_post_configure_reconnect_and_verify", reconnect)
 

--- a/meshtastic/tests/test_main_configure_channels.py
+++ b/meshtastic/tests/test_main_configure_channels.py
@@ -1872,7 +1872,7 @@ def test_configure_rejects_out_of_range_location_before_mutation(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-def test_remote_channel_url_plus_config_rejected_before_phase1_write(
+def test_remote_channel_url_with_config_rejected_before_direct_write(
     tmp_path: Path,
 ) -> None:
     """Remote mixed setURL/config operations must fail before changing the channel URL."""
@@ -1902,7 +1902,7 @@ def test_remote_channel_url_plus_config_rejected_before_phase1_write(
 def test_configure_write_failure_best_effort_closes_settings_transaction(
     tmp_path: Path,
 ) -> None:
-    """A Phase-2 write failure should not silently leave the edit transaction open."""
+    """Ensure write failure does not silently leave the edit transaction open."""
     config_path = tmp_path / "write-failure.yaml"
     config_path.write_text(
         yaml.safe_dump({"config": {"bluetooth": {"enabled": True}}}),
@@ -1998,11 +1998,11 @@ def test_configure_reconnect_verifies_normalized_channel_url(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-def test_configure_prevalidates_all_phase1_values_before_any_mutation(
+def test_configure_prevalidates_all_direct_values_before_any_mutation(
     tmp_path: Path,
 ) -> None:
-    """A later malformed Phase-1 value must not leave earlier direct writes applied."""
-    config_file = tmp_path / "phase1-invalid-location.yaml"
+    """Reject malformed direct values before applying any direct writes."""
+    config_file = tmp_path / "invalid-direct-location.yaml"
     config_file.write_text(
         "owner: valid-owner\nlocation:\n  lat: 91\n  lon: 1\n",
         encoding="utf-8",

--- a/meshtastic/tests/test_main_configure_channels.py
+++ b/meshtastic/tests/test_main_configure_channels.py
@@ -48,6 +48,7 @@ from ._main_legacy_support import (
 SDS_DISABLED_SENTINEL: int = 4_294_967_295
 MAIN_LOCAL_ADDR: str = cast(str, main_module.__dict__["LOCAL_ADDR"])
 
+
 @pytest.fixture(autouse=True)
 def _mock_newer_version_check(monkeypatch: pytest.MonkeyPatch) -> None:
     """Prevent external network calls during unit tests in this module.
@@ -58,6 +59,7 @@ def _mock_newer_version_check(monkeypatch: pytest.MonkeyPatch) -> None:
         Pytest monkeypatching fixture.
     """
     monkeypatch.setattr("meshtastic.util.check_if_newer_version", lambda: None)
+
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
@@ -1381,12 +1383,6 @@ def test_export_config_sets_missing_true_default_flags_false() -> None:
     assert module_config["mqtt"]["encryptionEnabled"] is False
 
 
-
-
-
-
-
-
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_export_config_configure_round_trip_security_keys(
@@ -1948,14 +1944,23 @@ def test_configure_commit_failure_is_not_retried(
 
 
 @pytest.mark.unit
-def test_legacy_mapping_validation_wrapper_delegates_to_renamed_helper() -> None:
+def test_legacy_mapping_validation_wrapper_delegates_to_renamed_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The retained __main__ compatibility seam must call the renamed validator."""
-    sections = {"audio": {}}
+    sections: dict[str, dict[str, Any]] = {"audio": {}}
+    delegate = MagicMock(return_value=sections)
+    monkeypatch.setattr(
+        "meshtastic.cli.configure_actions._validate_mapping_sections", delegate
+    )
 
     result = main_module._validate_non_empty_mapping_sections(
         top_level_key="module_config", section_mapping=sections
     )
 
+    delegate.assert_called_once()
+    assert delegate.call_args.kwargs["top_level_key"] == "module_config"
+    assert delegate.call_args.kwargs["section_mapping"] == sections
     assert result == sections
 
 
@@ -1981,7 +1986,9 @@ def test_configure_reconnect_verifies_normalized_channel_url(
     args = SimpleNamespace(configure=[str(config_path)], dest=MAIN_LOCAL_ADDR)
     reconnect = MagicMock(return_value=main_module._ConfigureReconnectResult.VERIFIED)
     monkeypatch.setattr("time.sleep", lambda _seconds: None)
-    monkeypatch.setattr(main_module, "_post_seturl_stability_check", lambda *_a, **_k: True)
+    monkeypatch.setattr(
+        main_module, "_post_seturl_stability_check", lambda *_a, **_k: True
+    )
     monkeypatch.setattr(main_module, "_post_configure_reconnect_and_verify", reconnect)
 
     main_module._handle_configure_command(iface, args, {})
@@ -2025,6 +2032,10 @@ def test_configure_prevalidates_all_phase1_values_before_any_mutation(
             {"lat": 0, "lon": 0, "alt": 1 << 31},
             "location.alt must fit the signed 32-bit position field",
         ),
+        (
+            {"lat": 0, "lon": 0, "alt": -(1 << 31) - 1},
+            "location.alt must fit the signed 32-bit position field",
+        ),
     ],
 )
 def test_configure_rejects_invalid_location_wire_values_before_mutation(
@@ -2045,3 +2056,31 @@ def test_configure_rejects_invalid_location_wire_values_before_mutation(
     _out, err = capsys.readouterr()
     assert expected_fragment in err
     target_node.setFixedPosition.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+@pytest.mark.parametrize(
+    ("lat", "lon"),
+    [(90.0, 180.0), (-90.0, -180.0)],
+)
+def test_configure_accepts_exact_location_boundaries(
+    lat: float,
+    lon: float,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inclusive geographic boundaries must remain valid configure inputs."""
+    config_path = tmp_path / "boundary-location.yaml"
+    config_path.write_text(
+        yaml.safe_dump({"location": {"lat": lat, "lon": lon}}), encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        "meshtastic.cli.configure_actions.time.sleep", lambda _seconds: None
+    )
+    iface, target_node = _build_configure_interface()
+    args = SimpleNamespace(configure=[str(config_path)], dest=MAIN_LOCAL_ADDR)
+
+    main_module._handle_configure_command(iface, args, {})
+
+    target_node.setFixedPosition.assert_called_once_with(lat, lon, 0)

--- a/meshtastic/tests/test_main_configure_channels.py
+++ b/meshtastic/tests/test_main_configure_channels.py
@@ -34,7 +34,6 @@ from ..node import Node
 from ..protobuf import config_pb2, localonly_pb2
 from ..protobuf.channel_pb2 import Channel  # pylint: disable=E0611
 from ..serial_interface import SerialInterface
-
 from ._main_legacy_support import (
     _build_configure_interface,
     _build_export_interface,
@@ -1970,7 +1969,7 @@ def test_configure_reconnect_verifies_normalized_channel_url(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Phase-3 verification should compare the same stripped URL written in Phase 1."""
+    """Post-reconnect verification should compare the stripped URL that was written."""
     channel_url = "https://meshtastic.org/e/#normalized"
     config_path = tmp_path / "normalized-url.yaml"
     config_path.write_text(

--- a/meshtastic/tests/test_main_configure_channels.py
+++ b/meshtastic/tests/test_main_configure_channels.py
@@ -434,7 +434,7 @@ def test_main_configure_rejects_invalid_subsection_payloads(
 
     _, err = capsys.readouterr()
     assert f"{top_key}.{section_name}" in err
-    assert "non-empty mapping" in err
+    assert "must be a mapping" in err
     assert excinfo.value.code == 1
     target_node.beginSettingsTransaction.assert_not_called()
 
@@ -1809,3 +1809,226 @@ def test_main_gpio_rd_no_gpio_channel(capsys: pytest.CaptureFixture[str]) -> Non
         # Error messages go to stderr, stdout contains "Connected to radio"
         assert re.search(r"No channel named 'gpio'", err)
         assert "Connected to radio" in out
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_configure_missing_file_exits_cleanly(tmp_path: Path) -> None:
+    """Unreadable configure paths should use the CLI error path without traceback."""
+    iface, _target_node = _build_configure_interface()
+    args = SimpleNamespace(
+        configure=[str(tmp_path / "missing.yaml")],
+        dest=MAIN_LOCAL_ADDR,
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        main_module._handle_configure_command(iface, args, {})
+
+    assert exc_info.value.code == 1
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+@pytest.mark.parametrize("owner_key", ["owner", "owner_short", "ownerShort"])
+def test_configure_rejects_null_owner_values_before_mutation(
+    owner_key: str,
+    tmp_path: Path,
+) -> None:
+    """YAML null owner values must never be written as the literal string 'None'."""
+    config_path = tmp_path / f"null-{owner_key}.yaml"
+    config_path.write_text(yaml.safe_dump({owner_key: None}), encoding="utf-8")
+    iface, target_node = _build_configure_interface()
+    args = SimpleNamespace(configure=[str(config_path)], dest=MAIN_LOCAL_ADDR)
+
+    with pytest.raises(SystemExit):
+        main_module._handle_configure_command(iface, args, {})
+
+    target_node.setOwner.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+@pytest.mark.parametrize(
+    ("location", "expected_fragment"),
+    [
+        ({"lat": 91, "lon": 0}, "location.lat"),
+        ({"lat": 0, "lon": -181}, "location.lon"),
+    ],
+)
+def test_configure_rejects_out_of_range_location_before_mutation(
+    location: dict[str, int],
+    expected_fragment: str,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Configure location must enforce geographic latitude/longitude bounds."""
+    config_path = tmp_path / "location.yaml"
+    config_path.write_text(yaml.safe_dump({"location": location}), encoding="utf-8")
+    iface, target_node = _build_configure_interface()
+    args = SimpleNamespace(configure=[str(config_path)], dest=MAIN_LOCAL_ADDR)
+
+    with pytest.raises(SystemExit):
+        main_module._handle_configure_command(iface, args, {})
+
+    _out, err = capsys.readouterr()
+    assert expected_fragment in err
+    target_node.setFixedPosition.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_remote_channel_url_plus_config_rejected_before_phase1_write(
+    tmp_path: Path,
+) -> None:
+    """Remote mixed setURL/config operations must fail before changing the channel URL."""
+    config_path = tmp_path / "remote-mixed.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "channel_url": "https://meshtastic.org/e/#remote-key",
+                "config": {"bluetooth": {"enabled": True}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    iface, target_node = _build_configure_interface()
+    args = SimpleNamespace(configure=[str(config_path)], dest="!87654321")
+
+    with pytest.raises(SystemExit):
+        main_module._handle_configure_command(iface, args, {})
+
+    target_node.setURL.assert_not_called()
+    target_node.setOwner.assert_not_called()
+    target_node.beginSettingsTransaction.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_configure_write_failure_best_effort_closes_settings_transaction(
+    tmp_path: Path,
+) -> None:
+    """A Phase-2 write failure should not silently leave the edit transaction open."""
+    config_path = tmp_path / "write-failure.yaml"
+    config_path.write_text(
+        yaml.safe_dump({"config": {"bluetooth": {"enabled": True}}}),
+        encoding="utf-8",
+    )
+    iface, target_node = _build_configure_interface()
+    target_node.writeConfig.side_effect = RuntimeError("write failed")
+    args = SimpleNamespace(configure=[str(config_path)], dest=MAIN_LOCAL_ADDR)
+
+    with pytest.raises(RuntimeError, match="write failed"):
+        main_module._handle_configure_command(iface, args, {})
+
+    target_node.beginSettingsTransaction.assert_called_once_with()
+    target_node.commitSettingsTransaction.assert_called_once_with()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_configure_commit_failure_is_not_retried(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An uncertain commit failure must propagate without sending a second commit."""
+    config_path = tmp_path / "commit-failure.yaml"
+    config_path.write_text(
+        yaml.safe_dump({"config": {"bluetooth": {"enabled": True}}}),
+        encoding="utf-8",
+    )
+    iface, target_node = _build_configure_interface()
+    target_node.commitSettingsTransaction.side_effect = RuntimeError("commit failed")
+    args = SimpleNamespace(configure=[str(config_path)], dest=MAIN_LOCAL_ADDR)
+
+    with pytest.raises(RuntimeError, match="commit failed"):
+        main_module._handle_configure_command(iface, args, {})
+
+    target_node.commitSettingsTransaction.assert_called_once_with()
+    assert "transaction state is unknown" in capsys.readouterr().out
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_configure_reconnect_verifies_normalized_channel_url(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Phase-3 verification should compare the same stripped URL written in Phase 1."""
+    channel_url = "https://meshtastic.org/e/#normalized"
+    config_path = tmp_path / "normalized-url.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "channel_url": f"  {channel_url}  ",
+                "config": {"bluetooth": {"enabled": True}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    iface, target_node = _build_configure_interface()
+    args = SimpleNamespace(configure=[str(config_path)], dest=MAIN_LOCAL_ADDR)
+    reconnect = MagicMock(return_value=main_module._ConfigureReconnectResult.VERIFIED)
+    monkeypatch.setattr(main_module, "_post_seturl_stability_check", lambda *_a, **_k: True)
+    monkeypatch.setattr(main_module, "_post_configure_reconnect_and_verify", reconnect)
+
+    main_module._handle_configure_command(iface, args, {})
+
+    target_node.setURL.assert_called_once_with(channel_url)
+    assert reconnect.call_args.kwargs["verify_channel_url"] == channel_url
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+def test_configure_prevalidates_all_phase1_values_before_any_mutation(
+    tmp_path: Path,
+) -> None:
+    """A later malformed Phase-1 value must not leave earlier direct writes applied."""
+    config_file = tmp_path / "phase1-invalid-location.yaml"
+    config_file.write_text(
+        "owner: valid-owner\nlocation:\n  lat: 91\n  lon: 1\n",
+        encoding="utf-8",
+    )
+    iface, node = _build_configure_interface()
+    args = SimpleNamespace(configure=[str(config_file)], dest=MAIN_LOCAL_ADDR)
+
+    with pytest.raises(SystemExit):
+        main_module._handle_configure_command(iface, args, {})
+
+    node.setOwner.assert_not_called()
+    node.setFixedPosition.assert_not_called()
+    node.setURL.assert_not_called()
+    node.beginSettingsTransaction.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("reset_mt_config")
+@pytest.mark.parametrize(
+    ("location", "expected_fragment"),
+    [
+        ({"lat": True, "lon": 0}, "location.lat must be a number"),
+        ({"lat": 0, "lon": False}, "location.lon must be a number"),
+        ({"lat": 0, "lon": 0, "alt": True}, "location.alt must be an integer"),
+        (
+            {"lat": 0, "lon": 0, "alt": 1 << 31},
+            "location.alt must fit the signed 32-bit position field",
+        ),
+    ],
+)
+def test_configure_rejects_invalid_location_wire_values_before_mutation(
+    location: dict[str, object],
+    expected_fragment: str,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Location values must fit their semantic and protobuf wire domains."""
+    config_path = tmp_path / "invalid-location-wire.yaml"
+    config_path.write_text(yaml.safe_dump({"location": location}), encoding="utf-8")
+    iface, target_node = _build_configure_interface()
+    args = SimpleNamespace(configure=[str(config_path)], dest=MAIN_LOCAL_ADDR)
+
+    with pytest.raises(SystemExit):
+        main_module._handle_configure_command(iface, args, {})
+
+    _out, err = capsys.readouterr()
+    assert expected_fragment in err
+    target_node.setFixedPosition.assert_not_called()

--- a/meshtastic/tests/test_main_configure_reconnect.py
+++ b/meshtastic/tests/test_main_configure_reconnect.py
@@ -76,11 +76,11 @@ def test_main_configure_post_reconnect_verifies_matching_config_values(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-def test_main_configure_phase1_direct_write_order(
+def test_main_configure_preserves_direct_write_order(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    config_path = tmp_path / "phase1_order.yaml"
+    config_path = tmp_path / "direct-write-order.yaml"
     config_path.write_text(
         yaml.safe_dump(
             {
@@ -98,7 +98,7 @@ def test_main_configure_phase1_direct_write_order(
     _patch_fast_monotonic(monkeypatch)
     _run_main_configure_file(config_path, iface, monkeypatch)
 
-    phase1_methods = (
+    direct_write_methods = (
         "setOwner",
         "setFixedPosition",
         "set_canned_message",
@@ -106,7 +106,7 @@ def test_main_configure_phase1_direct_write_order(
         "setURL",
     )
     method_names = [c[0] for c in target_node.method_calls]
-    relevant = [m for m in method_names if m in phase1_methods]
+    relevant = [m for m in method_names if m in direct_write_methods]
     expected = [
         "setOwner",
         "setOwner",
@@ -120,7 +120,7 @@ def test_main_configure_phase1_direct_write_order(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-def test_main_configure_channel_url_is_terminal_phase1_write(
+def test_main_configure_channel_url_is_last_direct_write(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -155,7 +155,7 @@ def test_main_configure_channel_url_is_terminal_phase1_write(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-def test_main_configure_seturl_unstable_aborts_before_phase2(
+def test_main_configure_seturl_unstable_aborts_before_transaction(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -192,7 +192,7 @@ def test_main_configure_seturl_unstable_aborts_before_phase2(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-def test_main_configure_seturl_stable_proceeds_to_phase2(
+def test_main_configure_seturl_stable_proceeds_to_transaction(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -249,7 +249,7 @@ def test_main_configure_channel_url_only_reports_possible_reconnect(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    config_path = tmp_path / "phase1_channel_url_only.yaml"
+    config_path = tmp_path / "channel-url-only.yaml"
     config_path.write_text(
         yaml.safe_dump({"channel_url": "https://meshtastic.org/e/#CgcSAQE6AggN"}),
         encoding="utf-8",
@@ -257,7 +257,7 @@ def test_main_configure_channel_url_only_reports_possible_reconnect(
     iface, target_node = _build_configure_interface()
     _run_main_configure_file(config_path, iface, monkeypatch)
     out, _ = capsys.readouterr()
-    assert "Phase 1: Applying direct configuration" in out
+    assert "Applying direct configuration values" in out
     assert (
         "Configuration applied. Channel URL updates may still trigger reconnect/reboot."
         in out
@@ -273,7 +273,7 @@ def test_main_configure_channel_url_skip_when_already_matching(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    config_path = tmp_path / "phase1_channel_url_skip.yaml"
+    config_path = tmp_path / "matching-channel-url.yaml"
     config_path.write_text(
         yaml.safe_dump({"channel_url": "https://meshtastic.org/e/#CgcSAQE6AggN"}),
         encoding="utf-8",

--- a/meshtastic/tests/test_main_configure_reconnect.py
+++ b/meshtastic/tests/test_main_configure_reconnect.py
@@ -30,9 +30,6 @@ from ..protobuf import config_pb2, localonly_pb2
 # from ..config_pb2 import Config
 
 
-
-
-
 @pytest.fixture(autouse=True)
 def _mock_newer_version_check(monkeypatch: pytest.MonkeyPatch) -> None:
     """Prevent external network calls during unit tests in this module.
@@ -47,12 +44,12 @@ def _mock_newer_version_check(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-def test_main_configure_phase3_verified_with_matching_config_values(
+def test_main_configure_post_reconnect_verifies_matching_config_values(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    config_path = tmp_path / "phase3_verified.yaml"
+    config_path = tmp_path / "post_reconnect_verified.yaml"
     config_path.write_text(
         yaml.safe_dump({"config": {"power": {"ls_secs": 222}}}),
         encoding="utf-8",
@@ -74,7 +71,7 @@ def test_main_configure_phase3_verified_with_matching_config_values(
     _patch_fast_monotonic(monkeypatch)
     _run_main_configure_file(config_path, iface, monkeypatch)
     out, _ = capsys.readouterr()
-    assert "All settings verified" in out
+    assert "all requested settings were verified" in out
 
 
 @pytest.mark.unit
@@ -229,12 +226,12 @@ def test_main_configure_seturl_stable_proceeds_to_phase2(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-def test_main_configure_phase3_no_reconnect_needed(
+def test_main_configure_without_transaction_needs_no_reconnect(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    config_path = tmp_path / "phase3_no_reboot.yaml"
+    config_path = tmp_path / "no_reconnect_needed.yaml"
     config_path.write_text(
         yaml.safe_dump({"owner": "TestUser"}),
         encoding="utf-8",
@@ -295,14 +292,14 @@ def test_main_configure_channel_url_skip_when_already_matching(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-def test_main_configure_phase3_channel_url_verified(
+def test_main_configure_post_reconnect_verifies_channel_url(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     from ..protobuf import apponly_pb2, channel_pb2
 
-    config_path = tmp_path / "phase3_channel_url.yaml"
+    config_path = tmp_path / "post_reconnect_channel_url.yaml"
     channel_settings = channel_pb2.ChannelSettings()
     channel_settings.psk = b"\x01"
     channel_settings.name = "test"
@@ -358,7 +355,7 @@ def test_main_configure_phase3_channel_url_verified(
     _patch_fast_monotonic(monkeypatch)
     _run_main_configure_file(config_path, iface, monkeypatch)
     out, _ = capsys.readouterr()
-    assert "Could not fully verify" in out
+    assert "not all requested settings could be verified" in out
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_main_factory_reset.py
+++ b/meshtastic/tests/test_main_factory_reset.py
@@ -492,3 +492,22 @@ def test_post_factory_reset_ready_probe_logs_final_close_failure(
         main_module._post_factory_reset_ready_probe(cast(Any, iface))
 
     assert "Factory reset: final serial close failed" in caplog.text
+
+
+@pytest.mark.unit
+def test_local_factory_reset_rejects_invalid_timeout_before_send() -> None:
+    """Invalid reset timeout input must fail before the destructive request is sent."""
+    iface = SimpleNamespace(_acknowledgment=Acknowledgment())
+    reset_node = SimpleNamespace(
+        iface=iface,
+        factoryReset=MagicMock(return_value=SimpleNamespace(id=123)),
+    )
+
+    with pytest.raises(ValueError, match="timeout must be positive"):
+        main_module._send_local_factory_reset_and_wait(
+            reset_node,
+            full=False,
+            timeout=0,
+        )
+
+    reset_node.factoryReset.assert_not_called()

--- a/meshtastic/tests/test_main_factory_reset.py
+++ b/meshtastic/tests/test_main_factory_reset.py
@@ -503,7 +503,9 @@ def test_local_factory_reset_rejects_invalid_timeout_before_send() -> None:
         factoryReset=MagicMock(return_value=SimpleNamespace(id=123)),
     )
 
-    with pytest.raises(ValueError, match="timeout must be positive"):
+    with pytest.raises(
+        ValueError, match="factory reset acceptance timeout must be positive"
+    ):
         main_module._send_local_factory_reset_and_wait(
             reset_node,
             full=False,

--- a/meshtastic/tests/test_main_preferences_export.py
+++ b/meshtastic/tests/test_main_preferences_export.py
@@ -415,7 +415,7 @@ def test_apply_configure_channel_url_redacts_and_applies(
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
-def test_main_configure_preflights_before_phase1_mutations(
+def test_main_configure_preflights_before_direct_mutations(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/meshtastic/tests/test_meshtasticd_multinode_ci.py
+++ b/meshtastic/tests/test_meshtasticd_multinode_ci.py
@@ -523,7 +523,7 @@ def test_meshtasticd_multinode_channel_blueprint_export_and_reuse(
             timeout=HOST_CONFIGURE_TIMEOUT_SECONDS,
             meshtastic_bin=meshtastic_bin,
         )
-        assert "Phase 1 complete." in configure_output
+        assert "Direct configuration values applied." in configure_output
         _wait_for_host_ready(
             HOST_B,
             meshtastic_bin,
@@ -861,7 +861,7 @@ def test_meshtasticd_multinode_large_channel_url_replace_all_over_tcp(
             timeout=HOST_CONFIGURE_TIMEOUT_SECONDS,
             meshtastic_bin=meshtastic_bin,
         )
-        assert "Phase 1 complete." in configure_output
+        assert "Direct configuration values applied." in configure_output
         _wait_for_host_ready(
             HOST_B,
             meshtastic_bin,

--- a/meshtastic/tests/test_node_channels.py
+++ b/meshtastic/tests/test_node_channels.py
@@ -20,7 +20,6 @@ from ..protobuf import (
 from ..protobuf.channel_pb2 import Channel  # pylint: disable=E0611
 from ..serial_interface import SerialInterface
 from ..util import fromPSK
-
 from ._node_legacy_support import (
     _decode_channel_set_from_url,
     _get_mock_call_arg,
@@ -945,6 +944,7 @@ def test_channel_lookup_helpers_return_none_when_no_match(
     assert anode.getDisabledChannel() is None
     assert anode._get_admin_channel_index() == 0
 
+
 @pytest.mark.unit
 def test_fixup_channels_truncates_and_reindexes_to_limit(
     autospec_local_node_iface: Callable[[type[Any]], MagicMock],
@@ -961,6 +961,7 @@ def test_fixup_channels_truncates_and_reindexes_to_limit(
     assert len(anode.channels) == CHANNEL_LIMIT
     assert [ch.index for ch in anode.channels] == list(range(CHANNEL_LIMIT))
 
+
 @pytest.mark.unit
 def test_fill_channels_handles_none_and_pads_to_limit(
     autospec_local_node_iface: Callable[[type[Any]], MagicMock],
@@ -976,6 +977,7 @@ def test_fill_channels_handles_none_and_pads_to_limit(
     assert anode.channels is not None
     assert len(anode.channels) == CHANNEL_LIMIT
     assert anode.channels[-1].role == Channel.Role.DISABLED
+
 
 @pytest.mark.unit
 def test_onResponseRequestChannel_routing_paths(
@@ -1006,6 +1008,7 @@ def test_onResponseRequestChannel_routing_paths(
     assert anode._channel_response_runtime.has_channel_request_failed() is False
     assert anode.partialChannels == [channel]
     anode._request_channel.assert_not_called()
+
 
 @pytest.mark.unit
 def test_onResponseRequestChannel_handles_partial_and_final_channel(
@@ -1042,6 +1045,7 @@ def test_onResponseRequestChannel_handles_partial_and_final_channel(
     assert anode.channels is not None
     assert len(anode.channels) == CHANNEL_LIMIT
 
+
 @pytest.mark.unit
 def test_get_channels_with_hash_handles_missing_fields(
     autospec_local_node_iface: Callable[[type[Any]], MagicMock],
@@ -1060,6 +1064,7 @@ def test_get_channels_with_hash_handles_missing_fields(
     assert entries[0]["hash"] is not None
     assert entries[1]["hash"] is None
 
+
 @pytest.mark.unit
 def test_fixup_channels_returns_immediately_when_channels_none(
     autospec_local_node_iface: Callable[[type[Any]], MagicMock],
@@ -1071,6 +1076,7 @@ def test_fixup_channels_returns_immediately_when_channels_none(
     anode._fixup_channels()
 
     assert anode.channels is None
+
 
 @pytest.mark.unit
 def test_getURL_requests_lora_when_local_config_empty(
@@ -1105,3 +1111,45 @@ def test_getURL_requests_lora_when_local_config_empty(
     channel_set = _decode_channel_set_from_url(url)
     assert len(channel_set.settings) == 1
     assert channel_set.settings[0].name == "primary"
+
+
+@pytest.mark.unit
+def test_invalidate_channel_cache_clears_state_under_owner_lock() -> None:
+    """Node cache invalidation should clear both channel caches while holding its lock."""
+    events: list[str] = []
+
+    class LockProbe:
+        """Record the lock lifetime around cache mutations."""
+
+        active = False
+
+        def __enter__(self) -> None:
+            self.active = True
+            events.append("enter")
+
+        def __exit__(self, *_args: object) -> None:
+            events.append("exit")
+            self.active = False
+
+    class CacheOwnerProbe(Node):
+        """Assert cache assignments occur while the owner lock is active."""
+
+        def __setattr__(self, name: str, value: Any) -> None:
+            if name in {"channels", "partialChannels"} and getattr(
+                self, "_assert_locked_cache_writes", False
+            ):
+                assert cast(LockProbe, self._channels_lock).active
+                events.append(name)
+            object.__setattr__(self, name, value)
+
+    node = cast(Any, object.__new__(CacheOwnerProbe))
+    node._channels_lock = LockProbe()
+    node.channels = [Channel(index=0, role=Channel.Role.PRIMARY)]
+    node.partialChannels = [Channel(index=1, role=Channel.Role.SECONDARY)]
+    node._assert_locked_cache_writes = True
+
+    Node._invalidate_channel_cache(node)
+
+    assert events == ["enter", "channels", "partialChannels", "exit"]
+    assert node.channels is None
+    assert node.partialChannels == []

--- a/meshtastic/tests/test_node_channels.py
+++ b/meshtastic/tests/test_node_channels.py
@@ -1121,7 +1121,7 @@ def test_invalidate_channel_cache_clears_state_under_owner_lock() -> None:
     class LockProbe:
         """Record the lock lifetime around cache mutations."""
 
-        active = False
+        active: bool = False
 
         def __enter__(self) -> None:
             self.active = True

--- a/tests/test_ble_state_manager.py
+++ b/tests/test_ble_state_manager.py
@@ -421,8 +421,8 @@ class TestBLEInterfaceStateIntegration:
         )  # Cannot "begin disconnecting" from already-disconnected state
 
 
-class TestPhase3LockConsolidation:
-    """Test Phase 3 lock consolidation and concurrent scenarios."""
+class TestStateLockConsolidation:
+    """Test consolidated state locking and concurrent scenarios."""
 
     def test_unified_lock_thread_safety(self) -> None:
         """Test that unified state lock provides thread safety for concurrent operations."""

--- a/tests/test_ble_state_manager.py
+++ b/tests/test_ble_state_manager.py
@@ -312,7 +312,7 @@ class TestBLEStateManager:
 
 
 class TestBLEInterfaceStateIntegration:
-    """Test integration between BLEStateManager and BLEInterface (Phase 2)."""
+    """Test integration between BLEStateManager and BLEInterface."""
 
     def test_state_manager_standalone_initialization(self):
         """Verify BLEStateManager can be instantiated standalone and exhibits expected initial properties and basic transition behavior.
@@ -336,7 +336,7 @@ class TestBLEInterfaceStateIntegration:
         assert not manager._can_connect
 
     def test_state_based_property_usage(self):
-        """Test that state-based properties work as expected for Phase 2 migration."""
+        """Test that state-based properties work as expected."""
 
         manager = BLEStateManager()
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

Refactors connected CLI execution from `meshtastic.__main__` into typed action modules coordinated by a central dispatcher. Existing CLI entry points and compatibility wrappers remain available.

## Key Changes

### Features

- Adds `CliContext` and `ActionOutcome` for shared CLI state and action results.
- Adds handlers for device administration, OTA, factory reset, firmware lockdown, configuration, channels, contacts, modem presets, QR operations, messaging, telemetry, GPIO, tunnels, logging, and other services.
- Adds dependency-injected action hooks for isolated testing.
- Adds validation for channels, destinations, GPIO values, coordinates, modem presets, owner values, configuration data, and destructive operations.

### Fixes

- Waits for ACK/NAK only when an operation sends a request.
- Prevents no-op operations from entering ACK wait states.
- Validates configuration before mutation where possible.
- Skips redundant channel URL writes.
- Handles reconnect and verification failures without unsafe post-commit behavior.
- Preserves primary action failures while reporting cleanup failures.
- Cleans up retained resources in reverse order.
- Invalidates node channel caches atomically while holding `_channels_lock`.
- Prevents continued mutation when injected CLI exit handlers return unexpectedly.
- Adds regression coverage for configuration boundaries, factory reset timeouts, channel handling, device actions, lifecycle cleanup, and input validation.

### Refactors

- Moves connected CLI logic out of `meshtastic.__main__`.
- Centralizes action ordering, ACK handling, disconnection, interface closure, and cleanup in `meshtastic/cli/dispatch.py`.
- Splits device, configuration, channel/contact, and messaging/service actions into separate modules.
- Adds `meshtastic/cli/configure_values.py` for direct configuration validation and normalization.
- Replaces selected configuration, factory-reset, verification, and pacing implementations with shared-helper adapters.
- Keeps legacy wrappers, exports, result contracts, and CLI behavior compatible.
- Updates related test names and messages to reflect direct configuration behavior.

## Compatibility and Migration

No CLI command or flag changes are required. Existing public entry points, function signatures, argparse destinations, and external APIs remain supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->