### PR TITLE
fix(ble): release disconnected transport resources

### DIFF
--- a/meshtastic/interfaces/ble/client.py
+++ b/meshtastic/interfaces/ble/client.py
@@ -1021,9 +1021,11 @@ class BLEClient:
     def close(self, timeout: float | None = None) -> None:
         """Close the BLEClient and perform a best-effort shutdown.
 
-        If an underlying Bleak client exists and is connected, this attempts a
-        bounded disconnect and suppresses any disconnect errors so shutdown
-        remains best-effort and idempotent. The method is thread-safe (uses an
+        If an underlying Bleak client exists, this attempts a bounded disconnect
+        and suppresses any disconnect errors so shutdown remains best-effort and
+        idempotent. Disconnect is required even when Bleak already reports the
+        peer disconnected because backend transports can still own resources
+        such as a BlueZ D-Bus connection. The method is thread-safe (uses an
         internal close lock), marks the wrapper as closed, and cancels any
         tracked pending futures to unblock waiting callers. This does not stop
         or affect the shared BLE event loop used by other clients.
@@ -1038,8 +1040,12 @@ class BLEClient:
             if getattr(self, "_closed", False):
                 return
 
-            # Best effort: disconnect active transport before closing this wrapper.
-            if getattr(self, "bleak_client", None) is not None and self.is_connected():
+            # Best effort: release the transport before closing this wrapper.
+            # Logical connection state is not a transport-ownership signal: after
+            # a remote BlueZ disconnect, Bleak reports ``is_connected = False``
+            # while its per-session D-Bus connection remains open until
+            # ``disconnect()`` runs.
+            if getattr(self, "bleak_client", None) is not None:
                 disconnect_timeout = (
                     DISCONNECT_TIMEOUT_SECONDS if timeout is None else timeout
                 )

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -671,82 +671,26 @@ class ClientManager:
         *,
         disconnect_timeout: float | None = None,
     ) -> None:
-        """Attempt to disconnect and close the given BLE client, suppressing any errors and optionally signal completion.
+        """Close the given BLE client and optionally signal completion.
 
         Parameters
         ----------
         client : BLEClient
-            BLE client to disconnect and close.
+            BLE client to close. The client owns its transport cleanup.
         event : Event | None
             Optional Event that will be set after cleanup completes. (Default value = None)
         disconnect_timeout : float | None
-            Optional maximum seconds passed to disconnect and close-time
-            disconnect operations.
+            Optional maximum seconds passed to the client's close-time transport
+            cleanup.
         """
         is_finalizing = getattr(sys, "is_finalizing", None)
-        skip_disconnect = bool(is_finalizing()) if callable(is_finalizing) else False
+        skip_close = bool(is_finalizing()) if callable(is_finalizing) else False
         safe_cleanup_hook = _resolve_declared_callable(
             self.error_handler, "safe_cleanup", "_safe_cleanup"
         )
 
         try:
-            if (
-                not skip_disconnect
-                and not _get_declared_member(client, "_closed", False)
-                and _get_declared_member(client, "bleak_client")
-            ):
-                is_connected = False
-                for probe_name in ("is_connected", "isConnected", "_is_connected"):
-                    is_connected_probe = _get_declared_member(client, probe_name)
-                    if callable(is_connected_probe):
-                        try:
-                            is_connected = bool(is_connected_probe())
-                        except (
-                            Exception
-                        ):  # noqa: BLE001 - shutdown must remain best effort
-                            logger.debug(
-                                "Failed to read BLE client connected state via %s during shutdown.",
-                                probe_name,
-                                exc_info=True,
-                            )
-                        if is_connected:
-                            break
-                    elif isinstance(is_connected_probe, bool):
-                        is_connected = is_connected_probe
-                        if is_connected:
-                            break
-                if is_connected:
-                    effective_disconnect_timeout = (
-                        DISCONNECT_TIMEOUT_SECONDS
-                        if disconnect_timeout is None
-                        else disconnect_timeout
-                    )
-
-                    def _disconnect_with_timeout() -> None:
-                        try:
-                            client.disconnect(
-                                await_timeout=effective_disconnect_timeout
-                            )
-                        except TypeError as exc:
-                            if not _is_unexpected_keyword_error(exc, "await_timeout"):
-                                raise
-                            client.disconnect()
-
-                    _run_safe_cleanup(
-                        _disconnect_with_timeout,
-                        "client disconnect",
-                        safe_cleanup_hook,
-                    )
-                else:
-                    logger.debug(
-                        "Skipping pre-close BLE client disconnect: client is not "
-                        "connected; close() will release any remaining transport resources."
-                    )
-            elif skip_disconnect:
-                logger.debug(
-                    "Skipping BLE client disconnect during interpreter finalization."
-                )
-            if not skip_disconnect:
+            if not skip_close:
                 close_error: TypeError | None = None
 
                 def _close_with_timeout() -> None:
@@ -768,7 +712,8 @@ class ClientManager:
                     raise close_error
             else:
                 logger.debug(
-                    "Skipping BLE client close during interpreter finalization."
+                    "Skipping BLE client and transport cleanup during interpreter "
+                    "finalization."
                 )
         finally:
             if event:

--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -739,7 +739,8 @@ class ClientManager:
                     )
                 else:
                     logger.debug(
-                        "Skipping BLE client disconnect during shutdown: client is not connected."
+                        "Skipping pre-close BLE client disconnect: client is not "
+                        "connected; close() will release any remaining transport resources."
                     )
             elif skip_disconnect:
                 logger.debug(

--- a/meshtastic/tests/test_ble_connection_runtime.py
+++ b/meshtastic/tests/test_ble_connection_runtime.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from concurrent.futures import Future
-from threading import Event, RLock
+from threading import Event, RLock, Thread
 from typing import Any, Coroutine, cast
 from unittest.mock import MagicMock
 
@@ -16,7 +16,6 @@ from meshtastic.interfaces.ble.connection import (
     ClientManager,
     ConnectionOrchestrator,
 )
-from meshtastic.interfaces.ble.constants import DISCONNECT_TIMEOUT_SECONDS
 from meshtastic.interfaces.ble.errors import BLEDBusTransportError, BLEErrorHandler
 from meshtastic.interfaces.ble.runner import BLECoroutineRunner
 
@@ -34,23 +33,11 @@ class _ErrorHandler:
 class _DummyClient:
     """Minimal BLE client double for shutdown behavior tests."""
 
-    def __init__(self, *, connected: bool) -> None:
-        self._closed = False
-        self._connected = connected
-        self.bleak_client = object()
-        self.disconnect_calls = 0
-        self.close_calls = 0
-        self.last_disconnect_timeout: float | None = None
+    def __init__(self) -> None:
+        self.close_calls: int = 0
         self.last_close_timeout: float | None = None
 
-    def is_connected(self) -> bool:
-        return self._connected
-
-    def disconnect(self, *, await_timeout: float) -> None:
-        self.disconnect_calls += 1
-        self.last_disconnect_timeout = await_timeout
-
-    def close(self, timeout: float | None = None) -> None:  # type: ignore[no-untyped-def]
+    def close(self, timeout: float | None = None) -> None:
         self.close_calls += 1
         self.last_close_timeout = timeout
 
@@ -58,47 +45,68 @@ class _DummyClient:
 class _LegacyDummyClient:
     """Legacy BLE client double that does not accept timeout in close()."""
 
-    def __init__(self, *, connected: bool) -> None:
-        self._connected = connected
-        self.bleak_client = object()
-        self.disconnect_calls = 0
-        self.close_calls = 0
-        self.last_disconnect_timeout: float | None = None
-
-    def is_connected(self) -> bool:
-        return self._connected
-
-    def disconnect(self, *, await_timeout: float) -> None:
-        self.disconnect_calls += 1
-        self.last_disconnect_timeout = await_timeout
+    def __init__(self) -> None:
+        self.close_calls: int = 0
 
     def close(self) -> None:
         self.close_calls += 1
 
 
 class _ImmediateRunner:
-    """Execute transport coroutines immediately for BLEClient unit tests."""
+    """Execute transport coroutines on an isolated event-loop thread."""
 
-    _thread = None
+    _thread: Thread | None = None
 
-    def _run_coroutine_threadsafe(
-        self, coro: Coroutine[Any, Any, Any]
-    ) -> Future[Any]:
+    def _run_coroutine_threadsafe(self, coro: Coroutine[Any, Any, Any]) -> Future[Any]:
         future: Future[Any] = Future()
-        future.set_result(asyncio.run(coro))
+
+        def _run() -> None:
+            try:
+                future.set_result(asyncio.run(coro))
+            except Exception as exc:  # noqa: BLE001 - mirror Future propagation
+                future.set_exception(exc)
+
+        thread = Thread(target=_run)
+        self._thread = thread
+        thread.start()
+        thread.join()
+        self._thread = None
         return future
 
 
-class _DisconnectedBleakTransport:
-    """Bleak transport that still needs release after its peer disconnects."""
+class _BleakTransport:
+    """Bleak transport double that records cleanup attempts."""
 
-    def __init__(self) -> None:
-        self.address = "AA:BB:CC:DD:EE:FF"
-        self.is_connected = False
-        self.disconnect_calls = 0
+    def __init__(
+        self,
+        *,
+        connected: bool,
+        disconnect_error: Exception | None = None,
+    ) -> None:
+        self.address: str = "AA:BB:CC:DD:EE:FF"
+        self.is_connected: bool = connected
+        self.disconnect_calls: int = 0
+        self.disconnect_error: Exception | None = disconnect_error
 
     async def disconnect(self) -> None:
         self.disconnect_calls += 1
+        if self.disconnect_error is not None:
+            raise self.disconnect_error
+
+
+def _make_ble_client(
+    *,
+    connected: bool,
+    disconnect_error: Exception | None = None,
+) -> tuple[BLEClient, _BleakTransport]:
+    client = BLEClient()
+    transport = _BleakTransport(
+        connected=connected,
+        disconnect_error=disconnect_error,
+    )
+    client.bleak_client = cast(Any, transport)
+    client._runner = cast(BLECoroutineRunner, _ImmediateRunner())
+    return client, transport
 
 
 def _make_client_manager() -> ClientManager:
@@ -113,10 +121,7 @@ def _make_client_manager() -> ClientManager:
 def test_safe_close_client_releases_transport_after_remote_disconnect() -> None:
     """Manager cleanup should release transport after a remote disconnect."""
     manager = _make_client_manager()
-    client = BLEClient()
-    transport = _DisconnectedBleakTransport()
-    client.bleak_client = cast(Any, transport)
-    client._runner = cast(BLECoroutineRunner, _ImmediateRunner())
+    client, transport = _make_ble_client(connected=False)
     done = Event()
 
     manager._safe_close_client(
@@ -130,37 +135,39 @@ def test_safe_close_client_releases_transport_after_remote_disconnect() -> None:
     assert client.bleak_client is None
 
 
-def test_safe_close_client_skips_disconnect_for_disconnected_client() -> None:
-    """Disconnected clients should not trigger an unnecessary disconnect timeout path."""
+def test_safe_close_client_disconnects_connected_transport_once() -> None:
+    """Manager cleanup should disconnect a connected transport exactly once."""
     manager = _make_client_manager()
-    client = _DummyClient(connected=False)
+    client, transport = _make_ble_client(connected=True)
     done = Event()
 
-    manager._safe_close_client(cast(BLEClient, client), event=done)
+    manager._safe_close_client(client, event=done)
 
     assert done.is_set()
-    assert client.disconnect_calls == 0
-    assert client.close_calls == 1
+    assert transport.disconnect_calls == 1
+    assert client.bleak_client is None
 
 
-def test_safe_close_client_disconnects_connected_client_before_close() -> None:
-    """Connected clients should still run bounded disconnect before close."""
+def test_safe_close_client_clears_transport_after_disconnect_failure() -> None:
+    """Cleanup should finish and clear the transport after disconnect failure."""
     manager = _make_client_manager()
-    client = _DummyClient(connected=True)
+    client, transport = _make_ble_client(
+        connected=False,
+        disconnect_error=RuntimeError("transport cleanup failed"),
+    )
     done = Event()
 
-    manager._safe_close_client(cast(BLEClient, client), event=done)
+    manager._safe_close_client(client, event=done)
 
     assert done.is_set()
-    assert client.disconnect_calls == 1
-    assert client.last_disconnect_timeout == DISCONNECT_TIMEOUT_SECONDS
-    assert client.close_calls == 1
+    assert transport.disconnect_calls == 1
+    assert client.bleak_client is None
 
 
 def test_safe_close_client_passes_timeout_to_close() -> None:
     """Bounded disconnect timeout should flow through to client.close()."""
     manager = _make_client_manager()
-    client = _DummyClient(connected=True)
+    client = _DummyClient()
     done = Event()
     custom_timeout = 3.5
 
@@ -171,8 +178,6 @@ def test_safe_close_client_passes_timeout_to_close() -> None:
     )
 
     assert done.is_set()
-    assert client.disconnect_calls == 1
-    assert client.last_disconnect_timeout == custom_timeout
     assert client.close_calls == 1
     assert client.last_close_timeout == custom_timeout
 
@@ -180,7 +185,7 @@ def test_safe_close_client_passes_timeout_to_close() -> None:
 def test_safe_close_client_fallback_for_legacy_close() -> None:
     """Legacy client.close() without timeout should still be called once."""
     manager = _make_client_manager()
-    client = _LegacyDummyClient(connected=True)
+    client = _LegacyDummyClient()
     done = Event()
 
     manager._safe_close_client(
@@ -190,7 +195,6 @@ def test_safe_close_client_fallback_for_legacy_close() -> None:
     )
 
     assert done.is_set()
-    assert client.disconnect_calls == 1
     assert client.close_calls == 1
 
 
@@ -199,16 +203,6 @@ def test_safe_close_client_reraises_unrelated_typeerror() -> None:
     manager = _make_client_manager()
 
     class _BadClient:
-        def __init__(self) -> None:
-            self.bleak_client = object()
-            self._closed = False
-
-        def is_connected(self) -> bool:
-            return True
-
-        def disconnect(self, *, await_timeout: float) -> None:
-            pass
-
         def close(self, timeout: float | None = None) -> None:
             raise TypeError("something else broke")
 

--- a/meshtastic/tests/test_ble_connection_runtime.py
+++ b/meshtastic/tests/test_ble_connection_runtime.py
@@ -12,6 +12,7 @@ import pytest
 from bleak.exc import BleakDBusError
 
 from meshtastic.interfaces.ble.client import BLEClient
+from meshtastic.interfaces.ble.constants import DISCONNECT_TIMEOUT_SECONDS
 from meshtastic.interfaces.ble.connection import (
     ClientManager,
     ConnectionOrchestrator,
@@ -160,6 +161,48 @@ def test_safe_close_client_clears_transport_after_disconnect_failure() -> None:
     manager._safe_close_client(client, event=done)
 
     assert done.is_set()
+    assert transport.disconnect_calls == 1
+    assert client.bleak_client is None
+
+
+def test_close_forwards_timeout_as_disconnect_await_timeout() -> None:
+    """BLEClient.close(timeout=...) must forward the value as disconnect(await_timeout=...)."""
+    client, _transport = _make_ble_client(connected=True)
+    captured: dict[str, float | None] = {}
+
+    def _spy_disconnect(*, await_timeout: float | None = None) -> None:
+        captured["await_timeout"] = await_timeout
+
+    client.disconnect = _spy_disconnect  # type: ignore[assignment]
+
+    custom_timeout = 4.25
+    client.close(timeout=custom_timeout)
+
+    assert captured.get("await_timeout") == custom_timeout
+
+
+def test_close_default_timeout_uses_disconnect_constant() -> None:
+    """close() with no timeout must forward DISCONNECT_TIMEOUT_SECONDS as await_timeout."""
+    client, _transport = _make_ble_client(connected=True)
+    captured: dict[str, float | None] = {}
+
+    def _spy_disconnect(*, await_timeout: float | None = None) -> None:
+        captured["await_timeout"] = await_timeout
+
+    client.disconnect = _spy_disconnect  # type: ignore[assignment]
+
+    client.close()
+
+    assert captured.get("await_timeout") == DISCONNECT_TIMEOUT_SECONDS
+
+
+def test_close_is_idempotent_and_disconnects_once() -> None:
+    """Repeated close() calls must disconnect the transport at most once."""
+    client, transport = _make_ble_client(connected=True)
+
+    client.close()
+    client.close()
+
     assert transport.disconnect_calls == 1
     assert client.bleak_client is None
 

--- a/meshtastic/tests/test_ble_connection_runtime.py
+++ b/meshtastic/tests/test_ble_connection_runtime.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
+from concurrent.futures import Future
 from threading import Event, RLock
-from typing import cast
+from typing import Any, Coroutine, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -16,6 +18,7 @@ from meshtastic.interfaces.ble.connection import (
 )
 from meshtastic.interfaces.ble.constants import DISCONNECT_TIMEOUT_SECONDS
 from meshtastic.interfaces.ble.errors import BLEDBusTransportError, BLEErrorHandler
+from meshtastic.interfaces.ble.runner import BLECoroutineRunner
 
 pytestmark = pytest.mark.unit
 
@@ -73,6 +76,31 @@ class _LegacyDummyClient:
         self.close_calls += 1
 
 
+class _ImmediateRunner:
+    """Execute transport coroutines immediately for BLEClient unit tests."""
+
+    _thread = None
+
+    def _run_coroutine_threadsafe(
+        self, coro: Coroutine[Any, Any, Any]
+    ) -> Future[Any]:
+        future: Future[Any] = Future()
+        future.set_result(asyncio.run(coro))
+        return future
+
+
+class _DisconnectedBleakTransport:
+    """Bleak transport that still needs release after its peer disconnects."""
+
+    def __init__(self) -> None:
+        self.address = "AA:BB:CC:DD:EE:FF"
+        self.is_connected = False
+        self.disconnect_calls = 0
+
+    async def disconnect(self) -> None:
+        self.disconnect_calls += 1
+
+
 def _make_client_manager() -> ClientManager:
     return ClientManager(
         state_manager=MagicMock(),
@@ -80,6 +108,26 @@ def _make_client_manager() -> ClientManager:
         thread_coordinator=MagicMock(),
         error_handler=cast(BLEErrorHandler, _ErrorHandler()),
     )
+
+
+def test_safe_close_client_releases_transport_after_remote_disconnect() -> None:
+    """Manager cleanup should release transport after a remote disconnect."""
+    manager = _make_client_manager()
+    client = BLEClient()
+    transport = _DisconnectedBleakTransport()
+    client.bleak_client = cast(Any, transport)
+    client._runner = cast(BLECoroutineRunner, _ImmediateRunner())
+    done = Event()
+
+    manager._safe_close_client(
+        client,
+        event=done,
+        disconnect_timeout=1.5,
+    )
+
+    assert done.is_set()
+    assert transport.disconnect_calls == 1
+    assert client.bleak_client is None
 
 
 def test_safe_close_client_skips_disconnect_for_disconnected_client() -> None:

--- a/tests/test_ble_connection_edge_cases.py
+++ b/tests/test_ble_connection_edge_cases.py
@@ -43,9 +43,9 @@ def _refresh_connection_symbols() -> None:
     globals()["ClientManager"] = connection_module.ClientManager
     globals()["ConnectionOrchestrator"] = connection_module.ConnectionOrchestrator
     globals()["ConnectionValidator"] = connection_module.ConnectionValidator
-    globals()[
-        "_is_device_not_found_error"
-    ] = connection_module._is_device_not_found_error
+    globals()["_is_device_not_found_error"] = (
+        connection_module._is_device_not_found_error
+    )
 
 
 class MockBLEError(Exception):
@@ -466,17 +466,13 @@ def test_client_manager_safe_close_client_prefers_public_safe_cleanup() -> None:
     manager = ClientManager(state_manager, lock, thread_coordinator, error_handler)
 
     mock_client = MagicMock()
-    mock_client._closed = False
-    mock_client.bleak_client = object()
-    mock_client.is_connected = MagicMock()
-    mock_client.is_connected.return_value = True
 
     manager._safe_close_client(mock_client)
 
-    assert error_handler.safe_cleanup.call_count == 2
+    error_handler.safe_cleanup.assert_called_once()
     error_handler._safe_cleanup.assert_not_called()
-    mock_client.disconnect.assert_called_once()
-    mock_client.close.assert_called_once()
+    mock_client.disconnect.assert_not_called()
+    mock_client.close.assert_called_once_with(timeout=None)
 
 
 @pytest.mark.unit
@@ -1963,10 +1959,10 @@ def test_reconnect_worker_returns_when_interface_already_connected() -> None:
 
 
 @pytest.mark.unit
-def test_client_manager_safe_close_client_fallback_on_unsupported_await_timeout() -> (
+def test_client_manager_safe_close_client_fallback_on_unsupported_close_timeout() -> (
     None
 ):
-    """_safe_close_client should fallback to no-arg disconnect when await_timeout is unsupported."""
+    """_safe_close_client should fall back when close() rejects timeout."""
     state_manager = BLEStateManager()
     lock = RLock()
     thread_coordinator = MagicMock()
@@ -1975,31 +1971,22 @@ def test_client_manager_safe_close_client_fallback_on_unsupported_await_timeout(
     manager = ClientManager(state_manager, lock, thread_coordinator, error_handler)
 
     mock_client = MagicMock()
-    mock_client._closed = False
-    mock_client.bleak_client = object()
-    mock_client.is_connected = MagicMock()
-    mock_client.is_connected.return_value = True
 
-    def _reject_await_timeout(*, await_timeout: float | None = None) -> None:
-        if await_timeout is not None:
-            raise TypeError(
-                "disconnect() got an unexpected keyword argument 'await_timeout'"
-            )
+    def _reject_timeout(*, timeout: float | None = None) -> None:
+        if timeout is not None:
+            raise TypeError("close() got an unexpected keyword argument 'timeout'")
 
-    mock_client.disconnect = MagicMock()
-    mock_client.disconnect.side_effect = _reject_await_timeout
+    mock_client.close = MagicMock(side_effect=_reject_timeout)
 
-    manager._safe_close_client(mock_client)
+    manager._safe_close_client(mock_client, disconnect_timeout=1.0)
 
-    assert mock_client.disconnect.call_count == 2
-    mock_client.close.assert_called_once()
+    assert mock_client.close.call_count == 2
+    mock_client.disconnect.assert_not_called()
 
 
 @pytest.mark.unit
-def test_client_manager_safe_close_client_does_not_fallback_on_unrelated_typeerror() -> (
-    None
-):
-    """_safe_close_client should NOT attempt no-arg disconnect fallback for unrelated TypeError."""
+def test_client_manager_safe_close_client_reraises_unrelated_close_typeerror() -> None:
+    """_safe_close_client should not retry an unrelated close TypeError."""
     state_manager = BLEStateManager()
     lock = RLock()
     thread_coordinator = MagicMock()
@@ -2008,23 +1995,18 @@ def test_client_manager_safe_close_client_does_not_fallback_on_unrelated_typeerr
     manager = ClientManager(state_manager, lock, thread_coordinator, error_handler)
 
     mock_client = MagicMock()
-    mock_client._closed = False
-    mock_client.bleak_client = object()
-    mock_client.is_connected = MagicMock()
-    mock_client.is_connected.return_value = True
 
-    def _raise_unrelated(*, await_timeout: float | None = None) -> None:
-        del await_timeout
+    def _raise_unrelated(*, timeout: float | None = None) -> None:
+        del timeout
         raise TypeError("takes 1 positional argument but 2 were given")
 
-    mock_client.disconnect = MagicMock()
-    mock_client.disconnect.side_effect = _raise_unrelated
+    mock_client.close = MagicMock(side_effect=_raise_unrelated)
 
-    # _safe_close_client should swallow the error and still run close()
-    manager._safe_close_client(mock_client)
+    with pytest.raises(TypeError, match="takes 1 positional argument"):
+        manager._safe_close_client(mock_client, disconnect_timeout=1.0)
 
-    assert mock_client.disconnect.call_count == 1
-    mock_client.close.assert_called_once()
+    mock_client.close.assert_called_once_with(timeout=1.0)
+    mock_client.disconnect.assert_not_called()
 
 
 @pytest.mark.unit

--- a/tests/test_ble_interface_fixtures.py
+++ b/tests/test_ble_interface_fixtures.py
@@ -604,12 +604,24 @@ class DummyClient:
         if self.on_unpair is not None:
             self.on_unpair()
 
-    def close(self) -> None:
-        """Record that the client was closed.
+    def close(self, timeout: float | None = None) -> None:
+        """Release the transport and record that the client was closed.
 
-        Increments the internal `close_calls` counter so tests can assert how many times `close()` was invoked.
+        This mirrors ``BLEClient.close()`` ownership: when a transport exists,
+        close performs a best-effort disconnect before clearing client state.
+
+        Parameters
+        ----------
+        timeout : float | None
+            Optional close-time disconnect timeout. The synchronous test double
+            accepts but does not enforce it.
         """
         self.close_calls += 1
+        if self.bleak_client is not None:
+            try:
+                self.disconnect(await_timeout=timeout)
+            except Exception:  # noqa: BLE001 - mirror best-effort production close
+                pass
         self._initialized = False
         self.bleak_client = None
 


### PR DESCRIPTION
## Overview

This fixes BLE reconnects after a remote disconnect by releasing the underlying Bleak transport even when it already reports `is_connected = False`.

Transport cleanup now has one owner: `BLEClient.close()`. This avoids leaving BlueZ D-Bus resources open and prevents connected clients from being disconnected twice during manager cleanup.

## Key Changes

### BLE transport cleanup

* Attempt a bounded transport disconnect whenever `BLEClient.close()` still owns a Bleak client.
* Release transport resources after remote disconnects where the logical connection is already inactive.
* Preserve best-effort cleanup, transport reference clearing, pending-future cancellation, and idempotent close behavior.

### Cleanup ownership

* Remove the duplicate pre-disconnect path from `ClientManager`.
* Delegate transport cleanup and timeout handling to `BLEClient.close()`.
* Continue signaling cleanup completion when disconnect fails.
* Preserve compatibility with clients whose legacy `close()` method does not accept a timeout.

## Testing

Added or updated coverage for:

* transport cleanup after a remote BLE disconnect;
* connected transport cleanup with exactly one disconnect call;
* disconnect failures still clearing the transport and signaling completion;
* close-timeout delegation and legacy fallback behavior;
* interpreter-finalization and repeated-close behavior;
* lifecycle-aware test fixtures matching the production cleanup contract.

Targeted validation passed 18 BLE cleanup and shutdown tests. Ruff formatting and lint checks also passed.

## Scope

* No Meshtastic protocol or message-format changes are introduced.
* No public API or migration changes are required.
* Existing reconnect policy is unchanged; this only ensures the previous BLE transport is fully released before reconnecting.
