### PR TITLE
Centralize Node channel state and mutation coordination

### DIFF
--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -8,7 +8,7 @@ in the mesh, including methods for localConfig, moduleConfig, and channels manag
 import logging
 import sys
 import threading
-from typing import TYPE_CHECKING, Any, Callable, NoReturn, Sequence, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, NoReturn, Sequence, TypeVar, cast
 from google.protobuf.descriptor import FieldDescriptor
 
 from meshtastic.node_runtime.channel_export_runtime import _NodeChannelExportRuntime
@@ -20,6 +20,7 @@ from meshtastic.node_runtime.channel_presentation_runtime import (
     _NodeChannelPresentationRuntime,
 )
 from meshtastic.node_runtime.channel_request_runtime import _NodeChannelRequestRuntime
+from meshtastic.node_runtime.channel_state import _ChannelLock, _NodeChannelState
 from meshtastic.node_runtime.admin_wait import (
     _send_admin_with_ack_scope,
     _wait_for_admin_ack,
@@ -109,6 +110,8 @@ class Node:  # pylint: disable=too-many-instance-attributes
     Includes methods for localConfig, moduleConfig and channels
     """
 
+    _channel_state_bootstrap_lock: ClassVar[_ChannelLock] = threading.Lock()
+
     def __init__(
         self,
         iface: "MeshInterface",
@@ -133,10 +136,8 @@ class Node:  # pylint: disable=too-many-instance-attributes
         self.nodeNum = toNodeNum(nodeNum) if isinstance(nodeNum, str) else nodeNum
         self.localConfig = localonly_pb2.LocalConfig()
         self.moduleConfig = localonly_pb2.LocalModuleConfig()
-        self.channels: list[channel_pb2.Channel] | None = None
-        self._channels_lock = threading.RLock()
+        self._channel_state = _NodeChannelState()
         self._timeout = Timeout(maxSecs=timeout)
-        self.partialChannels: list[channel_pb2.Channel] = []
         self.noProto = noProto
         self.cannedPluginMessage: str | None = None
         self.cannedPluginMessageMessages: str | None = None
@@ -148,25 +149,28 @@ class Node:  # pylint: disable=too-many-instance-attributes
         self._metadata_stdout_event: threading.Event | None = None
         self._admin_session_runtime = _NodeAdminSessionRuntime(self)
         self._admin_transport_runtime = _NodeAdminTransportRuntime(self)
-        self._channel_lookup_runtime = _NodeChannelLookupRuntime(self)
-        self._channel_normalization_runtime = _NodeChannelNormalizationRuntime(self)
-        self._channel_export_runtime = _NodeChannelExportRuntime(self)
+        self._channel_lookup_runtime = _NodeChannelLookupRuntime(self._channel_state)
+        self._channel_normalization_runtime = _NodeChannelNormalizationRuntime(
+            self._channel_state
+        )
+        self._channel_export_runtime = _NodeChannelExportRuntime(
+            self, channel_state=self._channel_state
+        )
         self._channel_request_runtime = _NodeChannelRequestRuntime(
-            self,
-            normalization_runtime=self._channel_normalization_runtime,
+            self, channel_state=self._channel_state
         )
         self._channel_presentation_runtime = _NodeChannelPresentationRuntime(
             self,
+            channel_state=self._channel_state,
             export_runtime=self._channel_export_runtime,
         )
         self._contact_runtime = contact_runtime._NodeContactRuntime(self)
         self._channel_write_runtime = _NodeChannelWriteRuntime(
-            self,
-            admin_session_runtime=self._admin_session_runtime,
-            admin_transport_runtime=self._admin_transport_runtime,
+            self, channel_state=self._channel_state
         )
         self._delete_channel_runtime = _NodeDeleteChannelRuntime(
             self,
+            channel_state=self._channel_state,
             channel_write_runtime=self._channel_write_runtime,
         )
         self._ack_nak_runtime = _NodeAckNakRuntime(self)
@@ -196,6 +200,68 @@ class Node:  # pylint: disable=too-many-instance-attributes
             None
         )
         self._lazy_init_lock = threading.RLock()
+
+    def _get_channel_state(self) -> _NodeChannelState:
+        """Return the channel-state owner, migrating legacy raw instance fields."""
+        channel_state = cast(
+            _NodeChannelState | None, self.__dict__.get("_channel_state")
+        )
+        if channel_state is not None:
+            return channel_state
+
+        with self._channel_state_bootstrap_lock:
+            channel_state = cast(
+                _NodeChannelState | None, self.__dict__.get("_channel_state")
+            )
+            if channel_state is not None:
+                return channel_state
+
+            missing = object()
+            legacy_channels = self.__dict__.pop("channels", missing)
+            legacy_partial_channels = self.__dict__.pop("partialChannels", missing)
+            legacy_lock = self.__dict__.pop("_channels_lock", missing)
+            channel_state = _NodeChannelState()
+            if legacy_lock is not missing:
+                channel_state._replace_lock(legacy_lock)  # noqa: SLF001
+            if legacy_channels is not missing:
+                channel_state.channels = legacy_channels
+            if legacy_partial_channels is not missing:
+                channel_state.partial_channels = legacy_partial_channels
+            object.__setattr__(self, "_channel_state", channel_state)
+        return channel_state
+
+    channels: list[channel_pb2.Channel] | None
+    partialChannels: list[channel_pb2.Channel]  # noqa: N815 - public compatibility
+
+    def __getattr__(self, name: str) -> Any:
+        """Resolve historical channel-cache instance attributes through the owner."""
+        if name == "_channel_state":
+            return self._get_channel_state()
+        if name == "channels":
+            return self._get_channel_state().channels
+        if name == "partialChannels":
+            return self._get_channel_state().partial_channels
+        raise AttributeError(f"{type(self).__name__!s} has no attribute {name!r}")
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Route historical channel-cache assignments through the state owner."""
+        if name == "channels":
+            self._get_channel_state().channels = value
+            return
+        if name == "partialChannels":
+            self._get_channel_state().partial_channels = value
+            return
+        object.__setattr__(self, name, value)
+
+    @property
+    def _channels_lock(self) -> _ChannelLock:
+        """Return the compatibility lock backed by the channel-state owner."""
+        return self._get_channel_state().lock
+
+    @_channels_lock.setter
+    def _channels_lock(self, value: _ChannelLock) -> None:
+        """Replace the compatibility lock for legacy instrumentation tests."""
+        self._get_channel_state()._replace_lock(value)  # noqa: SLF001
 
     @property
     def _content_cache_store(self) -> "_NodeContentCacheStore":
@@ -269,7 +335,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
                     )
 
                     self._channel_response_runtime_cache = _NodeChannelResponseRuntime(
-                        self
+                        self, channel_state=self._get_channel_state()
                     )
         return self._channel_response_runtime_cache
 
@@ -513,9 +579,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
 
     def _invalidate_channel_cache(self) -> None:
         """Clear cached channel state under the channel-state owner lock."""
-        with self._channels_lock:
-            self.channels = None
-            self.partialChannels = []
+        self._get_channel_state().invalidate()
 
     def onResponseRequestSettings(self, p: dict[str, Any]) -> None:
         """Process an admin response for a settings request and update the node's config objects.
@@ -884,9 +948,9 @@ class Node:  # pylint: disable=too-many-instance-attributes
             If channels or configuration are not loaded, the URL is invalid or
             contains no settings, or no free channel slot is available when adding.
         """
-        with self._channels_lock:
-            if self.channels is None:
-                self._raise_interface_error("Config or channels not loaded")
+        channel_state = self._get_channel_state()
+        if not channel_state.has_channels():
+            self._raise_interface_error("Config or channels not loaded")
         parsed_input = _SetUrlParser._parse(
             url,
             raise_interface_error=self._raise_interface_error,
@@ -894,6 +958,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
         transaction = _SetUrlTransactionCoordinator(
             self,
             parsed_input=parsed_input,
+            channel_state=channel_state,
         )
         if addOnly:
             transaction._apply_add_only()  # noqa: SLF001

--- a/meshtastic/node_runtime/channel_export_runtime.py
+++ b/meshtastic/node_runtime/channel_export_runtime.py
@@ -4,6 +4,7 @@ import base64
 import logging
 from typing import TYPE_CHECKING, Any
 
+from meshtastic.node_runtime.channel_state import _NodeChannelState
 from meshtastic.protobuf import apponly_pb2, channel_pb2, localonly_pb2
 from meshtastic.util import fromPSK, generate_channel_hash
 
@@ -18,18 +19,13 @@ LORA_TIMEOUT_MSG = "Timeout waiting for LoRa config"
 class _NodeChannelExportRuntime:
     """Owns channel URL export, channel-hash export, and primary PSK mutation."""
 
-    def __init__(self, node: "Node") -> None:
+    def __init__(self, node: "Node", *, channel_state: _NodeChannelState) -> None:
         self._node = node
+        self._channel_state = channel_state
 
     def _snapshot_channels(self) -> list[channel_pb2.Channel]:
         """Return detached channel snapshots captured under the channel lock."""
-        with self._node._channels_lock:  # noqa: SLF001
-            snapshot: list[channel_pb2.Channel] = []
-            for source_channel in self._node.channels or []:
-                copied_channel = channel_pb2.Channel()
-                copied_channel.CopyFrom(source_channel)
-                snapshot.append(copied_channel)
-            return snapshot
+        return self._channel_state.snapshot_channels()
 
     def _snapshot_local_config(self) -> localonly_pb2.LocalConfig:
         """Return detached localConfig snapshot for consistent field checks/copies."""
@@ -163,12 +159,17 @@ class _NodeChannelExportRuntime:
 
     def _turn_off_encryption_on_primary_channel(self) -> None:
         """Disable primary-channel encryption and persist updated channel state."""
+        with self._channel_state.mutation_lock:
+            self._turn_off_encryption_on_primary_channel_locked()
+
+    def _turn_off_encryption_on_primary_channel_locked(self) -> None:
+        """Persist primary-channel encryption state under the mutation lock."""
         primary_snapshot: channel_pb2.Channel | None = None
         original_channels_ref: list[channel_pb2.Channel] | None = None
         original_primary_slot: channel_pb2.Channel | None = None
         original_primary_snapshot: bytes | None = None
-        with self._node._channels_lock:  # noqa: SLF001
-            channels = self._node.channels
+        with self._channel_state.lock:
+            channels = self._channel_state.channels
             if not channels:
                 self._node._raise_interface_error(  # noqa: SLF001
                     "Error: No channels have been read"
@@ -191,20 +192,20 @@ class _NodeChannelExportRuntime:
                 )  # type narrowing for static analysis
         logger.info("Writing modified channels to device")
         self._node._write_channel_snapshot(primary_snapshot)  # noqa: SLF001
-        with self._node._channels_lock:  # noqa: SLF001
-            channels = self._node.channels
+        with self._channel_state.lock:
+            channels = self._channel_state.channels
             if not channels:
                 logger.warning(
                     "Primary channel write succeeded but local channel cache is unavailable; reload channels to refresh local state."
                 )
-                self._node.partialChannels = []
+                self._channel_state.partial_channels = []
                 return
             if channels is not original_channels_ref:
                 logger.warning(
                     "Primary channel write succeeded but channel cache changed concurrently; invalidating local channel cache."
                 )
-                self._node.channels = None
-                self._node.partialChannels = []
+                self._channel_state.channels = None
+                self._channel_state.partial_channels = []
                 return
             for channel in channels:
                 if channel.index == primary_snapshot.index:
@@ -212,8 +213,8 @@ class _NodeChannelExportRuntime:
                         logger.warning(
                             "Primary channel write succeeded but primary slot object changed concurrently; invalidating local channel cache."
                         )
-                        self._node.channels = None
-                        self._node.partialChannels = []
+                        self._channel_state.channels = None
+                        self._channel_state.partial_channels = []
                         return
                     if (
                         original_primary_snapshot is not None
@@ -222,15 +223,15 @@ class _NodeChannelExportRuntime:
                         logger.warning(
                             "Primary channel write succeeded but primary slot content changed concurrently; invalidating local channel cache."
                         )
-                        self._node.channels = None
-                        self._node.partialChannels = []
+                        self._channel_state.channels = None
+                        self._channel_state.partial_channels = []
                         return
                     channel.CopyFrom(primary_snapshot)
-                    self._node.partialChannels = []
+                    self._channel_state.partial_channels = []
                     return
             logger.warning(
                 "Primary channel write succeeded but local channel index %s is unavailable; invalidating local channel cache.",
                 primary_snapshot.index,
             )
-            self._node.channels = None
-            self._node.partialChannels = []
+            self._channel_state.channels = None
+            self._channel_state.partial_channels = []

--- a/meshtastic/node_runtime/channel_lookup_runtime.py
+++ b/meshtastic/node_runtime/channel_lookup_runtime.py
@@ -1,111 +1,50 @@
 """Channel lookup and admin-index resolution runtime owner."""
 
-from typing import TYPE_CHECKING
+from collections.abc import Callable
 
+from meshtastic.node_runtime.channel_state import _NodeChannelState
 from meshtastic.node_runtime.shared import (
     isNamedAdminChannelName as _isNamedAdminChannelName,
 )
 from meshtastic.protobuf import channel_pb2
 
-if TYPE_CHECKING:
-    from meshtastic.node import Node
-
 
 class _NodeChannelLookupRuntime:
-    """Owns lock-safe channel lookup and admin-channel index resolution."""
+    """Own lock-safe channel lookup and admin-channel index resolution."""
 
-    def __init__(self, node: "Node") -> None:
-        self._node = node
-
-    @staticmethod
-    def _copy_channel(channel: channel_pb2.Channel) -> channel_pb2.Channel:
-        """Return a defensive copy of a channel."""
-        copied = channel_pb2.Channel()
-        copied.CopyFrom(channel)
-        return copied
+    def __init__(self, channel_state: _NodeChannelState) -> None:
+        self._channel_state = channel_state
 
     def _get_channel_by_index(self, channel_index: int) -> channel_pb2.Channel | None:
-        """Return live channel by index when available, preserving compatibility.
-
-        Notes
-        -----
-        Returned channels are live references and may be mutated by other threads
-        after the lock is released. Use ``_get_channel_copy_by_index`` when a
-        stable read-only snapshot is required.
-        """
-        with self._node._channels_lock:  # noqa: SLF001
-            channels = self._node.channels
-            if channels and 0 <= channel_index < len(channels):
-                return channels[channel_index]
-            return None
+        """Return the historical live channel reference by index."""
+        return self._channel_state.get_live_by_index(channel_index)
 
     def _get_channel_copy_by_index(
         self, channel_index: int
     ) -> channel_pb2.Channel | None:
-        """Return defensive channel copy by index for read-only callers."""
-        with self._node._channels_lock:  # noqa: SLF001
-            channels = self._node.channels
-            if channels and 0 <= channel_index < len(channels):
-                return self._copy_channel(channels[channel_index])
-            return None
+        """Return a defensive channel copy by index for read-only callers."""
+        return self._channel_state.get_copy_by_index(channel_index)
 
     def _get_channel_by_name(self, name: str) -> channel_pb2.Channel | None:
-        """Return live channel whose settings.name exactly matches ``name``.
-
-        Notes
-        -----
-        Returned channels are live references and may be mutated by other threads
-        after the lock is released. Use ``_get_channel_copy_by_name`` when a
-        stable read-only snapshot is required.
-        """
-        with self._node._channels_lock:  # noqa: SLF001
-            for channel in self._node.channels or []:
-                if channel.settings and channel.settings.name == name:
-                    return channel
-            return None
+        """Return the historical live channel reference matching ``name``."""
+        return self._channel_state.get_live_by_name(name)
 
     def _get_channel_copy_by_name(self, name: str) -> channel_pb2.Channel | None:
-        """Return defensive channel copy found by exact settings.name match."""
-        with self._node._channels_lock:  # noqa: SLF001
-            for channel in self._node.channels or []:
-                if channel.settings and channel.settings.name == name:
-                    return self._copy_channel(channel)
-            return None
+        """Return a defensive channel copy matching ``name``."""
+        return self._channel_state.get_copy_by_name(name)
 
     def _get_disabled_channel(self) -> channel_pb2.Channel | None:
-        """Return first live disabled channel, if present.
-
-        Notes
-        -----
-        Returned channels are live references and may be mutated by other threads
-        after the lock is released. Use ``_get_disabled_channel_copy`` when a
-        stable read-only snapshot is required.
-        """
-        with self._node._channels_lock:  # noqa: SLF001
-            for channel in self._node.channels or []:
-                if channel.role == channel_pb2.Channel.Role.DISABLED:
-                    return channel
-            return None
+        """Return the historical live first disabled-channel reference."""
+        return self._channel_state.get_live_disabled()
 
     def _get_disabled_channel_copy(self) -> channel_pb2.Channel | None:
-        """Return defensive copy of first disabled channel, if present."""
-        with self._node._channels_lock:  # noqa: SLF001
-            for channel in self._node.channels or []:
-                if channel.role == channel_pb2.Channel.Role.DISABLED:
-                    return self._copy_channel(channel)
-            return None
+        """Return a defensive copy of the first disabled channel."""
+        return self._channel_state.get_copy_disabled()
 
     def _get_named_admin_channel_index(self) -> int | None:
         """Return index of explicitly named ``admin`` channel, if present."""
-        with self._node._channels_lock:  # noqa: SLF001
-            for channel in self._node.channels or []:
-                if (
-                    channel.role != channel_pb2.Channel.Role.DISABLED
-                    and channel.settings
-                    and _isNamedAdminChannelName(channel.settings.name)
-                ):
-                    return channel.index
-            return None
+        predicate: Callable[[str], bool] = _isNamedAdminChannelName
+        return self._channel_state.named_admin_index(is_named_admin=predicate)
 
     def _get_admin_channel_index(self) -> int:
         """Return named admin index when present; otherwise channel index zero."""

--- a/meshtastic/node_runtime/channel_normalization_runtime.py
+++ b/meshtastic/node_runtime/channel_normalization_runtime.py
@@ -1,64 +1,26 @@
 """Channel normalization/fill runtime owner."""
 
-import logging
-from typing import TYPE_CHECKING
-
-from meshtastic.node_runtime.shared import MAX_CHANNELS
-from meshtastic.protobuf import channel_pb2
-
-if TYPE_CHECKING:
-    from meshtastic.node import Node
-
-logger = logging.getLogger(__name__)
+from meshtastic.node_runtime.channel_state import _NodeChannelState
 
 
 class _NodeChannelNormalizationRuntime:
-    """Owns channel index normalization and disabled-channel fill behavior."""
+    """Own channel normalization behavior over the shared channel-state owner."""
 
-    def __init__(self, node: "Node") -> None:
-        self._node = node
+    def __init__(self, channel_state: _NodeChannelState) -> None:
+        self._channel_state = channel_state
 
     def _fixup_channels(self) -> None:
-        """Normalize channels under lock via ``_fixup_channels_locked`` semantics."""
-        with self._node._channels_lock:  # noqa: SLF001
-            self._fixup_channels_locked()
+        """Normalize cached channel indexes and disabled-channel fill."""
+        self._channel_state.normalize()
 
     def _fixup_channels_locked(self) -> None:
-        """Normalize channel indices/size while ``_channels_lock`` is held."""
-        channels = self._node.channels
-        if channels is None:
-            return
-
-        if len(channels) > MAX_CHANNELS:
-            logger.warning(
-                "Truncating channel list from %d to %d entries",
-                len(channels),
-                MAX_CHANNELS,
-            )
-            del channels[MAX_CHANNELS:]
-
-        if len(channels) < MAX_CHANNELS:
-            self._fill_channels_locked()
-        else:
-            for index, channel in enumerate(channels):
-                channel.index = index
+        """Normalize channels while the caller already holds the owner lock."""
+        self._channel_state._normalize_locked()  # noqa: SLF001
 
     def _fill_channels(self) -> None:
-        """Append disabled channels up to ``MAX_CHANNELS`` under lock."""
-        with self._node._channels_lock:  # noqa: SLF001
-            self._fill_channels_locked()
+        """Append disabled channels up to the device channel limit."""
+        self._channel_state.fill()
 
     def _fill_channels_locked(self) -> None:
-        """Append disabled channels up to ``MAX_CHANNELS`` while lock is held."""
-        channels = self._node.channels
-        if channels is None:
-            return
-
-        for index, channel in enumerate(channels):
-            channel.index = index
-
-        for index in range(len(channels), MAX_CHANNELS):
-            channel = channel_pb2.Channel()
-            channel.role = channel_pb2.Channel.Role.DISABLED
-            channel.index = index
-            channels.append(channel)
+        """Append disabled channels while the caller holds the owner lock."""
+        self._channel_state._fill_locked()  # noqa: SLF001

--- a/meshtastic/node_runtime/channel_presentation_runtime.py
+++ b/meshtastic/node_runtime/channel_presentation_runtime.py
@@ -9,6 +9,7 @@ from meshtastic.protobuf import channel_pb2
 from meshtastic.util import messageToJson, pskToString
 
 from .channel_export_runtime import _NodeChannelExportRuntime
+from .channel_state import _NodeChannelState
 
 if TYPE_CHECKING:
     from meshtastic.node import Node
@@ -30,20 +31,17 @@ class _NodeChannelPresentationRuntime:
         self,
         node: "Node",
         *,
+        channel_state: _NodeChannelState,
         export_runtime: _NodeChannelExportRuntime,
     ) -> None:
         self._node = node
+        self._channel_state = channel_state
         self._export_runtime = export_runtime
 
     def _show_channels(self) -> None:
         """Print channels and URL exports preserving historical output behavior."""
         print("Channels:")
-        with self._node._channels_lock:  # noqa: SLF001
-            channels_snapshot: list[channel_pb2.Channel] = []
-            for source_channel in self._node.channels or []:
-                copied_channel = channel_pb2.Channel()
-                copied_channel.CopyFrom(source_channel)
-                channels_snapshot.append(copied_channel)
+        channels_snapshot = self._channel_state.snapshot_channels()
         if channels_snapshot:
             logger.debug(
                 "channel snapshot captured (%d entries): %s",
@@ -96,6 +94,23 @@ class _NodeChannelPresentationRuntime:
         include_all: bool,
     ) -> str:
         """Resolve URL export path while preserving compatibility with export mocks."""
+        snapshot_export = getattr(
+            self._export_runtime,
+            "_get_url_from_snapshot",
+            None,
+        )
+        if (
+            callable(snapshot_export)
+            and getattr(snapshot_export, "__func__", None)
+            is _NodeChannelExportRuntime._get_url_from_snapshot  # noqa: SLF001
+        ):
+            return cast(
+                str,
+                snapshot_export(
+                    channels_snapshot,
+                    include_all=include_all,
+                ),
+            )
         get_url = getattr(self._export_runtime, "get_url", None)
         if callable(get_url):
             return cast(str, get_url(include_all=include_all))

--- a/meshtastic/node_runtime/channel_request_runtime.py
+++ b/meshtastic/node_runtime/channel_request_runtime.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Protocol, cast
 from meshtastic.protobuf import admin_pb2, channel_pb2, mesh_pb2
 from meshtastic.util import Timeout
 
-from .channel_normalization_runtime import _NodeChannelNormalizationRuntime
+from .channel_state import _NodeChannelState
 from .shared import MAX_CHANNELS
 
 if TYPE_CHECKING:
@@ -63,17 +63,19 @@ class _ChannelRequestCompletionProbe:
     """Expose channel-request completion as a boolean wait target."""
 
     def __init__(
-        self, *, node: "Node", channel_response_runtime: _HasChannelRequestFailed | None
+        self,
+        *,
+        channel_state: _NodeChannelState,
+        channel_response_runtime: _HasChannelRequestFailed | None,
     ) -> None:
-        self._node = node
+        self._channel_state = channel_state
         self._channel_response_runtime = channel_response_runtime
 
     @property
     def is_set(self) -> bool:
         """Return True once channels are loaded or the request has terminally failed."""
-        with self._node._channels_lock:  # noqa: SLF001
-            if self._node.channels is not None:
-                return True
+        if self._channel_state.has_channels():
+            return True
         has_channel_request_failed = _get_channel_request_failed_fn(
             self._channel_response_runtime
         )
@@ -89,21 +91,14 @@ class _NodeChannelRequestRuntime:
         self,
         node: "Node",
         *,
-        normalization_runtime: _NodeChannelNormalizationRuntime,
+        channel_state: _NodeChannelState,
     ) -> None:
         self._node = node
-        self._normalization_runtime = normalization_runtime
+        self._channel_state = channel_state
 
     def setChannels(self, channels: Sequence[channel_pb2.Channel]) -> None:
         """Set channels from sequence with copy + normalization semantics."""
-        with self._node._channels_lock:  # noqa: SLF001
-            copied_channels: list[channel_pb2.Channel] = []
-            for source_channel in channels:
-                copied_channel = channel_pb2.Channel()
-                copied_channel.CopyFrom(source_channel)
-                copied_channels.append(copied_channel)
-            self._node.channels = copied_channels
-            self._normalization_runtime._fixup_channels_locked()
+        self._channel_state.replace_with_copies(channels)
 
     def set_channels(self, channels: Sequence[channel_pb2.Channel]) -> None:
         """COMPAT_STABLE_SHIM: Silent alias for setChannels."""
@@ -120,9 +115,7 @@ class _NodeChannelRequestRuntime:
             )
             return
         if starting_index == 0:
-            with self._node._channels_lock:  # noqa: SLF001
-                self._node.channels = None
-                self._node.partialChannels = []
+            self._channel_state.reset_for_download()
         self.requestChannel(starting_index)
 
     def request_channels(self, *, starting_index: int = 0) -> None:
@@ -145,7 +138,7 @@ class _NodeChannelRequestRuntime:
             )
             if callable(has_channel_request_failed):
                 probe = _ChannelRequestCompletionProbe(
-                    node=self._node,
+                    channel_state=self._channel_state,
                     channel_response_runtime=channel_response_runtime,
                 )
                 completed = self._node._timeout.waitForSet(  # noqa: SLF001
@@ -154,9 +147,8 @@ class _NodeChannelRequestRuntime:
                 )
                 if not completed:
                     return False
-                with self._node._channels_lock:  # noqa: SLF001
-                    if self._node.channels is not None:
-                        return True
+                if self._channel_state.has_channels():
+                    return True
                 return not bool(has_channel_request_failed())
             return self._node._timeout.waitForSet(  # noqa: SLF001
                 self._node,

--- a/meshtastic/node_runtime/channel_state.py
+++ b/meshtastic/node_runtime/channel_state.py
@@ -1,0 +1,244 @@
+"""Owned channel cache state for :class:`meshtastic.node.Node`."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Callable, Sequence
+from types import TracebackType
+from typing import Any, Protocol
+
+from meshtastic.node_runtime.shared import MAX_CHANNELS
+from meshtastic.protobuf import channel_pb2
+
+logger = logging.getLogger(__name__)
+
+
+class _ChannelLock(Protocol):
+    """Minimal context-manager contract required by channel state."""
+
+    def __enter__(self) -> Any:
+        """Acquire the lock and return its context value."""
+        # pylint: disable-next=unnecessary-ellipsis
+        ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> Any:
+        """Release the lock after the protected operation."""
+        # pylint: disable-next=unnecessary-ellipsis
+        ...
+
+
+class _NodeChannelState:
+    """Own channel cache data and its synchronization boundary.
+
+    ``Node.channels`` and ``Node.partialChannels`` remain compatibility-facing
+    live attributes through properties on ``Node``. Internal channel runtimes
+    should operate through this owner so the cache data and lock have one
+    explicit home.
+    """
+
+    def __init__(self) -> None:
+        self._lock: _ChannelLock = threading.RLock()
+        self._mutation_lock: _ChannelLock = threading.Lock()
+        self._channels: list[channel_pb2.Channel] | None = None
+        self._partial_channels: list[channel_pb2.Channel] = []
+
+    @property
+    def lock(self) -> _ChannelLock:
+        """Return the lock guarding cached and partial channel state."""
+        return self._lock
+
+    def _replace_lock(self, lock: _ChannelLock) -> None:
+        """Replace the lock for legacy tests that instrument ``Node._channels_lock``."""
+        self._lock = lock
+
+    @property
+    def mutation_lock(self) -> _ChannelLock:
+        """Return the lock serializing multi-step channel mutations and device I/O."""
+        return self._mutation_lock
+
+    def _replace_mutation_lock(self, lock: _ChannelLock) -> None:
+        """Replace the mutation lock for transaction-boundary instrumentation."""
+        self._mutation_lock = lock
+
+    @property
+    def channels(self) -> list[channel_pb2.Channel] | None:
+        """Return the live cached channel list without acquiring the owner lock."""
+        return self._channels
+
+    @channels.setter
+    def channels(self, value: list[channel_pb2.Channel] | None) -> None:
+        """Replace the live cached channel list without acquiring the owner lock."""
+        self._channels = value
+
+    @property
+    def partial_channels(self) -> list[channel_pb2.Channel]:
+        """Return the live partial-download channel list without acquiring the lock."""
+        return self._partial_channels
+
+    @partial_channels.setter
+    def partial_channels(self, value: list[channel_pb2.Channel]) -> None:
+        """Replace partial-download channel state without acquiring the owner lock."""
+        self._partial_channels = value
+
+    def has_channels(self) -> bool:
+        """Return whether a complete channel cache is currently installed."""
+        with self._lock:
+            return self._channels is not None
+
+    def invalidate(self) -> None:
+        """Clear complete and partial channel caches atomically."""
+        with self._lock:
+            self._channels = None
+            self._partial_channels = []
+
+    def snapshot_channels(self) -> list[channel_pb2.Channel]:
+        """Return detached copies of all currently cached channels."""
+        with self._lock:
+            return [self._copy_channel(channel) for channel in self._channels or []]
+
+    def replace_with_copies(
+        self,
+        channels: Sequence[channel_pb2.Channel],
+        *,
+        normalize: bool = True,
+    ) -> None:
+        """Replace cached channels with defensive copies under the owner lock."""
+        copied_channels = [self._copy_channel(channel) for channel in channels]
+        with self._lock:
+            self._channels = copied_channels
+            if normalize:
+                self._normalize_locked()
+
+    def reset_for_download(self) -> None:
+        """Clear complete and partial cache before a fresh channel download."""
+        self.invalidate()
+
+    def append_partial_if_new(self, channel: channel_pb2.Channel) -> bool:
+        """Append a channel response when its index is not already staged."""
+        with self._lock:
+            if any(
+                existing.index == channel.index for existing in self._partial_channels
+            ):
+                return False
+            self._partial_channels.append(channel)
+            return True
+
+    def install_partial_channels(self) -> None:
+        """Install the accumulated partial list as the complete normalized cache."""
+        with self._lock:
+            self._channels = list(self._partial_channels)
+            self._normalize_locked()
+
+    def normalize(self) -> None:
+        """Normalize cached channel count and indexes under the owner lock."""
+        with self._lock:
+            self._normalize_locked()
+
+    def _normalize_locked(self) -> None:
+        """Normalize cached channels while the caller holds :attr:`lock`."""
+        channels = self._channels
+        if channels is None:
+            return
+        if len(channels) > MAX_CHANNELS:
+            logger.warning(
+                "Truncating channel list from %d to %d entries",
+                len(channels),
+                MAX_CHANNELS,
+            )
+            del channels[MAX_CHANNELS:]
+        if len(channels) < MAX_CHANNELS:
+            self._fill_locked()
+            return
+        for index, channel in enumerate(channels):
+            channel.index = index
+
+    def fill(self) -> None:
+        """Append disabled channels to the device channel limit under the lock."""
+        with self._lock:
+            self._fill_locked()
+
+    def _fill_locked(self) -> None:
+        """Append disabled channels while the caller holds :attr:`lock`."""
+        channels = self._channels
+        if channels is None:
+            return
+        for index, channel in enumerate(channels):
+            channel.index = index
+        for index in range(len(channels), MAX_CHANNELS):
+            channel = channel_pb2.Channel()
+            channel.role = channel_pb2.Channel.Role.DISABLED
+            channel.index = index
+            channels.append(channel)
+
+    def get_live_by_index(self, channel_index: int) -> channel_pb2.Channel | None:
+        """Return the historical live channel reference for ``channel_index``."""
+        with self._lock:
+            channels = self._channels
+            if channels and 0 <= channel_index < len(channels):
+                return channels[channel_index]
+            return None
+
+    def get_copy_by_index(self, channel_index: int) -> channel_pb2.Channel | None:
+        """Return a detached channel copy for ``channel_index`` when available."""
+        with self._lock:
+            channels = self._channels
+            if channels and 0 <= channel_index < len(channels):
+                return self._copy_channel(channels[channel_index])
+            return None
+
+    def get_live_by_name(self, name: str) -> channel_pb2.Channel | None:
+        """Return the historical live channel reference matching ``name``."""
+        with self._lock:
+            for channel in self._channels or []:
+                if channel.settings and channel.settings.name == name:
+                    return channel
+            return None
+
+    def get_copy_by_name(self, name: str) -> channel_pb2.Channel | None:
+        """Return a detached channel copy matching ``name`` when available."""
+        with self._lock:
+            for channel in self._channels or []:
+                if channel.settings and channel.settings.name == name:
+                    return self._copy_channel(channel)
+            return None
+
+    def get_live_disabled(self) -> channel_pb2.Channel | None:
+        """Return the historical live first disabled-channel reference."""
+        with self._lock:
+            for channel in self._channels or []:
+                if channel.role == channel_pb2.Channel.Role.DISABLED:
+                    return channel
+            return None
+
+    def get_copy_disabled(self) -> channel_pb2.Channel | None:
+        """Return a detached copy of the first disabled channel when available."""
+        with self._lock:
+            for channel in self._channels or []:
+                if channel.role == channel_pb2.Channel.Role.DISABLED:
+                    return self._copy_channel(channel)
+            return None
+
+    def named_admin_index(self, *, is_named_admin: Callable[[str], bool]) -> int | None:
+        """Return the index of the enabled channel accepted by ``is_named_admin``."""
+        with self._lock:
+            for channel in self._channels or []:
+                if (
+                    channel.role != channel_pb2.Channel.Role.DISABLED
+                    and channel.settings
+                    and is_named_admin(channel.settings.name)
+                ):
+                    return channel.index
+            return None
+
+    @staticmethod
+    def _copy_channel(channel: channel_pb2.Channel) -> channel_pb2.Channel:
+        """Return a defensive protobuf copy of ``channel``."""
+        copied = channel_pb2.Channel()
+        copied.CopyFrom(channel)
+        return copied

--- a/meshtastic/node_runtime/response_runtime.py
+++ b/meshtastic/node_runtime/response_runtime.py
@@ -7,6 +7,7 @@ from meshtastic.node_runtime.admin_wait import (
     _mark_admin_wait_acknowledged_for_packet,
     _record_admin_wait_error_for_packet,
 )
+from meshtastic.node_runtime.channel_state import _NodeChannelState
 from meshtastic.node_runtime.shared import ERROR_REASON_NONE, MAX_CHANNELS
 from meshtastic.protobuf import channel_pb2, config_pb2, mesh_pb2, portnums_pb2
 from meshtastic.util import stripnl
@@ -224,8 +225,9 @@ class _NodeMetadataResponseRuntime:
 class _NodeChannelResponseRuntime:
     """Owns channel-response routing/error handling, sequencing, and final installation."""
 
-    def __init__(self, node: "Node") -> None:
+    def __init__(self, node: "Node", *, channel_state: _NodeChannelState) -> None:
         self._node = node
+        self._channel_state = channel_state
         self._pending_channel_request_index: int | None = None
         self._pending_channel_retry_count = 0
         self._channel_request_failed = False
@@ -417,17 +419,12 @@ class _NodeChannelResponseRuntime:
         if self._should_skip_channel_response(channel_response):
             return
 
-        with self._node._channels_lock:  # noqa: SLF001
-            if any(
-                existing.index == channel_response.index
-                for existing in self._node.partialChannels
-            ):
-                logger.debug(
-                    "Ignoring duplicate channel response index=%s.",
-                    channel_response.index,
-                )
-                return
-            self._node.partialChannels.append(channel_response)
+        if not self._channel_state.append_partial_if_new(channel_response):
+            logger.debug(
+                "Ignoring duplicate channel response index=%s.",
+                channel_response.index,
+            )
+            return
         self._node._timeout.reset()  # We made forward progress
         safe_role = (
             channel_pb2.Channel.Role.Name(channel_response.role)
@@ -447,9 +444,7 @@ class _NodeChannelResponseRuntime:
 
         if index >= MAX_CHANNELS - 1:
             logger.debug("Finished downloading channels")
-            with self._node._channels_lock:  # noqa: SLF001
-                self._node.channels = list(self._node.partialChannels)
-                self._node._fixup_channels_locked()  # noqa: SLF001
+            self._channel_state.install_partial_channels()
             self._pending_channel_request_index = None
             self._pending_channel_retry_count = 0
             return

--- a/meshtastic/node_runtime/seturl/cache.py
+++ b/meshtastic/node_runtime/seturl/cache.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from meshtastic.node_runtime.channel_state import _NodeChannelState
 from meshtastic.node_runtime.seturl.helpers import _channels_fingerprint
 from meshtastic.protobuf import channel_pb2, config_pb2
 
@@ -19,13 +20,14 @@ _ERR_CONFIG_OR_CHANNELS_NOT_LOADED = "Config or channels not loaded"
 class _SetUrlCacheManager:
     """Owns local cache updates, invalidation, and restoration for setURL transactions."""
 
-    def __init__(self, node: Node) -> None:
+    def __init__(self, node: Node, *, channel_state: _NodeChannelState) -> None:
         self._node = node
+        self._channel_state = channel_state
 
     def _invalidate_channel_cache_locked(self, warning_message: str) -> None:
-        """Invalidate channel cache while already holding ``_channels_lock``."""
-        self._node.channels = None
-        self._node.partialChannels = []
+        """Invalidate channel cache while already holding ``_channel_state.lock``."""
+        self._channel_state.channels = None
+        self._channel_state.partial_channels = []
         logger.warning("%s", warning_message)
 
     def apply_add_only_success(
@@ -35,10 +37,10 @@ class _SetUrlCacheManager:
         expected_channels_fingerprint: tuple[bytes, ...] | None = None,
     ) -> None:
         """Apply addOnly channel cache updates after remote writes succeed."""
-        with self._node._channels_lock:  # noqa: SLF001
-            channels = self._node.channels
+        with self._channel_state.lock:
+            channels = self._channel_state.channels
             if channels is None:
-                self._node.partialChannels = []
+                self._channel_state.partial_channels = []
                 logger.warning(
                     "Channel cache unavailable after successful addOnly apply; reload channels to refresh local state."
                 )
@@ -60,7 +62,7 @@ class _SetUrlCacheManager:
                     )
                     break
             else:
-                self._node.partialChannels = []
+                self._channel_state.partial_channels = []
 
     def apply_replace_channel_write(
         self,
@@ -68,15 +70,14 @@ class _SetUrlCacheManager:
         *,
         expected_channels_fingerprint: tuple[bytes, ...] | None = None,
         expected_channels_ref: list[channel_pb2.Channel] | None = None,
-    ) -> None:
-        """Apply one replace-path channel cache update after a successful write."""
-        with self._node._channels_lock:  # noqa: SLF001
-            channels = self._node.channels
+    ) -> tuple[bytes, ...]:
+        """Apply a replace-path write and return the next guarded fingerprint."""
+        with self._channel_state.lock:
+            channels = self._channel_state.channels
             if channels is None:
                 self._node._raise_interface_error(  # noqa: SLF001
                     _ERR_CONFIG_OR_CHANNELS_NOT_LOADED
                 )
-                return  # unreachable; satisfies type checker
             channels_changed = False
             if (
                 expected_channels_ref is not None
@@ -94,18 +95,22 @@ class _SetUrlCacheManager:
                 self._node._raise_interface_error(  # noqa: SLF001
                     "Channel cache changed during replace-all cache update; aborting transaction."
                 )
-                return  # unreachable; satisfies type checker
             if not 0 <= staged_channel.index < len(channels):
+                self._invalidate_channel_cache_locked(
+                    "Channel index "
+                    f"{staged_channel.index} out of range during replace-all cache "
+                    "update; invalidating local channel cache."
+                )
                 self._node._raise_interface_error(  # noqa: SLF001
                     f"Channel index {staged_channel.index} out of range during cache update"
                 )
-                return  # unreachable; satisfies type checker
             channels[staged_channel.index].CopyFrom(staged_channel)
-            self._node.partialChannels = []
+            self._channel_state.partial_channels = []
+            return _channels_fingerprint(channels)
 
     def invalidate_channel_cache(self, warning_message: str) -> None:
         """Invalidate local channel cache after partial failure."""
-        with self._node._channels_lock:  # noqa: SLF001
+        with self._channel_state.lock:
             self._invalidate_channel_cache_locked(warning_message)
 
     def apply_lora_success(self, lora_config: config_pb2.Config.LoRaConfig) -> None:

--- a/meshtastic/node_runtime/seturl/coordinator.py
+++ b/meshtastic/node_runtime/seturl/coordinator.py
@@ -6,6 +6,7 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any
 
+from meshtastic.node_runtime.channel_state import _NodeChannelState
 from meshtastic.node_runtime.seturl.cache import _SetUrlCacheManager
 from meshtastic.node_runtime.seturl.context import _SetUrlAdminContext
 from meshtastic.node_runtime.seturl.execution import (
@@ -63,7 +64,13 @@ settle before we attempt serial reconnect."""
 class _SetUrlTransactionCoordinator:
     """Coordinates setURL transaction planning, execution, and cache policy with fail-fast semantics."""
 
-    def __init__(self, node: "Node", *, parsed_input: _SetUrlParsedInput) -> None:
+    def __init__(
+        self,
+        node: "Node",
+        *,
+        parsed_input: _SetUrlParsedInput,
+        channel_state: _NodeChannelState,
+    ) -> None:
         """Initialize the setURL transaction coordinator.
 
         Parameters
@@ -74,11 +81,15 @@ class _SetUrlTransactionCoordinator:
             Parsed setURL input containing channel set and flags.
         """
         self._node = node
+        self._channel_state = channel_state
         self._parsed_input = parsed_input
         self._admin_context = self._resolve_admin_context()
-        self._cache_manager = _SetUrlCacheManager(node)
+        self._cache_manager = _SetUrlCacheManager(
+            node, channel_state=self._channel_state
+        )
         self._execution_engine = _SetUrlExecutionEngine(
             node,
+            channel_state=self._channel_state,
             cache_manager=self._cache_manager,
         )
 
@@ -89,9 +100,7 @@ class _SetUrlTransactionCoordinator:
             self._node._raise_interface_error(  # noqa: SLF001
                 "Interface localNode not initialized"
             )
-        admin_index_for_write = (
-            admin_write_node._get_admin_channel_index()
-        )  # noqa: SLF001
+        admin_index_for_write = admin_write_node._get_admin_channel_index()  # noqa: SLF001
         named_admin_index_for_write = (
             admin_write_node._get_named_admin_channel_index()  # noqa: SLF001
         )
@@ -244,7 +253,7 @@ class _SetUrlTransactionCoordinator:
                 return False
             if (
                 getattr(iface, "myInfo", None) is not None
-                and self._node.channels is not None
+                and self._channel_state.has_channels()
             ):
                 return True
             time.sleep(0.1)
@@ -306,6 +315,16 @@ class _SetUrlTransactionCoordinator:
         plan: _SetUrlReplacePlan,
         failure_stage: _ReplaceAllStage | None = None,
     ) -> tuple[set[int], bool] | None:
+        """Reconnect, reload state, and identify replace-all work still pending.
+
+        The caller owns the channel-mutation lock for the complete replace
+        transaction. This helper may wait for transport recovery and config
+        reloads, but it never acquires the channel-state lock across those
+        waits; state comparison is performed only after the device is stable.
+
+        Returns ``None`` when bounded reconnect or config reload cannot
+        establish a trustworthy device state.
+        """
         if failure_stage == _ReplaceAllStage.LORA_CONFIG:
             logger.info(
                 "LoRa-stage failure; settling %.1fs before reconnect.",
@@ -381,15 +400,16 @@ class _SetUrlTransactionCoordinator:
                 )
                 continue
 
-            actual_channels = self._node.channels
-            if actual_channels is None:
-                logger.warning(
-                    "Device channels not available after reconnect; cannot resume."
+            with self._channel_state.lock:
+                actual_channels = self._channel_state.channels
+                if actual_channels is None:
+                    logger.warning(
+                        "Device channels not available after reconnect; cannot resume."
+                    )
+                    return None
+                remaining_indices = _compute_remaining_channel_writes(
+                    actual_channels, plan.staged_channels_by_index
                 )
-                return None
-            remaining_indices = _compute_remaining_channel_writes(
-                actual_channels, plan.staged_channels_by_index
-            )
             lora_needed = False
             if self._parsed_input.has_lora_update:
                 actual_lora = self._node.localConfig.lora
@@ -435,10 +455,17 @@ class _SetUrlTransactionCoordinator:
 
     def _apply_add_only(self) -> None:
         """Execute the addOnly setURL transaction pipeline."""
+        with self._channel_state.mutation_lock:
+            self._admin_context = self._resolve_admin_context()
+            self._apply_add_only_locked()
+
+    def _apply_add_only_locked(self) -> None:
+        """Execute addOnly while holding the per-node channel-mutation lock."""
         planner = _SetUrlAddOnlyPlanner(
             self._node,
             parsed_input=self._parsed_input,
             admin_context=self._admin_context,
+            channel_state=self._channel_state,
         )
         plan = planner.build_plan()
         for ignored_name in plan.ignored_channel_names:
@@ -499,10 +526,17 @@ class _SetUrlTransactionCoordinator:
         achieved within the bound, the final error is raised with
         precise reporting of the failure stage.
         """
+        with self._channel_state.mutation_lock:
+            self._admin_context = self._resolve_admin_context()
+            self._apply_replace_all_locked()
+
+    def _apply_replace_all_locked(self) -> None:
+        """Execute replace-all and recovery under the channel-mutation lock."""
         planner = _SetUrlReplacePlanner(
             self._node,
             parsed_input=self._parsed_input,
             admin_context=self._admin_context,
+            channel_state=self._channel_state,
         )
         plan = planner.build_plan()
         skip_channel_indices: set[int] = set()

--- a/meshtastic/node_runtime/seturl/execution.py
+++ b/meshtastic/node_runtime/seturl/execution.py
@@ -8,6 +8,7 @@ import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from meshtastic.node_runtime.channel_state import _NodeChannelState
 from meshtastic.node_runtime.seturl.cache import _SetUrlCacheManager
 from meshtastic.node_runtime.seturl.context import _SetUrlAdminContext
 from meshtastic.node_runtime.seturl.helpers import _channels_fingerprint
@@ -75,9 +76,11 @@ class _SetUrlExecutionEngine:
         self,
         node: Node,
         *,
+        channel_state: _NodeChannelState,
         cache_manager: _SetUrlCacheManager,
     ) -> None:
         self._node = node
+        self._channel_state = channel_state
         self._cache_manager = cache_manager
 
     @staticmethod
@@ -108,6 +111,65 @@ class _SetUrlExecutionEngine:
                 "LoRa config update was not started"
             )
         state.lora_write_started = True
+
+    def _validate_replace_cache(
+        self,
+        expected_channels_ref: list[channel_pb2.Channel],
+        expected_channels_fingerprint: tuple[bytes, ...],
+    ) -> None:
+        """Abort when channel state drifts from a replace transaction baseline."""
+        with self._channel_state.lock:
+            channels = self._channel_state.channels
+            channels_changed = channels is not expected_channels_ref
+            if not channels_changed:
+                channels_changed = (
+                    _channels_fingerprint(expected_channels_ref)
+                    != expected_channels_fingerprint
+                )
+        if channels_changed:
+            self._cache_manager.invalidate_channel_cache(
+                "Channel cache changed before replace-all write; invalidating local channel cache."
+            )
+            self._node._raise_interface_error(  # noqa: SLF001
+                "Channel cache changed before replace-all write; aborting transaction."
+            )
+
+    def _capture_replace_cache(
+        self,
+    ) -> tuple[list[channel_pb2.Channel], tuple[bytes, ...]]:
+        """Capture the current cache guard for a resumed replace transaction."""
+        with self._channel_state.lock:
+            channels = self._channel_state.channels
+            if channels is not None:
+                return channels, _channels_fingerprint(channels)
+        return self._node._raise_interface_error(  # noqa: SLF001
+            "Config or channels not loaded"
+        )
+
+    def _write_replace_channel(
+        self,
+        staged_channel: channel_pb2.Channel,
+        *,
+        admin_index: int | None,
+        state: _SetUrlReplaceExecutionState,
+        expected_channels_ref: list[channel_pb2.Channel],
+        expected_channels_fingerprint: tuple[bytes, ...],
+    ) -> tuple[bytes, ...]:
+        """Write one channel without the state lock, then commit it atomically."""
+        self._validate_replace_cache(
+            expected_channels_ref,
+            expected_channels_fingerprint,
+        )
+        self._node._write_channel_snapshot(  # noqa: SLF001
+            staged_channel,
+            adminIndex=admin_index,
+        )
+        state.written_channel_indices.append(staged_channel.index)
+        return self._cache_manager.apply_replace_channel_write(
+            staged_channel,
+            expected_channels_ref=expected_channels_ref,
+            expected_channels_fingerprint=expected_channels_fingerprint,
+        )
 
     def executeAddOnly(
         self,
@@ -177,28 +239,11 @@ class _SetUrlExecutionEngine:
             )
             if channel is not None
         }
-        cache_ref = (
-            plan.replace_original_channels_ref if skip_channel_indices is None else None
-        )
         if skip_channel_indices is None:
-            channels = self._node.channels
-            channels_changed = plan.replace_original_channels_ref is not channels
-            if (
-                not channels_changed
-                and plan.replace_original_channels_fingerprint
-                and channels is not None
-            ):
-                channels_changed = (
-                    _channels_fingerprint(channels)
-                    != plan.replace_original_channels_fingerprint
-                )
-            if channels_changed:
-                self._cache_manager.invalidate_channel_cache(
-                    "Channel cache changed before replace-all write; invalidating local channel cache."
-                )
-                self._node._raise_interface_error(  # noqa: SLF001
-                    "Channel cache changed before replace-all write; aborting transaction."
-                )
+            cache_ref = plan.replace_original_channels_ref
+            cache_fingerprint = plan.replace_original_channels_fingerprint
+        else:
+            cache_ref, cache_fingerprint = self._capture_replace_cache()
         state.stage = _ReplaceAllStage.CHANNEL_WRITES
         written_count = 0
         for staged_channel in plan.staged_channels:
@@ -217,14 +262,12 @@ class _SetUrlExecutionEngine:
                 self._safe_channel_role_name(staged_channel.role),
                 staged_channel.settings.name if staged_channel.settings else None,
             )
-            self._node._write_channel_snapshot(  # noqa: SLF001
+            cache_fingerprint = self._write_replace_channel(
                 staged_channel,
-                adminIndex=admin_context.admin_index_for_write,
-            )
-            state.written_channel_indices.append(staged_channel.index)
-            self._cache_manager.apply_replace_channel_write(
-                staged_channel,
+                admin_index=admin_context.admin_index_for_write,
+                state=state,
                 expected_channels_ref=cache_ref,
+                expected_channels_fingerprint=cache_fingerprint,
             )
             written_count += 1
 
@@ -259,16 +302,12 @@ class _SetUrlExecutionEngine:
                         else None
                     ),
                 )
-                self._node._write_channel_snapshot(  # noqa: SLF001
+                cache_fingerprint = self._write_replace_channel(
                     plan.deferred_new_named_admin_channel,
-                    adminIndex=admin_context.admin_index_for_write,
-                )
-                state.written_channel_indices.append(
-                    plan.deferred_new_named_admin_channel.index
-                )
-                self._cache_manager.apply_replace_channel_write(
-                    plan.deferred_new_named_admin_channel,
+                    admin_index=admin_context.admin_index_for_write,
+                    state=state,
                     expected_channels_ref=cache_ref,
+                    expected_channels_fingerprint=cache_fingerprint,
                 )
 
         if plan.deferred_previous_admin_slot_channel is not None:
@@ -291,14 +330,10 @@ class _SetUrlExecutionEngine:
                     plan.deferred_previous_admin_slot_channel.index,
                     updated_admin_index_for_write,
                 )
-                self._node._write_channel_snapshot(  # noqa: SLF001
+                self._write_replace_channel(
                     plan.deferred_previous_admin_slot_channel,
-                    adminIndex=updated_admin_index_for_write,
-                )
-                state.written_channel_indices.append(
-                    plan.deferred_previous_admin_slot_channel.index
-                )
-                self._cache_manager.apply_replace_channel_write(
-                    plan.deferred_previous_admin_slot_channel,
+                    admin_index=updated_admin_index_for_write,
+                    state=state,
                     expected_channels_ref=cache_ref,
+                    expected_channels_fingerprint=cache_fingerprint,
                 )

--- a/meshtastic/node_runtime/seturl/planner.py
+++ b/meshtastic/node_runtime/seturl/planner.py
@@ -6,6 +6,7 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from meshtastic.node_runtime.channel_state import _NodeChannelState
 from meshtastic.node_runtime.seturl.context import _SetUrlAdminContext
 from meshtastic.node_runtime.seturl.helpers import _channels_fingerprint
 from meshtastic.node_runtime.seturl.parser import _SetUrlParsedInput
@@ -58,8 +59,10 @@ class _SetUrlAddOnlyPlanner:
         *,
         parsed_input: _SetUrlParsedInput,
         admin_context: _SetUrlAdminContext,
+        channel_state: _NodeChannelState,
     ) -> None:
         self._node = node
+        self._channel_state = channel_state
         self._parsed_input = parsed_input
         self._admin_context = admin_context
 
@@ -70,8 +73,8 @@ class _SetUrlAddOnlyPlanner:
         original_channels_ref: list[channel_pb2.Channel] = []
         original_channels_by_index: dict[int, channel_pb2.Channel] = {}
         original_channels_fingerprint: tuple[bytes, ...] = ()
-        with self._node._channels_lock:  # noqa: SLF001
-            channels = self._node.channels
+        with self._channel_state.lock:
+            channels = self._channel_state.channels
             if channels is None:
                 self._node._raise_interface_error(  # noqa: SLF001
                     _ERR_CONFIG_OR_CHANNELS_NOT_LOADED
@@ -157,17 +160,19 @@ class _SetUrlReplacePlanner:
         *,
         parsed_input: _SetUrlParsedInput,
         admin_context: _SetUrlAdminContext,
+        channel_state: _NodeChannelState,
     ) -> None:
         self._node = node
+        self._channel_state = channel_state
         self._parsed_input = parsed_input
         self._admin_context = admin_context
 
     def build_plan(self) -> _SetUrlReplacePlan:
         """Build replace-all staging plan, deferred admin strategy, and snapshots."""
         replace_original_channels_fingerprint: tuple[bytes, ...] = ()
-        with self._node._channels_lock:  # noqa: SLF001
+        with self._channel_state.lock:
             replace_original_channels_ref: list[channel_pb2.Channel] = []
-            channels = self._node.channels
+            channels = self._channel_state.channels
             if channels is None:
                 self._node._raise_interface_error(  # noqa: SLF001
                     _ERR_CONFIG_OR_CHANNELS_NOT_LOADED

--- a/meshtastic/node_runtime/transport_runtime/channel.py
+++ b/meshtastic/node_runtime/transport_runtime/channel.py
@@ -8,14 +8,13 @@ from meshtastic.node_runtime.admin_wait import (
     _send_admin_with_ack_scope,
     _wait_for_admin_ack,
 )
+from meshtastic.node_runtime.channel_state import _NodeChannelState
 from meshtastic.node_runtime.shared import (
     MAX_CHANNELS,
 )
 from meshtastic.node_runtime.shared import (
     isNamedAdminChannelName as _isNamedAdminChannelName,
 )
-from meshtastic.node_runtime.transport_runtime.admin import _NodeAdminTransportRuntime
-from meshtastic.node_runtime.transport_runtime.session import _NodeAdminSessionRuntime
 from meshtastic.protobuf import admin_pb2, channel_pb2
 
 if TYPE_CHECKING:
@@ -38,12 +37,10 @@ class _NodeChannelWriteRuntime:
         self,
         node: "Node",
         *,
-        admin_session_runtime: _NodeAdminSessionRuntime,
-        admin_transport_runtime: _NodeAdminTransportRuntime,
+        channel_state: _NodeChannelState,
     ) -> None:
         self._node = node
-        self._admin_session_runtime = admin_session_runtime
-        self._admin_transport_runtime = admin_transport_runtime
+        self._channel_state = channel_state
 
     def _write_channel_snapshot(
         self,
@@ -93,22 +90,25 @@ class _NodeChannelWriteRuntime:
         self, channel_index: int, *, admin_index: int | None = None
     ) -> None:
         """Validate and write one channel by index using snapshot semantics."""
-        with self._node._channels_lock:
-            channels = self._node.channels
-            if channels is None:
-                self._node._raise_interface_error("Error: No channels have been read")
-            if len(channels) == 0:
-                self._node._raise_interface_error("Error: Channels list is empty")
-            if channel_index < 0 or channel_index >= len(channels):
-                self._node._raise_interface_error(
-                    f"Channel index {channel_index} out of range (0-{len(channels) - 1})"
-                )
-            channel_snapshot = channel_pb2.Channel()
-            channel_snapshot.CopyFrom(channels[channel_index])
-        self._write_channel_snapshot(
-            channel_snapshot,
-            admin_index=admin_index,
-        )
+        with self._channel_state.mutation_lock:
+            with self._channel_state.lock:
+                channels = self._channel_state.channels
+                if channels is None:
+                    self._node._raise_interface_error(
+                        "Error: No channels have been read"
+                    )
+                if len(channels) == 0:
+                    self._node._raise_interface_error("Error: Channels list is empty")
+                if channel_index < 0 or channel_index >= len(channels):
+                    self._node._raise_interface_error(
+                        f"Channel index {channel_index} out of range (0-{len(channels) - 1})"
+                    )
+                channel_snapshot = channel_pb2.Channel()
+                channel_snapshot.CopyFrom(channels[channel_index])
+            self._write_channel_snapshot(
+                channel_snapshot,
+                admin_index=admin_index,
+            )
 
 
 @dataclass(frozen=True)
@@ -131,9 +131,11 @@ class _NodeDeleteChannelRuntime:
         self,
         node: "Node",
         *,
+        channel_state: _NodeChannelState,
         channel_write_runtime: _NodeChannelWriteRuntime,
     ) -> None:
         self._node = node
+        self._channel_state = channel_state
         self._channel_write_runtime = channel_write_runtime
 
     @staticmethod
@@ -185,9 +187,9 @@ class _NodeDeleteChannelRuntime:
     def _build_rewrite_plan(self, channel_index: int) -> _DeleteChannelRewritePlan:
         """Build delete/rewrite plan with pre/post admin indexes.
 
-        Caller must hold self._node._channels_lock.
+        Caller must hold the channel-state owner lock.
         """
-        channels = self._node.channels
+        channels = self._channel_state.channels
         if channels is None:
             self._node._raise_interface_error("Error: No channels have been read")
         if len(channels) == 0:
@@ -284,46 +286,54 @@ class _NodeDeleteChannelRuntime:
                 admin_index_for_write = plan.post_delete_admin_index
 
     def _delete_channel(self, channel_index: int) -> None:
-        """Delete one channel and execute ordered rewrite plan.
+        """Delete one channel and execute its ordered rewrite plan.
 
-        The entire delete operation is serialized under the channels lock to prevent
-        concurrent in-place mutations from racing with the delete/rewrite sequence.
+        The per-node mutation lock serializes delete with every other channel
+        transaction. Planning and cache commits use the channel-state lock, but
+        device writes and remote ACK waits run outside that state lock. Inbound
+        channel responses therefore remain free to reach request correlation while a
+        rewrite is in flight. Post-write identity and fingerprint checks detect
+        concurrent cache changes before committing the staged result.
         """
-        with self._node._channels_lock:
-            rewrite_plan = self._build_rewrite_plan(channel_index)
+        with self._channel_state.mutation_lock:
+            with self._channel_state.lock:
+                rewrite_plan = self._build_rewrite_plan(channel_index)
+
             try:
                 self._execute_rewrite_plan(rewrite_plan)
             except Exception:
-                self._node.channels = None
-                self._node.partialChannels = []
+                self._channel_state.invalidate()
                 raise
-            current_channels = self._node.channels
-            if current_channels is None:
-                logger.warning(
-                    "Channel cache became unavailable during delete rewrite; skipping staged cache commit."
-                )
-                self._node.partialChannels = []
-                return
-            if current_channels is not rewrite_plan.original_channels_ref:
-                logger.warning(
-                    "Channel cache changed during delete rewrite; invalidating local channel cache."
-                )
-                self._node.channels = None
-                self._node.partialChannels = []
-                return
-            if (
-                _channels_fingerprint(current_channels)
-                != rewrite_plan.original_channels_fingerprint
-            ):
-                logger.warning(
-                    "Channel fingerprint mismatch after delete rewrite; invalidating local channel cache."
-                )
-                self._node.channels = None
-                self._node.partialChannels = []
-                return
-            current_channels.clear()
-            for staged_channel in rewrite_plan.staged_channels:
-                channel_copy = channel_pb2.Channel()
-                channel_copy.CopyFrom(staged_channel)
-                current_channels.append(channel_copy)
-            self._node._fixup_channels_locked()
+
+            with self._channel_state.lock:
+                current_channels = self._channel_state.channels
+                if current_channels is None:
+                    logger.warning(
+                        "Channel cache became unavailable during delete rewrite; skipping staged cache commit."
+                    )
+                    self._channel_state.partial_channels = []
+                    return
+                if current_channels is not rewrite_plan.original_channels_ref:
+                    logger.warning(
+                        "Channel cache changed during delete rewrite; invalidating local channel cache."
+                    )
+                    self._channel_state.channels = None
+                    self._channel_state.partial_channels = []
+                    return
+                if (
+                    _channels_fingerprint(current_channels)
+                    != rewrite_plan.original_channels_fingerprint
+                ):
+                    logger.warning(
+                        "Channel fingerprint mismatch after delete rewrite; invalidating local channel cache."
+                    )
+                    self._channel_state.channels = None
+                    self._channel_state.partial_channels = []
+                    return
+                current_channels.clear()
+                for staged_channel in rewrite_plan.staged_channels:
+                    channel_copy = channel_pb2.Channel()
+                    channel_copy.CopyFrom(staged_channel)
+                    current_channels.append(channel_copy)
+                self._channel_state._normalize_locked()  # noqa: SLF001
+                self._channel_state.partial_channels = []

--- a/meshtastic/tests/_node_channel_state_test_support.py
+++ b/meshtastic/tests/_node_channel_state_test_support.py
@@ -1,0 +1,42 @@
+"""Typed test support for Node doubles backed by owned channel state."""
+
+from unittest.mock import MagicMock
+
+from meshtastic.node_runtime.channel_state import _ChannelLock, _NodeChannelState
+from meshtastic.protobuf import channel_pb2
+
+
+def _attach_channel_state(node: MagicMock) -> _NodeChannelState:
+    """Back a Node double's compatibility attributes with one state owner."""
+    state = _NodeChannelState()
+
+    def _get_channels(_node: object) -> list[channel_pb2.Channel] | None:
+        return state.channels
+
+    def _set_channels(
+        _node: object, value: list[channel_pb2.Channel] | None
+    ) -> None:
+        state.channels = value
+
+    def _get_partial_channels(_node: object) -> list[channel_pb2.Channel]:
+        return state.partial_channels
+
+    def _set_partial_channels(
+        _node: object, value: list[channel_pb2.Channel]
+    ) -> None:
+        state.partial_channels = value
+
+    def _get_channels_lock(_node: object) -> _ChannelLock:
+        return state.lock
+
+    def _set_channels_lock(_node: object, value: _ChannelLock) -> None:
+        state._replace_lock(value)  # noqa: SLF001
+
+    node._test_channel_state = state
+    type(node).channels = property(_get_channels, _set_channels)
+    type(node).partialChannels = property(  # noqa: N802 - compatibility test surface
+        _get_partial_channels,
+        _set_partial_channels,
+    )
+    type(node)._channels_lock = property(_get_channels_lock, _set_channels_lock)
+    return state

--- a/meshtastic/tests/seturl/conftest.py
+++ b/meshtastic/tests/seturl/conftest.py
@@ -4,11 +4,13 @@
 import base64
 import threading
 from collections.abc import Callable
+from types import TracebackType
 from typing import NoReturn
 from unittest.mock import MagicMock
 
 import pytest
 
+from meshtastic.tests._node_channel_state_test_support import _attach_channel_state
 from meshtastic.node_runtime.seturl_runtime import (
     _SetUrlCacheManager,
     _SetUrlExecutionEngine,
@@ -18,6 +20,36 @@ from meshtastic.protobuf import (
     channel_pb2,
     localonly_pb2,
 )
+
+
+class _LockProbe:
+    """Instrument a reentrant lock so tests can assert its acquisition scope."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self.depth = 0
+
+    @property
+    def active(self) -> bool:
+        """Return whether the current test scope holds the lock."""
+        return self.depth > 0
+
+    def __enter__(self) -> "_LockProbe":
+        """Acquire the underlying lock and record the acquisition depth."""
+        self._lock.acquire()
+        self.depth += 1
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Record release and relinquish the underlying lock."""
+        del exc_type, exc_value, traceback
+        self.depth -= 1
+        self._lock.release()
 
 
 def _make_raise_error_side_effect() -> Callable[[str], NoReturn]:
@@ -137,6 +169,7 @@ def mock_local_node(mock_iface: MagicMock) -> MagicMock:
             "iface",
             "noProto",
             "_channels_lock",
+            "_test_channel_state",
             "channels",
             "partialChannels",
             "localConfig",
@@ -153,9 +186,10 @@ def mock_local_node(mock_iface: MagicMock) -> MagicMock:
     node.nodeNum = 1234567890
     node.iface = mock_iface
     node.noProto = False
-    node._channels_lock = threading.RLock()
-    node.channels = None
-    node.partialChannels = []
+    channel_state = _attach_channel_state(node)
+    channel_state._replace_lock(threading.RLock())
+    channel_state.channels = None
+    channel_state.partial_channels = []
     node.localConfig = localonly_pb2.LocalConfig()
     node._raise_interface_error = MagicMock(side_effect=Exception("interface error"))
     node._write_channel_snapshot = MagicMock()
@@ -184,7 +218,9 @@ def cache_manager(mock_local_node: MagicMock) -> _SetUrlCacheManager:
     _SetUrlCacheManager
         The cache manager instance under test.
     """
-    return _SetUrlCacheManager(mock_local_node)
+    return _SetUrlCacheManager(
+        mock_local_node, channel_state=mock_local_node._test_channel_state
+    )
 
 
 @pytest.fixture
@@ -205,7 +241,11 @@ def execution_engine(
     _SetUrlExecutionEngine
         The execution engine instance under test.
     """
-    return _SetUrlExecutionEngine(mock_local_node, cache_manager=cache_manager)
+    return _SetUrlExecutionEngine(
+        mock_local_node,
+        channel_state=mock_local_node._test_channel_state,
+        cache_manager=cache_manager,
+    )
 
 
 @pytest.fixture
@@ -259,6 +299,7 @@ def mock_local_node_with_reconnect(
             "iface",
             "noProto",
             "_channels_lock",
+            "_test_channel_state",
             "channels",
             "partialChannels",
             "localConfig",
@@ -275,9 +316,10 @@ def mock_local_node_with_reconnect(
     node.nodeNum = 1234567890
     node.iface = mock_iface_with_reconnect
     node.noProto = False
-    node._channels_lock = threading.RLock()
-    node.channels = None
-    node.partialChannels = []
+    channel_state = _attach_channel_state(node)
+    channel_state._replace_lock(threading.RLock())
+    channel_state.channels = None
+    channel_state.partial_channels = []
     node.localConfig = localonly_pb2.LocalConfig()
     node._raise_interface_error = MagicMock(side_effect=Exception("interface error"))
     node._write_channel_snapshot = MagicMock()

--- a/meshtastic/tests/seturl/test_cache_manager.py
+++ b/meshtastic/tests/seturl/test_cache_manager.py
@@ -138,9 +138,10 @@ class TestSetUrlCacheManager:
 
         staged_channel = _make_channel(0, channel_pb2.Channel.Role.PRIMARY, "new")
 
-        cache_manager.apply_replace_channel_write(staged_channel)
+        next_fingerprint = cache_manager.apply_replace_channel_write(staged_channel)
 
         assert mock_local_node.channels[0].settings.name == "new"
+        assert next_fingerprint == _channels_fingerprint(mock_local_node.channels)
 
     @pytest.mark.unit
     def test_apply_replace_channel_write_mismatched_expected_ref_invalidates(

--- a/meshtastic/tests/seturl/test_coordinator.py
+++ b/meshtastic/tests/seturl/test_coordinator.py
@@ -12,11 +12,16 @@ from meshtastic.node_runtime.seturl.execution import _ReplaceAllStage
 from meshtastic.node_runtime.seturl.planner import _SetUrlReplacePlanner
 from meshtastic.node_runtime.seturl_runtime import (
     _compute_remaining_channel_writes,
+    _SetUrlAddOnlyExecutionState,
+    _SetUrlAddOnlyPlan,
+    _SetUrlAdminContext,
     _SetUrlParsedInput,
+    _SetUrlReplaceExecutionState,
+    _SetUrlReplacePlan,
     _SetUrlTransactionCoordinator,
 )
 from meshtastic.protobuf import apponly_pb2, channel_pb2, localonly_pb2
-from meshtastic.tests.seturl.conftest import _make_channel
+from meshtastic.tests.seturl.conftest import _LockProbe, _make_channel
 
 
 def _make_reload_mock(
@@ -56,7 +61,11 @@ class TestSetUrlTransactionCoordinator:
         )
 
         with pytest.raises(ValueError, match="Interface localNode not initialized"):
-            _SetUrlTransactionCoordinator(mock_local_node, parsed_input=parsed_input)
+            _SetUrlTransactionCoordinator(
+                mock_local_node,
+                parsed_input=parsed_input,
+                channel_state=mock_local_node._test_channel_state,
+            )
 
     @pytest.mark.unit
     def test_init_creates_components(self, mock_local_node: MagicMock) -> None:
@@ -71,7 +80,9 @@ class TestSetUrlTransactionCoordinator:
         )
 
         coordinator = _SetUrlTransactionCoordinator(
-            mock_local_node, parsed_input=parsed_input
+            mock_local_node,
+            parsed_input=parsed_input,
+            channel_state=mock_local_node._test_channel_state,
         )
 
         assert coordinator._cache_manager is not None
@@ -94,7 +105,9 @@ class TestSetUrlTransactionCoordinator:
         )
 
         coordinator = _SetUrlTransactionCoordinator(
-            mock_local_node, parsed_input=parsed_input
+            mock_local_node,
+            parsed_input=parsed_input,
+            channel_state=mock_local_node._test_channel_state,
         )
 
         assert coordinator._admin_context.admin_index_for_write == 1
@@ -125,10 +138,18 @@ class TestSetUrlTransactionCoordinator:
         )
 
         coordinator = _SetUrlTransactionCoordinator(
-            mock_local_node, parsed_input=parsed_input
+            mock_local_node,
+            parsed_input=parsed_input,
+            channel_state=mock_local_node._test_channel_state,
         )
 
-        def _failing_execute(*, parsed_input, admin_context, plan, state):
+        def _failing_execute(
+            *,
+            parsed_input: _SetUrlParsedInput,
+            admin_context: _SetUrlAdminContext,
+            plan: _SetUrlAddOnlyPlan,
+            state: _SetUrlAddOnlyExecutionState,
+        ) -> None:
             state.written_indices.append(1)
             state.lora_write_started = True
             raise RuntimeError("simulated write timeout")
@@ -164,10 +185,18 @@ class TestSetUrlTransactionCoordinator:
         )
 
         coordinator = _SetUrlTransactionCoordinator(
-            mock_local_node, parsed_input=parsed_input
+            mock_local_node,
+            parsed_input=parsed_input,
+            channel_state=mock_local_node._test_channel_state,
         )
 
-        def _failing_execute(*, parsed_input, admin_context, plan, state):
+        def _failing_execute(
+            *,
+            parsed_input: _SetUrlParsedInput,
+            admin_context: _SetUrlAdminContext,
+            plan: _SetUrlAddOnlyPlan,
+            state: _SetUrlAddOnlyExecutionState,
+        ) -> None:
             state.written_indices.append(1)
             state.lora_write_started = False
             raise RuntimeError("simulated write timeout")
@@ -179,6 +208,41 @@ class TestSetUrlTransactionCoordinator:
 
         assert mock_local_node.channels is None
         assert mock_local_node.localConfig.lora.hop_limit == 5
+
+    @pytest.mark.unit
+    def test_add_only_holds_shared_mutation_lock_during_execution(
+        self, mock_local_node: MagicMock
+    ) -> None:
+        """Add-only planning, device writes, and cache commit share one lock."""
+        mock_local_node.channels = [
+            _make_channel(0, channel_pb2.Channel.Role.PRIMARY, "primary"),
+            _make_channel(1, channel_pb2.Channel.Role.DISABLED),
+        ]
+        channel_set = apponly_pb2.ChannelSet()
+        settings = channel_set.settings.add()
+        settings.name = "new"
+        settings.psk = b"\x01"
+        parsed_input = _SetUrlParsedInput(
+            channel_set=channel_set,
+            has_lora_update=False,
+        )
+        channel_state = mock_local_node._test_channel_state
+        mutation_lock = _LockProbe()
+        channel_state._replace_mutation_lock(mutation_lock)  # noqa: SLF001
+        coordinator = _SetUrlTransactionCoordinator(
+            mock_local_node,
+            parsed_input=parsed_input,
+            channel_state=channel_state,
+        )
+
+        def _execute_while_locked(**_kwargs: Any) -> None:
+            assert mutation_lock.active
+
+        coordinator._execution_engine.executeAddOnly = _execute_while_locked  # type: ignore[method-assign]
+
+        coordinator._apply_add_only()
+
+        assert mutation_lock.active is False
 
     @pytest.mark.unit
     def test_replace_all_resumes_and_finds_convergence(
@@ -201,20 +265,22 @@ class TestSetUrlTransactionCoordinator:
         )
 
         coordinator = _SetUrlTransactionCoordinator(
-            mock_local_node_with_reconnect, parsed_input=parsed_input
+            mock_local_node_with_reconnect,
+            parsed_input=parsed_input,
+            channel_state=mock_local_node_with_reconnect._test_channel_state,
         )
 
         call_count = 0
 
         def _failing_then_check(
             *,
-            parsed_input,
-            admin_context,
-            plan,
-            state,
-            skip_channel_indices=None,
-            skip_lora=False,
-        ):
+            parsed_input: _SetUrlParsedInput,
+            admin_context: _SetUrlAdminContext,
+            plan: _SetUrlReplacePlan,
+            state: _SetUrlReplaceExecutionState,
+            skip_channel_indices: set[int] | None = None,
+            skip_lora: bool = False,
+        ) -> None:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -222,6 +288,15 @@ class TestSetUrlTransactionCoordinator:
                 raise RuntimeError("simulated transport disconnect")
 
         coordinator._execution_engine.executeReplaceAll = _failing_then_check  # type: ignore[method-assign]
+        lock = _LockProbe()
+        mock_local_node_with_reconnect._test_channel_state._replace_lock(lock)
+
+        def _compute_while_locked(
+            actual_channels: list[channel_pb2.Channel],
+            desired_channels: dict[int, channel_pb2.Channel],
+        ) -> set[int]:
+            assert lock.active
+            return _compute_remaining_channel_writes(actual_channels, desired_channels)
 
         with (
             patch("meshtastic.node_runtime.seturl.coordinator.time.sleep"),
@@ -230,8 +305,13 @@ class TestSetUrlTransactionCoordinator:
                 "_bounded_config_reload",
                 _make_reload_mock(mock_local_node_with_reconnect, [desired_ch]),
             ),
+            patch(
+                "meshtastic.node_runtime.seturl.coordinator._compute_remaining_channel_writes",
+                side_effect=_compute_while_locked,
+            ) as compute_remaining,
         ):
             coordinator._apply_replace_all()
+        compute_remaining.assert_called_once()
         assert call_count == 1
 
     @pytest.mark.unit
@@ -260,20 +340,22 @@ class TestSetUrlTransactionCoordinator:
         )
 
         coordinator = _SetUrlTransactionCoordinator(
-            mock_local_node_with_reconnect, parsed_input=parsed_input
+            mock_local_node_with_reconnect,
+            parsed_input=parsed_input,
+            channel_state=mock_local_node_with_reconnect._test_channel_state,
         )
 
         call_count = 0
 
         def _first_fails_second_succeeds(
             *,
-            parsed_input,
-            admin_context,
-            plan,
-            state,
-            skip_channel_indices=None,
-            skip_lora=False,
-        ):
+            parsed_input: _SetUrlParsedInput,
+            admin_context: _SetUrlAdminContext,
+            plan: _SetUrlReplacePlan,
+            state: _SetUrlReplaceExecutionState,
+            skip_channel_indices: set[int] | None = None,
+            skip_lora: bool = False,
+        ) -> None:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -301,6 +383,56 @@ class TestSetUrlTransactionCoordinator:
         assert call_count == 2
 
     @pytest.mark.unit
+    def test_replace_all_holds_shared_mutation_lock_across_resume_attempts(
+        self, mock_local_node_with_reconnect: MagicMock
+    ) -> None:
+        """Reconnect recovery must remain inside the original mutation transaction."""
+        mock_local_node_with_reconnect.channels = [
+            _make_channel(0, channel_pb2.Channel.Role.PRIMARY, "old", b"\x02")
+        ]
+        channel_set = apponly_pb2.ChannelSet()
+        settings = channel_set.settings.add()
+        settings.name = "new"
+        settings.psk = b"\x01"
+        parsed_input = _SetUrlParsedInput(
+            channel_set=channel_set,
+            has_lora_update=False,
+        )
+        channel_state = mock_local_node_with_reconnect._test_channel_state
+        mutation_lock = _LockProbe()
+        channel_state._replace_mutation_lock(mutation_lock)  # noqa: SLF001
+        coordinator = _SetUrlTransactionCoordinator(
+            mock_local_node_with_reconnect,
+            parsed_input=parsed_input,
+            channel_state=channel_state,
+        )
+        execution_lock_states: list[bool] = []
+
+        def _fail_then_succeed(**_kwargs: Any) -> None:
+            execution_lock_states.append(mutation_lock.active)
+            if len(execution_lock_states) == 1:
+                raise RuntimeError("simulated disconnect")
+
+        def _recover_while_locked(
+            _plan: _SetUrlReplacePlan,
+            failure_stage: _ReplaceAllStage | None = None,
+        ) -> tuple[set[int], bool]:
+            del failure_stage
+            assert mutation_lock.active
+            mock_local_node_with_reconnect.channels = [
+                _make_channel(0, channel_pb2.Channel.Role.PRIMARY, "old", b"\x02")
+            ]
+            return {0}, False
+
+        coordinator._execution_engine.executeReplaceAll = _fail_then_succeed  # type: ignore[method-assign]
+        coordinator._reconnect_and_compute_remaining = _recover_while_locked  # type: ignore[assignment]
+
+        coordinator._apply_replace_all()
+
+        assert execution_lock_states == [True, True]
+        assert mutation_lock.active is False
+
+    @pytest.mark.unit
     def test_replace_all_resumes_when_no_channels_converged_yet(
         self, mock_local_node_with_reconnect: MagicMock
     ) -> None:
@@ -319,7 +451,9 @@ class TestSetUrlTransactionCoordinator:
         )
 
         coordinator = _SetUrlTransactionCoordinator(
-            mock_local_node_with_reconnect, parsed_input=parsed_input
+            mock_local_node_with_reconnect,
+            parsed_input=parsed_input,
+            channel_state=mock_local_node_with_reconnect._test_channel_state,
         )
 
         call_count = 0
@@ -327,13 +461,13 @@ class TestSetUrlTransactionCoordinator:
 
         def _first_fails_second_succeeds(
             *,
-            parsed_input,
-            admin_context,
-            plan,
-            state,
-            skip_channel_indices=None,
-            skip_lora=False,
-        ):
+            parsed_input: _SetUrlParsedInput,
+            admin_context: _SetUrlAdminContext,
+            plan: _SetUrlReplacePlan,
+            state: _SetUrlReplaceExecutionState,
+            skip_channel_indices: set[int] | None = None,
+            skip_lora: bool = False,
+        ) -> None:
             nonlocal call_count
             call_count += 1
             observed_skip_sets.append(skip_channel_indices)
@@ -376,18 +510,20 @@ class TestSetUrlTransactionCoordinator:
         )
 
         coordinator = _SetUrlTransactionCoordinator(
-            mock_local_node_with_reconnect, parsed_input=parsed_input
+            mock_local_node_with_reconnect,
+            parsed_input=parsed_input,
+            channel_state=mock_local_node_with_reconnect._test_channel_state,
         )
 
         def _always_fail(
             *,
-            parsed_input,
-            admin_context,
-            plan,
-            state,
-            skip_channel_indices=None,
-            skip_lora=False,
-        ):
+            parsed_input: _SetUrlParsedInput,
+            admin_context: _SetUrlAdminContext,
+            plan: _SetUrlReplacePlan,
+            state: _SetUrlReplaceExecutionState,
+            skip_channel_indices: set[int] | None = None,
+            skip_lora: bool = False,
+        ) -> None:
             state.written_channel_indices = []
             raise RuntimeError("persistent failure")
 
@@ -396,10 +532,10 @@ class TestSetUrlTransactionCoordinator:
         # Simulate time passage so that config reload timeout is reached quickly
         monotonic_time = [0.0]
 
-        def _mock_monotonic():
+        def _mock_monotonic() -> float:
             return monotonic_time[0]
 
-        def _mock_sleep(duration):
+        def _mock_sleep(duration: float) -> None:
             monotonic_time[0] += duration
 
         with (
@@ -437,18 +573,20 @@ class TestSetUrlTransactionCoordinator:
         )
 
         coordinator = _SetUrlTransactionCoordinator(
-            mock_local_node_with_reconnect, parsed_input=parsed_input
+            mock_local_node_with_reconnect,
+            parsed_input=parsed_input,
+            channel_state=mock_local_node_with_reconnect._test_channel_state,
         )
 
         def _fail_once(
             *,
-            parsed_input,
-            admin_context,
-            plan,
-            state,
-            skip_channel_indices=None,
-            skip_lora=False,
-        ):
+            parsed_input: _SetUrlParsedInput,
+            admin_context: _SetUrlAdminContext,
+            plan: _SetUrlReplacePlan,
+            state: _SetUrlReplaceExecutionState,
+            skip_channel_indices: set[int] | None = None,
+            skip_lora: bool = False,
+        ) -> None:
             raise RuntimeError("transport disconnect")
 
         coordinator._execution_engine.executeReplaceAll = _fail_once  # type: ignore[method-assign]
@@ -481,20 +619,22 @@ class TestSetUrlTransactionCoordinator:
         )
 
         coordinator = _SetUrlTransactionCoordinator(
-            mock_local_node_with_reconnect, parsed_input=parsed_input
+            mock_local_node_with_reconnect,
+            parsed_input=parsed_input,
+            channel_state=mock_local_node_with_reconnect._test_channel_state,
         )
 
         call_count = 0
 
         def _fail_at_lora(
             *,
-            parsed_input,
-            admin_context,
-            plan,
-            state,
-            skip_channel_indices=None,
-            skip_lora=False,
-        ):
+            parsed_input: _SetUrlParsedInput,
+            admin_context: _SetUrlAdminContext,
+            plan: _SetUrlReplacePlan,
+            state: _SetUrlReplaceExecutionState,
+            skip_channel_indices: set[int] | None = None,
+            skip_lora: bool = False,
+        ) -> None:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -506,7 +646,7 @@ class TestSetUrlTransactionCoordinator:
 
         sleep_durations: list[float] = []
 
-        def _track_sleep(duration):
+        def _track_sleep(duration: float) -> None:
             sleep_durations.append(duration)
 
         with (
@@ -546,7 +686,9 @@ class TestSetUrlTransactionCoordinator:
         )
 
         coordinator = _SetUrlTransactionCoordinator(
-            mock_local_node_with_reconnect, parsed_input=parsed_input
+            mock_local_node_with_reconnect,
+            parsed_input=parsed_input,
+            channel_state=mock_local_node_with_reconnect._test_channel_state,
         )
 
         call_count = 0
@@ -556,13 +698,13 @@ class TestSetUrlTransactionCoordinator:
 
         def _failing_then_check(
             *,
-            parsed_input,
-            admin_context,
-            plan,
-            state,
-            skip_channel_indices=None,
-            skip_lora=False,
-        ):
+            parsed_input: _SetUrlParsedInput,
+            admin_context: _SetUrlAdminContext,
+            plan: _SetUrlReplacePlan,
+            state: _SetUrlReplaceExecutionState,
+            skip_channel_indices: set[int] | None = None,
+            skip_lora: bool = False,
+        ) -> None:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -571,7 +713,7 @@ class TestSetUrlTransactionCoordinator:
 
         coordinator._execution_engine.executeReplaceAll = _failing_then_check  # type: ignore[method-assign]
 
-        def _connect_with_recovery():
+        def _connect_with_recovery() -> None:
             nonlocal connect_call_count
             connect_call_count += 1
             if connect_call_count >= 1:
@@ -579,7 +721,7 @@ class TestSetUrlTransactionCoordinator:
 
         iface.connect = MagicMock(side_effect=_connect_with_recovery)
 
-        def _sleep_with_flap(duration):
+        def _sleep_with_flap(duration: float) -> None:
             nonlocal sleep_call_count
             sleep_call_count += 1
             if sleep_call_count == 1:
@@ -621,18 +763,20 @@ class TestSetUrlTransactionCoordinator:
         )
 
         coordinator = _SetUrlTransactionCoordinator(
-            mock_local_node_with_reconnect, parsed_input=parsed_input
+            mock_local_node_with_reconnect,
+            parsed_input=parsed_input,
+            channel_state=mock_local_node_with_reconnect._test_channel_state,
         )
 
         def _always_fail(
             *,
-            parsed_input,
-            admin_context,
-            plan,
-            state,
-            skip_channel_indices=None,
-            skip_lora=False,
-        ):
+            parsed_input: _SetUrlParsedInput,
+            admin_context: _SetUrlAdminContext,
+            plan: _SetUrlReplacePlan,
+            state: _SetUrlReplaceExecutionState,
+            skip_channel_indices: set[int] | None = None,
+            skip_lora: bool = False,
+        ) -> None:
             state.written_channel_indices = []
             raise RuntimeError("persistent failure")
 
@@ -640,7 +784,7 @@ class TestSetUrlTransactionCoordinator:
 
         sleep_call_count = 0
 
-        def _flap_sleep(duration):
+        def _flap_sleep(duration: float) -> None:
             nonlocal sleep_call_count
             sleep_call_count += 1
             mock_local_node_with_reconnect.iface.isConnected.clear()
@@ -672,7 +816,9 @@ class TestSetUrlTransactionCoordinator:
         )
 
         coordinator = _SetUrlTransactionCoordinator(
-            mock_local_node_with_reconnect, parsed_input=parsed_input
+            mock_local_node_with_reconnect,
+            parsed_input=parsed_input,
+            channel_state=mock_local_node_with_reconnect._test_channel_state,
         )
 
         mock_local_node_with_reconnect.channels = [
@@ -682,6 +828,7 @@ class TestSetUrlTransactionCoordinator:
             mock_local_node_with_reconnect,
             parsed_input=parsed_input,
             admin_context=coordinator._admin_context,
+            channel_state=mock_local_node_with_reconnect._test_channel_state,
         ).build_plan()
 
         mock_local_node_with_reconnect.channels = None
@@ -690,10 +837,10 @@ class TestSetUrlTransactionCoordinator:
 
         monotonic_time = [0.0]
 
-        def _mock_monotonic():
+        def _mock_monotonic() -> float:
             return monotonic_time[0]
 
-        def _mock_sleep(duration):
+        def _mock_sleep(duration: float) -> None:
             monotonic_time[0] += duration
 
         with (
@@ -727,6 +874,7 @@ class TestSetUrlTransactionCoordinator:
         coordinator = _SetUrlTransactionCoordinator(
             mock_local_node_with_reconnect,
             parsed_input=parsed_input,
+            channel_state=mock_local_node_with_reconnect._test_channel_state,
         )
 
         mock_local_node_with_reconnect.channels = [
@@ -736,6 +884,7 @@ class TestSetUrlTransactionCoordinator:
             mock_local_node_with_reconnect,
             parsed_input=parsed_input,
             admin_context=coordinator._admin_context,
+            channel_state=mock_local_node_with_reconnect._test_channel_state,
         ).build_plan()
 
         mock_local_node_with_reconnect.iface.isConnected = None

--- a/meshtastic/tests/seturl/test_execution_engine.py
+++ b/meshtastic/tests/seturl/test_execution_engine.py
@@ -1,6 +1,6 @@
 """Tests for _SetUrlExecutionEngine."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -15,6 +15,7 @@ from meshtastic.node_runtime.seturl_runtime import (
 )
 from meshtastic.protobuf import apponly_pb2, channel_pb2, mesh_pb2
 from meshtastic.tests.seturl.conftest import (
+    _LockProbe,
     _make_channel,
     _make_channel_set_with_lora,
     _make_raise_error_side_effect,
@@ -203,16 +204,84 @@ class TestSetUrlExecutionEngine:
         )
 
         state = _SetUrlReplaceExecutionState()
+        lock = _LockProbe()
+        mock_local_node._test_channel_state._replace_lock(lock)
 
-        execution_engine.executeReplaceAll(
-            parsed_input=parsed_input,
-            admin_context=admin_context,
-            plan=plan,
-            state=state,
-        )
+        def _fingerprint_while_locked(
+            channels: list[channel_pb2.Channel],
+        ) -> tuple[bytes, ...]:
+            assert lock.active
+            return _channels_fingerprint(channels)
+
+        with patch(
+            "meshtastic.node_runtime.seturl.execution._channels_fingerprint",
+            side_effect=_fingerprint_while_locked,
+        ):
+            execution_engine.executeReplaceAll(
+                parsed_input=parsed_input,
+                admin_context=admin_context,
+                plan=plan,
+                state=state,
+            )
 
         mock_local_node._write_channel_snapshot.assert_called()
         assert 0 in state.written_channel_indices
+
+    @pytest.mark.unit
+    def test_execute_replace_all_aborts_on_in_place_mutation_during_write(
+        self,
+        execution_engine: _SetUrlExecutionEngine,
+        mock_local_node: MagicMock,
+    ) -> None:
+        """A concurrent in-place edit must not be overwritten after device I/O."""
+        original_channels = [
+            _make_channel(0, channel_pb2.Channel.Role.PRIMARY, "old"),
+            _make_channel(1, channel_pb2.Channel.Role.SECONDARY, "peer"),
+        ]
+        mock_local_node.channels = original_channels
+        staged = _make_channel(0, channel_pb2.Channel.Role.PRIMARY, "new")
+        plan = _SetUrlReplacePlan(
+            max_channels=2,
+            replace_original_channels_ref=original_channels,
+            replace_original_channels_fingerprint=_channels_fingerprint(
+                original_channels
+            ),
+            staged_channels=[staged],
+            staged_channels_by_index={0: staged},
+            deferred_new_named_admin_channel=None,
+            deferred_new_named_admin_index=None,
+            deferred_previous_admin_slot_channel=None,
+        )
+        parsed_input = _SetUrlParsedInput(
+            channel_set=apponly_pb2.ChannelSet(),
+            has_lora_update=False,
+        )
+        admin_context = MagicMock(admin_index_for_write=0)
+        state = _SetUrlReplaceExecutionState()
+
+        def _mutate_cache_during_write(*_args: object, **_kwargs: object) -> None:
+            original_channels[1].settings.name = "concurrent-edit"
+
+        mock_local_node._write_channel_snapshot.side_effect = _mutate_cache_during_write
+        mock_local_node._raise_interface_error = MagicMock(
+            side_effect=_make_raise_error_side_effect()
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="Channel cache changed during replace-all cache update",
+        ):
+            execution_engine.executeReplaceAll(
+                parsed_input=parsed_input,
+                admin_context=admin_context,
+                plan=plan,
+                state=state,
+            )
+
+        mock_local_node._write_channel_snapshot.assert_called_once()
+        assert state.written_channel_indices == [0]
+        assert mock_local_node.channels is None
+        assert mock_local_node.partialChannels == []
 
     @pytest.mark.unit
     def test_execute_replace_all_with_lora_update_skipped_send_raises(
@@ -423,12 +492,12 @@ class TestSetUrlExecutionEngine:
         mock_local_node._send_admin.assert_not_called()
 
     @pytest.mark.unit
-    def test_execute_replace_all_skip_set_skips_fingerprint_check(
+    def test_execute_replace_all_resume_uses_refreshed_cache_baseline(
         self,
         execution_engine: _SetUrlExecutionEngine,
         mock_local_node: MagicMock,
     ) -> None:
-        """execute_replace_all with skip_channel_indices bypasses fingerprint pre-check."""
+        """A resumed transaction guards the refreshed cache instead of the stale plan."""
         original_channels = [
             _make_channel(0, channel_pb2.Channel.Role.PRIMARY, "old"),
         ]

--- a/meshtastic/tests/seturl/test_planners.py
+++ b/meshtastic/tests/seturl/test_planners.py
@@ -44,6 +44,7 @@ class TestSetUrlReplacePlanner:
             mock_local_node,
             parsed_input=parsed_input,
             admin_context=admin_context,
+            channel_state=mock_local_node._test_channel_state,
         )
 
         plan = planner.build_plan()
@@ -80,6 +81,7 @@ class TestSetUrlReplacePlanner:
             mock_local_node,
             parsed_input=parsed_input,
             admin_context=admin_context,
+            channel_state=mock_local_node._test_channel_state,
         )
 
         with caplog.at_level(logging.WARNING):
@@ -120,6 +122,7 @@ class TestSetUrlReplacePlanner:
             mock_local_node,
             parsed_input=parsed_input,
             admin_context=admin_context,
+            channel_state=mock_local_node._test_channel_state,
         )
 
         with pytest.raises(ValueError, match="multiple channels named 'admin'"):

--- a/meshtastic/tests/test_node_channel_state.py
+++ b/meshtastic/tests/test_node_channel_state.py
@@ -1,0 +1,249 @@
+"""Behavioral tests for the owned Node channel-state boundary."""
+
+from __future__ import annotations
+
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from meshtastic.node import Node
+from meshtastic.node_runtime.channel_state import _NodeChannelState
+from meshtastic.node_runtime.shared import MAX_CHANNELS
+from meshtastic.protobuf import channel_pb2
+
+
+def _channel(index: int, name: str = "") -> channel_pb2.Channel:
+    """Build a channel fixture value."""
+    channel = channel_pb2.Channel(
+        index=index,
+        role=(
+            channel_pb2.Channel.Role.PRIMARY
+            if index == 0
+            else channel_pb2.Channel.Role.SECONDARY
+        ),
+    )
+    channel.settings.name = name
+    return channel
+
+
+@pytest.mark.unit
+def test_snapshot_channels_copies_while_owner_lock_is_held() -> None:
+    """Snapshots should be detached and synchronized by the state owner."""
+    state = _NodeChannelState()
+    original = _channel(0, "primary")
+    state.channels = [original]
+    lock = MagicMock()
+    lock_active = False
+
+    def _enter() -> None:
+        nonlocal lock_active
+        lock_active = True
+
+    def _exit(*_args: object) -> None:
+        nonlocal lock_active
+        lock_active = False
+
+    lock.__enter__ = MagicMock(side_effect=_enter)
+    lock.__exit__ = MagicMock(side_effect=_exit)
+    state._replace_lock(lock)  # noqa: SLF001
+    original_copy = state._copy_channel  # noqa: SLF001
+
+    def _copy_while_locked(
+        channel: channel_pb2.Channel,
+    ) -> channel_pb2.Channel:
+        assert lock_active
+        return original_copy(channel)
+
+    state._copy_channel = _copy_while_locked  # type: ignore[method-assign]  # noqa: SLF001
+
+    snapshot = state.snapshot_channels()
+
+    lock.__enter__.assert_called_once()
+    lock.__exit__.assert_called_once()
+    assert snapshot[0] is not original
+    assert snapshot[0] == original
+
+
+@pytest.mark.unit
+def test_copy_lookup_is_detached_before_owner_lock_releases() -> None:
+    """Copy lookups should perform protobuf copying inside the lock boundary."""
+    state = _NodeChannelState()
+    original = _channel(0, "primary")
+    state.channels = [original]
+    events: list[str] = []
+
+    class _LockProbe:
+        def __enter__(self) -> None:
+            events.append("enter")
+
+        def __exit__(self, *_args: object) -> None:
+            events.append("exit")
+
+    state._replace_lock(_LockProbe())  # noqa: SLF001
+    original_copy = state._copy_channel  # noqa: SLF001
+
+    def _copy_with_probe(channel: channel_pb2.Channel) -> channel_pb2.Channel:
+        assert events == ["enter"]
+        events.append("copy")
+        return original_copy(channel)
+
+    state._copy_channel = _copy_with_probe  # type: ignore[method-assign]  # noqa: SLF001
+
+    copied = state.get_copy_by_index(0)
+
+    assert copied is not original
+    assert events == ["enter", "copy", "exit"]
+
+
+@pytest.mark.unit
+def test_replace_with_copies_normalizes_without_mutating_inputs() -> None:
+    """Replacing state should copy inputs, reindex them, and fill disabled slots."""
+    first = _channel(7, "primary")
+    second = _channel(9, "secondary")
+    state = _NodeChannelState()
+
+    state.replace_with_copies([first, second])
+
+    assert state.channels is not None
+    assert len(state.channels) == MAX_CHANNELS
+    assert state.channels[0] is not first
+    assert state.channels[1] is not second
+    assert [channel.index for channel in state.channels] == list(range(MAX_CHANNELS))
+    assert first.index == 7
+    assert second.index == 9
+    assert all(
+        channel.role == channel_pb2.Channel.Role.DISABLED
+        for channel in state.channels[2:]
+    )
+
+
+@pytest.mark.unit
+def test_install_partial_channels_normalizes_complete_cache() -> None:
+    """A completed channel download should install and normalize staged responses."""
+    state = _NodeChannelState()
+    response = _channel(7, "downloaded")
+
+    assert state.append_partial_if_new(response) is True
+    assert state.append_partial_if_new(response) is False
+    state.install_partial_channels()
+
+    assert state.channels is not None
+    assert len(state.channels) == MAX_CHANNELS
+    assert state.channels[0] is response
+    assert state.channels[0].index == 0
+    assert state.channels[0].settings.name == "downloaded"
+
+
+@pytest.mark.unit
+def test_reset_for_download_clears_complete_and_partial_caches() -> None:
+    """A fresh download should atomically clear all existing channel state."""
+    state = _NodeChannelState()
+    state.channels = [_channel(0)]
+    state.partial_channels = [_channel(1)]
+
+    assert state.has_channels() is True
+
+    state.reset_for_download()
+
+    assert state.has_channels() is False
+    assert state.channels is None
+    assert state.partial_channels == []
+
+
+@pytest.mark.unit
+def test_normalization_operations_are_safe_without_cached_channels() -> None:
+    """Normalization entrypoints should be harmless before channels are loaded."""
+    state = _NodeChannelState()
+
+    state.normalize()
+    state.fill()
+
+    assert state.channels is None
+
+
+@pytest.mark.unit
+def test_node_legacy_channel_attributes_share_one_state_owner() -> None:
+    """Historical Node attributes should remain live views over the owned state."""
+    node = cast(Any, object.__new__(Node))
+    channels = [_channel(0)]
+    partial = [_channel(1)]
+
+    node.channels = channels
+    node.partialChannels = partial
+
+    state = node._get_channel_state()
+    assert node.channels is channels
+    assert node.partialChannels is partial
+    assert state.channels is channels
+    assert state.partial_channels is partial
+
+
+@pytest.mark.unit
+def test_node_legacy_lock_assignment_replaces_state_owner_lock() -> None:
+    """Historical lock instrumentation should still target the state-owner lock."""
+    node = cast(Any, object.__new__(Node))
+    replacement = MagicMock()
+
+    node._channels_lock = replacement
+
+    assert node._channels_lock is replacement
+    assert node._get_channel_state().lock is replacement
+
+
+@pytest.mark.unit
+def test_node_channel_state_bootstrap_migrates_raw_legacy_fields() -> None:
+    """Raw state restored from the legacy representation should migrate intact."""
+    node = cast(Any, object.__new__(Node))
+    channels = [_channel(0, "primary")]
+    partial = [_channel(1, "secondary")]
+    legacy_lock = MagicMock()
+    node.__dict__.update(
+        channels=channels,
+        partialChannels=partial,
+        _channels_lock=legacy_lock,
+    )
+
+    state = node._get_channel_state()
+
+    assert state.channels is channels
+    assert state.partial_channels is partial
+    assert state.lock is legacy_lock
+    assert node._channel_state is state
+    assert not {"channels", "partialChannels", "_channels_lock"} & node.__dict__.keys()
+
+
+@pytest.mark.unit
+def test_node_channel_state_bootstrap_is_singleton_under_concurrency() -> None:
+    """Concurrent bootstrap calls should publish exactly one channel-state owner."""
+    node = cast(Any, object.__new__(Node))
+    original_state_type = _NodeChannelState
+    creation_count = 0
+    creation_count_lock = threading.Lock()
+    start_barrier = threading.Barrier(8, timeout=10)
+
+    def _create_state() -> _NodeChannelState:
+        nonlocal creation_count
+        with creation_count_lock:
+            creation_count += 1
+        time.sleep(0.01)
+        return original_state_type()
+
+    def _get_state() -> _NodeChannelState:
+        start_barrier.wait()
+        return cast(_NodeChannelState, node._get_channel_state())
+
+    def _get_state_for_worker(_worker_index: int) -> _NodeChannelState:
+        return _get_state()
+
+    with (
+        patch("meshtastic.node._NodeChannelState", side_effect=_create_state),
+        ThreadPoolExecutor(max_workers=8) as executor,
+    ):
+        states = list(executor.map(_get_state_for_worker, range(8)))
+
+    assert creation_count == 1
+    assert all(state is states[0] for state in states)

--- a/meshtastic/tests/test_node_channels.py
+++ b/meshtastic/tests/test_node_channels.py
@@ -425,7 +425,7 @@ def test_waitForConfig_timeout(
     assert result is False
     wait_call = anode._timeout.waitForSet.call_args
     assert wait_call.kwargs["attrs"] == ("is_set",)
-    assert getattr(wait_call.args[0], "_node", None) is anode
+    assert getattr(wait_call.args[0], "_channel_state", None) is anode._channel_state
 
 
 @pytest.mark.unit
@@ -1117,6 +1117,7 @@ def test_getURL_requests_lora_when_local_config_empty(
 def test_invalidate_channel_cache_clears_state_under_owner_lock() -> None:
     """Node cache invalidation should clear both channel caches while holding its lock."""
     events: list[str] = []
+    state_at_exit: list[tuple[list[Channel] | None, list[Channel]]] = []
 
     class LockProbe:
         """Record the lock lifetime around cache mutations."""
@@ -1128,28 +1129,21 @@ def test_invalidate_channel_cache_clears_state_under_owner_lock() -> None:
             events.append("enter")
 
         def __exit__(self, *_args: object) -> None:
+            state_at_exit.append((node.channels, list(node.partialChannels)))
             events.append("exit")
             self.active = False
 
-    class CacheOwnerProbe(Node):
-        """Assert cache assignments occur while the owner lock is active."""
-
-        def __setattr__(self, name: str, value: Any) -> None:
-            if name in {"channels", "partialChannels"} and getattr(
-                self, "_assert_locked_cache_writes", False
-            ):
-                assert cast(LockProbe, self._channels_lock).active
-                events.append(name)
-            object.__setattr__(self, name, value)
-
-    node = cast(Any, object.__new__(CacheOwnerProbe))
-    node._channels_lock = LockProbe()
+    node = cast(Any, object.__new__(Node))
+    lock_probe = LockProbe()
+    node._channels_lock = lock_probe
+    assert node._channels_lock is lock_probe
+    assert node._get_channel_state().lock is lock_probe
     node.channels = [Channel(index=0, role=Channel.Role.PRIMARY)]
     node.partialChannels = [Channel(index=1, role=Channel.Role.SECONDARY)]
-    node._assert_locked_cache_writes = True
 
     Node._invalidate_channel_cache(node)
 
-    assert events == ["enter", "channels", "partialChannels", "exit"]
+    assert events == ["enter", "exit"]
+    assert state_at_exit == [(None, [])]
     assert node.channels is None
     assert node.partialChannels == []

--- a/meshtastic/tests/test_node_runtime_channel_export.py
+++ b/meshtastic/tests/test_node_runtime_channel_export.py
@@ -4,7 +4,6 @@
 
 import base64
 import logging
-import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -12,6 +11,8 @@ import pytest
 from meshtastic.mesh_interface import MeshInterface
 from meshtastic.node_runtime.channel_export_runtime import _NodeChannelExportRuntime
 from meshtastic.protobuf import apponly_pb2, channel_pb2, localonly_pb2
+
+from ._node_channel_state_test_support import _attach_channel_state
 
 EXPORT_URL_PREFIX = "https://meshtastic.org/e/#"
 
@@ -36,10 +37,11 @@ def mock_node() -> MagicMock:
             "waitForConfig",
             "_write_channel_snapshot",
             "partialChannels",
+            "_test_channel_state",
         ]
     )
-    node._channels_lock = threading.RLock()
-    node.channels = []
+    channel_state = _attach_channel_state(node)
+    channel_state.channels = []
     node.localConfig = localonly_pb2.LocalConfig()
     node._raise_interface_error = MagicMock(side_effect=Exception)
     node.requestConfig = MagicMock()
@@ -63,7 +65,9 @@ def export_runtime(mock_node: MagicMock) -> _NodeChannelExportRuntime:
     _NodeChannelExportRuntime
         The runtime instance under test.
     """
-    return _NodeChannelExportRuntime(mock_node)
+    return _NodeChannelExportRuntime(
+        mock_node, channel_state=mock_node._test_channel_state
+    )
 
 
 def _make_channel(
@@ -572,5 +576,55 @@ def test_turn_off_encryption_on_primary_channel_index_not_found(
         export_runtime._turn_off_encryption_on_primary_channel()
 
     assert "invalidating local channel cache" in caplog.text
+    assert mock_node.channels is None
+    assert mock_node.partialChannels == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("mutation", "expected_warning"),
+    [
+        ("replace-slot", "primary slot object changed concurrently"),
+        ("mutate-slot", "primary slot content changed concurrently"),
+        ("remove-index", "local channel index 0 is unavailable"),
+    ],
+)
+def test_turn_off_encryption_invalidates_in_place_concurrent_cache_changes(
+    export_runtime: _NodeChannelExportRuntime,
+    mock_node: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+    mutation: str,
+    expected_warning: str,
+) -> None:
+    """Successful writes must not commit over concurrent in-place cache changes."""
+    primary = _make_channel(
+        0, channel_pb2.Channel.Role.PRIMARY, name="primary", psk=b"\x01"
+    )
+    channels = [primary]
+    mock_node.channels = channels
+    mock_node.partialChannels = ["SENTINEL"]
+
+    def mutate_cache(_channel: channel_pb2.Channel) -> None:
+        if mutation == "replace-slot":
+            replacement = channel_pb2.Channel()
+            replacement.CopyFrom(primary)
+            channels[0] = replacement
+        elif mutation == "mutate-slot":
+            primary.settings.name = "concurrent-update"
+        else:
+            channels[:] = [
+                _make_channel(
+                    5,
+                    channel_pb2.Channel.Role.SECONDARY,
+                    name="different-index",
+                )
+            ]
+
+    mock_node._write_channel_snapshot.side_effect = mutate_cache
+
+    with caplog.at_level(logging.WARNING):
+        export_runtime._turn_off_encryption_on_primary_channel()
+
+    assert expected_warning in caplog.text
     assert mock_node.channels is None
     assert mock_node.partialChannels == []

--- a/meshtastic/tests/test_node_runtime_channel_lookup.py
+++ b/meshtastic/tests/test_node_runtime_channel_lookup.py
@@ -2,45 +2,23 @@
 
 # pylint: disable=redefined-outer-name
 
-import threading
-from unittest.mock import MagicMock
-
 import pytest
 
 from meshtastic.node_runtime.channel_lookup_runtime import _NodeChannelLookupRuntime
+from meshtastic.node_runtime.channel_state import _NodeChannelState
 from meshtastic.protobuf import channel_pb2
 
 
 @pytest.fixture
-def mock_node() -> MagicMock:
-    """Provide a minimal mock Node with channels list and lock for channel lookup tests.
-
-    Returns
-    -------
-    MagicMock
-        A mock Node with channels attribute and _channels_lock.
-    """
-    node = MagicMock(spec=["channels", "_channels_lock"])
-    node._channels_lock = threading.RLock()
-    node.channels = []
-    return node
+def channel_state() -> _NodeChannelState:
+    """Provide isolated owned channel state for lookup tests."""
+    return _NodeChannelState()
 
 
 @pytest.fixture
-def lookup(mock_node: MagicMock) -> _NodeChannelLookupRuntime:
-    """Provide a _NodeChannelLookupRuntime instance bound to the mock node.
-
-    Parameters
-    ----------
-    mock_node : MagicMock
-        The mock node fixture.
-
-    Returns
-    -------
-    _NodeChannelLookupRuntime
-        The runtime instance under test.
-    """
-    return _NodeChannelLookupRuntime(mock_node)
+def lookup(channel_state: _NodeChannelState) -> _NodeChannelLookupRuntime:
+    """Provide a lookup runtime bound to owned channel state."""
+    return _NodeChannelLookupRuntime(channel_state)
 
 
 def _make_channel(
@@ -72,12 +50,12 @@ def _make_channel(
 
 @pytest.mark.unit
 def test_get_channel_by_index_valid(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_channel_by_index returns the live channel for a valid index."""
     primary = _make_channel(0, channel_pb2.Channel.Role.PRIMARY, name="primary")
     secondary = _make_channel(1, channel_pb2.Channel.Role.SECONDARY, name="secondary")
-    mock_node.channels = [primary, secondary]
+    channel_state.channels = [primary, secondary]
 
     result = lookup._get_channel_by_index(0)
 
@@ -94,11 +72,11 @@ def test_get_channel_by_index_valid(
 
 @pytest.mark.unit
 def test_get_channel_by_index_out_of_range(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_channel_by_index returns None for out-of-range indices."""
     primary = _make_channel(0, channel_pb2.Channel.Role.PRIMARY)
-    mock_node.channels = [primary]
+    channel_state.channels = [primary]
 
     assert lookup._get_channel_by_index(-1) is None
     assert lookup._get_channel_by_index(1) is None
@@ -107,21 +85,21 @@ def test_get_channel_by_index_out_of_range(
 
 @pytest.mark.unit
 def test_get_channel_by_index_none_channels(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_channel_by_index returns None when channels is None."""
-    mock_node.channels = None
+    channel_state.channels = None
 
     assert lookup._get_channel_by_index(0) is None
 
 
 @pytest.mark.unit
 def test_get_channel_copy_by_index_returns_copy(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_channel_copy_by_index returns a defensive copy, not the live reference."""
     primary = _make_channel(0, channel_pb2.Channel.Role.PRIMARY, name="primary")
-    mock_node.channels = [primary]
+    channel_state.channels = [primary]
 
     copy = lookup._get_channel_copy_by_index(0)
 
@@ -133,11 +111,11 @@ def test_get_channel_copy_by_index_returns_copy(
 
 @pytest.mark.unit
 def test_get_channel_copy_by_index_modification_isolated(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """Modifying the copy does not affect the original channel."""
     primary = _make_channel(0, channel_pb2.Channel.Role.PRIMARY, name="original")
-    mock_node.channels = [primary]
+    channel_state.channels = [primary]
 
     copy = lookup._get_channel_copy_by_index(0)
     assert copy is not None
@@ -151,11 +129,11 @@ def test_get_channel_copy_by_index_modification_isolated(
 
 @pytest.mark.unit
 def test_get_channel_copy_by_index_out_of_range(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_channel_copy_by_index returns None for out-of-range indices."""
     primary = _make_channel(0, channel_pb2.Channel.Role.PRIMARY)
-    mock_node.channels = [primary]
+    channel_state.channels = [primary]
 
     assert lookup._get_channel_copy_by_index(-1) is None
     assert lookup._get_channel_copy_by_index(1) is None
@@ -163,12 +141,12 @@ def test_get_channel_copy_by_index_out_of_range(
 
 @pytest.mark.unit
 def test_get_channel_by_name_exists(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_channel_by_name returns the live channel when name matches."""
     primary = _make_channel(0, channel_pb2.Channel.Role.PRIMARY, name="main")
     secondary = _make_channel(1, channel_pb2.Channel.Role.SECONDARY, name="admin")
-    mock_node.channels = [primary, secondary]
+    channel_state.channels = [primary, secondary]
 
     result = lookup._get_channel_by_name("main")
 
@@ -184,11 +162,11 @@ def test_get_channel_by_name_exists(
 
 @pytest.mark.unit
 def test_get_channel_by_name_not_found(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_channel_by_name returns None when no channel has the given name."""
     primary = _make_channel(0, channel_pb2.Channel.Role.PRIMARY, name="main")
-    mock_node.channels = [primary]
+    channel_state.channels = [primary]
 
     assert lookup._get_channel_by_name("nonexistent") is None
     assert lookup._get_channel_by_name("Admin") is None  # case-sensitive
@@ -196,22 +174,22 @@ def test_get_channel_by_name_not_found(
 
 @pytest.mark.unit
 def test_get_channel_by_name_none_channels(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_channel_by_name returns None when channels is None."""
-    mock_node.channels = None
+    channel_state.channels = None
 
     assert lookup._get_channel_by_name("any") is None
 
 
 @pytest.mark.unit
 def test_get_channel_by_name_empty_name(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_channel_by_name with empty name matches channels with no settings.name."""
     primary = _make_channel(0, channel_pb2.Channel.Role.PRIMARY, name="")
     secondary = _make_channel(1, channel_pb2.Channel.Role.SECONDARY, name="named")
-    mock_node.channels = [primary, secondary]
+    channel_state.channels = [primary, secondary]
 
     result = lookup._get_channel_by_name("")
 
@@ -221,11 +199,11 @@ def test_get_channel_by_name_empty_name(
 
 @pytest.mark.unit
 def test_get_channel_copy_by_name_returns_copy(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_channel_copy_by_name returns a defensive copy found by name."""
     primary = _make_channel(0, channel_pb2.Channel.Role.PRIMARY, name="main")
-    mock_node.channels = [primary]
+    channel_state.channels = [primary]
 
     copy = lookup._get_channel_copy_by_name("main")
 
@@ -236,25 +214,25 @@ def test_get_channel_copy_by_name_returns_copy(
 
 @pytest.mark.unit
 def test_get_channel_copy_by_name_not_found(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_channel_copy_by_name returns None when name is not found."""
     primary = _make_channel(0, channel_pb2.Channel.Role.PRIMARY, name="main")
-    mock_node.channels = [primary]
+    channel_state.channels = [primary]
 
     assert lookup._get_channel_copy_by_name("nonexistent") is None
 
 
 @pytest.mark.unit
 def test_get_disabled_channel_exists(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_disabled_channel returns the first disabled channel."""
     primary = _make_channel(0, channel_pb2.Channel.Role.PRIMARY)
     secondary = _make_channel(1, channel_pb2.Channel.Role.SECONDARY)
     disabled1 = _make_channel(2, channel_pb2.Channel.Role.DISABLED)
     disabled2 = _make_channel(3, channel_pb2.Channel.Role.DISABLED)
-    mock_node.channels = [primary, secondary, disabled1, disabled2]
+    channel_state.channels = [primary, secondary, disabled1, disabled2]
 
     result = lookup._get_disabled_channel()
 
@@ -265,43 +243,43 @@ def test_get_disabled_channel_exists(
 
 @pytest.mark.unit
 def test_get_disabled_channel_none_exist(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_disabled_channel returns None when no disabled channel exists."""
     primary = _make_channel(0, channel_pb2.Channel.Role.PRIMARY)
     secondary = _make_channel(1, channel_pb2.Channel.Role.SECONDARY)
-    mock_node.channels = [primary, secondary]
+    channel_state.channels = [primary, secondary]
 
     assert lookup._get_disabled_channel() is None
 
 
 @pytest.mark.unit
 def test_get_disabled_channel_none_channels(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_disabled_channel returns None when channels is None."""
-    mock_node.channels = None
+    channel_state.channels = None
 
     assert lookup._get_disabled_channel() is None
 
 
 @pytest.mark.unit
 def test_get_disabled_channel_empty_list(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_disabled_channel returns None when channels is empty."""
-    mock_node.channels = []
+    channel_state.channels = []
 
     assert lookup._get_disabled_channel() is None
 
 
 @pytest.mark.unit
 def test_get_disabled_channel_copy_returns_copy(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_disabled_channel_copy returns a defensive copy of the disabled channel."""
     disabled = _make_channel(0, channel_pb2.Channel.Role.DISABLED)
-    mock_node.channels = [disabled]
+    channel_state.channels = [disabled]
 
     copy = lookup._get_disabled_channel_copy()
 
@@ -312,11 +290,11 @@ def test_get_disabled_channel_copy_returns_copy(
 
 @pytest.mark.unit
 def test_get_disabled_channel_copy_modification_isolated(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """Modifying the disabled channel copy does not affect the original."""
     disabled = _make_channel(0, channel_pb2.Channel.Role.DISABLED)
-    mock_node.channels = [disabled]
+    channel_state.channels = [disabled]
 
     copy = lookup._get_disabled_channel_copy()
     assert copy is not None
@@ -328,35 +306,35 @@ def test_get_disabled_channel_copy_modification_isolated(
 
 @pytest.mark.unit
 def test_get_disabled_channel_copy_none_channels(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_disabled_channel_copy returns None when channels is None."""
-    mock_node.channels = None
+    channel_state.channels = None
 
     assert lookup._get_disabled_channel_copy() is None
 
 
 @pytest.mark.unit
 def test_get_disabled_channel_copy_none_exist(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_disabled_channel_copy returns None when no disabled channel exists."""
     primary = _make_channel(0, channel_pb2.Channel.Role.PRIMARY)
     secondary = _make_channel(1, channel_pb2.Channel.Role.SECONDARY)
-    mock_node.channels = [primary, secondary]
+    channel_state.channels = [primary, secondary]
 
     assert lookup._get_disabled_channel_copy() is None
 
 
 @pytest.mark.unit
 def test_get_named_admin_channel_index_found(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_named_admin_channel_index returns the index of a named admin channel."""
     primary = _make_channel(0, channel_pb2.Channel.Role.PRIMARY, name="primary")
     admin = _make_channel(1, channel_pb2.Channel.Role.SECONDARY, name="admin")
     disabled = _make_channel(2, channel_pb2.Channel.Role.DISABLED)
-    mock_node.channels = [primary, admin, disabled]
+    channel_state.channels = [primary, admin, disabled]
 
     result = lookup._get_named_admin_channel_index()
 
@@ -365,12 +343,12 @@ def test_get_named_admin_channel_index_found(
 
 @pytest.mark.unit
 def test_get_named_admin_channel_index_case_insensitive(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_named_admin_channel_index matches 'admin' case-insensitively."""
     primary = _make_channel(0, channel_pb2.Channel.Role.PRIMARY, name="primary")
     admin = _make_channel(2, channel_pb2.Channel.Role.SECONDARY, name="ADMIN")
-    mock_node.channels = [primary, admin]
+    channel_state.channels = [primary, admin]
 
     result = lookup._get_named_admin_channel_index()
 
@@ -379,12 +357,12 @@ def test_get_named_admin_channel_index_case_insensitive(
 
 @pytest.mark.unit
 def test_get_named_admin_channel_index_ignores_disabled(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_named_admin_channel_index ignores DISABLED channels even if named admin."""
     primary = _make_channel(0, channel_pb2.Channel.Role.PRIMARY, name="primary")
     disabled_admin = _make_channel(1, channel_pb2.Channel.Role.DISABLED, name="admin")
-    mock_node.channels = [primary, disabled_admin]
+    channel_state.channels = [primary, disabled_admin]
 
     result = lookup._get_named_admin_channel_index()
 
@@ -393,34 +371,34 @@ def test_get_named_admin_channel_index_ignores_disabled(
 
 @pytest.mark.unit
 def test_get_named_admin_channel_index_not_found(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_named_admin_channel_index returns None when no admin channel exists."""
     primary = _make_channel(0, channel_pb2.Channel.Role.PRIMARY, name="primary")
     secondary = _make_channel(1, channel_pb2.Channel.Role.SECONDARY, name="other")
-    mock_node.channels = [primary, secondary]
+    channel_state.channels = [primary, secondary]
 
     assert lookup._get_named_admin_channel_index() is None
 
 
 @pytest.mark.unit
 def test_get_named_admin_channel_index_none_channels(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_named_admin_channel_index returns None when channels is None."""
-    mock_node.channels = None
+    channel_state.channels = None
 
     assert lookup._get_named_admin_channel_index() is None
 
 
 @pytest.mark.unit
 def test_get_admin_channel_index_returns_named_index(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_admin_channel_index returns the named admin index when present."""
     primary = _make_channel(0, channel_pb2.Channel.Role.PRIMARY, name="primary")
     admin = _make_channel(3, channel_pb2.Channel.Role.SECONDARY, name="admin")
-    mock_node.channels = [primary, admin]
+    channel_state.channels = [primary, admin]
 
     result = lookup._get_admin_channel_index()
 
@@ -429,12 +407,12 @@ def test_get_admin_channel_index_returns_named_index(
 
 @pytest.mark.unit
 def test_get_admin_channel_index_defaults_to_zero(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_admin_channel_index returns 0 when no named admin channel exists."""
     primary = _make_channel(0, channel_pb2.Channel.Role.PRIMARY, name="primary")
     secondary = _make_channel(1, channel_pb2.Channel.Role.SECONDARY, name="other")
-    mock_node.channels = [primary, secondary]
+    channel_state.channels = [primary, secondary]
 
     result = lookup._get_admin_channel_index()
 
@@ -443,10 +421,10 @@ def test_get_admin_channel_index_defaults_to_zero(
 
 @pytest.mark.unit
 def test_get_admin_channel_index_empty_channels(
-    lookup: _NodeChannelLookupRuntime, mock_node: MagicMock
+    lookup: _NodeChannelLookupRuntime, channel_state: _NodeChannelState
 ) -> None:
     """get_admin_channel_index returns 0 when channels is empty."""
-    mock_node.channels = []
+    channel_state.channels = []
 
     result = lookup._get_admin_channel_index()
 

--- a/meshtastic/tests/test_node_runtime_channel_normalization.py
+++ b/meshtastic/tests/test_node_runtime_channel_normalization.py
@@ -3,7 +3,6 @@
 # pylint: disable=redefined-outer-name
 
 import logging
-import threading
 from unittest.mock import MagicMock
 
 import pytest
@@ -11,23 +10,23 @@ import pytest
 from meshtastic.node_runtime.channel_normalization_runtime import (
     _NodeChannelNormalizationRuntime,
 )
+from meshtastic.node_runtime.channel_state import _NodeChannelState
 from meshtastic.node_runtime.shared import MAX_CHANNELS
 from meshtastic.protobuf import channel_pb2
 
 
 @pytest.fixture
-def mock_node() -> MagicMock:
-    """Provide a minimal mock Node with channels list and lock."""
-    node = MagicMock()
-    node.channels = []
-    node._channels_lock = threading.RLock()
-    return node
+def channel_state() -> _NodeChannelState:
+    """Provide isolated owned channel state."""
+    state = _NodeChannelState()
+    state.channels = []
+    return state
 
 
 @pytest.fixture
-def runtime(mock_node: MagicMock) -> _NodeChannelNormalizationRuntime:
-    """Provide a _NodeChannelNormalizationRuntime instance with mock node."""
-    return _NodeChannelNormalizationRuntime(mock_node)
+def runtime(channel_state: _NodeChannelState) -> _NodeChannelNormalizationRuntime:
+    """Provide a normalization runtime over owned channel state."""
+    return _NodeChannelNormalizationRuntime(channel_state)
 
 
 @pytest.mark.unit
@@ -35,38 +34,38 @@ class TestFixupChannelsLocked:
     """Tests for _NodeChannelNormalizationRuntime._fixup_channels_locked()."""
 
     def test_fixup_channels_locked_with_none_channels_returns_early(
-        self, mock_node: MagicMock
+        self, channel_state: _NodeChannelState
     ) -> None:
         """When channels is None, _fixup_channels_locked should return early."""
-        mock_node.channels = None
-        runtime = _NodeChannelNormalizationRuntime(mock_node)
+        channel_state.channels = None
+        runtime = _NodeChannelNormalizationRuntime(channel_state)
 
         # Should not raise and should return without error
         runtime._fixup_channels_locked()
 
         # Channels should still be None (no modification)
-        assert mock_node.channels is None
+        assert channel_state.channels is None
 
     def test_fixup_channels_locked_truncates_when_exceeds_max(
-        self, mock_node: MagicMock, caplog: pytest.LogCaptureFixture
+        self, channel_state: _NodeChannelState, caplog: pytest.LogCaptureFixture
     ) -> None:
         """When channels exceed MAX_CHANNELS, should truncate and log warning."""
         # Create more channels than MAX_CHANNELS
         num_channels = MAX_CHANNELS + 3
-        mock_node.channels = []
+        channel_state.channels = []
         for i in range(num_channels):
             ch = channel_pb2.Channel()
             ch.index = i
             ch.role = channel_pb2.Channel.Role.PRIMARY
-            mock_node.channels.append(ch)
+            channel_state.channels.append(ch)
 
-        runtime = _NodeChannelNormalizationRuntime(mock_node)
+        runtime = _NodeChannelNormalizationRuntime(channel_state)
 
         with caplog.at_level(logging.WARNING):
             runtime._fixup_channels_locked()
 
         # Should have truncated to MAX_CHANNELS
-        assert len(mock_node.channels) == MAX_CHANNELS
+        assert len(channel_state.channels) == MAX_CHANNELS
 
         # Should have logged a warning about truncation
         assert any(
@@ -78,55 +77,38 @@ class TestFixupChannelsLocked:
         )
 
     def test_fixup_channels_locked_reindexes_all_channels(
-        self, mock_node: MagicMock
+        self, channel_state: _NodeChannelState
     ) -> None:
         """All channels should have their index field set correctly."""
         # Create channels with incorrect indexes
-        mock_node.channels = []
+        channel_state.channels = []
         for i in range(3):
             ch = channel_pb2.Channel()
             ch.index = 99 + i  # Wrong index
             ch.role = channel_pb2.Channel.Role.PRIMARY
-            mock_node.channels.append(ch)
+            channel_state.channels.append(ch)
 
-        runtime = _NodeChannelNormalizationRuntime(mock_node)
+        runtime = _NodeChannelNormalizationRuntime(channel_state)
         runtime._fixup_channels_locked()
 
         # All channels should now have correct sequential indexes
-        for i, ch in enumerate(mock_node.channels):
+        for i, ch in enumerate(channel_state.channels):
             assert ch.index == i
-
-    def test_fixup_channels_locked_calls_fill_channels_locked(
-        self, mock_node: MagicMock
-    ) -> None:
-        """_fixup_channels_locked should call _fill_channels_locked at the end."""
-        runtime = _NodeChannelNormalizationRuntime(mock_node)
-        runtime._fill_channels_locked = MagicMock()  # type: ignore[method-assign]
-
-        runtime._fixup_channels_locked()
-
-        runtime._fill_channels_locked.assert_called_once()
 
 
 @pytest.mark.unit
 class TestFixupChannels:
     """Tests for _NodeChannelNormalizationRuntime._fixup_channels()."""
 
-    def test_fixup_channels_acquires_lock_and_calls_locked_version(
-        self, mock_node: MagicMock, runtime: _NodeChannelNormalizationRuntime
+    def test_fixup_channels_delegates_to_state_owner(
+        self, channel_state: _NodeChannelState, runtime: _NodeChannelNormalizationRuntime
     ) -> None:
-        """_fixup_channels should acquire lock and call _fixup_channels_locked."""
-        mock_node._channels_lock = MagicMock()
-        mock_node._channels_lock.__enter__ = MagicMock(return_value=None)
-        mock_node._channels_lock.__exit__ = MagicMock(return_value=False)
-        runtime._fixup_channels_locked = MagicMock()  # type: ignore[method-assign]
+        """_fixup_channels should let the state owner manage normalization locking."""
+        channel_state.normalize = MagicMock()  # type: ignore[method-assign]
 
         runtime._fixup_channels()
 
-        # Lock should have been acquired
-        mock_node._channels_lock.__enter__.assert_called_once()
-        mock_node._channels_lock.__exit__.assert_called_once()
-        runtime._fixup_channels_locked.assert_called_once()
+        channel_state.normalize.assert_called_once_with()
 
 
 @pytest.mark.unit
@@ -134,95 +116,95 @@ class TestFillChannelsLocked:
     """Tests for _NodeChannelNormalizationRuntime._fill_channels_locked()."""
 
     def test_fill_channels_locked_with_none_channels_returns_early(
-        self, mock_node: MagicMock
+        self, channel_state: _NodeChannelState
     ) -> None:
         """When channels is None, _fill_channels_locked should return early."""
-        mock_node.channels = None
-        runtime = _NodeChannelNormalizationRuntime(mock_node)
+        channel_state.channels = None
+        runtime = _NodeChannelNormalizationRuntime(channel_state)
 
         # Should not raise and should return without error
         runtime._fill_channels_locked()
 
         # Channels should still be None
-        assert mock_node.channels is None
+        assert channel_state.channels is None
 
     def test_fill_channels_locked_with_full_list_no_changes(
-        self, mock_node: MagicMock
+        self, channel_state: _NodeChannelState
     ) -> None:
         """When channel list is already at MAX_CHANNELS, no changes should occur."""
-        mock_node.channels = []
+        channel_state.channels = []
         for i in range(MAX_CHANNELS):
             ch = channel_pb2.Channel()
             ch.index = i
             ch.role = channel_pb2.Channel.Role.PRIMARY
-            mock_node.channels.append(ch)
+            channel_state.channels.append(ch)
 
-        original_channels = list(mock_node.channels)
-        runtime = _NodeChannelNormalizationRuntime(mock_node)
+        original_channels = list(channel_state.channels)
+        runtime = _NodeChannelNormalizationRuntime(channel_state)
 
         runtime._fill_channels_locked()
 
         # List length should not change
-        assert len(mock_node.channels) == MAX_CHANNELS
+        assert len(channel_state.channels) == MAX_CHANNELS
         # Original channels should be preserved
-        for i, ch in enumerate(mock_node.channels):
+        for i, ch in enumerate(channel_state.channels):
             assert ch is original_channels[i]
 
     def test_fill_channels_locked_fills_partial_list_with_disabled(
-        self, mock_node: MagicMock
+        self, channel_state: _NodeChannelState
     ) -> None:
         """Partial channel list should be filled with DISABLED channels."""
         initial_count = 3
-        mock_node.channels = []
+        channel_state.channels = []
         for i in range(initial_count):
             ch = channel_pb2.Channel()
             ch.index = i
             ch.role = channel_pb2.Channel.Role.PRIMARY
-            mock_node.channels.append(ch)
+            channel_state.channels.append(ch)
 
-        runtime = _NodeChannelNormalizationRuntime(mock_node)
+        runtime = _NodeChannelNormalizationRuntime(channel_state)
         runtime._fill_channels_locked()
 
         # Should now have MAX_CHANNELS total
-        assert len(mock_node.channels) == MAX_CHANNELS
+        assert len(channel_state.channels) == MAX_CHANNELS
 
         # First channels should be unchanged (PRIMARY)
         for i in range(initial_count):
-            assert mock_node.channels[i].role == channel_pb2.Channel.Role.PRIMARY
+            assert channel_state.channels[i].role == channel_pb2.Channel.Role.PRIMARY
 
         # Remaining channels should be DISABLED
         for i in range(initial_count, MAX_CHANNELS):
-            assert mock_node.channels[i].role == channel_pb2.Channel.Role.DISABLED
-            assert mock_node.channels[i].index == i
+            assert channel_state.channels[i].role == channel_pb2.Channel.Role.DISABLED
+            assert channel_state.channels[i].index == i
 
     def test_fill_channels_locked_reindexes_existing_channels_before_append(
-        self, mock_node: MagicMock
+        self, channel_state: _NodeChannelState
     ) -> None:
         """Existing channels should be reindexed before DISABLED channels are appended."""
         first = channel_pb2.Channel(index=3, role=channel_pb2.Channel.Role.PRIMARY)
         second = channel_pb2.Channel(index=9, role=channel_pb2.Channel.Role.SECONDARY)
-        mock_node.channels = [first, second]
-        runtime = _NodeChannelNormalizationRuntime(mock_node)
+        channel_state.channels = [first, second]
+        runtime = _NodeChannelNormalizationRuntime(channel_state)
 
         runtime._fill_channels_locked()
 
-        assert mock_node.channels[0].index == 0
-        assert mock_node.channels[1].index == 1
+        assert channel_state.channels[0].index == 0
+        assert channel_state.channels[1].index == 1
         for i in range(2, MAX_CHANNELS):
-            assert mock_node.channels[i].index == i
+            assert channel_state.channels[i].index == i
 
     def test_fill_channels_locked_with_empty_list_fills_all_disabled(
-        self, mock_node: MagicMock
+        self, channel_state: _NodeChannelState
     ) -> None:
         """Empty channel list should be filled entirely with DISABLED channels."""
-        mock_node.channels = []
-        runtime = _NodeChannelNormalizationRuntime(mock_node)
+        channel_state.channels = []
+        runtime = _NodeChannelNormalizationRuntime(channel_state)
 
         runtime._fill_channels_locked()
 
         # Should have MAX_CHANNELS all DISABLED
-        assert len(mock_node.channels) == MAX_CHANNELS
-        for i, ch in enumerate(mock_node.channels):
+        assert len(channel_state.channels) == MAX_CHANNELS
+        for i, ch in enumerate(channel_state.channels):
             assert ch.role == channel_pb2.Channel.Role.DISABLED
             assert ch.index == i
 
@@ -231,21 +213,15 @@ class TestFillChannelsLocked:
 class TestFillChannels:
     """Tests for _NodeChannelNormalizationRuntime._fill_channels()."""
 
-    def test_fill_channels_acquires_lock_and_calls_locked_version(
-        self, mock_node: MagicMock, runtime: _NodeChannelNormalizationRuntime
+    def test_fill_channels_delegates_to_state_owner(
+        self, channel_state: _NodeChannelState, runtime: _NodeChannelNormalizationRuntime
     ) -> None:
-        """_fill_channels should acquire lock and call _fill_channels_locked."""
-        mock_node._channels_lock = MagicMock()
-        mock_node._channels_lock.__enter__ = MagicMock(return_value=None)
-        mock_node._channels_lock.__exit__ = MagicMock(return_value=False)
-        runtime._fill_channels_locked = MagicMock()  # type: ignore[method-assign]
+        """_fill_channels should let the state owner manage fill locking."""
+        channel_state.fill = MagicMock()  # type: ignore[method-assign]
 
         runtime._fill_channels()
 
-        # Lock should have been acquired
-        mock_node._channels_lock.__enter__.assert_called_once()
-        mock_node._channels_lock.__exit__.assert_called_once()
-        runtime._fill_channels_locked.assert_called_once()
+        channel_state.fill.assert_called_once_with()
 
 
 @pytest.mark.unit
@@ -253,28 +229,28 @@ class TestIntegration:
     """Combined workflow tests for fixup and fill behavior."""
 
     def test_fixup_channels_full_workflow(
-        self, mock_node: MagicMock, caplog: pytest.LogCaptureFixture
+        self, channel_state: _NodeChannelState, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Full workflow: truncate, reindex, and fill with DISABLED channels."""
         # Create more channels than MAX_CHANNELS with wrong indexes
         num_channels = MAX_CHANNELS + 2
-        mock_node.channels = []
+        channel_state.channels = []
         for i in range(num_channels):
             ch = channel_pb2.Channel()
             ch.index = 100 + i  # Wrong indexes
             ch.role = channel_pb2.Channel.Role.SECONDARY
-            mock_node.channels.append(ch)
+            channel_state.channels.append(ch)
 
-        runtime = _NodeChannelNormalizationRuntime(mock_node)
+        runtime = _NodeChannelNormalizationRuntime(channel_state)
 
         with caplog.at_level(logging.WARNING):
             runtime._fixup_channels()
 
         # Should be truncated to MAX_CHANNELS
-        assert len(mock_node.channels) == MAX_CHANNELS
+        assert len(channel_state.channels) == MAX_CHANNELS
 
         # All channels should have correct sequential indexes
-        for i, ch in enumerate(mock_node.channels):
+        for i, ch in enumerate(channel_state.channels):
             assert ch.index == i
 
         # Warning should have been logged
@@ -282,30 +258,30 @@ class TestIntegration:
             "Truncating channel list" in record.message for record in caplog.records
         )
 
-    def test_fixup_channels_with_partial_list(self, mock_node: MagicMock) -> None:
+    def test_fixup_channels_with_partial_list(self, channel_state: _NodeChannelState) -> None:
         """Partial channel list should be reindexed and filled."""
         initial_count = 2
-        mock_node.channels = []
+        channel_state.channels = []
         for i in range(initial_count):
             ch = channel_pb2.Channel()
             ch.index = 50 + i  # Wrong indexes
             ch.role = channel_pb2.Channel.Role.PRIMARY
-            mock_node.channels.append(ch)
+            channel_state.channels.append(ch)
 
-        runtime = _NodeChannelNormalizationRuntime(mock_node)
+        runtime = _NodeChannelNormalizationRuntime(channel_state)
         runtime._fixup_channels()
 
         # Should be filled to MAX_CHANNELS
-        assert len(mock_node.channels) == MAX_CHANNELS
+        assert len(channel_state.channels) == MAX_CHANNELS
 
         # All channels should have correct sequential indexes
-        for i, ch in enumerate(mock_node.channels):
+        for i, ch in enumerate(channel_state.channels):
             assert ch.index == i
 
         # First channels should be PRIMARY
         for i in range(initial_count):
-            assert mock_node.channels[i].role == channel_pb2.Channel.Role.PRIMARY
+            assert channel_state.channels[i].role == channel_pb2.Channel.Role.PRIMARY
 
         # Remaining should be DISABLED
         for i in range(initial_count, MAX_CHANNELS):
-            assert mock_node.channels[i].role == channel_pb2.Channel.Role.DISABLED
+            assert channel_state.channels[i].role == channel_pb2.Channel.Role.DISABLED

--- a/meshtastic/tests/test_node_runtime_channel_presentation.py
+++ b/meshtastic/tests/test_node_runtime_channel_presentation.py
@@ -6,7 +6,7 @@ import re
 import threading
 from types import SimpleNamespace
 from typing import cast
-from unittest.mock import MagicMock, create_autospec
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 
@@ -15,6 +15,8 @@ from meshtastic.node_runtime.channel_presentation_runtime import (
     _NodeChannelPresentationRuntime,
 )
 from meshtastic.protobuf import channel_pb2, localonly_pb2
+
+from ._node_channel_state_test_support import _attach_channel_state
 
 
 @pytest.fixture
@@ -33,10 +35,11 @@ def mock_node() -> MagicMock:
             "iface",
             "localConfig",
             "moduleConfig",
+            "_test_channel_state",
         ]
     )
-    node.channels = []
-    node._channels_lock = threading.RLock()  # noqa: SLF001
+    channel_state = _attach_channel_state(node)
+    channel_state.channels = []
     node.iface = SimpleNamespace(_node_db_lock=threading.RLock())
     node.localConfig = None
     node.moduleConfig = None
@@ -59,7 +62,11 @@ def presentation_runtime(mock_node: MagicMock) -> _NodeChannelPresentationRuntim
     """
     export_runtime = create_autospec(_NodeChannelExportRuntime, instance=True)
     export_runtime.get_url.return_value = "https://meshtastic.org/e/#test"
-    return _NodeChannelPresentationRuntime(mock_node, export_runtime=export_runtime)
+    return _NodeChannelPresentationRuntime(
+        mock_node,
+        channel_state=mock_node._test_channel_state,
+        export_runtime=export_runtime,
+    )
 
 
 @pytest.mark.unit
@@ -106,6 +113,57 @@ def test_show_channels_with_channels(
 
 
 @pytest.mark.unit
+def test_show_channels_uses_one_snapshot_for_display_and_both_urls(
+    mock_node: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Printed channels and both exported URLs should share one state snapshot."""
+    primary = channel_pb2.Channel(index=0, role=channel_pb2.Channel.Role.PRIMARY)
+    primary.settings.name = "captured"
+    primary.settings.psk = b"\x01"
+    mock_node.channels = [primary]
+    export_runtime = _NodeChannelExportRuntime(
+        mock_node,
+        channel_state=mock_node._test_channel_state,
+    )
+    presentation_runtime = _NodeChannelPresentationRuntime(
+        mock_node,
+        channel_state=mock_node._test_channel_state,
+        export_runtime=export_runtime,
+    )
+
+    def _encode_snapshot(
+        channels_snapshot: list[channel_pb2.Channel],
+        *,
+        include_all: bool,
+    ) -> str:
+        assert channels_snapshot[0].settings.name == "captured"
+        return "complete-encoded" if include_all else "public-encoded"
+
+    with (
+        patch.object(
+            export_runtime,
+            "_build_and_encode_channel_set",
+            side_effect=_encode_snapshot,
+        ) as encode_snapshot,
+        patch.object(export_runtime, "get_url") as compatibility_export,
+    ):
+        presentation_runtime._show_channels()
+
+    assert encode_snapshot.call_count == 2
+    first_snapshot = encode_snapshot.call_args_list[0].args[0]
+    second_snapshot = encode_snapshot.call_args_list[1].args[0]
+    assert first_snapshot is second_snapshot
+    compatibility_export.assert_not_called()
+    out, _ = capsys.readouterr()
+    assert "Primary channel URL: https://meshtastic.org/e/#public-encoded" in out
+    assert (
+        "Complete URL (includes all channels): "
+        "https://meshtastic.org/e/#complete-encoded" in out
+    )
+
+
+@pytest.mark.unit
 def test_show_channels_handles_unknown_role_values(
     presentation_runtime: _NodeChannelPresentationRuntime,
     mock_node: MagicMock,
@@ -134,7 +192,9 @@ def test_show_channels_handles_export_errors_without_raising(
     export_runtime = create_autospec(_NodeChannelExportRuntime, instance=True)
     export_runtime.get_url.side_effect = RuntimeError("channels not loaded")
     presentation_runtime = _NodeChannelPresentationRuntime(
-        mock_node, export_runtime=export_runtime
+        mock_node,
+        channel_state=mock_node._test_channel_state,
+        export_runtime=export_runtime,
     )
     mock_node.channels = []
 
@@ -165,7 +225,9 @@ def test_show_channels_shows_complete_url_when_different_from_public(
 
     export_runtime.get_url.side_effect = get_url_side_effect
     presentation_runtime = _NodeChannelPresentationRuntime(
-        mock_node, export_runtime=export_runtime
+        mock_node,
+        channel_state=mock_node._test_channel_state,
+        export_runtime=export_runtime,
     )
 
     # Add multiple secondary channels so admin_url != public_url

--- a/meshtastic/tests/test_node_runtime_channel_request.py
+++ b/meshtastic/tests/test_node_runtime_channel_request.py
@@ -3,16 +3,16 @@
 # pylint: disable=redefined-outer-name
 
 import logging
-import threading
 import warnings
 from unittest.mock import MagicMock
 
 import pytest
 
-from meshtastic.node_runtime.channel_normalization_runtime import (
-    _NodeChannelNormalizationRuntime,
+from meshtastic.node_runtime.channel_request_runtime import (
+    _ChannelRequestCompletionProbe,
+    _NodeChannelRequestRuntime,
 )
-from meshtastic.node_runtime.channel_request_runtime import _NodeChannelRequestRuntime
+from meshtastic.node_runtime.channel_state import _NodeChannelState
 from meshtastic.node_runtime.shared import MAX_CHANNELS
 from meshtastic.protobuf import admin_pb2, channel_pb2, localonly_pb2, mesh_pb2
 
@@ -24,15 +24,11 @@ def mock_node() -> MagicMock:
     Returns
     -------
     MagicMock
-        A mock configured with nodeNum, _channels_lock, channels, partialChannels,
-        and _send_admin method.
+        A mock configured with nodeNum, admin send/wait state, and local config.
     """
     node = MagicMock(
         spec=[
             "nodeNum",
-            "_channels_lock",
-            "channels",
-            "partialChannels",
             "_send_admin",
             "_timeout",
             "iface",
@@ -41,60 +37,29 @@ def mock_node() -> MagicMock:
         ]
     )
     node.nodeNum = 1234567890
-    node._channels_lock = threading.RLock()  # noqa: SLF001
-    node.channels = None
-    node.partialChannels = []
     node._send_admin = MagicMock(return_value=mesh_pb2.MeshPacket())  # noqa: SLF001
     node.localConfig = localonly_pb2.LocalConfig()
     return node
 
 
 @pytest.fixture
-def mock_normalization_runtime(
-    mock_node: MagicMock,
-) -> _NodeChannelNormalizationRuntime:
-    """Create a real normalization runtime instance for the mock node.
-
-    Parameters
-    ----------
-    mock_node : MagicMock
-        The mock node fixture.
-
-    Returns
-    -------
-    _NodeChannelNormalizationRuntime
-        A real normalization runtime instance attached to the mock node.
-    """
-    return _NodeChannelNormalizationRuntime(mock_node)
+def channel_state() -> _NodeChannelState:
+    """Provide isolated owned channel state for channel requests."""
+    return _NodeChannelState()
 
 
 @pytest.fixture
 def channel_request_runtime(
-    mock_node: MagicMock, mock_normalization_runtime: _NodeChannelNormalizationRuntime
+    mock_node: MagicMock, channel_state: _NodeChannelState
 ) -> _NodeChannelRequestRuntime:
-    """Create a channel request runtime instance for testing.
-
-    Parameters
-    ----------
-    mock_node : MagicMock
-        The mock node fixture.
-    mock_normalization_runtime : _NodeChannelNormalizationRuntime
-        The normalization runtime fixture.
-
-    Returns
-    -------
-    _NodeChannelRequestRuntime
-        A channel request runtime instance attached to the mock node.
-    """
-    return _NodeChannelRequestRuntime(
-        mock_node, normalization_runtime=mock_normalization_runtime
-    )
+    """Create a channel request runtime over the shared state owner."""
+    return _NodeChannelRequestRuntime(mock_node, channel_state=channel_state)
 
 
 @pytest.mark.unit
 def test_setChannels_with_valid_channels_copies_and_normalizes(
     channel_request_runtime: _NodeChannelRequestRuntime,
-    mock_node: MagicMock,
+    channel_state: _NodeChannelState,
 ) -> None:
     """SetChannels should copy input channels and call fixup_channels_locked.
 
@@ -115,36 +80,37 @@ def test_setChannels_with_valid_channels_copies_and_normalizes(
     channel_request_runtime.setChannels(source_channels)
 
     # Verify channels were copied (not the same objects)
-    assert mock_node.channels is not None
-    assert len(mock_node.channels) == MAX_CHANNELS
+    assert channel_state.channels is not None
+    assert len(channel_state.channels) == MAX_CHANNELS
     # Verify they are copies, not the same objects
-    assert mock_node.channels[0] is not source_channel1
-    assert mock_node.channels[1] is not source_channel2
+    assert channel_state.channels[0] is not source_channel1
+    assert channel_state.channels[1] is not source_channel2
     # Verify content was copied for first two channels
-    assert mock_node.channels[0].index == 0
-    assert mock_node.channels[0].role == channel_pb2.Channel.Role.PRIMARY
-    assert mock_node.channels[1].index == 1
-    assert mock_node.channels[1].role == channel_pb2.Channel.Role.SECONDARY
+    assert channel_state.channels[0].index == 0
+    assert channel_state.channels[0].role == channel_pb2.Channel.Role.PRIMARY
+    assert channel_state.channels[1].index == 1
+    assert channel_state.channels[1].role == channel_pb2.Channel.Role.SECONDARY
     # Verify remaining channels are DISABLED (filled by fill_channels_locked)
     for i in range(2, MAX_CHANNELS):
-        assert mock_node.channels[i].role == channel_pb2.Channel.Role.DISABLED
+        assert channel_state.channels[i].role == channel_pb2.Channel.Role.DISABLED
 
 
 @pytest.mark.unit
 def test_requestChannels_with_starting_index_zero_resets_channels(
     channel_request_runtime: _NodeChannelRequestRuntime,
+    channel_state: _NodeChannelState,
     mock_node: MagicMock,
 ) -> None:
     """RequestChannels with starting_index=0 should reset channels and partialChannels."""
     # Set up pre-existing channels
-    mock_node.channels = [channel_pb2.Channel()]
-    mock_node.partialChannels = [channel_pb2.Channel()]
+    channel_state.channels = [channel_pb2.Channel()]
+    channel_state.partial_channels = [channel_pb2.Channel()]
 
     channel_request_runtime.requestChannels(starting_index=0)
 
     # Verify channels were reset
-    assert mock_node.channels is None
-    assert mock_node.partialChannels == []
+    assert channel_state.channels is None
+    assert channel_state.partial_channels == []
     # Verify request_channel was called
     mock_node._send_admin.assert_called_once()  # noqa: SLF001
 
@@ -152,19 +118,20 @@ def test_requestChannels_with_starting_index_zero_resets_channels(
 @pytest.mark.unit
 def test_requestChannels_with_starting_index_nonzero_preserves_channels(
     channel_request_runtime: _NodeChannelRequestRuntime,
+    channel_state: _NodeChannelState,
     mock_node: MagicMock,
 ) -> None:
     """RequestChannels with starting_index>0 should not reset channels or partialChannels."""
     # Set up pre-existing channels
     existing_channel = channel_pb2.Channel()
-    mock_node.channels = [existing_channel]
-    mock_node.partialChannels = [channel_pb2.Channel()]
+    channel_state.channels = [existing_channel]
+    channel_state.partial_channels = [channel_pb2.Channel()]
 
     channel_request_runtime.requestChannels(starting_index=2)
 
     # Verify channels were NOT reset
-    assert mock_node.channels == [existing_channel]
-    assert len(mock_node.partialChannels) == 1
+    assert channel_state.channels == [existing_channel]
+    assert len(channel_state.partial_channels) == 1
     # Verify request_channel was still called
     mock_node._send_admin.assert_called_once()  # noqa: SLF001
 
@@ -184,19 +151,48 @@ def test_requestChannels_calls_canonical_request_channel_method(
 
 
 @pytest.mark.unit
-def test_waitForConfig_delegates_to_timeout_wait_for_set(
+def test_waitForConfig_falls_back_to_node_attribute_without_response_runtime(
     channel_request_runtime: _NodeChannelRequestRuntime,
     mock_node: MagicMock,
 ) -> None:
-    """WaitForConfig should delegate to _timeout.waitForSet with correct attributes."""
+    """Without a response runtime, preserve the historical ``Node.channels`` wait."""
     mock_timeout = MagicMock()
     mock_timeout.waitForSet.return_value = True
     mock_node._timeout = mock_timeout  # noqa: SLF001
+
+    assert not hasattr(mock_node, "_channel_response_runtime")
 
     result = channel_request_runtime.waitForConfig(attribute="channels")
 
     assert result is True
     mock_timeout.waitForSet.assert_called_once_with(mock_node, attrs=("channels",))
+
+
+@pytest.mark.unit
+def test_waitForConfig_observes_channels_installed_during_response_wait(
+    channel_request_runtime: _NodeChannelRequestRuntime,
+    channel_state: _NodeChannelState,
+    mock_node: MagicMock,
+) -> None:
+    """Channel completion should be observed through the shared state owner."""
+    response_runtime = MagicMock()
+    response_runtime.hasChannelRequestFailed.return_value = False
+    mock_node._channel_response_runtime = response_runtime
+
+    def _install_channels(
+        completion_probe: _ChannelRequestCompletionProbe,
+        *,
+        attrs: tuple[str, ...],
+    ) -> bool:
+        assert attrs == ("is_set",)
+        channel_state.channels = [channel_pb2.Channel()]
+        assert completion_probe.is_set is True
+        return True
+
+    mock_node._timeout.waitForSet.side_effect = _install_channels  # noqa: SLF001
+
+    assert channel_request_runtime.waitForConfig(attribute="channels") is True
+    response_runtime.hasChannelRequestFailed.assert_not_called()
 
 
 @pytest.mark.unit
@@ -306,7 +302,7 @@ def test_request_channel_send_exception_marks_request_failed(
     mock_node.iface = mock_iface
 
     channel_response_runtime = MagicMock()
-    mock_node._channel_response_runtime = channel_response_runtime  # type: ignore[attr-defined]
+    mock_node._channel_response_runtime = channel_response_runtime
     mock_node._send_admin.side_effect = RuntimeError("send failed")  # noqa: SLF001
 
     with pytest.raises(RuntimeError, match="send failed"):

--- a/meshtastic/tests/test_node_runtime_response.py
+++ b/meshtastic/tests/test_node_runtime_response.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from ._node_channel_state_test_support import _attach_channel_state
 from ..node_runtime.response_runtime import (
     _NodeChannelResponseRuntime,
     _NodeMetadataResponseRuntime,
@@ -51,17 +52,15 @@ def mock_node_for_channel() -> MagicMock:
             "partialChannels",
             "channels",
             "_request_channel",
-            "_fixup_channels_locked",
+            "_test_channel_state",
         ]
     )
     node._timeout = MagicMock()
     node._timeout.expireTime = time.time() + 300
     node._timeout.reset = MagicMock()
-    node._channels_lock = threading.Lock()
-    node.partialChannels = []
-    node.channels = None
+    channel_state = _attach_channel_state(node)
+    channel_state._replace_lock(threading.RLock())
     node._request_channel = MagicMock()
-    node._fixup_channels_locked = MagicMock()
     return node
 
 
@@ -430,7 +429,9 @@ class TestNodeChannelResponseRuntime:
         self, mock_node_for_channel: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Handle channel response with missing decoded should return early."""
-        runtime = _NodeChannelResponseRuntime(mock_node_for_channel)
+        runtime = _NodeChannelResponseRuntime(
+            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+        )
         packet: dict[str, Any] = {"decoded": None}
 
         with caplog.at_level(logging.WARNING):
@@ -443,7 +444,9 @@ class TestNodeChannelResponseRuntime:
         self, mock_node_for_channel: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Handle channel response with routing error should retry in-flight request."""
-        runtime = _NodeChannelResponseRuntime(mock_node_for_channel)
+        runtime = _NodeChannelResponseRuntime(
+            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+        )
         runtime.mark_channel_request_sent(3)
         packet: dict[str, Any] = {
             "decoded": {
@@ -465,7 +468,9 @@ class TestNodeChannelResponseRuntime:
         self, mock_node_for_channel: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Handle channel response with routing success should wait for ADMIN_APP payload."""
-        runtime = _NodeChannelResponseRuntime(mock_node_for_channel)
+        runtime = _NodeChannelResponseRuntime(
+            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+        )
 
         packet: dict[str, Any] = {
             "decoded": {
@@ -488,7 +493,9 @@ class TestNodeChannelResponseRuntime:
         self, mock_node_for_channel: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Handle channel response with admin message should append to partialChannels."""
-        runtime = _NodeChannelResponseRuntime(mock_node_for_channel)
+        runtime = _NodeChannelResponseRuntime(
+            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+        )
         runtime.mark_channel_request_sent(0)
 
         raw = admin_pb2.AdminMessage()
@@ -516,7 +523,9 @@ class TestNodeChannelResponseRuntime:
         self, mock_node_for_channel: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Handle channel response with last channel index should finalize channels."""
-        runtime = _NodeChannelResponseRuntime(mock_node_for_channel)
+        runtime = _NodeChannelResponseRuntime(
+            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+        )
         runtime.mark_channel_request_sent(7)
 
         # MAX_CHANNELS is 8, so index 7 (the 8th channel) should finalize
@@ -533,31 +542,27 @@ class TestNodeChannelResponseRuntime:
             }
         }
 
-        lock_held_during_fixup = False
-
-        def fixup_side_effect() -> None:
-            nonlocal lock_held_during_fixup
-            lock_held_during_fixup = mock_node_for_channel._channels_lock.locked()
-
-        mock_node_for_channel._fixup_channels_locked.side_effect = fixup_side_effect
-
         with caplog.at_level(logging.DEBUG):
             runtime.handle_channel_response(packet)
 
         assert "Finished downloading channels" in caplog.text
-        mock_node_for_channel._fixup_channels_locked.assert_called_once()
-        assert lock_held_during_fixup is True
         assert mock_node_for_channel.channels is not None
-        assert len(mock_node_for_channel.channels) == 1
-        assert mock_node_for_channel.channels[0].index == 7
+        assert len(mock_node_for_channel.channels) == 8
+        assert mock_node_for_channel.channels[0].index == 0
         assert mock_node_for_channel.channels[0].settings.name == "ch8"
+        assert all(
+            channel.index == index
+            for index, channel in enumerate(mock_node_for_channel.channels)
+        )
 
     @pytest.mark.unit
     def test_handle_channel_response_non_last_channel_requests_next(
         self, mock_node_for_channel: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Handle channel response with non-last channel should request next channel."""
-        runtime = _NodeChannelResponseRuntime(mock_node_for_channel)
+        runtime = _NodeChannelResponseRuntime(
+            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+        )
         runtime.mark_channel_request_sent(3)
 
         raw = admin_pb2.AdminMessage()
@@ -583,7 +588,9 @@ class TestNodeChannelResponseRuntime:
         self, mock_node_for_channel: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Late duplicate channel response after successful retry should not restart installation."""
-        runtime = _NodeChannelResponseRuntime(mock_node_for_channel)
+        runtime = _NodeChannelResponseRuntime(
+            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+        )
         runtime.mark_channel_request_sent(0)
 
         raw = admin_pb2.AdminMessage()
@@ -618,7 +625,9 @@ class TestNodeChannelResponseRuntime:
         self, mock_node_for_channel: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Handle channel response with missing admin should log warning."""
-        runtime = _NodeChannelResponseRuntime(mock_node_for_channel)
+        runtime = _NodeChannelResponseRuntime(
+            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+        )
         packet: dict[str, Any] = {
             "decoded": {
                 "portnum": "ADMIN_APP",
@@ -635,7 +644,9 @@ class TestNodeChannelResponseRuntime:
         self, mock_node_for_channel: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Handle channel response with missing admin.raw should log warning."""
-        runtime = _NodeChannelResponseRuntime(mock_node_for_channel)
+        runtime = _NodeChannelResponseRuntime(
+            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+        )
         packet: dict[str, Any] = {
             "decoded": {
                 "portnum": "ADMIN_APP",
@@ -653,7 +664,9 @@ class TestNodeChannelResponseRuntime:
         self, mock_node_for_channel: MagicMock
     ) -> None:
         """_handle_routing_response should return False for non-ROUTING_APP portnum."""
-        runtime = _NodeChannelResponseRuntime(mock_node_for_channel)
+        runtime = _NodeChannelResponseRuntime(
+            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+        )
         decoded: dict[str, Any] = {
             "portnum": "ADMIN_APP",
             "routing": {"errorReason": "NONE"},
@@ -668,7 +681,9 @@ class TestNodeChannelResponseRuntime:
         self, mock_node_for_channel: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
         """_handle_routing_response should guard malformed routing payloads."""
-        runtime = _NodeChannelResponseRuntime(mock_node_for_channel)
+        runtime = _NodeChannelResponseRuntime(
+            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+        )
         decoded: dict[str, Any] = {
             "portnum": portnums_pb2.PortNum.Name(portnums_pb2.PortNum.ROUTING_APP),
         }
@@ -686,7 +701,9 @@ class TestNodeChannelResponseRuntime:
         self, mock_node_for_channel: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
         """_handle_routing_response should wait for ADMIN_APP payload on routing success."""
-        runtime = _NodeChannelResponseRuntime(mock_node_for_channel)
+        runtime = _NodeChannelResponseRuntime(
+            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+        )
 
         decoded: dict[str, Any] = {
             "portnum": portnums_pb2.PortNum.Name(portnums_pb2.PortNum.ROUTING_APP),
@@ -708,7 +725,9 @@ class TestNodeChannelResponseRuntime:
         self, mock_node_for_channel: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Routing errors without a pending index should set terminal channel-failure state."""
-        runtime = _NodeChannelResponseRuntime(mock_node_for_channel)
+        runtime = _NodeChannelResponseRuntime(
+            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+        )
         decoded: dict[str, Any] = {
             "portnum": portnums_pb2.PortNum.Name(portnums_pb2.PortNum.ROUTING_APP),
             "routing": {"errorReason": "NO_RESPONSE"},
@@ -727,7 +746,9 @@ class TestNodeChannelResponseRuntime:
         self, mock_node_for_channel: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Routing retry should mark failure if the retry send is skipped."""
-        runtime = _NodeChannelResponseRuntime(mock_node_for_channel)
+        runtime = _NodeChannelResponseRuntime(
+            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+        )
         runtime.mark_channel_request_sent(4)
         mock_node_for_channel._request_channel.return_value = None
         decoded: dict[str, Any] = {
@@ -747,7 +768,9 @@ class TestNodeChannelResponseRuntime:
         self, mock_node_for_channel: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Persistent routing failures should stop retrying after the configured retry limit."""
-        runtime = _NodeChannelResponseRuntime(mock_node_for_channel)
+        runtime = _NodeChannelResponseRuntime(
+            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+        )
         runtime.mark_channel_request_sent(2)
         decoded: dict[str, Any] = {
             "portnum": portnums_pb2.PortNum.Name(portnums_pb2.PortNum.ROUTING_APP),

--- a/meshtastic/tests/test_node_runtime_transport.py
+++ b/meshtastic/tests/test_node_runtime_transport.py
@@ -27,6 +27,8 @@ from meshtastic.node_runtime.transport_runtime import (
 from meshtastic.protobuf import admin_pb2, channel_pb2, mesh_pb2, portnums_pb2
 from meshtastic.util import Acknowledgment
 
+from ._node_channel_state_test_support import _attach_channel_state
+
 
 # Sentinel exception for testing error paths (avoid bare Exception in tests)
 class _SentinelError(Exception):
@@ -88,6 +90,7 @@ def mock_local_node(mock_iface: MagicMock) -> MagicMock:
             "_send_admin",
             "ensureSessionKey",
             "_channels_lock",
+            "_test_channel_state",
             "channels",
             "partialChannels",
             "_raise_interface_error",
@@ -103,9 +106,10 @@ def mock_local_node(mock_iface: MagicMock) -> MagicMock:
     node.requestConfig = MagicMock()
     node._send_admin = MagicMock(return_value=mesh_pb2.MeshPacket())
     node.ensureSessionKey = MagicMock()
-    node._channels_lock = threading.RLock()
-    node.channels = None
-    node.partialChannels = []
+    channel_state = _attach_channel_state(node)
+    channel_state._replace_lock(threading.RLock())
+    channel_state.channels = None
+    channel_state.partial_channels = []
     node._raise_interface_error = MagicMock(
         side_effect=_SentinelError("interface error")
     )
@@ -142,6 +146,7 @@ def mock_remote_node(mock_iface: MagicMock) -> MagicMock:
             "_send_admin",
             "ensureSessionKey",
             "_channels_lock",
+            "_test_channel_state",
             "channels",
             "partialChannels",
             "_raise_interface_error",
@@ -155,9 +160,10 @@ def mock_remote_node(mock_iface: MagicMock) -> MagicMock:
     node.requestConfig = MagicMock()
     node._send_admin = MagicMock(return_value=mesh_pb2.MeshPacket())
     node.ensureSessionKey = MagicMock()
-    node._channels_lock = threading.RLock()
-    node.channels = None
-    node.partialChannels = []
+    channel_state = _attach_channel_state(node)
+    channel_state._replace_lock(threading.RLock())
+    channel_state.channels = None
+    channel_state.partial_channels = []
     node._raise_interface_error = MagicMock(
         side_effect=_SentinelError("interface error")
     )
@@ -335,12 +341,8 @@ class TestNodeChannelWriteRuntime:
         _NodeChannelWriteRuntime
             A channel write runtime instance.
         """
-        session_runtime = _NodeAdminSessionRuntime(mock_local_node)
-        transport_runtime = _NodeAdminTransportRuntime(mock_local_node)
         return _NodeChannelWriteRuntime(
-            mock_local_node,
-            admin_session_runtime=session_runtime,
-            admin_transport_runtime=transport_runtime,
+            mock_local_node, channel_state=mock_local_node._test_channel_state
         )
 
     @pytest.mark.unit
@@ -450,15 +452,13 @@ class TestNodeDeleteChannelRuntime:
         _NodeDeleteChannelRuntime
             A delete channel runtime instance.
         """
-        session_runtime = _NodeAdminSessionRuntime(mock_local_node)
-        transport_runtime = _NodeAdminTransportRuntime(mock_local_node)
         channel_write_runtime = _NodeChannelWriteRuntime(
-            mock_local_node,
-            admin_session_runtime=session_runtime,
-            admin_transport_runtime=transport_runtime,
+            mock_local_node, channel_state=mock_local_node._test_channel_state
         )
         return _NodeDeleteChannelRuntime(
-            mock_local_node, channel_write_runtime=channel_write_runtime
+            mock_local_node,
+            channel_state=mock_local_node._test_channel_state,
+            channel_write_runtime=channel_write_runtime,
         )
 
     @pytest.mark.unit
@@ -591,15 +591,13 @@ class TestNodeDeleteChannelRuntime:
         mock_remote_node.channels = channels
 
         # Create runtime for remote node
-        session_runtime = _NodeAdminSessionRuntime(mock_remote_node)
-        transport_runtime = _NodeAdminTransportRuntime(mock_remote_node)
         channel_write_runtime = _NodeChannelWriteRuntime(
-            mock_remote_node,
-            admin_session_runtime=session_runtime,
-            admin_transport_runtime=transport_runtime,
+            mock_remote_node, channel_state=mock_remote_node._test_channel_state
         )
         delete_runtime = _NodeDeleteChannelRuntime(
-            mock_remote_node, channel_write_runtime=channel_write_runtime
+            mock_remote_node,
+            channel_state=mock_remote_node._test_channel_state,
+            channel_write_runtime=channel_write_runtime,
         )
 
         with mock_remote_node._channels_lock:
@@ -656,6 +654,9 @@ class TestNodeDeleteChannelRuntime:
             channels.append(ch)
 
         mock_local_node.channels = channels
+        mock_local_node.partialChannels = [
+            channel_pb2.Channel(index=7, role=channel_pb2.Channel.Role.SECONDARY)
+        ]
 
         # Patch _write_channel_snapshot to avoid actual I/O
         with patch.object(
@@ -667,6 +668,7 @@ class TestNodeDeleteChannelRuntime:
         assert mock_local_node.channels is not None
         # Channel 1 should now be DISABLED (shifted from index 2)
         assert mock_local_node.channels[1].role == channel_pb2.Channel.Role.DISABLED
+        assert mock_local_node.partialChannels == []
 
     @pytest.mark.unit
     def test_delete_channel_switches_admin_index_after_slot_rewrite(
@@ -727,9 +729,72 @@ class TestNodeDeleteChannelRuntime:
             -1,
         )
         assert pre_delete_idx >= 0, "pre_delete_admin write should exist"
-        assert (
-            post_delete_idx > pre_delete_idx
-        ), "post_delete_admin should appear after pre_delete_admin"
+        assert post_delete_idx > pre_delete_idx, (
+            "post_delete_admin should appear after pre_delete_admin"
+        )
+
+    @pytest.mark.unit
+    def test_delete_channel_releases_state_lock_before_device_writes(
+        self,
+        delete_channel_runtime: _NodeDeleteChannelRuntime,
+        mock_local_node: MagicMock,
+    ) -> None:
+        """Device writes must not hold the lock needed by inbound channel responses."""
+        state = mock_local_node._test_channel_state
+        channels = [
+            channel_pb2.Channel(
+                index=index,
+                role=(
+                    channel_pb2.Channel.Role.PRIMARY
+                    if index == 0
+                    else channel_pb2.Channel.Role.SECONDARY
+                    if index == 1
+                    else channel_pb2.Channel.Role.DISABLED
+                ),
+            )
+            for index in range(MAX_CHANNELS)
+        ]
+        state.channels = channels
+
+        class _LockProbe:
+            def __init__(self) -> None:
+                self._lock = threading.RLock()
+                self.depth = 0
+
+            @property
+            def active(self) -> bool:
+                return self.depth > 0
+
+            def __enter__(self) -> "_LockProbe":
+                self._lock.acquire()
+                self.depth += 1
+                return self
+
+            def __exit__(self, *_args: object) -> None:
+                self.depth -= 1
+                self._lock.release()
+
+        state_lock = _LockProbe()
+        mutation_lock = _LockProbe()
+        state._replace_lock(state_lock)  # noqa: SLF001
+        state._replace_mutation_lock(mutation_lock)  # noqa: SLF001
+        observed_write_lock_states: list[tuple[bool, bool]] = []
+
+        def _record_write_lock_state(*_args: Any, **_kwargs: Any) -> None:
+            observed_write_lock_states.append((state_lock.active, mutation_lock.active))
+
+        with patch.object(
+            delete_channel_runtime._channel_write_runtime,
+            "_write_channel_snapshot",
+            side_effect=_record_write_lock_state,
+        ):
+            delete_channel_runtime._delete_channel(1)
+
+        assert len(observed_write_lock_states) == 1
+        assert all(
+            not state_active and rewrite_active
+            for state_active, rewrite_active in observed_write_lock_states
+        )
 
     @pytest.mark.unit
     def test_delete_channel_handles_cache_unavailable(
@@ -809,6 +874,45 @@ class TestNodeDeleteChannelRuntime:
             delete_channel_runtime._delete_channel(1)
 
         assert "Channel cache changed during delete rewrite" in caplog.text
+        assert mock_local_node.channels is None
+        assert mock_local_node.partialChannels == []
+
+    @pytest.mark.unit
+    def test_delete_channel_invalidates_in_place_cache_mutation(
+        self,
+        delete_channel_runtime: _NodeDeleteChannelRuntime,
+        mock_local_node: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A same-list mutation during rewrites should fail the fingerprint guard."""
+        channels = []
+        for index in range(MAX_CHANNELS):
+            channel = channel_pb2.Channel(index=index)
+            channel.role = (
+                channel_pb2.Channel.Role.PRIMARY
+                if index == 0
+                else channel_pb2.Channel.Role.SECONDARY
+                if index == 1
+                else channel_pb2.Channel.Role.DISABLED
+            )
+            channels.append(channel)
+        mock_local_node.channels = channels
+        mock_local_node.partialChannels = [channel_pb2.Channel(index=7)]
+
+        def mutate_cache(*_args: Any, **_kwargs: Any) -> None:
+            channels[0].settings.name = "concurrent-update"
+
+        with (
+            caplog.at_level(logging.WARNING),
+            patch.object(
+                delete_channel_runtime._channel_write_runtime,
+                "_write_channel_snapshot",
+                side_effect=mutate_cache,
+            ),
+        ):
+            delete_channel_runtime._delete_channel(1)
+
+        assert "Channel fingerprint mismatch" in caplog.text
         assert mock_local_node.channels is None
         assert mock_local_node.partialChannels == []
 

--- a/meshtastic/tests/test_node_seturl.py
+++ b/meshtastic/tests/test_node_seturl.py
@@ -5,7 +5,7 @@ import logging
 import re
 from collections.abc import Callable
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pytest import LogCaptureFixture
@@ -838,13 +838,13 @@ def test_setURL_replace_disables_channels_omitted_from_url(
 
 
 @pytest.mark.unit
-def test_setURL_replace_raises_if_channels_disappear_during_assignment(
+def test_setURL_replace_rejects_channel_cache_loss_before_writes(
     autospec_local_node_iface: Callable[[type[Any]], MagicMock],
 ) -> None:
-    """SetURL replace-path should recheck channels before assignment in each loop iteration."""
+    """Replace-all should reject channel-cache loss before starting device writes."""
     anode = Node(autospec_local_node_iface(MeshInterface), "!12345678", noProto=True)
     anode.channels = [Channel(index=0, role=Channel.Role.DISABLED)]
-    # The third acquisition is the per-entry replace assignment recheck.
+    # Drop the cache when execution validates the plan against current state.
     channels_lock = _DropChannelsOnEnterCountLock(anode, trigger_enter=3)
     anode._channels_lock = channels_lock  # type: ignore[assignment]
 
@@ -854,12 +854,17 @@ def test_setURL_replace_raises_if_channels_disappear_during_assignment(
     setting.psk = b"\x01"
     url = _encode_channel_set_to_url(channel_set)
 
-    with pytest.raises(
-        MeshInterface.MeshInterfaceError,
-        match="Channel write for index 0 was not started",
+    with (
+        patch.object(anode, "_write_channel_snapshot") as write_channel,
+        pytest.raises(
+            MeshInterface.MeshInterfaceError,
+            match="Channel cache changed before replace-all write; aborting transaction",
+        ),
     ):
         anode.setURL(url, addOnly=False)
-    assert channels_lock.enters == 4
+
+    write_channel.assert_not_called()
+    assert anode.channels is None
 
 
 @pytest.mark.unit
@@ -940,6 +945,7 @@ def test_setURL_replace_rechecks_channels_before_length_calculation(
         anode.setURL(_encode_channel_set_to_url(channel_set))
     assert channels_lock.enters == 2
 
+
 @pytest.mark.unit
 def test_setURL_raises_when_channels_not_loaded(
     autospec_local_node_iface: Callable[[type[Any]], MagicMock],
@@ -950,6 +956,7 @@ def test_setURL_raises_when_channels_not_loaded(
         MeshInterface.MeshInterfaceError, match="Config or channels not loaded"
     ):
         anode.setURL("")
+
 
 @pytest.mark.unit
 def test_setURL_ignores_channels_over_device_limit(

--- a/meshtastic/tests/test_send_pipeline.py
+++ b/meshtastic/tests/test_send_pipeline.py
@@ -1157,6 +1157,7 @@ class TestWaitForConfig:
         from meshtastic.node_runtime.channel_request_runtime import (
             _NodeChannelRequestRuntime,
         )
+        from meshtastic.node_runtime.channel_state import _NodeChannelState
 
         mock_node = MagicMock()
         desc = MagicMock()
@@ -1164,9 +1165,8 @@ class TestWaitForConfig:
         mock_node.localConfig = MagicMock()
         mock_node.localConfig.DESCRIPTOR = desc
 
-        mock_norm = MagicMock()
         real_runtime = _NodeChannelRequestRuntime(
-            mock_node, normalization_runtime=mock_norm
+            mock_node, channel_state=_NodeChannelState()
         )
 
         mock_interface._timeout.waitForSet.return_value = True


### PR DESCRIPTION
## Overview

This change gives Node channel cache state a single internal owner. `_NodeChannelState` now owns complete and partial channel data, synchronization, normalization, lookups, and per-node mutation coordination. Channel and SetURL runtimes use that shared owner while the historical `Node.channels`, `Node.partialChannels`, and `Node._channels_lock` behavior remains available for compatibility.

### Key changes

**Features**

* Add `_NodeChannelState` as the shared owner for channel caches, snapshots, lookups, normalization, disabled-channel filling, and partial channel responses.
* Add a separate per-node mutation lock for multi-step channel changes that include device I/O.
* Preserve lazy migration of legacy raw channel fields into the shared owner.

**Fixes**

* Serialize delete and SetURL mutations without holding the channel-state lock across device writes, ACK waits, reconnects, or resume attempts.
* Revalidate cache identity and channel fingerprints before committing staged local state after device writes.
* Clear stale partial-channel state after successful mutations and keep presentation/export operations on coherent snapshots.

**Refactors**

* Route channel lookup, export, normalization, presentation, request, response, transport, and SetURL components through the shared state owner.
* Consolidate channel-state test setup and add focused lock-ordering, cache-drift, migration, and concurrency coverage.

### Compatibility

There are no public API changes. Historical `Node.channels`, `Node.partialChannels`, and `Node._channels_lock` access remains supported. Direct construction of internal channel and SetURL runtime components now requires the shared `_NodeChannelState`; those runtime modules remain internal implementation details.
