### PR TITLE
Narrow MeshInterface runtime dependencies with capability ports

### DIFF
--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -33,6 +33,11 @@ from meshtastic.mesh_interface_runtime.flows import (
     TelemetryType,
 )
 from meshtastic.mesh_interface_runtime.node_view import NodeView
+from meshtastic.mesh_interface_runtime.ports import (
+    _NodeViewPort,
+    _ReceivePipelinePort,
+    _SendPipelinePort,
+)
 from meshtastic.mesh_interface_runtime.queue_send import (
     QUEUE_WAIT_TIMEOUT_SECONDS,
     QueueWaitError,
@@ -418,9 +423,9 @@ class MeshInterface:  # pylint: disable=R0902
         self._from_radio_dispatch_map_cache: (
             dict[str, Callable[[_FromRadioContext], list[_PublicationIntent]]] | None
         ) = None
-        self._receive_pipeline = ReceivePipeline(self)
-        self._send_pipeline = SendPipeline(self)
-        self._node_view = NodeView(self)
+        self._receive_pipeline = ReceivePipeline(_ReceivePipelinePort(self))
+        self._send_pipeline = SendPipeline(_SendPipelinePort(self))
+        self._node_view = NodeView(_NodeViewPort(self))
 
         # We could have just not passed in debugOut to MeshInterface, and instead told consumers to subscribe to
         # the meshtastic.log.line publish instead.  Alas though changing that now would be a breaking API change

--- a/meshtastic/mesh_interface_runtime/node_view.py
+++ b/meshtastic/mesh_interface_runtime/node_view.py
@@ -6,7 +6,7 @@ import json
 import logging
 import sys
 import threading
-from typing import IO, TYPE_CHECKING, Any, TypeAlias
+from typing import IO, Any, TypeAlias
 
 try:
     import print_color  # type: ignore[import-untyped]
@@ -26,9 +26,7 @@ from meshtastic.util import (
 )
 
 from . import node_data, node_presentation
-
-if TYPE_CHECKING:
-    from meshtastic.mesh_interface import MeshInterface
+from .ports import _NodeViewPort
 
 JSONValue: TypeAlias = (
     None | bool | int | float | str | list["JSONValue"] | dict[str, "JSONValue"]
@@ -90,48 +88,48 @@ class NodeView:
     """Node accessor and presentation methods for MeshInterface.
 
     This class provides node lookup, node DB helpers, and presentation/display
-    methods (showInfo, showNodes). It delegates to the parent MeshInterface for
-    shared state.
+    methods (showInfo, showNodes). Shared interface state is accessed through a
+    narrow internal capability port.
     """
 
-    def __init__(self, interface: "MeshInterface") -> None:
-        """Initialize NodeView with a parent MeshInterface.
+    def __init__(self, port: _NodeViewPort) -> None:
+        """Initialize the node view with its interface capability port.
 
         Parameters
         ----------
-        interface : MeshInterface
-            The parent MeshInterface instance.
+        port : _NodeViewPort
+            Narrow access to node state and facade compatibility seams.
         """
-        self._interface = interface
+        self._port = port
 
     @property
     def _node_db_lock(self) -> threading.RLock:
-        return self._interface._node_db_lock
+        return self._port.node_db_lock
 
     @property
     def localNode(self) -> meshtastic.node.Node:
         """Return the local node for this interface."""
-        return self._interface.localNode
+        return self._port.local_node
 
     @property
     def nodes(self) -> dict[str, dict[str, Any]] | None:
         """Return the node info dictionary, or None if not initialized."""
-        return self._interface.nodes
+        return self._port.nodes
 
     @property
     def nodesByNum(self) -> dict[int, dict[str, Any]] | None:
         """Return the node-number-to-info dictionary, or None if not initialized."""
-        return self._interface.nodesByNum
+        return self._port.nodes_by_num
 
     @property
     def myInfo(self) -> mesh_pb2.MyNodeInfo | None:
         """Return the MyNodeInfo for this interface, or None."""
-        return self._interface.myInfo
+        return self._port.my_info
 
     @property
     def metadata(self) -> mesh_pb2.DeviceMetadata | None:
         """Return device metadata, or None if not yet received."""
-        return self._interface.metadata
+        return self._port.metadata
 
     def _print_log_line(self, line: str) -> None:
         """Print a formatted device log line to the configured debug output.
@@ -141,8 +139,8 @@ class NodeView:
         line : str
             The raw log text to print.
         """
-        interface = self._interface
-        if print_color is not None and interface.debugOut == sys.stdout:
+        debug_out = self._port.debug_out
+        if print_color is not None and debug_out == sys.stdout:
             if "DEBUG" in line:
                 print_color.print(line, color="cyan")
             elif "INFO" in line:
@@ -153,10 +151,10 @@ class NodeView:
                 print_color.print(line, color="red")
             else:
                 print_color.print(line)
-        elif callable(interface.debugOut):
-            interface.debugOut(line)
-        elif interface.debugOut is not None and hasattr(interface.debugOut, "write"):
-            interface.debugOut.write(line + "\n")
+        elif callable(debug_out):
+            debug_out(line)
+        elif debug_out is not None and hasattr(debug_out, "write"):
+            debug_out.write(line + "\n")
 
     def _handle_log_line(self, line: str) -> None:
         """Publish a device log line to the "meshtastic.log.line" topic, normalizing any trailing newline.
@@ -169,7 +167,7 @@ class NodeView:
         if line.endswith("\n"):
             line = line[:-1]
 
-        pub.sendMessage("meshtastic.log.line", line=line, interface=self._interface)
+        pub.sendMessage("meshtastic.log.line", line=line, interface=self._port.facade)
 
     def _handle_log_record(self, record: mesh_pb2.LogRecord) -> None:
         """Process a protobuf LogRecord by extracting its message text and handling it as a device log line.
@@ -408,14 +406,13 @@ class NodeView:
         MeshInterfaceError
             If channel retrieval repeatedly fails or times out.
         """
-        MeshInterface = self._interface.__class__
         if nodeId in (LOCAL_ADDR, BROADCAST_ADDR):
             return self.localNode
         n = meshtastic.node.Node(
-            self._interface,
+            self._port.facade,
             nodeId,
             timeout=timeout,
-            noProto=getattr(self._interface, "noProto", False),
+            noProto=self._port.no_proto,
         )
         if requestChannels:
             logger.debug("About to requestChannels")
@@ -429,7 +426,7 @@ class NodeView:
                     if new_index != last_index:
                         retries_left = requestChannelAttempts - 1
                     if retries_left <= 0:
-                        raise MeshInterface.MeshInterfaceError(
+                        raise self._port.error_type(
                             "Error: Timed out waiting for channels, giving up"
                         )
                     logger.warning(
@@ -515,8 +512,6 @@ class NodeView:
         str | None
             The canned message text, or `None` if there is no local node or no canned message configured.
         """
-        if getattr(self, "_interface", None) is None:
-            return None
         node = self.localNode
         if node is not None:
             return node.get_canned_message()
@@ -530,8 +525,6 @@ class NodeView:
         str | None
             The ringtone name or identifier as a string, or None if the local node or ringtone is unavailable.
         """
-        if getattr(self, "_interface", None) is None:
-            return None
         node = self.localNode
         if node is not None:
             return node.get_ringtone()
@@ -622,15 +615,14 @@ class NodeView:
         MeshInterface.MeshInterfaceError
             If nodeNum is the broadcast node number or if the node database has not been initialized.
         """
-        MeshInterface = self._interface.__class__
         if nodeNum == BROADCAST_NUM:
-            raise MeshInterface.MeshInterfaceError(
+            raise self._port.error_type(
                 "Can not create/find nodenum by the broadcast num"
             )
 
         with self._node_db_lock:
             if self.nodesByNum is None:
-                raise MeshInterface.MeshInterfaceError("Node database not initialized")
+                raise self._port.error_type("Node database not initialized")
 
             if nodeNum in self.nodesByNum:
                 return self.nodesByNum[nodeNum]

--- a/meshtastic/mesh_interface_runtime/ports.py
+++ b/meshtastic/mesh_interface_runtime/ports.py
@@ -1,0 +1,269 @@
+"""Narrow collaborator ports for MeshInterface runtime components."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable, Mapping
+from typing import TYPE_CHECKING, Any
+
+from meshtastic.mesh_interface_runtime.queue_send import _QueueSendRuntime
+from meshtastic.mesh_interface_runtime.request_wait import _RequestWaitRuntime
+from meshtastic.protobuf import mesh_pb2
+from meshtastic.util import Acknowledgment, Timeout
+
+if TYPE_CHECKING:
+    from meshtastic.mesh_interface import MeshInterface
+    from meshtastic.node import Node
+    from meshtastic.region_presets import RegionPresetInfo
+
+
+def _interface_error_type(interface: Any) -> type[Exception]:
+    """Resolve the MeshInterface error type without depending on mock internals.
+
+    Parameters
+    ----------
+    interface : Any
+        Real interface or compatibility test double.
+
+    Returns
+    -------
+    type[Exception]
+        Concrete interface error type.
+
+    Raises
+    ------
+    TypeError
+        If the supplied collaborator exposes no concrete exception type.
+    """
+    candidates = (
+        getattr(interface, "MeshInterfaceError", None),
+        getattr(interface.__class__, "MeshInterfaceError", None),
+    )
+    for candidate in candidates:
+        if isinstance(candidate, type) and issubclass(candidate, Exception):
+            return candidate
+    raise TypeError("Interface collaborator exposes no MeshInterfaceError type")
+
+
+class _InterfacePortBase:
+    """Provide facade capabilities shared by MeshInterface runtime ports."""
+
+    def __init__(self, interface: "MeshInterface") -> None:
+        self._interface = interface
+
+    @property
+    def facade(self) -> "MeshInterface":
+        """Return the facade when a public compatibility contract requires identity."""
+        return self._interface
+
+    @property
+    def error_type(self) -> type[Exception]:
+        """Return the interface-specific exception type."""
+        return _interface_error_type(self._interface)
+
+    @property
+    def node_db_lock(self) -> threading.RLock:
+        """Return the lock protecting the node database."""
+        return self._interface._node_db_lock  # noqa: SLF001
+
+    @property
+    def local_node(self) -> "Node":
+        """Return the local Node facade."""
+        return self._interface.localNode
+
+    @property
+    def my_info(self) -> mesh_pb2.MyNodeInfo | None:
+        """Return local node identity information."""
+        return self._interface.myInfo
+
+    @property
+    def nodes(self) -> dict[str, dict[str, Any]] | None:
+        """Return the node database indexed by node ID."""
+        return self._interface.nodes
+
+    @property
+    def nodes_by_num(self) -> dict[int, dict[str, Any]] | None:
+        """Return the node database indexed by node number."""
+        return self._interface.nodesByNum
+
+
+class _NoProtoInterfacePort(_InterfacePortBase):
+    """Add the protocol-disable capability used by send and node-view ports."""
+
+    @property
+    def no_proto(self) -> bool:
+        """Return whether protobuf protocol traffic is disabled."""
+        return bool(getattr(self._interface, "noProto", False))
+
+
+class _SendPipelinePort(_NoProtoInterfacePort):
+    """Expose only MeshInterface capabilities required by the send pipeline."""
+
+    @property
+    def request_wait_runtime(self) -> _RequestWaitRuntime:
+        """Return request/response wait state."""
+        return self._interface._request_wait_runtime  # noqa: SLF001
+
+    @property
+    def queue_send_runtime(self) -> _QueueSendRuntime:
+        """Return the firmware TX-queue coordinator."""
+        return self._interface._queue_send_runtime  # noqa: SLF001
+
+    @property
+    def config_id(self) -> int | None:
+        """Return the current configuration identifier."""
+        return self._interface.configId
+
+    @property
+    def acknowledgment(self) -> Acknowledgment:
+        """Return the historical unscoped ACK/NAK state."""
+        return self._interface._acknowledgment  # noqa: SLF001
+
+    @property
+    def timeout(self) -> Timeout:
+        """Return the interface timeout helper."""
+        return self._interface._timeout  # noqa: SLF001
+
+    def generate_packet_id(self) -> int:
+        """Generate a packet ID through the facade's compatibility seam."""
+        return self._interface._generate_packet_id()  # noqa: SLF001
+
+    def send_packet(
+        self,
+        packet: mesh_pb2.MeshPacket,
+        destination_id: int | str,
+        *,
+        want_ack: bool,
+        hop_limit: int | None,
+        pki_encrypted: bool | None,
+        public_key: bytes | None,
+    ) -> mesh_pb2.MeshPacket:
+        """Send a packet through the facade seam used by existing monkeypatches."""
+        return self._interface._send_packet(  # noqa: SLF001
+            packet,
+            destination_id,
+            wantAck=want_ack,
+            hopLimit=hop_limit,
+            pkiEncrypted=pki_encrypted,
+            publicKey=public_key,
+        )
+
+    def wait_connected(self) -> None:
+        """Wait until the interface connection is ready."""
+        self._interface._wait_connected()  # noqa: SLF001
+
+    def send_to_radio(self, to_radio: mesh_pb2.ToRadio) -> None:
+        """Send a ToRadio message through the facade compatibility seam."""
+        self._interface._send_to_radio(to_radio)  # noqa: SLF001
+
+    def send_to_radio_impl(self, to_radio: mesh_pb2.ToRadio) -> None:
+        """Invoke the transport-specific ToRadio implementation."""
+        self._interface._send_to_radio_impl(to_radio)  # noqa: SLF001
+
+    def wait_for_initial_config(self) -> bool:
+        """Wait for interface identity and node database bootstrap state."""
+        return self.timeout.waitForSet(self._interface, attrs=("myInfo", "nodes"))
+
+
+class _ReceivePipelinePort(_InterfacePortBase):
+    """Expose state and mutations required by the receive pipeline."""
+
+    @property
+    def request_wait_runtime(self) -> _RequestWaitRuntime:
+        """Return request/response wait state."""
+        return self._interface._request_wait_runtime  # noqa: SLF001
+
+    @property
+    def queue_send_runtime(self) -> _QueueSendRuntime:
+        """Return the firmware TX-queue coordinator."""
+        return self._interface._queue_send_runtime  # noqa: SLF001
+
+    @property
+    def config_id(self) -> int | None:
+        """Return the current configuration identifier."""
+        return self._interface.configId
+
+    @property
+    def metadata(self) -> mesh_pb2.DeviceMetadata | None:
+        """Return current device metadata."""
+        return self._interface.metadata
+
+    def record_bootstrap_decode_error(self) -> int:
+        """Record one malformed bootstrap frame when the facade supports it."""
+        recorder_name = "_record_bootstrap_decode_error"
+        interface = self._interface
+        has_recorder = recorder_name in vars(interface) or hasattr(
+            type(interface), recorder_name
+        )
+        recorder = getattr(interface, recorder_name, None) if has_recorder else None
+        return recorder() if callable(recorder) else 0
+
+    def set_my_info(self, my_info: mesh_pb2.MyNodeInfo) -> None:
+        """Install local node identity and synchronize the local Node number."""
+        self._interface.myInfo = my_info
+        self._interface.localNode.nodeNum = my_info.my_node_num
+
+    def set_metadata(self, metadata: mesh_pb2.DeviceMetadata) -> None:
+        """Install device metadata."""
+        self._interface.metadata = metadata
+
+    def set_region_presets(
+        self,
+        raw_map: mesh_pb2.LoRaRegionPresetMap,
+        decoded: Mapping[int, "RegionPresetInfo"],
+    ) -> None:
+        """Install raw and decoded region-preset compatibility data."""
+        self._interface.regionPresetMap = raw_map
+        self._interface.regionPresets = decoded
+
+    def set_lockdown_status(self, status: mesh_pb2.LockdownStatus) -> None:
+        """Install the current lockdown status."""
+        self._interface.lockdownStatus = status
+
+    def restart_config_after_reboot(self) -> None:
+        """Run the facade's disconnect and configuration-restart sequence."""
+        self._interface._disconnected()  # noqa: SLF001
+        self._interface._start_config()  # noqa: SLF001
+
+    def append_local_channel(self, channel: Any) -> None:
+        """Append one channel descriptor to the bootstrap channel buffer."""
+        self._interface._localChannels.append(channel)  # noqa: SLF001
+
+    def local_channels_snapshot(self) -> list[Any]:
+        """Return a shallow snapshot of bootstrap channel descriptors."""
+        return list(self._interface._localChannels)  # noqa: SLF001
+
+    def handle_log_line(self, line: str) -> None:
+        """Forward one device log line to the facade log handler."""
+        self._interface._handle_log_line(line)  # noqa: SLF001
+
+    def complete_config(self, local_channels: list[Any]) -> None:
+        """Install bootstrap channels and mark the interface connected."""
+        self._interface.localNode.setChannels(local_channels)
+        self._interface._connected()  # noqa: SLF001
+
+    def invoke_receive_callback(
+        self,
+        callback: Callable[[Any, dict[str, Any]], Any],
+        packet: dict[str, Any],
+    ) -> None:
+        """Invoke a protocol callback with the historical facade argument."""
+        callback(self._interface, packet)
+
+    def extract_request_id(self, packet: dict[str, Any]) -> int | None:
+        """Extract a request ID through the facade's compatibility seam."""
+        return self._interface._extract_request_id_from_packet(packet)  # noqa: SLF001
+
+
+class _NodeViewPort(_NoProtoInterfacePort):
+    """Expose MeshInterface state needed by node lookup and presentation."""
+
+    @property
+    def metadata(self) -> mesh_pb2.DeviceMetadata | None:
+        """Return device metadata."""
+        return self._interface.metadata
+
+    @property
+    def debug_out(self) -> Any:
+        """Return the historical debug-output sink."""
+        return self._interface.debugOut

--- a/meshtastic/mesh_interface_runtime/receive_pipeline.py
+++ b/meshtastic/mesh_interface_runtime/receive_pipeline.py
@@ -26,8 +26,13 @@ from meshtastic.protobuf import (
 from meshtastic.region_presets import decode_region_preset_map
 from meshtastic.util import stripnl
 
+from .ports import _ReceivePipelinePort
+from .queue_send import _QueueSendRuntime
+from .request_wait import _RequestWaitRuntime
+
+
 if TYPE_CHECKING:
-    from meshtastic.mesh_interface import MeshInterface
+    from meshtastic.node import Node
 
 logger = logging.getLogger(__name__)
 
@@ -132,15 +137,15 @@ class ReceivePipeline:
     normalization, dispatch, and publication of inbound packets.
     """
 
-    def __init__(self, interface: "MeshInterface") -> None:
-        """Initialize the receive pipeline with a parent MeshInterface.
+    def __init__(self, port: _ReceivePipelinePort) -> None:
+        """Initialize the receive pipeline with its interface capability port.
 
         Parameters
         ----------
-        interface : MeshInterface
-            The parent MeshInterface instance providing access to interface state.
+        port : _ReceivePipelinePort
+            Narrow access to receive-side interface state and compatibility seams.
         """
-        self._interface = interface
+        self._port = port
         self._from_radio_dispatch_map_cache: (
             dict[str, Callable[[_FromRadioContext], list[_PublicationIntent]]] | None
         ) = None
@@ -148,47 +153,47 @@ class ReceivePipeline:
     @property
     def _node_db_lock(self) -> threading.RLock:
         """Return the node database lock from the parent interface."""
-        return self._interface._node_db_lock
+        return self._port.node_db_lock
 
     @property
-    def _request_wait_runtime(self) -> Any:
+    def _request_wait_runtime(self) -> _RequestWaitRuntime:
         """Return the request wait runtime from the parent interface."""
-        return self._interface._request_wait_runtime
+        return self._port.request_wait_runtime
 
     @property
-    def _queue_send_runtime(self) -> Any:
+    def _queue_send_runtime(self) -> _QueueSendRuntime:
         """Return the queue send runtime from the parent interface."""
-        return self._interface._queue_send_runtime
+        return self._port.queue_send_runtime
 
     @property
     def configId(self) -> int | None:
         """Return the config ID from the parent interface."""
-        return self._interface.configId
+        return self._port.config_id
 
     @property
-    def localNode(self) -> Any:
+    def localNode(self) -> "Node":
         """Return the local node from the parent interface."""
-        return self._interface.localNode
+        return self._port.local_node
 
     @property
     def myInfo(self) -> mesh_pb2.MyNodeInfo | None:
         """Return the myInfo from the parent interface."""
-        return self._interface.myInfo
+        return self._port.my_info
 
     @property
     def metadata(self) -> mesh_pb2.DeviceMetadata | None:
         """Return the device metadata from the parent interface."""
-        return self._interface.metadata
+        return self._port.metadata
 
     @property
     def nodes(self) -> dict[str, dict[str, Any]] | None:
         """Return the nodes dictionary from the parent interface."""
-        return self._interface.nodes
+        return self._port.nodes
 
     @property
     def nodesByNum(self) -> dict[int, dict[str, Any]] | None:
         """Return the nodes by number dictionary from the parent interface."""
-        return self._interface.nodesByNum
+        return self._port.nodes_by_num
 
     def _handle_from_radio(self, fromRadioBytes: bytes) -> None:
         """Handle a raw FromRadio payload using parse -> normalize -> dispatch -> publish phases."""
@@ -210,14 +215,7 @@ class ReceivePipeline:
         try:
             from_radio.ParseFromString(from_radio_bytes)
         except protobuf_message.DecodeError:
-            recorder_name = "_record_bootstrap_decode_error"
-            has_recorder = recorder_name in vars(self._interface) or hasattr(
-                type(self._interface), recorder_name
-            )
-            record_error = (
-                getattr(self._interface, recorder_name, None) if has_recorder else None
-            )
-            bootstrap_error_count = record_error() if callable(record_error) else 0
+            bootstrap_error_count = self._port.record_bootstrap_decode_error()
             if bootstrap_error_count:
                 logger.warning(
                     "Discarding malformed FromRadio frame during connection bootstrap "
@@ -306,8 +304,7 @@ class ReceivePipeline:
         with self._node_db_lock:
             my_info = mesh_pb2.MyNodeInfo()
             my_info.CopyFrom(from_radio.my_info)
-            self._interface.myInfo = my_info
-            self._interface.localNode.nodeNum = my_info.my_node_num
+            self._port.set_my_info(my_info)
         logger.debug("Received myinfo: %s", stripnl(from_radio.my_info))
         return []
 
@@ -319,7 +316,7 @@ class ReceivePipeline:
         with self._node_db_lock:
             metadata = mesh_pb2.DeviceMetadata()
             metadata.CopyFrom(from_radio.metadata)
-            self._interface.metadata = metadata
+            self._port.set_metadata(metadata)
         logger.debug("Received device metadata: %s", stripnl(from_radio.metadata))
         return []
 
@@ -331,8 +328,7 @@ class ReceivePipeline:
         raw_map.CopyFrom(context.message.region_presets)
         decoded = decode_region_preset_map(raw_map)
         with self._node_db_lock:
-            self._interface.regionPresetMap = raw_map
-            self._interface.regionPresets = decoded
+            self._port.set_region_presets(raw_map, decoded)
         logger.debug(
             "Received LoRa region preset compatibility map: %d region(s)",
             len(decoded),
@@ -352,7 +348,7 @@ class ReceivePipeline:
         status = mesh_pb2.LockdownStatus()
         status.CopyFrom(context.message.lockdown_status)
         with self._node_db_lock:
-            self._interface.lockdownStatus = status
+            self._port.set_lockdown_status(status)
         return [self._publication_intent(LOCKDOWN_STATUS_TOPIC, status=status)]
 
     def _handle_from_radio_node_info(
@@ -457,8 +453,7 @@ class ReceivePipeline:
         self, _context: _FromRadioContext
     ) -> list[_PublicationIntent]:
         """Handle reboot notifications by disconnecting and restarting config flow."""
-        self._interface._disconnected()
-        self._interface._start_config()
+        self._port.restart_config_after_reboot()
         return []
 
     def _handle_from_radio_config_update(
@@ -532,7 +527,7 @@ class ReceivePipeline:
         payload_snapshot = dict(payload)
 
         def publish_work() -> None:
-            pub.sendMessage(topic, interface=self._interface, **payload_snapshot)
+            pub.sendMessage(topic, interface=self._port.facade, **payload_snapshot)
 
         publishingThread.queueWork(publish_work)
 
@@ -547,13 +542,13 @@ class ReceivePipeline:
     def _get_or_create_by_num(self, nodeNum: int) -> dict[str, Any]:
         """Retrieve the node record for a numeric node ID, creating a minimal placeholder if none exists."""
         if nodeNum == BROADCAST_NUM:
-            raise self._interface.MeshInterfaceError(
+            raise self._port.error_type(
                 "Can not create/find nodenum by the broadcast num"
             )
 
         with self._node_db_lock:
             if self.nodesByNum is None:
-                raise self._interface.MeshInterfaceError(
+                raise self._port.error_type(
                     "Node database not initialized"
                 )
 
@@ -575,18 +570,17 @@ class ReceivePipeline:
     def _handle_channel(self, channel: channel_pb2.Channel) -> None:
         """Record a received local channel descriptor for later configuration."""
         with self._node_db_lock:
-            self._interface._localChannels.append(channel)
+            self._port.append_local_channel(channel)
 
     def _handle_log_record(self, record: mesh_pb2.LogRecord) -> None:
         """Process a protobuf LogRecord by extracting its message text."""
-        self._interface._handle_log_line(record.message)
+        self._port.handle_log_line(record.message)
 
     def _handle_config_complete(self) -> None:
         """Finalize initial configuration by applying collected local channels."""
         with self._node_db_lock:
-            local_channels = list(self._interface._localChannels)
-        self._interface.localNode.setChannels(local_channels)
-        self._interface._connected()
+            local_channels = self._port.local_channels_snapshot()
+        self._port.complete_config(local_channels)
 
     def _handle_queue_status_from_radio(
         self, queueStatus: mesh_pb2.QueueStatus
@@ -797,8 +791,8 @@ class ReceivePipeline:
         if packet_context.on_receive_callback is None:
             return
         try:
-            packet_context.on_receive_callback(
-                self._interface, packet_context.packet_dict
+            self._port.invoke_receive_callback(
+                packet_context.on_receive_callback, packet_context.packet_dict
             )
         except Exception:
             logger.exception(
@@ -819,5 +813,5 @@ class ReceivePipeline:
             skip_response_callback_for_decode_failure=(
                 packet_context.skip_response_callback_for_decode_failure
             ),
-            extract_request_id=self._interface._extract_request_id_from_packet,
+            extract_request_id=self._port.extract_request_id,
         )

--- a/meshtastic/mesh_interface_runtime/send_pipeline.py
+++ b/meshtastic/mesh_interface_runtime/send_pipeline.py
@@ -23,6 +23,8 @@ from meshtastic.mesh_interface_runtime.flows import (
     sendTraceroute,
     sendWaypoint,
 )
+from meshtastic.mesh_interface_runtime.ports import _SendPipelinePort
+from meshtastic.mesh_interface_runtime.queue_send import _QueueSendRuntime
 from meshtastic.mesh_interface_runtime.request_wait import (
     LEGACY_UNSCOPED_WAIT_ATTR_BY_PORTNUM,
     WAIT_ATTR_NAK,
@@ -36,8 +38,9 @@ from meshtastic.protobuf import mesh_pb2, portnums_pb2
 from meshtastic.traceroute import TraceRouteResult
 from meshtastic.util import Acknowledgment, Timeout, stripnl
 
+
 if TYPE_CHECKING:
-    from meshtastic.mesh_interface import MeshInterface
+    from meshtastic.node import Node
 
 logger = logging.getLogger(__name__)
 
@@ -139,70 +142,70 @@ class SendPipeline:
     position, telemetry, waypoint, and traceroute operations.
     """
 
-    def __init__(self, interface: "MeshInterface") -> None:
-        """Initialize the send pipeline with a parent MeshInterface.
+    def __init__(self, port: _SendPipelinePort) -> None:
+        """Initialize the send pipeline with its interface capability port.
 
         Parameters
         ----------
-        interface : MeshInterface
-            The parent MeshInterface instance providing access to interface state.
+        port : _SendPipelinePort
+            Narrow access to send-side interface state and compatibility seams.
         """
-        self._interface = interface
+        self._port = port
 
     @property
     def _node_db_lock(self) -> threading.RLock:
         """Return the node database lock from the parent interface."""
-        return self._interface._node_db_lock
+        return self._port.node_db_lock
 
     @property
     def _request_wait_runtime(self) -> _RequestWaitRuntime:
         """Return the request wait runtime from the parent interface."""
-        return self._interface._request_wait_runtime
+        return self._port.request_wait_runtime
 
     @property
-    def _queue_send_runtime(self) -> Any:
+    def _queue_send_runtime(self) -> _QueueSendRuntime:
         """Return the queue send runtime from the parent interface."""
-        return self._interface._queue_send_runtime
+        return self._port.queue_send_runtime
 
     @property
-    def localNode(self) -> Any:
+    def localNode(self) -> "Node":
         """Return the local node from the parent interface."""
-        return self._interface.localNode
+        return self._port.local_node
 
     @property
-    def myInfo(self) -> Any:
+    def myInfo(self) -> mesh_pb2.MyNodeInfo | None:
         """Return the myInfo from the parent interface."""
-        return self._interface.myInfo
+        return self._port.my_info
 
     @property
     def nodes(self) -> dict[str, dict[str, Any]] | None:
         """Return the nodes dictionary from the parent interface."""
-        return self._interface.nodes
+        return self._port.nodes
 
     @property
     def nodesByNum(self) -> dict[int, dict[str, Any]] | None:
         """Return the nodes by number dictionary from the parent interface."""
-        return self._interface.nodesByNum
+        return self._port.nodes_by_num
 
     @property
     def configId(self) -> int | None:
         """Return the config ID from the parent interface."""
-        return self._interface.configId
+        return self._port.config_id
 
     @property
     def noProto(self) -> bool:
         """Return the noProto flag from the parent interface."""
-        return self._interface.noProto
+        return self._port.no_proto
 
     @property
     def _acknowledgment(self) -> Acknowledgment:
         """Return the acknowledgment from the parent interface."""
-        return self._interface._acknowledgment
+        return self._port.acknowledgment
 
     @property
     def _timeout(self) -> Timeout:
         """Return the timeout from the parent interface."""
-        return self._interface._timeout
+        return self._port.timeout
 
     # pylint: disable=too-many-positional-arguments
     def sendText(
@@ -342,27 +345,23 @@ class SendPipeline:
             mesh_pb2.Constants.DATA_PAYLOAD_LEN,
         )
         if len(payload) > mesh_pb2.Constants.DATA_PAYLOAD_LEN:
-            raise self._interface.MeshInterfaceError("Data payload too big")
+            raise self._port.error_type("Data payload too big")
 
         if portNum == portnums_pb2.PortNum.UNKNOWN_APP:
-            raise self._interface.MeshInterfaceError(
-                "A non-zero port number must be specified"
-            )
+            raise self._port.error_type("A non-zero port number must be specified")
 
         meshPacket = mesh_pb2.MeshPacket()
         meshPacket.channel = channelIndex
         meshPacket.decoded.payload = payload
         meshPacket.decoded.portnum = portNum
         meshPacket.decoded.want_response = wantResponse
-        meshPacket.id = self._interface._generate_packet_id()
+        meshPacket.id = self._port.generate_packet_id()
         for _ in range(PACKET_ID_GENERATION_MAX_RETRIES):
             if meshPacket.id != 0:
                 break
-            meshPacket.id = self._interface._generate_packet_id()
+            meshPacket.id = self._port.generate_packet_id()
         else:
-            raise self._interface.MeshInterfaceError(
-                "Failed to generate non-zero packet ID"
-            )
+            raise self._port.error_type("Failed to generate non-zero packet ID")
         if replyId is not None:
             meshPacket.decoded.reply_id = replyId
         meshPacket.priority = priority
@@ -379,13 +378,13 @@ class SendPipeline:
                 matcher=responseMatcher,
             )
         try:
-            return self._interface._send_packet(
+            return self._port.send_packet(
                 meshPacket,
                 destinationId,
-                wantAck=wantAck,
-                hopLimit=hopLimit,
-                pkiEncrypted=pkiEncrypted,
-                publicKey=publicKey,
+                want_ack=wantAck,
+                hop_limit=hopLimit,
+                pki_encrypted=pkiEncrypted,
+                public_key=publicKey,
             )
         except Exception:
             if response_wait_attr is not None:
@@ -457,7 +456,7 @@ class SendPipeline:
         self._request_wait_runtime.raise_wait_error_if_present(
             acknowledgment_attr,
             request_id=request_id,
-            error_factory=self._interface.MeshInterfaceError,
+            error_factory=self._port.error_type,
         )
 
     def _retire_wait_request(
@@ -507,7 +506,7 @@ class SendPipeline:
 
     def onResponsePosition(self, p: dict[str, Any]) -> None:
         """Process a position response packet and emit a concise human-readable summary."""
-        _on_response_position(self._interface, p)
+        _on_response_position(self._port.facade, p)
 
     # pylint: disable=too-many-positional-arguments
     def sendPosition(
@@ -523,7 +522,7 @@ class SendPipeline:
     ) -> mesh_pb2.MeshPacket:
         """Send the device's position to a specific node or to broadcast."""
         return sendPosition(
-            self._interface,
+            self._port.facade,
             latitude=latitude,
             longitude=longitude,
             altitude=altitude,
@@ -536,7 +535,7 @@ class SendPipeline:
 
     def onResponseTraceRoute(self, p: dict[str, Any]) -> None:
         """Emit human-readable traceroute results from a RouteDiscovery payload."""
-        _on_response_traceroute(self._interface, p)
+        _on_response_traceroute(self._port.facade, p)
 
     # pylint: disable=too-many-positional-arguments
     def sendTraceRoute(
@@ -544,7 +543,7 @@ class SendPipeline:
     ) -> None:
         """Initiate a traceroute request toward a destination node and wait for responses."""
         return sendTraceroute(
-            self._interface, dest, hopLimit, channelIndex=channelIndex
+            self._port.facade, dest, hopLimit, channelIndex=channelIndex
         )
 
     def requestTraceRoute(
@@ -552,7 +551,7 @@ class SendPipeline:
     ) -> TraceRouteResult:
         """Initiate a traceroute request and return its structured response."""
         return _request_traceroute(
-            self._interface, dest, hopLimit, channelIndex=channelIndex
+            self._port.facade, dest, hopLimit, channelIndex=channelIndex
         )
 
     def sendTelemetry(
@@ -565,7 +564,7 @@ class SendPipeline:
     ) -> None:
         """Send a telemetry message to a node or broadcast and optionally wait for a telemetry response."""
         return sendTelemetry(
-            self._interface,
+            self._port.facade,
             destinationId=destinationId,
             wantResponse=wantResponse,
             channelIndex=channelIndex,
@@ -575,11 +574,11 @@ class SendPipeline:
 
     def onResponseTelemetry(self, p: dict[str, Any]) -> None:
         """Handle an incoming telemetry response."""
-        _on_response_telemetry(self._interface, p)
+        _on_response_telemetry(self._port.facade, p)
 
     def onResponseWaypoint(self, p: dict[str, Any]) -> None:
         """Handle a waypoint response or routing error contained in a received packet."""
-        _on_response_waypoint(self._interface, p)
+        _on_response_waypoint(self._port.facade, p)
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     def sendWaypoint(
@@ -599,7 +598,7 @@ class SendPipeline:
     ) -> mesh_pb2.MeshPacket:
         """Send a waypoint to a node or broadcast."""
         return sendWaypoint(
-            self._interface,
+            self._port.facade,
             name=name,
             description=description,
             icon=icon,
@@ -626,7 +625,7 @@ class SendPipeline:
     ) -> mesh_pb2.MeshPacket:
         """Delete a waypoint by sending a Waypoint message with expire=0 to a destination."""
         return deleteWaypoint(
-            self._interface,
+            self._port.facade,
             waypointId=waypoint_id,
             destinationId=destinationId,
             wantAck=wantAck,
@@ -667,15 +666,13 @@ class SendPipeline:
             my_node_num = self.myInfo.my_node_num if self.myInfo is not None else None
 
         if my_node_num is not None and destinationId != my_node_num:
-            self._interface._wait_connected()
+            self._port.wait_connected()
 
         toRadio = mesh_pb2.ToRadio()
 
         nodeNum: int = 0
         if destinationId is None:
-            raise self._interface.MeshInterfaceError(
-                f"Invalid destinationId: {destinationId}"
-            )
+            raise self._port.error_type(f"Invalid destinationId: {destinationId}")
         elif isinstance(destinationId, int):
             # Note: bool is a subclass of int in Python, so True/False are
             # handled here as node numbers 1/0 for compatibility.
@@ -686,7 +683,7 @@ class SendPipeline:
             if my_node_num is not None:
                 nodeNum = my_node_num
             else:
-                raise self._interface.MeshInterfaceError("No myInfo found.")
+                raise self._port.error_type("No myInfo found.")
         elif isinstance(destinationId, str):
             compact_hex_body = _extract_hex_node_id_body(destinationId)
             if compact_hex_body is not None:
@@ -701,20 +698,20 @@ class SendPipeline:
                     if isinstance(node_num, int):
                         nodeNum = node_num
                     else:
-                        raise self._interface.MeshInterfaceError(
+                        raise self._port.error_type(
                             _format_missing_node_num_error(destinationId)
                         )
                 elif has_nodes:
-                    raise self._interface.MeshInterfaceError(
+                    raise self._port.error_type(
                         _format_node_not_found_in_db_error(destinationId)
                     )
                 else:
-                    raise self._interface.MeshInterfaceError(
+                    raise self._port.error_type(
                         _format_node_db_unavailable_error(destinationId)
                     )
         else:
             # Defensive: should be unreachable given type hints (int | str)
-            raise self._interface.MeshInterfaceError(
+            raise self._port.error_type(
                 f"Unexpected destinationId type: {type(destinationId)}"
             )
 
@@ -739,7 +736,7 @@ class SendPipeline:
             meshPacket.public_key = publicKey
 
         if meshPacket.id == 0:
-            meshPacket.id = self._interface._generate_packet_id()
+            meshPacket.id = self._port.generate_packet_id()
 
         toRadio.packet.CopyFrom(meshPacket)
         if self.noProto:
@@ -748,7 +745,7 @@ class SendPipeline:
             )
         else:
             logger.debug("Sending packet: %s", stripnl(meshPacket))
-            self._interface._send_to_radio(toRadio)
+            self._port.send_to_radio(toRadio)
         return meshPacket
 
     # pylint: disable=too-many-positional-arguments
@@ -775,16 +772,14 @@ class SendPipeline:
     def waitForConfig(self) -> None:
         """Block until the radio configuration and the local node's configuration are available."""
         success = (
-            self._timeout.waitForSet(self._interface, attrs=("myInfo", "nodes"))
+            self._port.wait_for_initial_config()
             and self.localNode.waitForConfig()
             and self.localNode._channel_request_runtime._timeout_for_field(
                 "lora", LORA_CONFIG_WAIT_SECONDS
             )
         )
         if not success:
-            raise self._interface.MeshInterfaceError(
-                "Timed out waiting for interface config"
-            )
+            raise self._port.error_type("Timed out waiting for interface config")
 
     def _wait_for_ack_nak(self, request_id: int) -> None:
         """Wait for one request-scoped admin ACK/NAK response."""
@@ -796,9 +791,7 @@ class SendPipeline:
             )
             self._raise_wait_error_if_present(WAIT_ATTR_NAK, request_id=request_id)
             if not success:
-                raise self._interface.MeshInterfaceError(
-                    "Timed out waiting for an acknowledgment"
-                )
+                raise self._port.error_type("Timed out waiting for an acknowledgment")
         finally:
             self._retire_wait_request(WAIT_ATTR_NAK, request_id=request_id)
 
@@ -807,9 +800,7 @@ class SendPipeline:
         success = self._timeout.waitForAckNak(self._acknowledgment)
         self._raise_wait_error_if_present(WAIT_ATTR_NAK)
         if not success:
-            raise self._interface.MeshInterfaceError(
-                "Timed out waiting for an acknowledgment"
-            )
+            raise self._port.error_type("Timed out waiting for an acknowledgment")
 
     def waitForTraceRoute(
         self, waitFactor: float, request_id: int | None = None
@@ -830,9 +821,7 @@ class SendPipeline:
                 WAIT_ATTR_TRACEROUTE, request_id=request_id
             )
             if not success:
-                raise self._interface.MeshInterfaceError(
-                    "Timed out waiting for traceroute"
-                )
+                raise self._port.error_type("Timed out waiting for traceroute")
         finally:
             self._retire_wait_request(WAIT_ATTR_TRACEROUTE, request_id=request_id)
 
@@ -851,9 +840,7 @@ class SendPipeline:
                 WAIT_ATTR_TELEMETRY, request_id=request_id
             )
             if not success:
-                raise self._interface.MeshInterfaceError(
-                    "Timed out waiting for telemetry"
-                )
+                raise self._port.error_type("Timed out waiting for telemetry")
         finally:
             self._retire_wait_request(WAIT_ATTR_TELEMETRY, request_id=request_id)
 
@@ -870,9 +857,7 @@ class SendPipeline:
                 )
             self._raise_wait_error_if_present(WAIT_ATTR_POSITION, request_id=request_id)
             if not success:
-                raise self._interface.MeshInterfaceError(
-                    "Timed out waiting for position"
-                )
+                raise self._port.error_type("Timed out waiting for position")
         finally:
             self._retire_wait_request(WAIT_ATTR_POSITION, request_id=request_id)
 
@@ -889,9 +874,7 @@ class SendPipeline:
                 )
             self._raise_wait_error_if_present(WAIT_ATTR_WAYPOINT, request_id=request_id)
             if not success:
-                raise self._interface.MeshInterfaceError(
-                    "Timed out waiting for waypoint"
-                )
+                raise self._port.error_type("Timed out waiting for waypoint")
         finally:
             self._retire_wait_request(WAIT_ATTR_WAYPOINT, request_id=request_id)
 
@@ -911,7 +894,7 @@ class SendPipeline:
 
     def _send_to_radio_impl(self, toRadio: mesh_pb2.ToRadio) -> None:
         """Transport hook that delivers a ToRadio protobuf to the radio device."""
-        self._interface._send_to_radio_impl(toRadio)
+        self._port.send_to_radio_impl(toRadio)
 
     def _send_disconnect(self) -> None:
         """Notify the radio device that this interface is disconnecting."""

--- a/meshtastic/tests/test_mesh_interface_runtime_ports.py
+++ b/meshtastic/tests/test_mesh_interface_runtime_ports.py
@@ -1,0 +1,111 @@
+"""Behavioral tests for narrow MeshInterface runtime capability ports."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from meshtastic.mesh_interface import MeshInterface
+from meshtastic.mesh_interface_runtime.ports import (
+    _NodeViewPort,
+    _ReceivePipelinePort,
+    _SendPipelinePort,
+    _interface_error_type,
+)
+from meshtastic.protobuf import mesh_pb2
+
+
+@pytest.mark.unit
+def test_interface_error_type_prefers_concrete_instance_override() -> None:
+    """Compatibility doubles can provide their own concrete interface error type."""
+
+    class TestInterfaceError(Exception):
+        """Test-only interface error."""
+
+    interface = MagicMock()
+    interface.MeshInterfaceError = TestInterfaceError
+
+    assert _interface_error_type(interface) is TestInterfaceError
+
+
+@pytest.mark.unit
+def test_interface_error_type_supports_spec_based_interface_double() -> None:
+    """Spec-based mocks retain the facade class error contract."""
+    interface = MagicMock(spec=MeshInterface)
+
+    assert _interface_error_type(interface) is MeshInterface.MeshInterfaceError
+
+
+@pytest.mark.unit
+def test_interface_error_type_rejects_collaborator_without_error_contract() -> None:
+    """Missing MeshInterfaceError should fail at the port boundary, not at first use."""
+
+    class IncompleteInterface:
+        """Test collaborator without the required error type."""
+
+    with pytest.raises(TypeError, match="MeshInterfaceError"):
+        _interface_error_type(IncompleteInterface())
+
+
+@pytest.mark.unit
+def test_send_port_defaults_missing_no_proto_to_false() -> None:
+    """Compatibility doubles may omit the instance-only ``noProto`` attribute."""
+    interface = MagicMock(spec=MeshInterface)
+
+    assert _SendPipelinePort(interface).no_proto is False
+
+
+@pytest.mark.unit
+def test_receive_port_ignores_missing_bootstrap_recorder_on_loose_mock() -> None:
+    """A loose test double must not fabricate a callable bootstrap recorder."""
+    interface = MagicMock()
+    interface.MeshInterfaceError = MeshInterface.MeshInterfaceError
+
+    assert _ReceivePipelinePort(interface).record_bootstrap_decode_error() == 0
+
+
+@pytest.mark.unit
+def test_receive_port_completes_config_through_facade_seams() -> None:
+    """Configuration completion installs channels before publishing connection state."""
+    interface = MagicMock()
+    channels = [MagicMock()]
+
+    _ReceivePipelinePort(interface).complete_config(channels)
+
+    interface.localNode.setChannels.assert_called_once_with(channels)
+    interface._connected.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_send_port_preserves_facade_send_packet_monkeypatch_seam() -> None:
+    """The send port delegates packet transmission through ``_send_packet``."""
+    interface = MagicMock()
+    sent = mesh_pb2.MeshPacket(id=42)
+    interface._send_packet.return_value = sent
+    packet = mesh_pb2.MeshPacket(id=41)
+
+    result = _SendPipelinePort(interface).send_packet(
+        packet,
+        "!12345678",
+        want_ack=True,
+        hop_limit=5,
+        pki_encrypted=False,
+        public_key=b"key",
+    )
+
+    assert result is sent
+    interface._send_packet.assert_called_once_with(
+        packet,
+        "!12345678",
+        wantAck=True,
+        hopLimit=5,
+        pkiEncrypted=False,
+        publicKey=b"key",
+    )
+
+
+@pytest.mark.unit
+def test_node_view_port_defaults_missing_no_proto_to_false() -> None:
+    """Compatibility doubles without ``noProto`` retain the historical default."""
+    interface = MagicMock(spec=MeshInterface)
+
+    assert _NodeViewPort(interface).no_proto is False

--- a/meshtastic/tests/test_node_view.py
+++ b/meshtastic/tests/test_node_view.py
@@ -11,6 +11,7 @@ import pytest
 
 from meshtastic import BROADCAST_ADDR, BROADCAST_NUM, LOCAL_ADDR
 from meshtastic.mesh_interface import MeshInterface
+from meshtastic.mesh_interface_runtime.ports import _NodeViewPort
 from meshtastic.mesh_interface_runtime.node_view import (
     NodeView,
     _normalize_json_serializable,
@@ -39,7 +40,7 @@ def mock_interface() -> MagicMock:
 @pytest.fixture
 def node_view(mock_interface: MagicMock) -> NodeView:
     """Create a NodeView instance with mocked interface."""
-    return NodeView(mock_interface)
+    return NodeView(_NodeViewPort(mock_interface))
 
 
 class TestTimeAgo:
@@ -116,9 +117,9 @@ class TestNodeViewInit:
     @pytest.mark.unit
     def test_node_view_init(self, mock_interface: MagicMock) -> None:
         """Test NodeView initialization."""
-        view = NodeView(mock_interface)
+        view = NodeView(_NodeViewPort(mock_interface))
 
-        assert view._interface is mock_interface
+        assert view._port.facade is mock_interface
 
 
 class TestNodeViewProperties:

--- a/meshtastic/tests/test_receive_pipeline.py
+++ b/meshtastic/tests/test_receive_pipeline.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from meshtastic.mesh_interface import MeshInterface
+from meshtastic.mesh_interface_runtime.ports import _ReceivePipelinePort
 from meshtastic.mesh_interface_runtime.receive_pipeline import (
     DECODE_FAILED_PREFIX,
     LOCAL_CONFIG_FROM_RADIO_FIELDS,
@@ -51,7 +52,7 @@ def mock_interface() -> MagicMock:
 @pytest.fixture
 def receive_pipeline(mock_interface: MagicMock) -> ReceivePipeline:
     """Create a ReceivePipeline instance with mocked interface."""
-    return ReceivePipeline(mock_interface)
+    return ReceivePipeline(_ReceivePipelinePort(mock_interface))
 
 
 class TestModuleLevelConstants:
@@ -185,9 +186,9 @@ class TestReceivePipelineInit:
     @pytest.mark.unit
     def test_receive_pipeline_init(self, mock_interface: MagicMock) -> None:
         """Test ReceivePipeline initialization."""
-        pipeline = ReceivePipeline(mock_interface)
+        pipeline = ReceivePipeline(_ReceivePipelinePort(mock_interface))
 
-        assert pipeline._interface is mock_interface
+        assert pipeline._port.facade is mock_interface
         assert pipeline._from_radio_dispatch_map_cache is None
 
 
@@ -1268,7 +1269,7 @@ class TestInvokePacketOnReceive:
         receive_pipeline._invoke_packet_on_receive(packet_context)
 
         callback.assert_called_once_with(
-            receive_pipeline._interface, packet_context.packet_dict
+            receive_pipeline._port.facade, packet_context.packet_dict
         )
 
     @pytest.mark.unit

--- a/meshtastic/tests/test_receive_pipeline_config_fields.py
+++ b/meshtastic/tests/test_receive_pipeline_config_fields.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import pytest
 from google.protobuf.descriptor import Descriptor
 
+from meshtastic.mesh_interface_runtime.ports import _ReceivePipelinePort
 from meshtastic.mesh_interface_runtime.receive_pipeline import (
     LOCAL_CONFIG_FROM_RADIO_FIELDS,
     MODULE_CONFIG_FROM_RADIO_FIELDS,
@@ -49,7 +50,7 @@ def _pipeline_with_local_node() -> tuple[ReceivePipeline, SimpleNamespace]:
         _node_db_lock=threading.RLock(),
         localNode=local_node,
     )
-    return ReceivePipeline(interface), local_node  # type: ignore[arg-type]
+    return ReceivePipeline(_ReceivePipelinePort(interface)), local_node  # type: ignore[arg-type]
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_runtime_coverage.py
+++ b/meshtastic/tests/test_runtime_coverage.py
@@ -19,6 +19,7 @@ from meshtastic import (
     DECODE_ERROR_KEY,
 )
 from meshtastic.mesh_interface import MeshInterface
+from meshtastic.mesh_interface_runtime.ports import _ReceivePipelinePort
 from meshtastic.mesh_interface_runtime.receive_pipeline import (
     DECODE_FAILED_PREFIX,
     ReceivePipeline,
@@ -90,7 +91,7 @@ def ack_runtime(mock_node: MagicMock) -> _NodeAckNakRuntime:
 @pytest.fixture
 def receive_pipeline(mock_interface_with_ack: MagicMock) -> ReceivePipeline:
     """Create a ReceivePipeline instance."""
-    return ReceivePipeline(mock_interface_with_ack)
+    return ReceivePipeline(_ReceivePipelinePort(mock_interface_with_ack))
 
 
 # =============================================================================

--- a/meshtastic/tests/test_send_pipeline.py
+++ b/meshtastic/tests/test_send_pipeline.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from meshtastic import BROADCAST_ADDR, BROADCAST_NUM, LOCAL_ADDR
+from meshtastic.mesh_interface_runtime.ports import _SendPipelinePort
 from meshtastic.mesh_interface_runtime.request_wait import (
     WAIT_ATTR_NAK,
     WAIT_ATTR_POSITION,
@@ -79,7 +80,7 @@ def mock_interface() -> MagicMock:
 @pytest.fixture
 def send_pipeline(mock_interface: MagicMock) -> SendPipeline:
     """Create a SendPipeline instance with mocked interface."""
-    return SendPipeline(mock_interface)
+    return SendPipeline(_SendPipelinePort(mock_interface))
 
 
 class TestModuleLevelConstants:
@@ -249,9 +250,9 @@ class TestSendPipelineInit:
     @pytest.mark.unit
     def test_send_pipeline_init(self, mock_interface: MagicMock) -> None:
         """Test SendPipeline initialization."""
-        pipeline = SendPipeline(mock_interface)
+        pipeline = SendPipeline(_SendPipelinePort(mock_interface))
 
-        assert pipeline._interface is mock_interface
+        assert pipeline._port.facade is mock_interface
 
 
 class TestSendPipelineProperties:
@@ -450,7 +451,7 @@ class TestSendDataWithWait:
                 """Serialize the protobuf message."""
                 return b"serialized protobuf"
 
-        with patch.object(send_pipeline._interface, "_send_packet") as mock_send_packet:
+        with patch.object(send_pipeline._port.facade, "_send_packet") as mock_send_packet:
             mock_send_packet.return_value = MagicMock()
             send_pipeline._send_data_with_wait(
                 MockProtobuf(),
@@ -468,7 +469,7 @@ class TestSendDataWithWait:
         big_data = b"x" * (mesh_pb2.Constants.DATA_PAYLOAD_LEN + 1)
 
         with pytest.raises(
-            send_pipeline._interface.MeshInterfaceError, match="too big"
+            send_pipeline._port.facade.MeshInterfaceError, match="too big"
         ):
             send_pipeline._send_data_with_wait(
                 big_data,
@@ -495,7 +496,7 @@ class TestSendDataWithWait:
         """Test that _send_data_with_wait registers response handler."""
         callback = MagicMock()
 
-        with patch.object(send_pipeline._interface, "_send_packet") as mock_send_packet:
+        with patch.object(send_pipeline._port.facade, "_send_packet") as mock_send_packet:
             with patch.object(
                 send_pipeline, "_add_response_handler"
             ) as mock_add_handler:
@@ -721,7 +722,7 @@ class TestOnResponsePosition:
         ) as mock_flow:
             send_pipeline.onResponsePosition(packet)
 
-        mock_flow.assert_called_once_with(send_pipeline._interface, packet)
+        mock_flow.assert_called_once_with(send_pipeline._port.facade, packet)
 
 
 class TestSendPosition:
@@ -763,7 +764,7 @@ class TestOnResponseTraceRoute:
         ) as mock_flow:
             send_pipeline.onResponseTraceRoute(packet)
 
-        mock_flow.assert_called_once_with(send_pipeline._interface, packet)
+        mock_flow.assert_called_once_with(send_pipeline._port.facade, packet)
 
 
 class TestSendTraceRoute:
@@ -778,7 +779,7 @@ class TestSendTraceRoute:
             send_pipeline.sendTraceRoute("!1234abcd", hopLimit=3, channelIndex=0)
 
         mock_flow.assert_called_once_with(
-            send_pipeline._interface, "!1234abcd", 3, channelIndex=0
+            send_pipeline._port.facade, "!1234abcd", 3, channelIndex=0
         )
 
     @pytest.mark.unit
@@ -793,7 +794,7 @@ class TestSendTraceRoute:
 
         assert result is mock_flow.return_value
         mock_flow.assert_called_once_with(
-            send_pipeline._interface, "!1234abcd", 3, channelIndex=1
+            send_pipeline._port.facade, "!1234abcd", 3, channelIndex=1
         )
 
 
@@ -828,7 +829,7 @@ class TestOnResponseTelemetry:
         ) as mock_flow:
             send_pipeline.onResponseTelemetry(packet)
 
-        mock_flow.assert_called_once_with(send_pipeline._interface, packet)
+        mock_flow.assert_called_once_with(send_pipeline._port.facade, packet)
 
 
 class TestOnResponseWaypoint:
@@ -844,7 +845,7 @@ class TestOnResponseWaypoint:
         ) as mock_flow:
             send_pipeline.onResponseWaypoint(packet)
 
-        mock_flow.assert_called_once_with(send_pipeline._interface, packet)
+        mock_flow.assert_called_once_with(send_pipeline._port.facade, packet)
 
 
 class TestSendWaypoint:

--- a/meshtastic/tests/test_serial_bootstrap_recovery.py
+++ b/meshtastic/tests/test_serial_bootstrap_recovery.py
@@ -8,6 +8,7 @@ import pytest
 from google.protobuf.message import DecodeError
 
 from meshtastic.mesh_interface import MeshInterface
+from meshtastic.mesh_interface_runtime.ports import _ReceivePipelinePort
 from meshtastic.mesh_interface_runtime.receive_pipeline import ReceivePipeline
 from meshtastic.serial_interface import (
     SERIAL_BOOTSTRAP_DECODE_ERROR_REASON,
@@ -20,7 +21,7 @@ from meshtastic.stream_interface import StreamInterface
 @pytest.mark.unit
 def test_receive_pipeline_records_malformed_bootstrap_frame() -> None:
     with MeshInterface(noProto=True) as interface:
-        pipeline = ReceivePipeline(interface)
+        pipeline = ReceivePipeline(_ReceivePipelinePort(interface))
 
         with pytest.raises(DecodeError):
             pipeline._parse_from_radio_bytes(b"\x80")  # noqa: SLF001
@@ -36,7 +37,7 @@ def test_receive_pipeline_honors_instance_bootstrap_error_recorder(
     with MeshInterface(noProto=True) as interface:
         recorder = MagicMock(return_value=3)
         monkeypatch.setattr(interface, "_record_bootstrap_decode_error", recorder)
-        pipeline = ReceivePipeline(interface)
+        pipeline = ReceivePipeline(_ReceivePipelinePort(interface))
 
         with pytest.raises(DecodeError):
             pipeline._parse_from_radio_bytes(b"\x80")  # noqa: SLF001


### PR DESCRIPTION
## Overview

This change narrows how MeshInterface runtime components access the facade. `SendPipeline`, `ReceivePipeline`, and `NodeView` now receive dedicated capability ports instead of depending directly on the full `MeshInterface`, while preserving the existing public callbacks, monkeypatch seams, packet flow, and error behavior.

### Key changes

**Features**

* Add `_SendPipelinePort`, `_ReceivePipelinePort`, and `_NodeViewPort` with typed access to the state and operations each runtime needs.
* Add focused tests for error-type resolution, configuration completion, bootstrap handling, send delegation, and protocol-disable behavior.

**Fixes**

* Keep `noProto` handling consistent across ports, including compatibility doubles that omit the attribute.
* Preserve concrete runtime, `Node`, and protobuf types through pipeline delegation instead of widening them to `Any`.
* Preserve interface-specific error construction and explicitly test the invalid-collaborator path.

**Refactors**

* Move direct private MeshInterface access behind the port adapters.
* Rewire send, receive, and node-view runtimes to use the capability ports while retaining the facade only where historical callback, pubsub, flow-helper, or `Node` construction contracts require its identity.

### Compatibility

There are no public API changes. Existing `MeshInterface` callbacks and compatibility seams remain unchanged. Direct construction of the internal `SendPipeline`, `ReceivePipeline`, or `NodeView` classes now uses the corresponding port object.
