### PR TITLE
Normalize internal MeshInterface runtime naming

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1615,7 +1615,7 @@ def _validate_cli_show_fields(interface: MeshInterface, show_fields: list[str]) 
     observed_nodes = (
         list(nodes_by_num.values()) if isinstance(nodes_by_num, dict) else []
     )
-    available = node_data.getKnownFieldPaths(observed_nodes)
+    available = node_data.get_known_field_paths(observed_nodes)
     available_set = set(available)
     invalid = [field for field in show_fields if field not in available_set]
     if invalid:

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -662,7 +662,7 @@ class MeshInterface:  # pylint: disable=R0902
 
         Delegates to self.node_view.showInfo().
         """
-        return self._node_view.showInfo(file)
+        return self._node_view.show_info(file)
 
     def showNodes(
         self, includeSelf: bool = True, showFields: list[str] | None = None
@@ -671,7 +671,7 @@ class MeshInterface:  # pylint: disable=R0902
 
         Delegates to self.node_view.showNodes().
         """
-        return self._node_view.showNodes(includeSelf, showFields)
+        return self._node_view.show_nodes(includeSelf, showFields)
 
     def getNode(
         self,
@@ -684,7 +684,7 @@ class MeshInterface:  # pylint: disable=R0902
 
         Delegates to self.node_view.getNode().
         """
-        return self._node_view.getNode(
+        return self._node_view.get_node(
             nodeId, requestChannels, requestChannelAttempts, timeout
         )
 
@@ -730,7 +730,7 @@ class MeshInterface:  # pylint: disable=R0902
         mesh_pb2.MeshPacket
             The packet that was sent; its `id` field will be populated and can be used to track acknowledgments or naks.
         """
-        return self._send_pipeline.sendText(
+        return self._send_pipeline.send_text(
             text,
             destinationId=destinationId,
             wantAck=wantAck,
@@ -771,7 +771,7 @@ class MeshInterface:  # pylint: disable=R0902
         mesh_pb2.MeshPacket
             The sent mesh packet with its `id` populated.
         """
-        return self._send_pipeline.sendAlert(
+        return self._send_pipeline.send_alert(
             text,
             destinationId=destinationId,
             onResponse=onResponse,
@@ -789,7 +789,7 @@ class MeshInterface:  # pylint: disable=R0902
         data : bytes
             MQTT payload to forward.
         """
-        self._send_pipeline.sendMqttClientProxyMessage(topic, data)
+        self._send_pipeline.send_mqtt_client_proxy_message(topic, data)
 
     def sendData(  # pylint: disable=R0913,too-many-positional-arguments
         self,
@@ -850,7 +850,7 @@ class MeshInterface:  # pylint: disable=R0902
         `_send_data_with_wait()` and is not part of the public `sendData()`
         contract.
         """
-        return self._send_pipeline.sendData(
+        return self._send_pipeline.send_data(
             data,
             destinationId=destinationId,
             portNum=portNum,
@@ -998,7 +998,7 @@ class MeshInterface:  # pylint: disable=R0902
         mesh_pb2.MeshPacket
             The sent packet with its `id` populated.
         """
-        return self._send_pipeline.sendPosition(
+        return self._send_pipeline.send_position(
             latitude=latitude,
             longitude=longitude,
             altitude=altitude,
@@ -1159,7 +1159,7 @@ class MeshInterface:  # pylint: disable=R0902
             the nested `decoded["routing"]["errorReason"]` may be present.
 
         """
-        self._send_pipeline.onResponsePosition(p)
+        self._send_pipeline.on_response_position(p)
 
     def sendTraceRoute(
         self, dest: int | str, hopLimit: int, channelIndex: int = 0
@@ -1184,7 +1184,7 @@ class MeshInterface:  # pylint: disable=R0902
         MeshInterfaceError
             If waiting for traceroute responses times out or the operation fails.
         """
-        self._send_pipeline.sendTraceRoute(dest, hopLimit, channelIndex=channelIndex)
+        self._send_pipeline.send_trace_route(dest, hopLimit, channelIndex=channelIndex)
 
     def requestTraceRoute(
         self, dest: int | str, hopLimit: int, channelIndex: int = 0
@@ -1210,7 +1210,7 @@ class MeshInterface:  # pylint: disable=R0902
         MeshInterfaceError
             If the request fails, times out, or returns an invalid payload.
         """
-        return self._send_pipeline.requestTraceRoute(
+        return self._send_pipeline.request_trace_route(
             dest, hopLimit, channelIndex=channelIndex
         )
 
@@ -1222,7 +1222,7 @@ class MeshInterface:  # pylint: disable=R0902
         p : dict[str, Any]
             The traceroute response packet.
         """
-        self._send_pipeline.onResponseTraceRoute(p)
+        self._send_pipeline.on_response_trace_route(p)
 
     # pylint: disable=too-many-positional-arguments
     def sendTelemetry(
@@ -1250,7 +1250,7 @@ class MeshInterface:  # pylint: disable=R0902
         hopLimit : int | None
             Optional hop limit override for the outgoing packet. (Default value = None)
         """
-        self._send_pipeline.sendTelemetry(
+        self._send_pipeline.send_telemetry(
             destinationId=destinationId,
             wantResponse=wantResponse,
             channelIndex=channelIndex,
@@ -1266,7 +1266,7 @@ class MeshInterface:  # pylint: disable=R0902
         p : dict[str, Any]
             Decoded packet dictionary produced by _handle_packet_from_radio.
         """
-        self._send_pipeline.onResponseTelemetry(p)
+        self._send_pipeline.on_response_telemetry(p)
 
     def onResponseWaypoint(self, p: dict[str, Any]) -> None:
         """Handle a waypoint response or routing error contained in a received packet.
@@ -1276,7 +1276,7 @@ class MeshInterface:  # pylint: disable=R0902
         p : dict[str, Any]
             Packet dictionary containing a 'decoded' mapping.
         """
-        self._send_pipeline.onResponseWaypoint(p)
+        self._send_pipeline.on_response_waypoint(p)
 
     def sendWaypoint(  # pylint: disable=R0913,too-many-positional-arguments
         self,
@@ -1327,7 +1327,7 @@ class MeshInterface:  # pylint: disable=R0902
         mesh_pb2.MeshPacket
             The MeshPacket that was sent; its `id` is populated for tracking.
         """
-        return self._send_pipeline.sendWaypoint(
+        return self._send_pipeline.send_waypoint(
             name=name,
             description=description,
             icon=icon,
@@ -1374,7 +1374,7 @@ class MeshInterface:  # pylint: disable=R0902
         mesh_pb2.MeshPacket
             The MeshPacket that was sent; its `id` field is populated and can be used to track acknowledgements.
         """
-        return self._send_pipeline.deleteWaypoint(
+        return self._send_pipeline.delete_waypoint(
             waypoint_id=waypoint_id,
             destinationId=destinationId,
             wantAck=wantAck,
@@ -1391,7 +1391,7 @@ class MeshInterface:  # pylint: disable=R0902
         MeshInterface.MeshInterfaceError
             If the configuration is not received before the interface timeout.
         """
-        self._send_pipeline.waitForConfig()
+        self._send_pipeline.wait_for_config()
 
     def _wait_for_ack_nak(self, request_id: int) -> None:
         """Wait for the ACK/NAK correlated to one internal request id."""
@@ -1405,14 +1405,14 @@ class MeshInterface:  # pylint: disable=R0902
         MeshInterface.MeshInterfaceError
             If waiting times out before an ACK/NAK is received.
         """
-        self._send_pipeline.waitForAckNak()
+        self._send_pipeline.wait_for_ack_nak()
 
     def waitForTraceRoute(
         self, waitFactor: float, request_id: int | None = None
     ) -> None:
         """Wait for trace route completion using the configured timeout.
 
-        Delegates to self._send_pipeline.waitForTraceRoute().
+        Delegates to self._send_pipeline.wait_for_trace_route().
 
         Parameters
         ----------
@@ -1427,12 +1427,12 @@ class MeshInterface:  # pylint: disable=R0902
         MeshInterface.MeshInterfaceError
             If the wait times out before a traceroute response is received.
         """
-        self._send_pipeline.waitForTraceRoute(waitFactor, request_id=request_id)
+        self._send_pipeline.wait_for_trace_route(waitFactor, request_id=request_id)
 
     def waitForTelemetry(self, request_id: int | None = None) -> None:
         """Wait for a telemetry response or until the configured timeout elapses.
 
-        Delegates to self._send_pipeline.waitForTelemetry().
+        Delegates to self._send_pipeline.wait_for_telemetry().
 
         Parameters
         ----------
@@ -1445,12 +1445,12 @@ class MeshInterface:  # pylint: disable=R0902
         MeshInterface.MeshInterfaceError
             If a telemetry response is not received before the configured timeout.
         """
-        self._send_pipeline.waitForTelemetry(request_id=request_id)
+        self._send_pipeline.wait_for_telemetry(request_id=request_id)
 
     def waitForPosition(self, request_id: int | None = None) -> None:
         """Block until a position acknowledgment is received.
 
-        Delegates to self._send_pipeline.waitForPosition().
+        Delegates to self._send_pipeline.wait_for_position().
 
         Parameters
         ----------
@@ -1463,12 +1463,12 @@ class MeshInterface:  # pylint: disable=R0902
         MeshInterface.MeshInterfaceError
             If waiting for the position times out.
         """
-        self._send_pipeline.waitForPosition(request_id=request_id)
+        self._send_pipeline.wait_for_position(request_id=request_id)
 
     def waitForWaypoint(self, request_id: int | None = None) -> None:
         """Block until a waypoint acknowledgment is received.
 
-        Delegates to self._send_pipeline.waitForWaypoint().
+        Delegates to self._send_pipeline.wait_for_waypoint().
 
         Parameters
         ----------
@@ -1481,56 +1481,56 @@ class MeshInterface:  # pylint: disable=R0902
         MeshInterface.MeshInterfaceError
             If the wait times out before a waypoint acknowledgment is received.
         """
-        self._send_pipeline.waitForWaypoint(request_id=request_id)
+        self._send_pipeline.wait_for_waypoint(request_id=request_id)
 
     def getMyNodeInfo(self) -> dict[str, Any] | None:
         """Get the stored node-info dictionary for the local node.
 
         Delegates to self.node_view.getMyNodeInfo().
         """
-        return self._node_view.getMyNodeInfo()
+        return self._node_view.get_my_node_info()
 
     def getMyUser(self) -> dict[str, Any] | None:
         """Get the user information for the local node.
 
         Delegates to self.node_view.getMyUser().
         """
-        return self._node_view.getMyUser()
+        return self._node_view.get_my_user()
 
     def getLongName(self) -> str | None:
         """Get the local user's configured long name.
 
         Delegates to self.node_view.getLongName().
         """
-        return self._node_view.getLongName()
+        return self._node_view.get_long_name()
 
     def getShortName(self) -> str | None:
         """Get the local node user's short name.
 
         Delegates to self.node_view.getShortName().
         """
-        return self._node_view.getShortName()
+        return self._node_view.get_short_name()
 
     def getPublicKey(self) -> bytes | None:
         """Return the local node's public key if available.
 
         Delegates to self.node_view.getPublicKey().
         """
-        return self._node_view.getPublicKey()
+        return self._node_view.get_public_key()
 
     def getCannedMessage(self) -> str | None:
         """Retrieve the canned (predefined) message configured for the local node.
 
         Delegates to self.node_view.getCannedMessage().
         """
-        return self._node_view.getCannedMessage()
+        return self._node_view.get_canned_message()
 
     def getRingtone(self) -> str | None:
         """Get the local node's ringtone name or identifier.
 
         Delegates to self.node_view.getRingtone().
         """
-        return self._node_view.getRingtone()
+        return self._node_view.get_ringtone()
 
     def _connection_timeout_override(
         self, attribute_name: str, default: float | None = None

--- a/meshtastic/mesh_interface_runtime/flows.py
+++ b/meshtastic/mesh_interface_runtime/flows.py
@@ -105,7 +105,7 @@ def _on_response_position(interface: "MeshInterface", p: dict[str, Any]) -> None
 
 
 # pylint: disable=too-many-positional-arguments
-def sendPosition(
+def send_position(
     interface: "MeshInterface",
     latitude: float = 0.0,
     longitude: float = 0.0,
@@ -331,7 +331,7 @@ def _send_traceroute(
     return result
 
 
-def sendTraceroute(
+def send_traceroute(
     interface: "MeshInterface",
     dest: int | str,
     hopLimit: int,
@@ -444,7 +444,7 @@ def _on_response_telemetry(interface: "MeshInterface", p: dict[str, Any]) -> Non
 
 
 # pylint: disable=too-many-positional-arguments
-def sendTelemetry(
+def send_telemetry(
     interface: "MeshInterface",
     destinationId: int | str = BROADCAST_ADDR,
     wantResponse: bool = False,
@@ -569,7 +569,7 @@ def _on_response_waypoint(interface: "MeshInterface", p: dict[str, Any]) -> None
 
 
 # pylint: disable=too-many-arguments,too-many-positional-arguments
-def sendWaypoint(
+def send_waypoint(
     interface: "MeshInterface",
     name: str,
     description: str,
@@ -640,7 +640,7 @@ def sendWaypoint(
 
 
 # pylint: disable=too-many-positional-arguments
-def deleteWaypoint(
+def delete_waypoint(
     interface: "MeshInterface",
     waypointId: int,
     destinationId: int | str = BROADCAST_ADDR,

--- a/meshtastic/mesh_interface_runtime/node_data.py
+++ b/meshtastic/mesh_interface_runtime/node_data.py
@@ -7,7 +7,7 @@ from google.protobuf.descriptor import Descriptor
 from meshtastic.protobuf import mesh_pb2, telemetry_pb2
 
 
-def extractNodeFieldValue(node_dict: dict[str, Any], field_path: str) -> Any:
+def extract_node_field_value(node_dict: dict[str, Any], field_path: str) -> Any:
     """Retrieve a nested value from a dictionary using a dotted key path.
 
     Parameters
@@ -61,12 +61,12 @@ DEFAULT_SHOW_FIELDS: list[str] = [
 ]
 
 
-def getDefaultShowFields() -> list[str]:
+def get_default_show_fields() -> list[str]:
     """Return the default list of fields to display in showNodes output."""
     return DEFAULT_SHOW_FIELDS.copy()
 
 
-def filterNodes(
+def filter_nodes(
     nodes: list[dict[str, Any]],
     include_self: bool,
     local_node_num: int,
@@ -92,7 +92,7 @@ def filterNodes(
     return [node for node in nodes if node.get("num") != local_node_num]
 
 
-def sortNodes(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def sort_nodes(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Sort nodes by lastHeard timestamp in descending order.
 
     Parameters
@@ -126,7 +126,7 @@ def _descriptor_field_paths(descriptor: Descriptor, prefix: str = "") -> set[str
     return paths
 
 
-def getKnownFieldPaths(nodes: list[dict[str, Any]] | None = None) -> list[str]:
+def get_known_field_paths(nodes: list[dict[str, Any]] | None = None) -> list[str]:
     """Return known CLI node-table field paths from schema plus observed node data."""
     paths: set[str] = set(DEFAULT_SHOW_FIELDS)
     paths.update(_descriptor_field_paths(mesh_pb2.NodeInfo.DESCRIPTOR))

--- a/meshtastic/mesh_interface_runtime/node_view.py
+++ b/meshtastic/mesh_interface_runtime/node_view.py
@@ -88,7 +88,7 @@ class NodeView:
     """Node accessor and presentation methods for MeshInterface.
 
     This class provides node lookup, node DB helpers, and presentation/display
-    methods (showInfo, showNodes). Shared interface state is accessed through a
+    methods (show_info, show_nodes). Shared interface state is accessed through a
     narrow internal capability port.
     """
 
@@ -107,7 +107,7 @@ class NodeView:
         return self._port.node_db_lock
 
     @property
-    def localNode(self) -> meshtastic.node.Node:
+    def local_node(self) -> meshtastic.node.Node:
         """Return the local node for this interface."""
         return self._port.local_node
 
@@ -117,12 +117,12 @@ class NodeView:
         return self._port.nodes
 
     @property
-    def nodesByNum(self) -> dict[int, dict[str, Any]] | None:
+    def nodes_by_num(self) -> dict[int, dict[str, Any]] | None:
         """Return the node-number-to-info dictionary, or None if not initialized."""
         return self._port.nodes_by_num
 
     @property
-    def myInfo(self) -> mesh_pb2.MyNodeInfo | None:
+    def my_info(self) -> mesh_pb2.MyNodeInfo | None:
         """Return the MyNodeInfo for this interface, or None."""
         return self._port.my_info
 
@@ -179,7 +179,7 @@ class NodeView:
         """
         self._handle_log_line(record.message)
 
-    def showInfo(self, file: IO[str] | None = None) -> str:
+    def show_info(self, file: IO[str] | None = None) -> str:
         """Return a human-readable JSON summary of the mesh interface including owner, local node info, metadata, and known nodes.
 
         The summary omits internal node fields (`raw`, `decoded`, `payload`) and normalizes stored MAC addresses
@@ -195,9 +195,9 @@ class NodeView:
         summary : str
             The formatted summary text that was written to `file`.
         """
-        owner = f"Owner: {self.getLongName()} ({self.getShortName()})"
+        owner = f"Owner: {self.get_long_name()} ({self.get_short_name()})"
         with self._node_db_lock:
-            my_info = self.myInfo
+            my_info = self.my_info
             metadata_info = self.metadata
             nodes_snapshot = (
                 [copy.deepcopy(node) for node in self.nodes.values()]
@@ -263,7 +263,7 @@ class NodeView:
             fields_data: dict[str, Any] = {}
             for col_name in fields:
                 if "." in col_name:
-                    raw_value = node_data.extractNodeFieldValue(node, col_name)
+                    raw_value = node_data.extract_node_field_value(node, col_name)
                 elif col_name == "since":
                     raw_value = node.get("lastHeard")
                 else:
@@ -301,7 +301,7 @@ class NodeView:
             tabulate(rows, headers="keys", missingval="N/A", tablefmt="fancy_grid")
         )
 
-    def showNodes(
+    def show_nodes(
         self, includeSelf: bool = True, showFields: list[str] | None = None
     ) -> str:
         """Produce a formatted table summarizing known mesh nodes.
@@ -325,14 +325,14 @@ class NodeView:
         """
         # Determine fields to show
         if not showFields:
-            fields = node_data.getDefaultShowFields()
+            fields = node_data.get_default_show_fields()
         else:
             fields = ["N", *showFields] if "N" not in showFields else list(showFields)
 
         # Get node data under lock
         with self._node_db_lock:
-            nodes_snapshot = list(self.nodesByNum.values()) if self.nodesByNum else []
-            local_node_num = self.localNode.nodeNum
+            nodes_snapshot = list(self.nodes_by_num.values()) if self.nodes_by_num else []
+            local_node_num = self.local_node.nodeNum
 
         if nodes_snapshot:
             node_count = len(nodes_snapshot)
@@ -352,12 +352,12 @@ class NodeView:
             )
 
         # Filter nodes
-        filtered_nodes = node_data.filterNodes(
+        filtered_nodes = node_data.filter_nodes(
             nodes_snapshot, includeSelf, local_node_num
         )
 
         # Sort nodes by lastHeard
-        sorted_nodes = node_data.sortNodes(filtered_nodes)
+        sorted_nodes = node_data.sort_nodes(filtered_nodes)
 
         # Build table data with field extraction and formatting
         rows = self._build_table_data(sorted_nodes, fields)
@@ -371,7 +371,7 @@ class NodeView:
         print(table)
         return table
 
-    def getNode(
+    def get_node(
         self,
         nodeId: str,
         requestChannels: bool = True,
@@ -407,7 +407,7 @@ class NodeView:
             If channel retrieval repeatedly fails or times out.
         """
         if nodeId in (LOCAL_ADDR, BROADCAST_ADDR):
-            return self.localNode
+            return self.local_node
         n = meshtastic.node.Node(
             self._port.facade,
             nodeId,
@@ -438,21 +438,21 @@ class NodeView:
                     break
         return n
 
-    def getMyNodeInfo(self) -> dict[str, Any] | None:
+    def get_my_node_info(self) -> dict[str, Any] | None:
         """Get the stored node-info dictionary for the local node.
 
         Returns
         -------
         dict[str, Any] | None
-            The local node's node-info entry from `nodesByNum`, or `None` if `myInfo`
-            or `nodesByNum` is unset or the local node entry is missing.
+            The local node's node-info entry from `nodes_by_num`, or `None` if `my_info`
+            or `nodes_by_num` is unset or the local node entry is missing.
         """
         with self._node_db_lock:
-            if self.myInfo is None or self.nodesByNum is None:
+            if self.my_info is None or self.nodes_by_num is None:
                 return None
-            return self.nodesByNum.get(self.myInfo.my_node_num)
+            return self.nodes_by_num.get(self.my_info.my_node_num)
 
-    def getMyUser(self) -> dict[str, Any] | None:
+    def get_my_user(self) -> dict[str, Any] | None:
         """Get the user information for the local node.
 
         Returns
@@ -460,12 +460,12 @@ class NodeView:
         user : dict[str, Any] | None
             The local node's `user` dictionary, or `None` if no local node info or no `user` field is present.
         """
-        nodeInfo = self.getMyNodeInfo()
+        nodeInfo = self.get_my_node_info()
         if nodeInfo is not None:
             return nodeInfo.get("user")
         return None
 
-    def getLongName(self) -> str | None:
+    def get_long_name(self) -> str | None:
         """Get the local user's configured long name.
 
         Returns
@@ -473,12 +473,12 @@ class NodeView:
         str | None
             The long name string if configured, `None` otherwise.
         """
-        user = self.getMyUser()
+        user = self.get_my_user()
         if user is not None:
             return user.get("longName")
         return None
 
-    def getShortName(self) -> str | None:
+    def get_short_name(self) -> str | None:
         """Get the local node user's short name.
 
         Returns
@@ -486,12 +486,12 @@ class NodeView:
         str | None
             The user's `shortName` if present, `None` otherwise.
         """
-        user = self.getMyUser()
+        user = self.get_my_user()
         if user is not None:
             return user.get("shortName")
         return None
 
-    def getPublicKey(self) -> bytes | None:
+    def get_public_key(self) -> bytes | None:
         """Return the local node's public key if available.
 
         Returns
@@ -499,12 +499,12 @@ class NodeView:
         bytes | None
             The local node's public key bytes if present, `None` otherwise.
         """
-        user = self.getMyUser()
+        user = self.get_my_user()
         if user is not None:
             return user.get("publicKey")
         return None
 
-    def getCannedMessage(self) -> str | None:
+    def get_canned_message(self) -> str | None:
         """Retrieve the canned (predefined) message configured for the local node.
 
         Returns
@@ -512,12 +512,12 @@ class NodeView:
         str | None
             The canned message text, or `None` if there is no local node or no canned message configured.
         """
-        node = self.localNode
+        node = self.local_node
         if node is not None:
             return node.get_canned_message()
         return None
 
-    def getRingtone(self) -> str | None:
+    def get_ringtone(self) -> str | None:
         """Get the local node's ringtone name or identifier.
 
         Returns
@@ -525,7 +525,7 @@ class NodeView:
         str | None
             The ringtone name or identifier as a string, or None if the local node or ringtone is unavailable.
         """
-        node = self.localNode
+        node = self.local_node
         if node is not None:
             return node.get_ringtone()
         return None
@@ -577,7 +577,7 @@ class NodeView:
             return BROADCAST_ADDR if isDest else "Unknown"
 
         with self._node_db_lock:
-            nodes = self.nodesByNum
+            nodes = self.nodes_by_num
             if nodes is None:
                 logger.debug(
                     "Node database not initialized while resolving node id for %s", num
@@ -608,7 +608,7 @@ class NodeView:
         Returns
         -------
         dict[str, Any]
-            The node info dictionary stored in self.nodesByNum for the given nodeNum.
+            The node info dictionary stored in self.nodes_by_num for the given nodeNum.
 
         Raises
         ------
@@ -621,11 +621,11 @@ class NodeView:
             )
 
         with self._node_db_lock:
-            if self.nodesByNum is None:
+            if self.nodes_by_num is None:
                 raise self._port.error_type("Node database not initialized")
 
-            if nodeNum in self.nodesByNum:
-                return self.nodesByNum[nodeNum]
+            if nodeNum in self.nodes_by_num:
+                return self.nodes_by_num[nodeNum]
             presumptive_id = f"!{nodeNum:08x}"
             n = {
                 "num": nodeNum,
@@ -636,5 +636,5 @@ class NodeView:
                     "hwModel": "UNSET",
                 },
             }
-            self.nodesByNum[nodeNum] = n
+            self.nodes_by_num[nodeNum] = n
             return n

--- a/meshtastic/mesh_interface_runtime/receive_pipeline.py
+++ b/meshtastic/mesh_interface_runtime/receive_pipeline.py
@@ -166,18 +166,18 @@ class ReceivePipeline:
         return self._port.queue_send_runtime
 
     @property
-    def configId(self) -> int | None:
+    def config_id(self) -> int | None:
         """Return the config ID from the parent interface."""
         return self._port.config_id
 
     @property
-    def localNode(self) -> "Node":
+    def local_node(self) -> "Node":
         """Return the local node from the parent interface."""
         return self._port.local_node
 
     @property
-    def myInfo(self) -> mesh_pb2.MyNodeInfo | None:
-        """Return the myInfo from the parent interface."""
+    def my_info(self) -> mesh_pb2.MyNodeInfo | None:
+        """Return the my_info from the parent interface."""
         return self._port.my_info
 
     @property
@@ -191,7 +191,7 @@ class ReceivePipeline:
         return self._port.nodes
 
     @property
-    def nodesByNum(self) -> dict[int, dict[str, Any]] | None:
+    def nodes_by_num(self) -> dict[int, dict[str, Any]] | None:
         """Return the nodes by number dictionary from the parent interface."""
         return self._port.nodes_by_num
 
@@ -246,7 +246,7 @@ class ReceivePipeline:
         """Normalize parsed FromRadio data for dispatch and mutation handlers."""
         logger.debug("Received from radio: %s", from_radio)
         with self._node_db_lock:
-            config_id = self.configId
+            config_id = self.config_id
         return _FromRadioContext(
             message=from_radio,
             message_dict=_LazyMessageDict(from_radio),
@@ -473,7 +473,7 @@ class ReceivePipeline:
         """Apply all present localConfig fields from inbound config payload."""
         applied = False
         source_fields = config.DESCRIPTOR.fields_by_name
-        target_fields = self.localNode.localConfig.DESCRIPTOR.fields_by_name
+        target_fields = self.local_node.localConfig.DESCRIPTOR.fields_by_name
         for field_name in LOCAL_CONFIG_FROM_RADIO_FIELDS:
             if field_name not in source_fields:
                 continue
@@ -484,7 +484,7 @@ class ReceivePipeline:
                 )
                 continue
             if config.HasField(field_name):  # type: ignore[arg-type]  # field_name is from known-valid LOCAL_CONFIG_FROM_RADIO_FIELDS
-                getattr(self.localNode.localConfig, field_name).CopyFrom(
+                getattr(self.local_node.localConfig, field_name).CopyFrom(
                     getattr(config, field_name)
                 )
                 applied = True
@@ -496,7 +496,7 @@ class ReceivePipeline:
         """Apply all present moduleConfig fields from inbound moduleConfig payload."""
         applied = False
         source_fields = module_config.DESCRIPTOR.fields_by_name
-        target_fields = self.localNode.moduleConfig.DESCRIPTOR.fields_by_name
+        target_fields = self.local_node.moduleConfig.DESCRIPTOR.fields_by_name
         for field_name in MODULE_CONFIG_FROM_RADIO_FIELDS:
             if field_name not in source_fields:
                 continue
@@ -507,7 +507,7 @@ class ReceivePipeline:
                 )
                 continue
             if module_config.HasField(field_name):  # type: ignore[arg-type]  # field_name is from known-valid MODULE_CONFIG_FROM_RADIO_FIELDS
-                getattr(self.localNode.moduleConfig, field_name).CopyFrom(
+                getattr(self.local_node.moduleConfig, field_name).CopyFrom(
                     getattr(module_config, field_name)
                 )
                 applied = True
@@ -547,13 +547,13 @@ class ReceivePipeline:
             )
 
         with self._node_db_lock:
-            if self.nodesByNum is None:
+            if self.nodes_by_num is None:
                 raise self._port.error_type(
                     "Node database not initialized"
                 )
 
-            if nodeNum in self.nodesByNum:
-                return self.nodesByNum[nodeNum]
+            if nodeNum in self.nodes_by_num:
+                return self.nodes_by_num[nodeNum]
             presumptive_id = f"!{nodeNum:08x}"
             n = {
                 "num": nodeNum,
@@ -564,7 +564,7 @@ class ReceivePipeline:
                     "hwModel": "UNSET",
                 },
             }
-            self.nodesByNum[nodeNum] = n
+            self.nodes_by_num[nodeNum] = n
             return n
 
     def _handle_channel(self, channel: channel_pb2.Channel) -> None:
@@ -687,7 +687,7 @@ class ReceivePipeline:
             return BROADCAST_ADDR if isDest else "Unknown"
 
         with self._node_db_lock:
-            nodes = self.nodesByNum
+            nodes = self.nodes_by_num
             if nodes is None:
                 logger.debug(
                     "Node database not initialized while resolving node id for %s", num

--- a/meshtastic/mesh_interface_runtime/send_pipeline.py
+++ b/meshtastic/mesh_interface_runtime/send_pipeline.py
@@ -17,11 +17,11 @@ from meshtastic.mesh_interface_runtime.flows import (
     _on_response_traceroute,
     _on_response_waypoint,
     _request_traceroute,
-    deleteWaypoint,
-    sendPosition,
-    sendTelemetry,
-    sendTraceroute,
-    sendWaypoint,
+    delete_waypoint,
+    send_position,
+    send_telemetry,
+    send_traceroute,
+    send_waypoint,
 )
 from meshtastic.mesh_interface_runtime.ports import _SendPipelinePort
 from meshtastic.mesh_interface_runtime.queue_send import _QueueSendRuntime
@@ -168,13 +168,13 @@ class SendPipeline:
         return self._port.queue_send_runtime
 
     @property
-    def localNode(self) -> "Node":
+    def local_node(self) -> "Node":
         """Return the local node from the parent interface."""
         return self._port.local_node
 
     @property
-    def myInfo(self) -> mesh_pb2.MyNodeInfo | None:
-        """Return the myInfo from the parent interface."""
+    def my_info(self) -> mesh_pb2.MyNodeInfo | None:
+        """Return the my_info from the parent interface."""
         return self._port.my_info
 
     @property
@@ -183,18 +183,18 @@ class SendPipeline:
         return self._port.nodes
 
     @property
-    def nodesByNum(self) -> dict[int, dict[str, Any]] | None:
+    def nodes_by_num(self) -> dict[int, dict[str, Any]] | None:
         """Return the nodes by number dictionary from the parent interface."""
         return self._port.nodes_by_num
 
     @property
-    def configId(self) -> int | None:
+    def config_id(self) -> int | None:
         """Return the config ID from the parent interface."""
         return self._port.config_id
 
     @property
-    def noProto(self) -> bool:
-        """Return the noProto flag from the parent interface."""
+    def no_proto(self) -> bool:
+        """Return the no_proto flag from the parent interface."""
         return self._port.no_proto
 
     @property
@@ -208,7 +208,7 @@ class SendPipeline:
         return self._port.timeout
 
     # pylint: disable=too-many-positional-arguments
-    def sendText(
+    def send_text(
         self,
         text: str,
         destinationId: int | str = BROADCAST_ADDR,
@@ -221,7 +221,7 @@ class SendPipeline:
         hopLimit: int | None = None,
     ) -> mesh_pb2.MeshPacket:
         """Send UTF-8 text to a node (or broadcast) and return the transmitted MeshPacket."""
-        return self.sendData(
+        return self.send_data(
             text.encode("utf-8"),
             destinationId,
             portNum=portNum,
@@ -234,7 +234,7 @@ class SendPipeline:
         )
 
     # pylint: disable=too-many-positional-arguments
-    def sendAlert(
+    def send_alert(
         self,
         text: str,
         destinationId: int | str = BROADCAST_ADDR,
@@ -243,7 +243,7 @@ class SendPipeline:
         hopLimit: int | None = None,
     ) -> mesh_pb2.MeshPacket:
         """Send a high-priority alert text to a node."""
-        return self.sendData(
+        return self.send_data(
             text.encode("utf-8"),
             destinationId,
             portNum=portnums_pb2.PortNum.ALERT_APP,
@@ -255,7 +255,7 @@ class SendPipeline:
             hopLimit=hopLimit,
         )
 
-    def sendMqttClientProxyMessage(self, topic: str, data: bytes) -> None:
+    def send_mqtt_client_proxy_message(self, topic: str, data: bytes) -> None:
         """Send an MQTT client-proxy message through the radio."""
         prox = mesh_pb2.MqttClientProxyMessage()
         prox.topic = topic
@@ -265,7 +265,7 @@ class SendPipeline:
         self._send_to_radio(toRadio)
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments
-    def sendData(
+    def send_data(
         self,
         data: PayloadData,
         destinationId: int | str = BROADCAST_ADDR,
@@ -504,12 +504,12 @@ class SendPipeline:
             request_id=request_id,
         )
 
-    def onResponsePosition(self, p: dict[str, Any]) -> None:
+    def on_response_position(self, p: dict[str, Any]) -> None:
         """Process a position response packet and emit a concise human-readable summary."""
         _on_response_position(self._port.facade, p)
 
     # pylint: disable=too-many-positional-arguments
-    def sendPosition(
+    def send_position(
         self,
         latitude: float = 0.0,
         longitude: float = 0.0,
@@ -521,7 +521,7 @@ class SendPipeline:
         hopLimit: int | None = None,
     ) -> mesh_pb2.MeshPacket:
         """Send the device's position to a specific node or to broadcast."""
-        return sendPosition(
+        return send_position(
             self._port.facade,
             latitude=latitude,
             longitude=longitude,
@@ -533,20 +533,20 @@ class SendPipeline:
             hopLimit=hopLimit,
         )
 
-    def onResponseTraceRoute(self, p: dict[str, Any]) -> None:
+    def on_response_trace_route(self, p: dict[str, Any]) -> None:
         """Emit human-readable traceroute results from a RouteDiscovery payload."""
         _on_response_traceroute(self._port.facade, p)
 
     # pylint: disable=too-many-positional-arguments
-    def sendTraceRoute(
+    def send_trace_route(
         self, dest: int | str, hopLimit: int, channelIndex: int = 0
     ) -> None:
         """Initiate a traceroute request toward a destination node and wait for responses."""
-        return sendTraceroute(
+        return send_traceroute(
             self._port.facade, dest, hopLimit, channelIndex=channelIndex
         )
 
-    def requestTraceRoute(
+    def request_trace_route(
         self, dest: int | str, hopLimit: int, channelIndex: int = 0
     ) -> TraceRouteResult:
         """Initiate a traceroute request and return its structured response."""
@@ -554,7 +554,7 @@ class SendPipeline:
             self._port.facade, dest, hopLimit, channelIndex=channelIndex
         )
 
-    def sendTelemetry(
+    def send_telemetry(
         self,
         destinationId: int | str = BROADCAST_ADDR,
         wantResponse: bool = False,
@@ -563,7 +563,7 @@ class SendPipeline:
         hopLimit: int | None = None,
     ) -> None:
         """Send a telemetry message to a node or broadcast and optionally wait for a telemetry response."""
-        return sendTelemetry(
+        return send_telemetry(
             self._port.facade,
             destinationId=destinationId,
             wantResponse=wantResponse,
@@ -572,16 +572,16 @@ class SendPipeline:
             hopLimit=hopLimit,
         )
 
-    def onResponseTelemetry(self, p: dict[str, Any]) -> None:
+    def on_response_telemetry(self, p: dict[str, Any]) -> None:
         """Handle an incoming telemetry response."""
         _on_response_telemetry(self._port.facade, p)
 
-    def onResponseWaypoint(self, p: dict[str, Any]) -> None:
+    def on_response_waypoint(self, p: dict[str, Any]) -> None:
         """Handle a waypoint response or routing error contained in a received packet."""
         _on_response_waypoint(self._port.facade, p)
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments
-    def sendWaypoint(
+    def send_waypoint(
         self,
         name: str,
         description: str,
@@ -597,7 +597,7 @@ class SendPipeline:
         hopLimit: int | None = None,
     ) -> mesh_pb2.MeshPacket:
         """Send a waypoint to a node or broadcast."""
-        return sendWaypoint(
+        return send_waypoint(
             self._port.facade,
             name=name,
             description=description,
@@ -614,7 +614,7 @@ class SendPipeline:
         )
 
     # pylint: disable=too-many-positional-arguments
-    def deleteWaypoint(
+    def delete_waypoint(
         self,
         waypoint_id: int,
         destinationId: int | str = BROADCAST_ADDR,
@@ -624,7 +624,7 @@ class SendPipeline:
         hopLimit: int | None = None,
     ) -> mesh_pb2.MeshPacket:
         """Delete a waypoint by sending a Waypoint message with expire=0 to a destination."""
-        return deleteWaypoint(
+        return delete_waypoint(
             self._port.facade,
             waypointId=waypoint_id,
             destinationId=destinationId,
@@ -663,7 +663,7 @@ class SendPipeline:
     ) -> mesh_pb2.MeshPacket:
         """Send a MeshPacket to a specific node or broadcast."""
         with self._node_db_lock:
-            my_node_num = self.myInfo.my_node_num if self.myInfo is not None else None
+            my_node_num = self.my_info.my_node_num if self.my_info is not None else None
 
         if my_node_num is not None and destinationId != my_node_num:
             self._port.wait_connected()
@@ -722,7 +722,7 @@ class SendPipeline:
             meshPacket.hop_limit = hopLimit
         else:
             with self._node_db_lock:
-                local_node = self.localNode
+                local_node = self.local_node
                 if local_node is None or local_node.localConfig is None:
                     default_hop_limit = DEFAULT_HOP_LIMIT  # Sensible default
                 else:
@@ -739,7 +739,7 @@ class SendPipeline:
             meshPacket.id = self._port.generate_packet_id()
 
         toRadio.packet.CopyFrom(meshPacket)
-        if self.noProto:
+        if self.no_proto:
             logger.warning(
                 "Not sending packet because protocol use is disabled by noProto"
             )
@@ -748,33 +748,12 @@ class SendPipeline:
             self._port.send_to_radio(toRadio)
         return meshPacket
 
-    # pylint: disable=too-many-positional-arguments
-    def _sendPacket(
-        self,
-        meshPacket: mesh_pb2.MeshPacket,
-        destinationId: int | str = BROADCAST_ADDR,
-        wantAck: bool = False,
-        hopLimit: int | None = None,
-        pkiEncrypted: bool | None = False,
-        publicKey: bytes | None = None,
-    ) -> mesh_pb2.MeshPacket:
-        """Backward-compatible alias for `_send_packet`."""
-        # COMPAT_STABLE_SHIM
-        return self._send_packet(
-            meshPacket=meshPacket,
-            destinationId=destinationId,
-            wantAck=wantAck,
-            hopLimit=hopLimit,
-            pkiEncrypted=pkiEncrypted,
-            publicKey=publicKey,
-        )
-
-    def waitForConfig(self) -> None:
+    def wait_for_config(self) -> None:
         """Block until the radio configuration and the local node's configuration are available."""
         success = (
             self._port.wait_for_initial_config()
-            and self.localNode.waitForConfig()
-            and self.localNode._channel_request_runtime._timeout_for_field(
+            and self.local_node.waitForConfig()
+            and self.local_node._channel_request_runtime._timeout_for_field(
                 "lora", LORA_CONFIG_WAIT_SECONDS
             )
         )
@@ -795,14 +774,14 @@ class SendPipeline:
         finally:
             self._retire_wait_request(WAIT_ATTR_NAK, request_id=request_id)
 
-    def waitForAckNak(self) -> None:
+    def wait_for_ack_nak(self) -> None:
         """Wait until an acknowledgement (ACK) or negative acknowledgement (NAK) is received or the wait times out."""
         success = self._timeout.waitForAckNak(self._acknowledgment)
         self._raise_wait_error_if_present(WAIT_ATTR_NAK)
         if not success:
             raise self._port.error_type("Timed out waiting for an acknowledgment")
 
-    def waitForTraceRoute(
+    def wait_for_trace_route(
         self, waitFactor: float, request_id: int | None = None
     ) -> None:
         """Wait for trace route completion using the configured timeout."""
@@ -825,7 +804,7 @@ class SendPipeline:
         finally:
             self._retire_wait_request(WAIT_ATTR_TRACEROUTE, request_id=request_id)
 
-    def waitForTelemetry(self, request_id: int | None = None) -> None:
+    def wait_for_telemetry(self, request_id: int | None = None) -> None:
         """Wait for a telemetry response or until the configured timeout elapses."""
         try:
             if request_id is None:
@@ -844,7 +823,7 @@ class SendPipeline:
         finally:
             self._retire_wait_request(WAIT_ATTR_TELEMETRY, request_id=request_id)
 
-    def waitForPosition(self, request_id: int | None = None) -> None:
+    def wait_for_position(self, request_id: int | None = None) -> None:
         """Block until a position acknowledgment is received."""
         try:
             if request_id is None:
@@ -861,7 +840,7 @@ class SendPipeline:
         finally:
             self._retire_wait_request(WAIT_ATTR_POSITION, request_id=request_id)
 
-    def waitForWaypoint(self, request_id: int | None = None) -> None:
+    def wait_for_waypoint(self, request_id: int | None = None) -> None:
         """Block until a waypoint acknowledgment is received."""
         try:
             if request_id is None:
@@ -880,7 +859,7 @@ class SendPipeline:
 
     def _send_to_radio(self, toRadio: mesh_pb2.ToRadio) -> None:
         """Queue and transmit a ToRadio protobuf to the radio device."""
-        if self.noProto:
+        if self.no_proto:
             logger.warning(
                 "Not sending packet because protocol use is disabled by noProto"
             )
@@ -902,7 +881,7 @@ class SendPipeline:
         m.disconnect = True
         self._send_to_radio(m)
 
-    def sendHeartbeat(self) -> None:
+    def send_heartbeat(self) -> None:
         """Send a heartbeat message to the radio to indicate the interface is alive."""
         p = mesh_pb2.ToRadio()
         p.heartbeat.CopyFrom(mesh_pb2.Heartbeat())

--- a/meshtastic/tests/test_mesh_interface_behavioral_compat.py
+++ b/meshtastic/tests/test_mesh_interface_behavioral_compat.py
@@ -1617,7 +1617,7 @@ class TestSendWaitEdgeCases:
         }
 
         # Process through the onResponse handler
-        iface._send_pipeline.onResponseTraceRoute(routing_packet)
+        iface._send_pipeline.on_response_trace_route(routing_packet)
 
         # Verify error was recorded
         assert (acknowledgment_attr, request_id) in iface._response_wait_errors
@@ -1648,7 +1648,7 @@ class TestSendWaitEdgeCases:
         }
 
         # Process through the onResponse handler
-        iface._send_pipeline.onResponseTraceRoute(malformed_packet)
+        iface._send_pipeline.on_response_trace_route(malformed_packet)
 
         # Verify error was recorded
         assert (acknowledgment_attr, request_id) in iface._response_wait_errors
@@ -1706,7 +1706,7 @@ class TestSendWaitEdgeCases:
         assert (acknowledgment_attr, request_id) not in iface._response_wait_acks
 
         # Process response
-        iface._send_pipeline.onResponseTraceRoute(response_packet)
+        iface._send_pipeline.on_response_trace_route(response_packet)
 
         # Verify ACK was recorded
         assert (acknowledgment_attr, request_id) in iface._response_wait_acks
@@ -1746,7 +1746,7 @@ class TestSendWaitEdgeCases:
         )
 
         # Process response
-        iface._send_pipeline.onResponseTraceRoute(response_packet)
+        iface._send_pipeline.on_response_trace_route(response_packet)
 
         # Verify ACK was recorded (response was processed successfully)
         assert (acknowledgment_attr, request_id) in iface._response_wait_acks

--- a/meshtastic/tests/test_mesh_interface_send_concurrency.py
+++ b/meshtastic/tests/test_mesh_interface_send_concurrency.py
@@ -503,7 +503,7 @@ def test_send_alert_and_mqtt_proxy_paths(monkeypatch: pytest.MonkeyPatch) -> Non
     """sendAlert() and sendMqttClientProxyMessage() should delegate with expected payloads."""
     with MeshInterface(noProto=True) as iface:
         send_alert = MagicMock(return_value=mesh_pb2.MeshPacket())
-        monkeypatch.setattr(iface._send_pipeline, "sendAlert", send_alert)
+        monkeypatch.setattr(iface._send_pipeline, "send_alert", send_alert)
         response_cb = MagicMock()
         iface.sendAlert(
             "SOS",
@@ -522,7 +522,7 @@ def test_send_alert_and_mqtt_proxy_paths(monkeypatch: pytest.MonkeyPatch) -> Non
 
         send_mqtt = MagicMock()
         monkeypatch.setattr(
-            iface._send_pipeline, "sendMqttClientProxyMessage", send_mqtt
+            iface._send_pipeline, "send_mqtt_client_proxy_message", send_mqtt
         )
         iface.sendMqttClientProxyMessage("mesh/topic", b"payload")
 

--- a/meshtastic/tests/test_mesh_interface_wait_receive.py
+++ b/meshtastic/tests/test_mesh_interface_wait_receive.py
@@ -1791,15 +1791,15 @@ class _FakeSendPipeline:
     def __init__(self) -> None:
         self.calls: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
 
-    def sendText(self, *args: object, **kwargs: object) -> str:
+    def send_text(self, *args: object, **kwargs: object) -> str:
         self.calls.append(("sendText", args, kwargs))
         return "sent-text"
 
-    def sendAlert(self, *args: object, **kwargs: object) -> str:
+    def send_alert(self, *args: object, **kwargs: object) -> str:
         self.calls.append(("sendAlert", args, kwargs))
         return "sent-alert"
 
-    def sendMqttClientProxyMessage(self, *args: object, **kwargs: object) -> None:
+    def send_mqtt_client_proxy_message(self, *args: object, **kwargs: object) -> None:
         self.calls.append(("sendMqttClientProxyMessage", args, kwargs))
 
 
@@ -1857,7 +1857,7 @@ def test_mesh_interface_handle_packet_delegates_to_receive_pipeline() -> None:
 
 @pytest.mark.unit
 def test_mesh_interface_send_text_delegates_to_send_pipeline() -> None:
-    """SendText should route through _send_pipeline.sendText, not local impl."""
+    """SendText should route through _send_pipeline.send_text, not local impl."""
     interface = MeshInterface.__new__(MeshInterface)
     fake: Any = _FakeSendPipeline()
     interface._send_pipeline = fake
@@ -1879,7 +1879,7 @@ def test_mesh_interface_send_text_delegates_to_send_pipeline() -> None:
 
 @pytest.mark.unit
 def test_mesh_interface_send_alert_delegates_to_send_pipeline() -> None:
-    """SendAlert should route through _send_pipeline.sendAlert, not local impl."""
+    """SendAlert should route through _send_pipeline.send_alert, not local impl."""
     interface = MeshInterface.__new__(MeshInterface)
     fake: Any = _FakeSendPipeline()
     interface._send_pipeline = fake

--- a/meshtastic/tests/test_node_data_field_paths.py
+++ b/meshtastic/tests/test_node_data_field_paths.py
@@ -7,7 +7,7 @@ from meshtastic.mesh_interface_runtime import node_data
 
 @pytest.mark.unit
 def test_known_field_paths_include_node_and_telemetry_schema() -> None:
-    fields = set(node_data.getKnownFieldPaths())
+    fields = set(node_data.get_known_field_paths())
 
     assert "user.id" in fields
     assert "position.latitude" in fields
@@ -19,7 +19,7 @@ def test_known_field_paths_include_node_and_telemetry_schema() -> None:
 @pytest.mark.unit
 def test_known_field_paths_include_observed_extension_fields() -> None:
     fields = set(
-        node_data.getKnownFieldPaths(
+        node_data.get_known_field_paths(
             [{"num": 1, "vendorExtension": {"sampleValue": 7}}]
         )
     )

--- a/meshtastic/tests/test_node_view.py
+++ b/meshtastic/tests/test_node_view.py
@@ -137,7 +137,7 @@ class TestNodeViewProperties:
         self, node_view: NodeView, mock_interface: MagicMock
     ) -> None:
         """Test localNode property."""
-        assert node_view.localNode is mock_interface.localNode
+        assert node_view.local_node is mock_interface.localNode
 
     @pytest.mark.unit
     def test_nodes_property(
@@ -155,7 +155,7 @@ class TestNodeViewProperties:
         """Test nodesByNum property."""
         nodes_by_num = {1234: {"num": 1234}}
         mock_interface.nodesByNum = nodes_by_num
-        assert node_view.nodesByNum is nodes_by_num
+        assert node_view.nodes_by_num is nodes_by_num
 
     @pytest.mark.unit
     def test_my_info_property(
@@ -164,7 +164,7 @@ class TestNodeViewProperties:
         """Test myInfo property."""
         my_info = mesh_pb2.MyNodeInfo()
         mock_interface.myInfo = my_info
-        assert node_view.myInfo is my_info
+        assert node_view.my_info is my_info
 
     @pytest.mark.unit
     def test_metadata_property(
@@ -273,7 +273,7 @@ class TestShowInfo:
         mock_interface.nodes = {}
 
         output = StringIO()
-        result = node_view.showInfo(file=output)
+        result = node_view.show_info(file=output)
 
         assert "Owner:" in result
         assert "Nodes in mesh:" in result
@@ -296,7 +296,7 @@ class TestShowInfo:
         }
 
         output = StringIO()
-        result = node_view.showInfo(file=output)
+        result = node_view.show_info(file=output)
 
         assert "!1234" in result
         assert "Test Node" in result
@@ -320,7 +320,7 @@ class TestBuildTableData:
             with patch(
                 "meshtastic.mesh_interface_runtime.node_view.node_presentation"
             ) as mock_presentation:
-                mock_node_data.extractNodeFieldValue.return_value = "extracted_value"
+                mock_node_data.extract_node_field_value.return_value = "extracted_value"
                 mock_presentation._format_node_field.return_value = "formatted_value"
                 mock_presentation._get_human_readable_column_label.return_value = (
                     "Human Label"
@@ -365,7 +365,7 @@ class TestShowNodes:
 
         with patch.object(node_view, "_render_node_table") as mock_render:
             mock_render.return_value = "Empty Table"
-            result = node_view.showNodes()
+            result = node_view.show_nodes()
 
         assert result == "Empty Table"
 
@@ -385,15 +385,15 @@ class TestShowNodes:
                 ) as mock_node_data:
                     mock_build.return_value = [{"N": 1, "Name": "Test Node"}]
                     mock_render.return_value = "Rendered Table"
-                    mock_node_data.filterNodes.return_value = [
+                    mock_node_data.filter_nodes.return_value = [
                         mock_interface.nodesByNum[1234]
                     ]
-                    mock_node_data.sortNodes.return_value = [
+                    mock_node_data.sort_nodes.return_value = [
                         mock_interface.nodesByNum[1234]
                     ]
-                    mock_node_data.getDefaultShowFields.return_value = ["N", "Name"]
+                    mock_node_data.get_default_show_fields.return_value = ["N", "Name"]
 
-                    result = node_view.showNodes()
+                    result = node_view.show_nodes()
 
         assert result == "Rendered Table"
 
@@ -406,7 +406,7 @@ class TestGetNode:
         self, node_view: NodeView, mock_interface: MagicMock
     ) -> None:
         """Test getting node for local address."""
-        result = node_view.getNode(LOCAL_ADDR)
+        result = node_view.get_node(LOCAL_ADDR)
 
         assert result is mock_interface.localNode
 
@@ -415,7 +415,7 @@ class TestGetNode:
         self, node_view: NodeView, mock_interface: MagicMock
     ) -> None:
         """Test getting node for broadcast address."""
-        result = node_view.getNode(BROADCAST_ADDR)
+        result = node_view.get_node(BROADCAST_ADDR)
 
         assert result is mock_interface.localNode
 
@@ -429,7 +429,7 @@ class TestGetNode:
             mock_node_class.return_value = mock_node
             mock_node.waitForConfig.return_value = True
 
-            result = node_view.getNode("!1234abcd", requestChannels=False)
+            result = node_view.get_node("!1234abcd", requestChannels=False)
 
         assert result is mock_node
 
@@ -447,7 +447,7 @@ class TestGetMyNodeInfo:
         mock_interface.myInfo = my_info
         mock_interface.nodesByNum = {12345: {"num": 12345, "user": {"id": "!1234"}}}
 
-        result = node_view.getMyNodeInfo()
+        result = node_view.get_my_node_info()
 
         assert result is not None
         assert result["num"] == 12345
@@ -459,7 +459,7 @@ class TestGetMyNodeInfo:
         """Test getting my node info when myInfo is None."""
         mock_interface.myInfo = None
 
-        result = node_view.getMyNodeInfo()
+        result = node_view.get_my_node_info()
 
         assert result is None
 
@@ -478,7 +478,7 @@ class TestGetMyUser:
             12345: {"num": 12345, "user": {"id": "!1234", "longName": "Test User"}}
         }
 
-        result = node_view.getMyUser()
+        result = node_view.get_my_user()
 
         assert result is not None
         assert result["longName"] == "Test User"
@@ -490,7 +490,7 @@ class TestGetMyUser:
         """Test getting my user when no node info."""
         mock_interface.myInfo = None
 
-        result = node_view.getMyUser()
+        result = node_view.get_my_user()
 
         assert result is None
 
@@ -512,7 +512,7 @@ class TestGetLongName:
             }
         }
 
-        result = node_view.getLongName()
+        result = node_view.get_long_name()
 
         assert result == "Test User Long Name"
 
@@ -523,7 +523,7 @@ class TestGetLongName:
         """Test getting long name when no user info."""
         mock_interface.myInfo = None
 
-        result = node_view.getLongName()
+        result = node_view.get_long_name()
 
         assert result is None
 
@@ -542,7 +542,7 @@ class TestGetShortName:
             12345: {"num": 12345, "user": {"id": "!1234", "shortName": "TU"}}
         }
 
-        result = node_view.getShortName()
+        result = node_view.get_short_name()
 
         assert result == "TU"
 
@@ -553,7 +553,7 @@ class TestGetShortName:
         """Test getting short name when no user info."""
         mock_interface.myInfo = None
 
-        result = node_view.getShortName()
+        result = node_view.get_short_name()
 
         assert result is None
 
@@ -573,7 +573,7 @@ class TestGetPublicKey:
             12345: {"num": 12345, "user": {"id": "!1234", "publicKey": public_key}}
         }
 
-        result = node_view.getPublicKey()
+        result = node_view.get_public_key()
 
         assert result == public_key
 
@@ -584,7 +584,7 @@ class TestGetPublicKey:
         """Test getting public key when no user info."""
         mock_interface.myInfo = None
 
-        result = node_view.getPublicKey()
+        result = node_view.get_public_key()
 
         assert result is None
 
@@ -599,7 +599,7 @@ class TestGetCannedMessage:
         """Test that getCannedMessage delegates to localNode."""
         mock_interface.localNode.get_canned_message.return_value = "Canned message text"
 
-        result = node_view.getCannedMessage()
+        result = node_view.get_canned_message()
 
         assert result == "Canned message text"
         mock_interface.localNode.get_canned_message.assert_called_once()
@@ -615,7 +615,7 @@ class TestGetRingtone:
         """Test that getRingtone delegates to localNode."""
         mock_interface.localNode.get_ringtone.return_value = "Ringtone melody"
 
-        result = node_view.getRingtone()
+        result = node_view.get_ringtone()
 
         assert result == "Ringtone melody"
         mock_interface.localNode.get_ringtone.assert_called_once()

--- a/meshtastic/tests/test_receive_pipeline.py
+++ b/meshtastic/tests/test_receive_pipeline.py
@@ -226,16 +226,16 @@ class TestReceivePipelineProperties:
         self, receive_pipeline: ReceivePipeline, mock_interface: MagicMock
     ) -> None:
         """Test configId property."""
-        assert receive_pipeline.configId == 123
+        assert receive_pipeline.config_id == 123
         mock_interface.configId = 456
-        assert receive_pipeline.configId == 456
+        assert receive_pipeline.config_id == 456
 
     @pytest.mark.unit
     def test_local_node_property(
         self, receive_pipeline: ReceivePipeline, mock_interface: MagicMock
     ) -> None:
         """Test localNode property."""
-        assert receive_pipeline.localNode is mock_interface.localNode
+        assert receive_pipeline.local_node is mock_interface.localNode
 
     @pytest.mark.unit
     def test_my_info_property(
@@ -244,7 +244,7 @@ class TestReceivePipelineProperties:
         """Test myInfo property."""
         my_info = mesh_pb2.MyNodeInfo()
         mock_interface.myInfo = my_info
-        assert receive_pipeline.myInfo is my_info
+        assert receive_pipeline.my_info is my_info
 
     @pytest.mark.unit
     def test_metadata_property(
@@ -271,7 +271,7 @@ class TestReceivePipelineProperties:
         """Test nodesByNum property."""
         nodes_by_num = {1234: {"num": 1234}}
         mock_interface.nodesByNum = nodes_by_num
-        assert receive_pipeline.nodesByNum is nodes_by_num
+        assert receive_pipeline.nodes_by_num is nodes_by_num
 
 
 class TestParseFromRadioBytes:

--- a/meshtastic/tests/test_send_pipeline.py
+++ b/meshtastic/tests/test_send_pipeline.py
@@ -286,14 +286,14 @@ class TestSendPipelineProperties:
         self, send_pipeline: SendPipeline, mock_interface: MagicMock
     ) -> None:
         """Test localNode property."""
-        assert send_pipeline.localNode is mock_interface.localNode
+        assert send_pipeline.local_node is mock_interface.localNode
 
     @pytest.mark.unit
     def test_my_info_property(
         self, send_pipeline: SendPipeline, mock_interface: MagicMock
     ) -> None:
         """Test myInfo property."""
-        assert send_pipeline.myInfo is mock_interface.myInfo
+        assert send_pipeline.my_info is mock_interface.myInfo
 
     @pytest.mark.unit
     def test_nodes_property(
@@ -307,16 +307,16 @@ class TestSendPipelineProperties:
         self, send_pipeline: SendPipeline, mock_interface: MagicMock
     ) -> None:
         """Test nodesByNum property."""
-        assert send_pipeline.nodesByNum is mock_interface.nodesByNum
+        assert send_pipeline.nodes_by_num is mock_interface.nodesByNum
 
     @pytest.mark.unit
     def test_config_id_property(
         self, send_pipeline: SendPipeline, mock_interface: MagicMock
     ) -> None:
         """Test configId property (lines 162-164)."""
-        assert send_pipeline.configId == 123
+        assert send_pipeline.config_id == 123
         mock_interface.configId = 456
-        assert send_pipeline.configId == 456
+        assert send_pipeline.config_id == 456
 
     @pytest.mark.unit
     def test_no_proto_property(
@@ -324,9 +324,9 @@ class TestSendPipelineProperties:
     ) -> None:
         """Test noProto property (lines 167-169)."""
         mock_interface.noProto = True
-        assert send_pipeline.noProto is True
+        assert send_pipeline.no_proto is True
         mock_interface.noProto = False
-        assert send_pipeline.noProto is False
+        assert send_pipeline.no_proto is False
 
     @pytest.mark.unit
     def test_acknowledgment_property(
@@ -349,9 +349,9 @@ class TestSendText:
     @pytest.mark.unit
     def test_send_text_calls_send_data(self, send_pipeline: SendPipeline) -> None:
         """Test that sendText calls sendData with encoded text."""
-        with patch.object(send_pipeline, "sendData") as mock_send_data:
+        with patch.object(send_pipeline, "send_data") as mock_send_data:
             mock_send_data.return_value = MagicMock()
-            send_pipeline.sendText(
+            send_pipeline.send_text(
                 text="Hello, World!",
                 destinationId="!1234abcd",
                 wantAck=True,
@@ -371,9 +371,9 @@ class TestSendAlert:
     @pytest.mark.unit
     def test_send_alert_calls_send_data(self, send_pipeline: SendPipeline) -> None:
         """Test that sendAlert calls sendData with ALERT_APP port."""
-        with patch.object(send_pipeline, "sendData") as mock_send_data:
+        with patch.object(send_pipeline, "send_data") as mock_send_data:
             mock_send_data.return_value = MagicMock()
-            send_pipeline.sendAlert(
+            send_pipeline.send_alert(
                 text="Alert message",
                 destinationId=BROADCAST_ADDR,
                 channelIndex=0,
@@ -393,7 +393,7 @@ class TestSendMqttClientProxyMessage:
     def test_send_mqtt_client_proxy_message(self, send_pipeline: SendPipeline) -> None:
         """Test sending MQTT client proxy message."""
         with patch.object(send_pipeline, "_send_to_radio") as mock_send:
-            send_pipeline.sendMqttClientProxyMessage("test/topic", b"test data")
+            send_pipeline.send_mqtt_client_proxy_message("test/topic", b"test data")
 
         mock_send.assert_called_once()
         call_args = mock_send.call_args[0][0]
@@ -410,7 +410,7 @@ class TestSendData:
         with patch.object(send_pipeline, "_clear_wait_error") as mock_clear:
             with patch.object(send_pipeline, "_send_data_with_wait") as mock_send:
                 mock_send.return_value = MagicMock()
-                send_pipeline.sendData(
+                send_pipeline.send_data(
                     b"test data",
                     destinationId=BROADCAST_ADDR,
                     portNum=portnums_pb2.PortNum.POSITION_APP,
@@ -426,7 +426,7 @@ class TestSendData:
         with patch.object(send_pipeline, "_clear_wait_error") as mock_clear:
             with patch.object(send_pipeline, "_send_data_with_wait") as mock_send:
                 mock_send.return_value = MagicMock()
-                send_pipeline.sendData(
+                send_pipeline.send_data(
                     b"test data",
                     destinationId=BROADCAST_ADDR,
                     portNum=portnums_pb2.PortNum.TEXT_MESSAGE_APP,
@@ -720,7 +720,7 @@ class TestOnResponsePosition:
         with patch(
             "meshtastic.mesh_interface_runtime.send_pipeline._on_response_position"
         ) as mock_flow:
-            send_pipeline.onResponsePosition(packet)
+            send_pipeline.on_response_position(packet)
 
         mock_flow.assert_called_once_with(send_pipeline._port.facade, packet)
 
@@ -732,10 +732,10 @@ class TestSendPosition:
     def test_send_position_delegates(self, send_pipeline: SendPipeline) -> None:
         """Test sendPosition delegates to flow function."""
         with patch(
-            "meshtastic.mesh_interface_runtime.send_pipeline.sendPosition"
+            "meshtastic.mesh_interface_runtime.send_pipeline.send_position"
         ) as mock_flow:
             mock_flow.return_value = MagicMock()
-            send_pipeline.sendPosition(
+            send_pipeline.send_position(
                 latitude=37.456,
                 longitude=-122.2345,
                 altitude=100,
@@ -762,7 +762,7 @@ class TestOnResponseTraceRoute:
         with patch(
             "meshtastic.mesh_interface_runtime.send_pipeline._on_response_traceroute"
         ) as mock_flow:
-            send_pipeline.onResponseTraceRoute(packet)
+            send_pipeline.on_response_trace_route(packet)
 
         mock_flow.assert_called_once_with(send_pipeline._port.facade, packet)
 
@@ -774,9 +774,9 @@ class TestSendTraceRoute:
     def test_send_traceroute_delegates(self, send_pipeline: SendPipeline) -> None:
         """Test sendTraceRoute delegates to flow function."""
         with patch(
-            "meshtastic.mesh_interface_runtime.send_pipeline.sendTraceroute"
+            "meshtastic.mesh_interface_runtime.send_pipeline.send_traceroute"
         ) as mock_flow:
-            send_pipeline.sendTraceRoute("!1234abcd", hopLimit=3, channelIndex=0)
+            send_pipeline.send_trace_route("!1234abcd", hopLimit=3, channelIndex=0)
 
         mock_flow.assert_called_once_with(
             send_pipeline._port.facade, "!1234abcd", 3, channelIndex=0
@@ -788,7 +788,7 @@ class TestSendTraceRoute:
         with patch(
             "meshtastic.mesh_interface_runtime.send_pipeline._request_traceroute"
         ) as mock_flow:
-            result = send_pipeline.requestTraceRoute(
+            result = send_pipeline.request_trace_route(
                 "!1234abcd", hopLimit=3, channelIndex=1
             )
 
@@ -805,9 +805,9 @@ class TestSendTelemetry:
     def test_send_telemetry_delegates(self, send_pipeline: SendPipeline) -> None:
         """Test sendTelemetry delegates to flow function."""
         with patch(
-            "meshtastic.mesh_interface_runtime.send_pipeline.sendTelemetry"
+            "meshtastic.mesh_interface_runtime.send_pipeline.send_telemetry"
         ) as mock_flow:
-            send_pipeline.sendTelemetry(
+            send_pipeline.send_telemetry(
                 destinationId=BROADCAST_ADDR,
                 wantResponse=True,
                 channelIndex=0,
@@ -827,7 +827,7 @@ class TestOnResponseTelemetry:
         with patch(
             "meshtastic.mesh_interface_runtime.send_pipeline._on_response_telemetry"
         ) as mock_flow:
-            send_pipeline.onResponseTelemetry(packet)
+            send_pipeline.on_response_telemetry(packet)
 
         mock_flow.assert_called_once_with(send_pipeline._port.facade, packet)
 
@@ -843,7 +843,7 @@ class TestOnResponseWaypoint:
         with patch(
             "meshtastic.mesh_interface_runtime.send_pipeline._on_response_waypoint"
         ) as mock_flow:
-            send_pipeline.onResponseWaypoint(packet)
+            send_pipeline.on_response_waypoint(packet)
 
         mock_flow.assert_called_once_with(send_pipeline._port.facade, packet)
 
@@ -855,10 +855,10 @@ class TestSendWaypoint:
     def test_send_waypoint_delegates(self, send_pipeline: SendPipeline) -> None:
         """Test sendWaypoint delegates to flow function."""
         with patch(
-            "meshtastic.mesh_interface_runtime.send_pipeline.sendWaypoint"
+            "meshtastic.mesh_interface_runtime.send_pipeline.send_waypoint"
         ) as mock_flow:
             mock_flow.return_value = MagicMock()
-            send_pipeline.sendWaypoint(
+            send_pipeline.send_waypoint(
                 name="Test Waypoint",
                 description="Test Description",
                 icon=1,
@@ -877,10 +877,10 @@ class TestDeleteWaypoint:
     def test_delete_waypoint_delegates(self, send_pipeline: SendPipeline) -> None:
         """Test deleteWaypoint delegates to flow function."""
         with patch(
-            "meshtastic.mesh_interface_runtime.send_pipeline.deleteWaypoint"
+            "meshtastic.mesh_interface_runtime.send_pipeline.delete_waypoint"
         ) as mock_flow:
             mock_flow.return_value = MagicMock()
-            send_pipeline.deleteWaypoint(
+            send_pipeline.delete_waypoint(
                 waypoint_id=12345,
                 destinationId=BROADCAST_ADDR,
             )
@@ -1077,24 +1077,6 @@ class TestSendPacket:
         assert "noProto" in caplog.text
 
 
-class TestSendPacketAlias:
-    """Tests for _sendPacket alias (lines 699-716)."""
-
-    @pytest.mark.unit
-    def test_send_packet_alias(self, send_pipeline: SendPipeline) -> None:
-        """Test that _sendPacket is an alias for _send_packet."""
-        mesh_packet = mesh_pb2.MeshPacket()
-
-        with patch.object(send_pipeline, "_send_packet") as mock_send:
-            send_pipeline._sendPacket(
-                mesh_packet,
-                destinationId=BROADCAST_ADDR,
-                wantAck=True,
-                hopLimit=3,
-            )
-
-        mock_send.assert_called_once()
-
 
 class TestWaitForConfig:
     """Tests for waitForConfig method (lines 718-727)."""
@@ -1110,7 +1092,7 @@ class TestWaitForConfig:
             True
         )
 
-        send_pipeline.waitForConfig()
+        send_pipeline.wait_for_config()
 
         mock_interface.localNode._channel_request_runtime._timeout_for_field.assert_called_once_with(
             "lora", LORA_CONFIG_WAIT_SECONDS
@@ -1125,7 +1107,7 @@ class TestWaitForConfig:
         mock_interface.localNode.waitForConfig.return_value = True
 
         with pytest.raises(Exception, match="Timed out"):
-            send_pipeline.waitForConfig()
+            send_pipeline.wait_for_config()
 
     @pytest.mark.unit
     def test_wait_for_config_lora_wait_failure_raises(
@@ -1142,7 +1124,7 @@ class TestWaitForConfig:
             mock_interface.MeshInterfaceError,
             match="Timed out waiting for interface config",
         ):
-            send_pipeline.waitForConfig()
+            send_pipeline.wait_for_config()
 
     @pytest.mark.unit
     def test_wait_for_config_lora_field_absent_graceful_success(
@@ -1174,7 +1156,7 @@ class TestWaitForConfig:
         mock_interface.localNode.waitForConfig.return_value = True
         mock_interface.localNode._channel_request_runtime = real_runtime
 
-        send_pipeline.waitForConfig()
+        send_pipeline.wait_for_config()
 
 
 class TestWaitForAckNak:
@@ -1191,7 +1173,7 @@ class TestWaitForAckNak:
         )
 
         # Should not raise
-        send_pipeline.waitForAckNak()
+        send_pipeline.wait_for_ack_nak()
 
     @pytest.mark.unit
     def test_wait_for_ack_nak_timeout_raises(
@@ -1204,7 +1186,7 @@ class TestWaitForAckNak:
         )
 
         with pytest.raises(Exception, match="Timed out"):
-            send_pipeline.waitForAckNak()
+            send_pipeline.wait_for_ack_nak()
 
 
 class TestWaitForTraceRoute:
@@ -1222,7 +1204,7 @@ class TestWaitForTraceRoute:
         mock_interface._request_wait_runtime.retire_wait_request.side_effect = None
 
         # Should not raise
-        send_pipeline.waitForTraceRoute(waitFactor=1.0)
+        send_pipeline.wait_for_trace_route(waitFactor=1.0)
 
     @pytest.mark.unit
     def test_wait_for_traceroute_with_request_id(
@@ -1236,7 +1218,7 @@ class TestWaitForTraceRoute:
         mock_interface._request_wait_runtime.retire_wait_request.side_effect = None
 
         # Should not raise
-        send_pipeline.waitForTraceRoute(waitFactor=1.0, request_id=12345)
+        send_pipeline.wait_for_trace_route(waitFactor=1.0, request_id=12345)
 
 
 class TestWaitForTelemetry:
@@ -1254,7 +1236,7 @@ class TestWaitForTelemetry:
         mock_interface._request_wait_runtime.retire_wait_request.side_effect = None
 
         # Should not raise
-        send_pipeline.waitForTelemetry()
+        send_pipeline.wait_for_telemetry()
 
     @pytest.mark.unit
     def test_wait_for_telemetry_with_request_id(
@@ -1268,7 +1250,7 @@ class TestWaitForTelemetry:
         mock_interface._request_wait_runtime.retire_wait_request.side_effect = None
 
         # Should not raise
-        send_pipeline.waitForTelemetry(request_id=12345)
+        send_pipeline.wait_for_telemetry(request_id=12345)
 
 
 class TestWaitForPosition:
@@ -1286,7 +1268,7 @@ class TestWaitForPosition:
         mock_interface._request_wait_runtime.retire_wait_request.side_effect = None
 
         # Should not raise
-        send_pipeline.waitForPosition()
+        send_pipeline.wait_for_position()
 
     @pytest.mark.unit
     def test_wait_for_position_with_request_id(
@@ -1300,7 +1282,7 @@ class TestWaitForPosition:
         mock_interface._request_wait_runtime.retire_wait_request.side_effect = None
 
         # Should not raise
-        send_pipeline.waitForPosition(request_id=12345)
+        send_pipeline.wait_for_position(request_id=12345)
 
 
 class TestWaitForWaypoint:
@@ -1318,7 +1300,7 @@ class TestWaitForWaypoint:
         mock_interface._request_wait_runtime.retire_wait_request.side_effect = None
 
         # Should not raise
-        send_pipeline.waitForWaypoint()
+        send_pipeline.wait_for_waypoint()
 
     @pytest.mark.unit
     def test_wait_for_waypoint_with_request_id(
@@ -1332,7 +1314,7 @@ class TestWaitForWaypoint:
         mock_interface._request_wait_runtime.retire_wait_request.side_effect = None
 
         # Should not raise
-        send_pipeline.waitForWaypoint(request_id=12345)
+        send_pipeline.wait_for_waypoint(request_id=12345)
 
 
 class TestSendToRadio:
@@ -1418,7 +1400,7 @@ class TestSendHeartbeat:
     def test_send_heartbeat(self, send_pipeline: SendPipeline) -> None:
         """Test sending heartbeat message."""
         with patch.object(send_pipeline, "_send_to_radio") as mock_send:
-            send_pipeline.sendHeartbeat()
+            send_pipeline.send_heartbeat()
 
         mock_send.assert_called_once()
         # call_args[0][0] would be the ToRadio message with heartbeat field set


### PR DESCRIPTION
## Overview

This change normalizes implementation-only MeshInterface runtime names to snake_case. The cleanup is limited to internal runtime collaborators and helper functions; the public `MeshInterface` API and documented compatibility shims keep their existing names and signatures.

### Key changes

**Refactors**

* Normalize `SendPipeline`, `ReceivePipeline`, and `NodeView` methods and properties to snake_case.
* Normalize internal flow helpers and node-data utilities, and update their internal call sites and tests.
* Update MeshInterface delegation and CLI field validation to call the normalized internal helpers without changing their public entry points.

**Compatibility**

* Keep the public `MeshInterface` camelCase surface unchanged.
* Keep the documented `MeshInterface._sendPacket()` compatibility shim unchanged.
* Remove only the duplicate private `_sendPacket` alias on the internal `SendPipeline`, which is not part of the supported runtime compatibility surface.

**Tests**

* Update runtime, behavioral compatibility, send-concurrency, wait/receive, node-view, and node-data tests for the internal names.
* Preserve existing observable log text and callback behavior.