### PR TITLE
Normalize internal Node runtime naming

### DIFF
--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -561,7 +561,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
             list will be normalized (indices fixed) and padded as needed to meet expected
             channel count.
         """
-        self._channel_request_runtime.setChannels(channels)
+        self._channel_request_runtime.set_channels(channels)
 
     def requestChannels(self, startingIndex: int = 0) -> None:
         """Request channel definitions from the node, starting at the given channel index.
@@ -575,7 +575,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
         startingIndex : int
             Zero-based channel index to start fetching from (typically 0-7). (Default value = 0)
         """
-        self._channel_request_runtime.requestChannels(starting_index=startingIndex)
+        self._channel_request_runtime.request_channels(starting_index=startingIndex)
 
     def _invalidate_channel_cache(self) -> None:
         """Clear cached channel state under the channel-state owner lock."""
@@ -597,7 +597,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
             contain either `getConfigResponse` or `getModuleConfigResponse` and accompanying
             `raw` bytes for the returned field.
         """
-        self._settings_response_runtime.handleSettingsResponse(p)
+        self._settings_response_runtime.handle_settings_response(p)
 
     def requestConfig(
         self, configType: int | FieldDescriptor, adminIndex: int | None = None
@@ -621,7 +621,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
             configured admin channel is used. Pass 0 to force channel 0.
             (Default value = None)
         """
-        self._settings_runtime.requestConfig(
+        self._settings_runtime.request_config(
             configType,
             admin_index=adminIndex,
         )
@@ -650,7 +650,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
         bool
             True if the attribute was set before the timeout expired, False otherwise.
         """
-        return self._channel_request_runtime.waitForConfig(attribute=attribute)
+        return self._channel_request_runtime.wait_for_config(attribute=attribute)
 
     def _raise_interface_error(self, message: str) -> NoReturn:
         """Raise a MeshInterface-style error with the provided message.
@@ -696,7 +696,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
             If `config_name` is not one of the supported names, or if
             localConfig/moduleConfig has not been loaded.
         """
-        self._settings_runtime.writeConfig(config_name)
+        self._settings_runtime.write_config(config_name)
 
     def _write_channel_snapshot(
         self,
@@ -903,7 +903,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
         MeshInterfaceError
             If `long_name` or `short_name` is provided but empty or whitespace-only after trimming.
         """
-        return self._owner_profile_runtime.setOwner(
+        return self._owner_profile_runtime.set_owner(
             long_name=long_name,
             short_name=short_name,
             is_licensed=is_licensed,
@@ -1058,7 +1058,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
             module is not present, the ringtone is unavailable, or the request
             timed out.
         """
-        return self._content_request_runtime.readRingtone()
+        return self._content_request_runtime.read_ringtone()
 
     def _set_ringtone(self, ringtone: str) -> mesh_pb2.MeshPacket | None:
         """Set the node's ringtone.
@@ -1083,7 +1083,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
         MeshInterfaceError
             If `ringtone` length exceeds 230 characters.
         """
-        return self._content_request_runtime.writeRingtone(ringtone)
+        return self._content_request_runtime.write_ringtone(ringtone)
 
     def onResponseRequestCannedMessagePluginMessageMessages(
         self, p: dict[str, Any]
@@ -1114,7 +1114,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
         str | None
             str or None: The assembled canned message if available, or None if the module is unavailable or no response was received.
         """
-        return self._content_request_runtime.readCannedMessage()
+        return self._content_request_runtime.read_canned_message()
 
     def _set_canned_message(self, message: str) -> mesh_pb2.MeshPacket | None:
         """Set the device's canned message.
@@ -1139,7 +1139,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
         MeshInterfaceError
             If `message` length is greater than 200 characters.
         """
-        return self._content_request_runtime.writeCannedMessage(message)
+        return self._content_request_runtime.write_canned_message(message)
 
     # COMPAT_STABLE_SHIM: alias for getRingtone
     def get_ringtone(self) -> str | None:
@@ -1267,7 +1267,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
         mesh_pb2.MeshPacket | None
             A MeshPacket for the sent admin request, or `None` if the admin message was not sent.
         """
-        return self._admin_command_runtime.exitSimulator()
+        return self._admin_command_runtime.exit_simulator()
 
     def reboot(self, secs: int = 10) -> mesh_pb2.MeshPacket | None:
         """Request the node to reboot after a delay.
@@ -1296,7 +1296,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
         mesh_pb2.MeshPacket | None
             The sent admin packet if available, or `None` otherwise.
         """
-        return self._admin_command_runtime.beginSettingsTransaction()
+        return self._admin_command_runtime.begin_settings_transaction()
 
     def commitSettingsTransaction(self) -> mesh_pb2.MeshPacket | None:
         """Commit the node's open settings edit transaction.
@@ -1308,7 +1308,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
         mesh_pb2.MeshPacket | None
             The sent Admin `MeshPacket` when available, or `None`.
         """
-        return self._admin_command_runtime.commitSettingsTransaction()
+        return self._admin_command_runtime.commit_settings_transaction()
 
     def rebootOTA(self, secs: int = 10) -> mesh_pb2.MeshPacket | None:
         """Request the node to perform an OTA reboot after a given delay.
@@ -1323,7 +1323,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
         mesh_pb2.MeshPacket | None
             The sent Admin message packet, or `None` if no packet was produced.
         """
-        return self._admin_command_runtime.rebootOta(secs)
+        return self._admin_command_runtime.reboot_ota(secs)
 
     def startOTA(
         self,
@@ -1359,7 +1359,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
         MeshInterfaceError
             If called for a non-local node.
         """
-        return self._admin_command_runtime.startOta(
+        return self._admin_command_runtime.start_ota(
             mode=mode,
             ota_file_hash=ota_file_hash,
             ota_mode=ota_mode,
@@ -1378,7 +1378,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
         mesh_pb2.MeshPacket | None
             The sent Admin message packet, or `None` if no packet was sent.
         """
-        return self._admin_command_runtime.enterDfuMode()
+        return self._admin_command_runtime.enter_dfu_mode()
 
     def shutdown(self, secs: int = 10) -> mesh_pb2.MeshPacket | None:
         """Request the node to shut down after a given number of seconds.
@@ -1442,7 +1442,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
         mesh_pb2.MeshPacket | None
             The sent admin packet if sending succeeded, or None otherwise.
         """
-        return self._admin_command_runtime.factoryReset(full=full)
+        return self._admin_command_runtime.factory_reset(full=full)
 
     def _get_factory_reset_request_value(self) -> int:
         """Return factory-reset sentinel value used for admin reset requests."""
@@ -1465,7 +1465,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
         mesh_pb2.MeshPacket | None
             The admin packet returned by the send operation if available, `None` otherwise.
         """
-        return self._admin_command_runtime.removeNode(nodeId)
+        return self._admin_command_runtime.remove_node(nodeId)
 
     def setFavorite(self, nodeId: int | str) -> mesh_pb2.MeshPacket | None:
         """Mark a node as a favorite in the target device's NodeDB.
@@ -1480,7 +1480,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
         mesh_pb2.MeshPacket | None
             The response packet if one was received, `None` otherwise.
         """
-        return self._admin_command_runtime.setFavorite(nodeId)
+        return self._admin_command_runtime.set_favorite(nodeId)
 
     def removeFavorite(self, nodeId: int | str) -> mesh_pb2.MeshPacket | None:
         """Unmark a node as a favorite in the device's NodeDB.
@@ -1495,7 +1495,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
         mesh_pb2.MeshPacket | None
             The Admin packet sent to the device, or `None` if no packet was sent.
         """
-        return self._admin_command_runtime.removeFavorite(nodeId)
+        return self._admin_command_runtime.remove_favorite(nodeId)
 
     def setIgnored(self, nodeId: int | str) -> mesh_pb2.MeshPacket | None:
         """Mark a node in the device NodeDB as ignored.
@@ -1510,7 +1510,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
         mesh_pb2.MeshPacket | None
             The AdminMessage/packet sent to request the change, or `None` if no packet was sent.
         """
-        return self._admin_command_runtime.setIgnored(nodeId)
+        return self._admin_command_runtime.set_ignored(nodeId)
 
     def removeIgnored(self, nodeId: int | str) -> mesh_pb2.MeshPacket | None:
         """Unmark a node as ignored in the device's NodeDB.
@@ -1525,7 +1525,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
         mesh_pb2.MeshPacket | None
             `mesh_pb2.MeshPacket` if an AdminMessage was sent, `None` otherwise.
         """
-        return self._admin_command_runtime.removeIgnored(nodeId)
+        return self._admin_command_runtime.remove_ignored(nodeId)
 
     def resetNodeDb(self) -> mesh_pb2.MeshPacket | None:
         """Request that the node clear its stored NodeDB (node database).
@@ -1538,7 +1538,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
         mesh_pb2.MeshPacket | None
             The AdminMessage packet sent, or `None` if no packet was sent.
         """
-        return self._admin_command_runtime.resetNodeDb()
+        return self._admin_command_runtime.reset_node_db()
 
     def setFixedPosition(
         self, lat: int | float | None, lon: int | float | None, alt: int | None
@@ -1639,7 +1639,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
             Decoded packet containing at minimum a 'decoded' key with routing and
             admin/raw get_device_metadata_response fields.
         """
-        self._metadata_response_runtime.handleMetadataResponse(p)
+        self._metadata_response_runtime.handle_metadata_response(p)
 
     def onResponseRequestChannel(self, p: dict[str, Any]) -> None:
         """Process a response packet for a previously requested channel and update the Node's channel state.
@@ -1657,7 +1657,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
             - a routing message with 'routing.errorReason', or
             - an admin message with 'admin.raw.get_channel_response' (a Channel protobuf-like object with an `index` field).
         """
-        self._channel_response_runtime.handleChannelResponse(p)
+        self._channel_response_runtime.handle_channel_response(p)
 
     def onAckNak(self, p: dict[str, Any]) -> None:
         """Handle an incoming ACK/NAK admin response and update interface acknowledgment state.
@@ -1693,7 +1693,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
         mesh_pb2.MeshPacket | None
             The AdminMessage packet sent to the interface, or `None` if sending was skipped (e.g., protocol disabled).
         """
-        return self._channel_request_runtime.requestChannel(channelNum)
+        return self._channel_request_runtime.request_channel(channelNum)
 
     # pylint: disable=R1710
     def _send_admin(

--- a/meshtastic/node_runtime/__init__.py
+++ b/meshtastic/node_runtime/__init__.py
@@ -17,8 +17,6 @@ from .shared import (
     MAX_SHORT_NAME_LEN,
     METADATA_STDOUT_COMPAT_WAIT_SECONDS,
     NAMED_ADMIN_CHANNEL_NAME,
-    isNamedAdminChannelName,
-    orderedAdminIndexes,
 )
 
 __all__ = [
@@ -32,6 +30,4 @@ __all__ = [
     "MAX_SHORT_NAME_LEN",
     "METADATA_STDOUT_COMPAT_WAIT_SECONDS",
     "NAMED_ADMIN_CHANNEL_NAME",
-    "isNamedAdminChannelName",
-    "orderedAdminIndexes",
 ]

--- a/meshtastic/node_runtime/channel_export_runtime.py
+++ b/meshtastic/node_runtime/channel_export_runtime.py
@@ -96,17 +96,13 @@ class _NodeChannelExportRuntime:
         encoded = base64.urlsafe_b64encode(serialized_channel_set).decode("ascii")
         return encoded.rstrip("=")
 
-    def getUrl(self, *, includeAll: bool = True) -> str:
-        """Build channel URL export with preserved includeAll and LoRa semantics."""
+    def get_url(self, *, include_all: bool = True) -> str:
+        """Build a channel URL while preserving LoRa export semantics."""
         channels_snapshot = self._snapshot_channels()
         encoded = self._build_and_encode_channel_set(
-            channels_snapshot, include_all=includeAll
+            channels_snapshot, include_all=include_all
         )
         return f"https://meshtastic.org/e/#{encoded}"
-
-    def get_url(self, *, include_all: bool = True) -> str:
-        """COMPAT_STABLE_SHIM: Alias for getUrl."""
-        return self.getUrl(includeAll=include_all)
 
     def _get_url_from_snapshot(
         self,
@@ -124,8 +120,8 @@ class _NodeChannelExportRuntime:
         )
         return f"https://meshtastic.org/e/#{encoded}"
 
-    def getChannelsWithHash(self) -> list[dict[str, Any]]:
-        """Return index/role/name/hash descriptors for current channel snapshot."""
+    def get_channels_with_hash(self) -> list[dict[str, Any]]:
+        """Return index/role/name/hash descriptors for the current channels."""
         result: list[dict[str, Any]] = []
         channels_snapshot = self._snapshot_channels()
         if channels_snapshot:
@@ -152,10 +148,6 @@ class _NodeChannelExportRuntime:
                     }
                 )
         return result
-
-    def get_channels_with_hash(self) -> list[dict[str, Any]]:
-        """COMPAT_STABLE_SHIM: Alias for getChannelsWithHash."""
-        return self.getChannelsWithHash()
 
     def _turn_off_encryption_on_primary_channel(self) -> None:
         """Disable primary-channel encryption and persist updated channel state."""

--- a/meshtastic/node_runtime/channel_lookup_runtime.py
+++ b/meshtastic/node_runtime/channel_lookup_runtime.py
@@ -3,9 +3,7 @@
 from collections.abc import Callable
 
 from meshtastic.node_runtime.channel_state import _NodeChannelState
-from meshtastic.node_runtime.shared import (
-    isNamedAdminChannelName as _isNamedAdminChannelName,
-)
+from meshtastic.node_runtime.shared import _is_named_admin_channel_name
 from meshtastic.protobuf import channel_pb2
 
 
@@ -43,7 +41,7 @@ class _NodeChannelLookupRuntime:
 
     def _get_named_admin_channel_index(self) -> int | None:
         """Return index of explicitly named ``admin`` channel, if present."""
-        predicate: Callable[[str], bool] = _isNamedAdminChannelName
+        predicate: Callable[[str], bool] = _is_named_admin_channel_name
         return self._channel_state.named_admin_index(is_named_admin=predicate)
 
     def _get_admin_channel_index(self) -> int:

--- a/meshtastic/node_runtime/channel_request_runtime.py
+++ b/meshtastic/node_runtime/channel_request_runtime.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 class _HasChannelRequestFailed(Protocol):
     """Protocol for objects providing channel request failure check."""
 
-    def hasChannelRequestFailed(self) -> bool:
+    def has_channel_request_failed(self) -> bool:
         """Return True if a channel request has failed."""
         ...  # pylint: disable=unnecessary-ellipsis
 
@@ -27,16 +27,8 @@ class _HasChannelRequestFailed(Protocol):
 def _get_channel_request_failed_fn(
     channel_response_runtime: object,
 ) -> Callable[[], bool] | None:
-    """Extract hasChannelRequestFailed or has_channel_request_failed as callable."""
-    fn = getattr(
-        channel_response_runtime,
-        "hasChannelRequestFailed",
-        None,
-    ) or getattr(
-        channel_response_runtime,
-        "has_channel_request_failed",
-        None,
-    )
+    """Extract the channel-request failure probe when available."""
+    fn = getattr(channel_response_runtime, "has_channel_request_failed", None)
     if callable(fn):
         return cast(Callable[[], bool] | None, fn)
     return None
@@ -96,15 +88,11 @@ class _NodeChannelRequestRuntime:
         self._node = node
         self._channel_state = channel_state
 
-    def setChannels(self, channels: Sequence[channel_pb2.Channel]) -> None:
-        """Set channels from sequence with copy + normalization semantics."""
+    def set_channels(self, channels: Sequence[channel_pb2.Channel]) -> None:
+        """Set channels from a sequence with copy and normalization semantics."""
         self._channel_state.replace_with_copies(channels)
 
-    def set_channels(self, channels: Sequence[channel_pb2.Channel]) -> None:
-        """COMPAT_STABLE_SHIM: Silent alias for setChannels."""
-        return self.setChannels(channels)
-
-    def requestChannels(self, *, starting_index: int = 0) -> None:
+    def request_channels(self, *, starting_index: int = 0) -> None:
         """Bootstrap channel request flow from ``starting_index``."""
         logger.debug("requestChannels for nodeNum:%s", self._node.nodeNum)
         if not 0 <= starting_index < MAX_CHANNELS:
@@ -116,13 +104,9 @@ class _NodeChannelRequestRuntime:
             return
         if starting_index == 0:
             self._channel_state.reset_for_download()
-        self.requestChannel(starting_index)
+        self.request_channel(starting_index)
 
-    def request_channels(self, *, starting_index: int = 0) -> None:
-        """COMPAT_STABLE_SHIM: Silent alias for requestChannels."""
-        return self.requestChannels(starting_index=starting_index)
-
-    def waitForConfig(self, *, attribute: str = "channels") -> bool:
+    def wait_for_config(self, *, attribute: str = "channels") -> bool:
         """Wait for node attribute using historical timeout semantics."""
         if attribute == "channels":
             channel_response_runtime = getattr(
@@ -131,8 +115,7 @@ class _NodeChannelRequestRuntime:
                 None,
             )
             has_channel_request_failed = (
-                getattr(channel_response_runtime, "hasChannelRequestFailed", None)
-                or getattr(channel_response_runtime, "has_channel_request_failed", None)
+                getattr(channel_response_runtime, "has_channel_request_failed", None)
                 if channel_response_runtime is not None
                 else None
             )
@@ -171,10 +154,6 @@ class _NodeChannelRequestRuntime:
             attrs=(attribute,),
         )
 
-    def wait_for_config(self, *, attribute: str = "channels") -> bool:
-        """COMPAT_STABLE_SHIM: Silent alias for waitForConfig."""
-        return self.waitForConfig(attribute=attribute)
-
     def _timeout_for_field(self, field_name: str, max_secs: float) -> bool:
         """Wait for a localConfig field with a dedicated timeout.
 
@@ -199,7 +178,7 @@ class _NodeChannelRequestRuntime:
 
         return False
 
-    def requestChannel(self, channel_num: int) -> mesh_pb2.MeshPacket | None:
+    def request_channel(self, channel_num: int) -> mesh_pb2.MeshPacket | None:
         """Send one get-channel request preserving progress logging behavior."""
         if not 0 <= channel_num < MAX_CHANNELS:
             logger.warning(
@@ -214,18 +193,12 @@ class _NodeChannelRequestRuntime:
             None,
         )
         mark_channel_request_sent = (
-            getattr(channel_response_runtime, "markChannelRequestSent", None)
-            or getattr(channel_response_runtime, "mark_channel_request_sent", None)
+            getattr(channel_response_runtime, "mark_channel_request_sent", None)
             if channel_response_runtime is not None
             else None
         )
         mark_channel_request_send_failed = (
             getattr(
-                channel_response_runtime,
-                "markChannelRequestSendFailed",
-                None,
-            )
-            or getattr(
                 channel_response_runtime,
                 "mark_channel_request_send_failed",
                 None,
@@ -262,7 +235,3 @@ class _NodeChannelRequestRuntime:
             if callable(mark_channel_request_send_failed):
                 mark_channel_request_send_failed(channel_num)
         return request
-
-    def request_channel(self, channel_num: int) -> mesh_pb2.MeshPacket | None:
-        """COMPAT_STABLE_SHIM: Silent alias for requestChannel."""
-        return self.requestChannel(channel_num)

--- a/meshtastic/node_runtime/content_runtime.py
+++ b/meshtastic/node_runtime/content_runtime.py
@@ -419,7 +419,7 @@ class _NodeAdminContentRuntime:
             return None
         return self._node.onAckNak
 
-    def readRingtone(self) -> str | None:
+    def read_ringtone(self) -> str | None:
         """Read ringtone using cached-short-circuit + request/wait orchestration."""
         with self._ringtone_operation_lock:
             logger.debug("in get_ringtone()")
@@ -448,7 +448,7 @@ class _NodeAdminContentRuntime:
                 resolve_result=self._cache_store._resolve_ringtone_after_read,
             )
 
-    def writeRingtone(self, ringtone: str) -> mesh_pb2.MeshPacket | None:
+    def write_ringtone(self, ringtone: str) -> mesh_pb2.MeshPacket | None:
         """Write ringtone payload and invalidate local ringtone cache."""
         with self._ringtone_operation_lock:
             if not self._module_available_or_warn(
@@ -472,7 +472,7 @@ class _NodeAdminContentRuntime:
                 self._cache_store._invalidate_ringtone_cache()
             return send_result
 
-    def readCannedMessage(self) -> str | None:
+    def read_canned_message(self) -> str | None:
         """Read canned-message payload using cached-short-circuit + request/wait orchestration."""
         with self._canned_message_operation_lock:
             logger.debug("in get_canned_message()")
@@ -503,7 +503,7 @@ class _NodeAdminContentRuntime:
                 resolve_result=self._cache_store._resolve_canned_message_after_read,
             )
 
-    def writeCannedMessage(self, message: str) -> mesh_pb2.MeshPacket | None:
+    def write_canned_message(self, message: str) -> mesh_pb2.MeshPacket | None:
         """Write canned-message payload and invalidate local canned-message cache."""
         with self._canned_message_operation_lock:
             if not self._module_available_or_warn(

--- a/meshtastic/node_runtime/response_runtime.py
+++ b/meshtastic/node_runtime/response_runtime.py
@@ -160,7 +160,7 @@ class _NodeMetadataResponseRuntime:
                 f"excluded_modules: {self._node.excluded_modules_list(metadata.excluded_modules)}"
             )
 
-    def handleMetadataResponse(self, packet: dict[str, Any]) -> None:
+    def handle_metadata_response(self, packet: dict[str, Any]) -> None:
         """Process metadata response packet and preserve historical ACK/timeout semantics."""
         logger.debug("onRequestGetMetadata() p:%s", packet)
         decoded = packet.get("decoded")
@@ -217,10 +217,6 @@ class _NodeMetadataResponseRuntime:
         self._emit_metadata_lines(metadata_response)
         self._node._signal_metadata_stdout_event()
 
-    def handle_metadata_response(self, packet: dict[str, Any]) -> None:
-        """COMPAT_STABLE_SHIM: Silent alias for handleMetadataResponse."""
-        return self.handleMetadataResponse(packet)
-
 
 class _NodeChannelResponseRuntime:
     """Owns channel-response routing/error handling, sequencing, and final installation."""
@@ -232,18 +228,14 @@ class _NodeChannelResponseRuntime:
         self._pending_channel_retry_count = 0
         self._channel_request_failed = False
 
-    def markChannelRequestSent(self, channel_index: int) -> None:
+    def mark_channel_request_sent(self, channel_index: int) -> None:
         """Record the outstanding zero-based channel request index."""
         if self._pending_channel_request_index != channel_index:
             self._pending_channel_retry_count = 0
         self._pending_channel_request_index = channel_index
         self._channel_request_failed = False
 
-    def mark_channel_request_sent(self, channel_index: int) -> None:
-        """COMPAT_STABLE_SHIM: Silent alias for markChannelRequestSent."""
-        return self.markChannelRequestSent(channel_index)
-
-    def markChannelRequestSendFailed(self, channel_index: int) -> None:
+    def mark_channel_request_send_failed(self, channel_index: int) -> None:
         """Record terminal failure when a channel request could not be sent."""
         if self._pending_channel_request_index != channel_index:
             self._pending_channel_retry_count = 0
@@ -251,17 +243,9 @@ class _NodeChannelResponseRuntime:
         self._channel_request_failed = True
         self._node._timeout.reset()  # noqa: SLF001
 
-    def mark_channel_request_send_failed(self, channel_index: int) -> None:
-        """COMPAT_STABLE_SHIM: Silent alias for markChannelRequestSendFailed."""
-        return self.markChannelRequestSendFailed(channel_index)
-
-    def hasChannelRequestFailed(self) -> bool:
+    def has_channel_request_failed(self) -> bool:
         """Return whether the active channel download has terminally failed."""
         return self._channel_request_failed
-
-    def has_channel_request_failed(self) -> bool:
-        """COMPAT_STABLE_SHIM: Silent alias for hasChannelRequestFailed."""
-        return self.hasChannelRequestFailed()
 
     def _retry_pending_channel_request(self, error_reason: str) -> None:
         """Retry the in-flight request once for transient routing failures."""
@@ -408,7 +392,7 @@ class _NodeChannelResponseRuntime:
             return True
         return False
 
-    def handleChannelResponse(self, packet: dict[str, Any]) -> None:
+    def handle_channel_response(self, packet: dict[str, Any]) -> None:
         """Process channel response packet and maintain partial/final channel sequencing."""
         is_valid, channel_response = self._validate_channel_response_packet(packet)
         if not is_valid:
@@ -457,7 +441,3 @@ class _NodeChannelResponseRuntime:
             )
             self._channel_request_failed = True
             self._node._timeout.reset()  # noqa: SLF001
-
-    def handle_channel_response(self, packet: dict[str, Any]) -> None:
-        """COMPAT_STABLE_SHIM: Silent alias for handleChannelResponse."""
-        return self.handleChannelResponse(packet)

--- a/meshtastic/node_runtime/settings_runtime/admin.py
+++ b/meshtastic/node_runtime/settings_runtime/admin.py
@@ -53,7 +53,7 @@ class _NodeAdminCommandRuntime:
             _wait_for_admin_ack(self._node, request)
         return request
 
-    def sendOwnerMessage(
+    def send_owner_message(
         self, message: admin_pb2.AdminMessage
     ) -> mesh_pb2.MeshPacket | None:
         """Send set_owner message with historical session and remote-ACK behavior."""
@@ -63,7 +63,7 @@ class _NodeAdminCommandRuntime:
             use_remote_ack_callback=True,
         )
 
-    def exitSimulator(self) -> mesh_pb2.MeshPacket | None:
+    def exit_simulator(self) -> mesh_pb2.MeshPacket | None:
         """Send exit-simulator admin command."""
         message = admin_pb2.AdminMessage()
         message.exit_simulator = True
@@ -85,7 +85,7 @@ class _NodeAdminCommandRuntime:
             use_remote_ack_callback=True,
         )
 
-    def beginSettingsTransaction(self) -> mesh_pb2.MeshPacket | None:
+    def begin_settings_transaction(self) -> mesh_pb2.MeshPacket | None:
         """Send begin-edit-settings command."""
         message = admin_pb2.AdminMessage()
         message.begin_edit_settings = True
@@ -96,7 +96,7 @@ class _NodeAdminCommandRuntime:
             use_remote_ack_callback=True,
         )
 
-    def commitSettingsTransaction(self) -> mesh_pb2.MeshPacket | None:
+    def commit_settings_transaction(self) -> mesh_pb2.MeshPacket | None:
         """Send commit-edit-settings command."""
         message = admin_pb2.AdminMessage()
         message.commit_edit_settings = True
@@ -107,7 +107,7 @@ class _NodeAdminCommandRuntime:
             use_remote_ack_callback=True,
         )
 
-    def rebootOta(self, secs: int) -> mesh_pb2.MeshPacket | None:
+    def reboot_ota(self, secs: int) -> mesh_pb2.MeshPacket | None:
         """Send reboot-to-OTA command."""
         message = admin_pb2.AdminMessage()
         message.reboot_ota_seconds = secs
@@ -144,7 +144,7 @@ class _NodeAdminCommandRuntime:
             raise ValueError("Conflicting OTA hash arguments provided")
         return hash_values.pop()
 
-    def startOta(
+    def start_ota(
         self,
         mode: int | None = None,
         ota_file_hash: bytes | None = None,
@@ -189,10 +189,8 @@ class _NodeAdminCommandRuntime:
             use_remote_ack_callback=False,
         )
 
-    # COMPAT_STABLE_SHIM: snake_case alias for startOta
-    start_ota = startOta
 
-    def enterDfuMode(self) -> mesh_pb2.MeshPacket | None:
+    def enter_dfu_mode(self) -> mesh_pb2.MeshPacket | None:
         """Send enter-DFU-mode command."""
         message = admin_pb2.AdminMessage()
         message.enter_dfu_mode_request = True
@@ -203,8 +201,6 @@ class _NodeAdminCommandRuntime:
             use_remote_ack_callback=True,
         )
 
-    # COMPAT_STABLE_SHIM: snake_case alias for enterDfuMode
-    enter_dfu_mode = enterDfuMode
 
     def shutdown(self, secs: int) -> mesh_pb2.MeshPacket | None:
         """Send shutdown command with delayed shutdown seconds."""
@@ -217,7 +213,7 @@ class _NodeAdminCommandRuntime:
             use_remote_ack_callback=True,
         )
 
-    def factoryReset(self, *, full: bool) -> mesh_pb2.MeshPacket | None:
+    def factory_reset(self, *, full: bool) -> mesh_pb2.MeshPacket | None:
         """Send factory-reset command, preserving full/config split behavior."""
         message = admin_pb2.AdminMessage()
         if full:
@@ -249,8 +245,6 @@ class _NodeAdminCommandRuntime:
             use_remote_ack_callback=True,
         )
 
-    # COMPAT_STABLE_SHIM: snake_case alias for factoryReset
-    factory_reset = factoryReset
 
     def _send_node_id_command(
         self,
@@ -268,7 +262,7 @@ class _NodeAdminCommandRuntime:
             use_remote_ack_callback=True,
         )
 
-    def removeNode(self, node_id: int | str) -> mesh_pb2.MeshPacket | None:
+    def remove_node(self, node_id: int | str) -> mesh_pb2.MeshPacket | None:
         """Send remove-by-nodenum command."""
         return self._send_node_id_command(
             node_id=node_id,
@@ -277,10 +271,8 @@ class _NodeAdminCommandRuntime:
             ),
         )
 
-    # COMPAT_STABLE_SHIM: snake_case alias for removeNode
-    remove_node = removeNode
 
-    def setFavorite(self, node_id: int | str) -> mesh_pb2.MeshPacket | None:
+    def set_favorite(self, node_id: int | str) -> mesh_pb2.MeshPacket | None:
         """Send set-favorite command."""
         return self._send_node_id_command(
             node_id=node_id,
@@ -289,10 +281,8 @@ class _NodeAdminCommandRuntime:
             ),
         )
 
-    # COMPAT_STABLE_SHIM: snake_case alias for setFavorite
-    set_favorite = setFavorite
 
-    def removeFavorite(self, node_id: int | str) -> mesh_pb2.MeshPacket | None:
+    def remove_favorite(self, node_id: int | str) -> mesh_pb2.MeshPacket | None:
         """Send remove-favorite command."""
         return self._send_node_id_command(
             node_id=node_id,
@@ -301,10 +291,8 @@ class _NodeAdminCommandRuntime:
             ),
         )
 
-    # COMPAT_STABLE_SHIM: snake_case alias for removeFavorite
-    remove_favorite = removeFavorite
 
-    def setIgnored(self, node_id: int | str) -> mesh_pb2.MeshPacket | None:
+    def set_ignored(self, node_id: int | str) -> mesh_pb2.MeshPacket | None:
         """Send set-ignored command."""
         return self._send_node_id_command(
             node_id=node_id,
@@ -313,10 +301,8 @@ class _NodeAdminCommandRuntime:
             ),
         )
 
-    # COMPAT_STABLE_SHIM: snake_case alias for setIgnored
-    set_ignored = setIgnored
 
-    def removeIgnored(self, node_id: int | str) -> mesh_pb2.MeshPacket | None:
+    def remove_ignored(self, node_id: int | str) -> mesh_pb2.MeshPacket | None:
         """Send remove-ignored command."""
         return self._send_node_id_command(
             node_id=node_id,
@@ -325,10 +311,8 @@ class _NodeAdminCommandRuntime:
             ),
         )
 
-    # COMPAT_STABLE_SHIM: snake_case alias for removeIgnored
-    remove_ignored = removeIgnored
 
-    def resetNodeDb(self) -> mesh_pb2.MeshPacket | None:
+    def reset_node_db(self) -> mesh_pb2.MeshPacket | None:
         """Send NodeDB reset command."""
         message = admin_pb2.AdminMessage()
         message.nodedb_reset = True
@@ -338,6 +322,3 @@ class _NodeAdminCommandRuntime:
             ensure_session_key=True,
             use_remote_ack_callback=True,
         )
-
-    # COMPAT_STABLE_SHIM: snake_case alias for resetNodeDb
-    reset_node_db = resetNodeDb

--- a/meshtastic/node_runtime/settings_runtime/config_runtime.py
+++ b/meshtastic/node_runtime/settings_runtime/config_runtime.py
@@ -32,7 +32,7 @@ class _NodeSettingsRuntime:
         self._node = node
         self._message_builder = message_builder
 
-    def requestConfig(
+    def request_config(
         self,
         config_type: int | FieldDescriptor,
         *,
@@ -94,7 +94,7 @@ class _NodeSettingsRuntime:
             "Request config from the device before writing."
         )
 
-    def writeConfig(self, config_name: str) -> None:
+    def write_config(self, config_name: str) -> None:
         """Send one settings write with preserved callback selection."""
         self._message_builder.validate_config_name(config_name)
         self._validate_write_configs_loaded(config_name)

--- a/meshtastic/node_runtime/settings_runtime/owner.py
+++ b/meshtastic/node_runtime/settings_runtime/owner.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 class _NodeOwnerProfileRuntime:
-    """Owns setOwner validation/truncation/message-build and send orchestration."""
+    """Owns owner-profile validation, truncation, message build, and sending."""
 
     def __init__(
         self,
@@ -32,7 +32,7 @@ class _NodeOwnerProfileRuntime:
         self._node = node
         self._admin_command_runtime = admin_command_runtime
 
-    def setOwner(
+    def set_owner(
         self,
         *,
         long_name: str | None = None,
@@ -40,7 +40,7 @@ class _NodeOwnerProfileRuntime:
         is_licensed: bool = False,
         is_unmessagable: bool | None = None,
     ) -> mesh_pb2.MeshPacket | None:
-        """Apply setOwner validation/truncation and send policy.
+        """Apply owner-profile validation, truncation, and send policy.
 
         Parameters
         ----------
@@ -101,4 +101,4 @@ class _NodeOwnerProfileRuntime:
             "p.set_owner.is_unmessagable:%s",
             message.set_owner.is_unmessagable,
         )
-        return self._admin_command_runtime.sendOwnerMessage(message)
+        return self._admin_command_runtime.send_owner_message(message)

--- a/meshtastic/node_runtime/settings_runtime/response.py
+++ b/meshtastic/node_runtime/settings_runtime/response.py
@@ -95,7 +95,7 @@ class _NodeSettingsResponseRuntime:
         )
         return None
 
-    def handleSettingsResponse(self, packet: dict[str, Any]) -> None:
+    def handle_settings_response(self, packet: dict[str, Any]) -> None:
         """Process one settings response packet with preserved ACK/NAK semantics."""
         logger.debug("handleSettingsResponse() response received")
         decoded = packet.get("decoded")

--- a/meshtastic/node_runtime/seturl/coordinator.py
+++ b/meshtastic/node_runtime/seturl/coordinator.py
@@ -480,7 +480,7 @@ class _SetUrlTransactionCoordinator:
         )
         execution_state = _SetUrlAddOnlyExecutionState()
         try:
-            self._execution_engine.executeAddOnly(
+            self._execution_engine.execute_add_only(
                 parsed_input=self._parsed_input,
                 admin_context=self._admin_context,
                 plan=plan,
@@ -549,7 +549,7 @@ class _SetUrlTransactionCoordinator:
             execution_state = _SetUrlReplaceExecutionState()
             resume_skip_channel_indices = skip_channel_indices if attempt > 0 else None
             try:
-                self._execution_engine.executeReplaceAll(
+                self._execution_engine.execute_replace_all(
                     parsed_input=self._parsed_input,
                     admin_context=self._admin_context,
                     plan=plan,

--- a/meshtastic/node_runtime/seturl/execution.py
+++ b/meshtastic/node_runtime/seturl/execution.py
@@ -41,7 +41,7 @@ admin channel topology and need extra settle time."""
 class _ReplaceAllStage(enum.Enum):
     """Stage of a replace-all write sequence.
 
-    Tracks which phase of ``executeReplaceAll`` is currently in progress
+    Tracks which step of ``execute_replace_all`` is currently in progress
     so that error reporting can identify the exact failure point and a
     future reconnect-aware wrapper can decide whether resume is safe.
     """
@@ -171,7 +171,7 @@ class _SetUrlExecutionEngine:
             expected_channels_fingerprint=expected_channels_fingerprint,
         )
 
-    def executeAddOnly(
+    def execute_add_only(
         self,
         *,
         parsed_input: _SetUrlParsedInput,
@@ -213,7 +213,7 @@ class _SetUrlExecutionEngine:
             )
             state.written_indices.append(staged_channel.index)
 
-    def executeReplaceAll(
+    def execute_replace_all(
         self,
         *,
         parsed_input: _SetUrlParsedInput,

--- a/meshtastic/node_runtime/seturl/planner.py
+++ b/meshtastic/node_runtime/seturl/planner.py
@@ -10,9 +10,7 @@ from meshtastic.node_runtime.channel_state import _NodeChannelState
 from meshtastic.node_runtime.seturl.context import _SetUrlAdminContext
 from meshtastic.node_runtime.seturl.helpers import _channels_fingerprint
 from meshtastic.node_runtime.seturl.parser import _SetUrlParsedInput
-from meshtastic.node_runtime.shared import (
-    isNamedAdminChannelName as _isNamedAdminChannelName,
-)
+from meshtastic.node_runtime.shared import _is_named_admin_channel_name
 from meshtastic.protobuf import channel_pb2
 
 if TYPE_CHECKING:
@@ -133,7 +131,7 @@ class _SetUrlAddOnlyPlanner:
                 (
                     candidate
                     for candidate in channels_to_write
-                    if _isNamedAdminChannelName(candidate[1])
+                    if _is_named_admin_channel_name(candidate[1])
                 ),
                 None,
             )
@@ -212,7 +210,7 @@ class _SetUrlReplacePlanner:
             for staged_channel in staged_channels
             if staged_channel.settings
             and staged_channel.settings.name
-            and _isNamedAdminChannelName(staged_channel.settings.name)
+            and _is_named_admin_channel_name(staged_channel.settings.name)
         ]
         if len(staged_named_admin_channels) > 1:
             self._node._raise_interface_error(  # noqa: SLF001

--- a/meshtastic/node_runtime/shared.py
+++ b/meshtastic/node_runtime/shared.py
@@ -40,9 +40,3 @@ def _ordered_admin_indexes(*indexes: int | None) -> list[int]:
             continue
         ordered.append(index)
     return ordered
-
-
-# COMPAT_STABLE_SHIM: internal callers historically imported these helpers
-# without a leading underscore; keep them callable without warnings.
-isNamedAdminChannelName = _is_named_admin_channel_name
-orderedAdminIndexes = _ordered_admin_indexes

--- a/meshtastic/node_runtime/transport_runtime/channel.py
+++ b/meshtastic/node_runtime/transport_runtime/channel.py
@@ -12,9 +12,7 @@ from meshtastic.node_runtime.channel_state import _NodeChannelState
 from meshtastic.node_runtime.shared import (
     MAX_CHANNELS,
 )
-from meshtastic.node_runtime.shared import (
-    isNamedAdminChannelName as _isNamedAdminChannelName,
-)
+from meshtastic.node_runtime.shared import _is_named_admin_channel_name
 from meshtastic.protobuf import admin_pb2, channel_pb2
 
 if TYPE_CHECKING:
@@ -159,7 +157,7 @@ class _NodeDeleteChannelRuntime:
             if (
                 channel.role != channel_pb2.Channel.Role.DISABLED
                 and channel.settings
-                and _isNamedAdminChannelName(channel.settings.name)
+                and _is_named_admin_channel_name(channel.settings.name)
             ):
                 return channel.index
         return 0

--- a/meshtastic/tests/seturl/test_coordinator.py
+++ b/meshtastic/tests/seturl/test_coordinator.py
@@ -154,7 +154,7 @@ class TestSetUrlTransactionCoordinator:
             state.lora_write_started = True
             raise RuntimeError("simulated write timeout")
 
-        coordinator._execution_engine.executeAddOnly = _failing_execute  # type: ignore[method-assign]
+        coordinator._execution_engine.execute_add_only = _failing_execute  # type: ignore[method-assign]
 
         with pytest.raises(RuntimeError, match="simulated write timeout"):
             coordinator._apply_add_only()
@@ -201,7 +201,7 @@ class TestSetUrlTransactionCoordinator:
             state.lora_write_started = False
             raise RuntimeError("simulated write timeout")
 
-        coordinator._execution_engine.executeAddOnly = _failing_execute  # type: ignore[method-assign]
+        coordinator._execution_engine.execute_add_only = _failing_execute  # type: ignore[method-assign]
 
         with pytest.raises(RuntimeError, match="simulated write timeout"):
             coordinator._apply_add_only()
@@ -238,7 +238,7 @@ class TestSetUrlTransactionCoordinator:
         def _execute_while_locked(**_kwargs: Any) -> None:
             assert mutation_lock.active
 
-        coordinator._execution_engine.executeAddOnly = _execute_while_locked  # type: ignore[method-assign]
+        coordinator._execution_engine.execute_add_only = _execute_while_locked  # type: ignore[method-assign]
 
         coordinator._apply_add_only()
 
@@ -287,7 +287,7 @@ class TestSetUrlTransactionCoordinator:
                 state.written_channel_indices.append(0)
                 raise RuntimeError("simulated transport disconnect")
 
-        coordinator._execution_engine.executeReplaceAll = _failing_then_check  # type: ignore[method-assign]
+        coordinator._execution_engine.execute_replace_all = _failing_then_check  # type: ignore[method-assign]
         lock = _LockProbe()
         mock_local_node_with_reconnect._test_channel_state._replace_lock(lock)
 
@@ -365,7 +365,7 @@ class TestSetUrlTransactionCoordinator:
             assert 0 in skip_channel_indices
             assert 1 not in skip_channel_indices
 
-        coordinator._execution_engine.executeReplaceAll = _first_fails_second_succeeds  # type: ignore[method-assign]
+        coordinator._execution_engine.execute_replace_all = _first_fails_second_succeeds  # type: ignore[method-assign]
 
         restored_channels = [
             desired_0,
@@ -424,7 +424,7 @@ class TestSetUrlTransactionCoordinator:
             ]
             return {0}, False
 
-        coordinator._execution_engine.executeReplaceAll = _fail_then_succeed  # type: ignore[method-assign]
+        coordinator._execution_engine.execute_replace_all = _fail_then_succeed  # type: ignore[method-assign]
         coordinator._reconnect_and_compute_remaining = _recover_while_locked  # type: ignore[assignment]
 
         coordinator._apply_replace_all()
@@ -475,7 +475,7 @@ class TestSetUrlTransactionCoordinator:
                 raise RuntimeError("simulated disconnect before writes")
             assert skip_channel_indices == set()
 
-        coordinator._execution_engine.executeReplaceAll = _first_fails_second_succeeds  # type: ignore[method-assign]
+        coordinator._execution_engine.execute_replace_all = _first_fails_second_succeeds  # type: ignore[method-assign]
 
         with (
             patch("meshtastic.node_runtime.seturl.coordinator.time.sleep"),
@@ -527,7 +527,7 @@ class TestSetUrlTransactionCoordinator:
             state.written_channel_indices = []
             raise RuntimeError("persistent failure")
 
-        coordinator._execution_engine.executeReplaceAll = _always_fail  # type: ignore[method-assign]
+        coordinator._execution_engine.execute_replace_all = _always_fail  # type: ignore[method-assign]
 
         # Simulate time passage so that config reload timeout is reached quickly
         monotonic_time = [0.0]
@@ -589,7 +589,7 @@ class TestSetUrlTransactionCoordinator:
         ) -> None:
             raise RuntimeError("transport disconnect")
 
-        coordinator._execution_engine.executeReplaceAll = _fail_once  # type: ignore[method-assign]
+        coordinator._execution_engine.execute_replace_all = _fail_once  # type: ignore[method-assign]
 
         with (
             patch("meshtastic.node_runtime.seturl.coordinator.time.sleep"),
@@ -642,7 +642,7 @@ class TestSetUrlTransactionCoordinator:
                 state.stage = _ReplaceAllStage.LORA_CONFIG
                 raise RuntimeError("simulated LoRa-stage disconnect")
 
-        coordinator._execution_engine.executeReplaceAll = _fail_at_lora  # type: ignore[method-assign]
+        coordinator._execution_engine.execute_replace_all = _fail_at_lora  # type: ignore[method-assign]
 
         sleep_durations: list[float] = []
 
@@ -711,7 +711,7 @@ class TestSetUrlTransactionCoordinator:
                 state.written_channel_indices.append(0)
                 raise RuntimeError("simulated transport disconnect")
 
-        coordinator._execution_engine.executeReplaceAll = _failing_then_check  # type: ignore[method-assign]
+        coordinator._execution_engine.execute_replace_all = _failing_then_check  # type: ignore[method-assign]
 
         def _connect_with_recovery() -> None:
             nonlocal connect_call_count
@@ -780,7 +780,7 @@ class TestSetUrlTransactionCoordinator:
             state.written_channel_indices = []
             raise RuntimeError("persistent failure")
 
-        coordinator._execution_engine.executeReplaceAll = _always_fail  # type: ignore[method-assign]
+        coordinator._execution_engine.execute_replace_all = _always_fail  # type: ignore[method-assign]
 
         sleep_call_count = 0
 

--- a/meshtastic/tests/seturl/test_execution_engine.py
+++ b/meshtastic/tests/seturl/test_execution_engine.py
@@ -57,7 +57,7 @@ class TestSetUrlExecutionEngine:
 
         state = _SetUrlAddOnlyExecutionState()
 
-        execution_engine.executeAddOnly(
+        execution_engine.execute_add_only(
             parsed_input=parsed_input,
             admin_context=admin_context,
             plan=plan,
@@ -104,7 +104,7 @@ class TestSetUrlExecutionEngine:
 
         state = _SetUrlAddOnlyExecutionState()
 
-        execution_engine.executeAddOnly(
+        execution_engine.execute_add_only(
             parsed_input=parsed_input,
             admin_context=admin_context,
             plan=plan,
@@ -154,7 +154,7 @@ class TestSetUrlExecutionEngine:
         )
 
         with pytest.raises(ValueError, match="LoRa config update was not started"):
-            execution_engine.executeAddOnly(
+            execution_engine.execute_add_only(
                 parsed_input=parsed_input,
                 admin_context=admin_context,
                 plan=plan,
@@ -217,7 +217,7 @@ class TestSetUrlExecutionEngine:
             "meshtastic.node_runtime.seturl.execution._channels_fingerprint",
             side_effect=_fingerprint_while_locked,
         ):
-            execution_engine.executeReplaceAll(
+            execution_engine.execute_replace_all(
                 parsed_input=parsed_input,
                 admin_context=admin_context,
                 plan=plan,
@@ -271,7 +271,7 @@ class TestSetUrlExecutionEngine:
             ValueError,
             match="Channel cache changed during replace-all cache update",
         ):
-            execution_engine.executeReplaceAll(
+            execution_engine.execute_replace_all(
                 parsed_input=parsed_input,
                 admin_context=admin_context,
                 plan=plan,
@@ -322,7 +322,7 @@ class TestSetUrlExecutionEngine:
         )
 
         with pytest.raises(ValueError, match="LoRa config update was not started"):
-            execution_engine.executeReplaceAll(
+            execution_engine.execute_replace_all(
                 parsed_input=parsed_input,
                 admin_context=admin_context,
                 plan=plan,
@@ -365,7 +365,7 @@ class TestSetUrlExecutionEngine:
         mock_local_node.ensureSessionKey = MagicMock()
         mock_local_node._send_admin = MagicMock(return_value=mesh_pb2.MeshPacket())
 
-        execution_engine.executeReplaceAll(
+        execution_engine.execute_replace_all(
             parsed_input=parsed_input,
             admin_context=admin_context,
             plan=plan,
@@ -431,7 +431,7 @@ class TestSetUrlExecutionEngine:
 
         state = _SetUrlReplaceExecutionState()
 
-        execution_engine.executeReplaceAll(
+        execution_engine.execute_replace_all(
             parsed_input=parsed_input,
             admin_context=admin_context,
             plan=plan,
@@ -480,7 +480,7 @@ class TestSetUrlExecutionEngine:
         )
         state = _SetUrlReplaceExecutionState()
 
-        execution_engine.executeReplaceAll(
+        execution_engine.execute_replace_all(
             parsed_input=parsed_input,
             admin_context=admin_context,
             plan=plan,
@@ -532,7 +532,7 @@ class TestSetUrlExecutionEngine:
         )
 
         state = _SetUrlReplaceExecutionState()
-        execution_engine.executeReplaceAll(
+        execution_engine.execute_replace_all(
             parsed_input=parsed_input,
             admin_context=admin_context,
             plan=plan,

--- a/meshtastic/tests/test_admin_ack_wait_scoping.py
+++ b/meshtastic/tests/test_admin_ack_wait_scoping.py
@@ -358,7 +358,7 @@ def test_settings_response_marks_scoped_request_completion() -> None:
         }
     }
 
-    _NodeSettingsResponseRuntime(node).handleSettingsResponse(packet)  # type: ignore[arg-type]
+    _NodeSettingsResponseRuntime(node).handle_settings_response(packet)  # type: ignore[arg-type]
 
     assert iface._acknowledgment.receivedAck is True
     iface._mark_wait_acknowledged.assert_called_once_with(
@@ -374,7 +374,7 @@ def test_settings_routing_error_records_scoped_request_failure() -> None:
     iface, node = _settings_doubles(616)
     packet = {"decoded": {"routing": {"errorReason": "NO_RESPONSE"}}}
 
-    _NodeSettingsResponseRuntime(node).handleSettingsResponse(packet)  # type: ignore[arg-type]
+    _NodeSettingsResponseRuntime(node).handle_settings_response(packet)  # type: ignore[arg-type]
 
     assert iface._acknowledgment.receivedNak is True
     assert iface._set_wait_error.call_args_list == [
@@ -493,7 +493,7 @@ def test_metadata_response_marks_scoped_request_completion() -> None:
         }
     }
 
-    _NodeMetadataResponseRuntime(node).handleMetadataResponse(packet)  # type: ignore[arg-type]
+    _NodeMetadataResponseRuntime(node).handle_metadata_response(packet)  # type: ignore[arg-type]
 
     assert iface._acknowledgment.receivedAck is True
     iface._mark_wait_acknowledged.assert_called_once_with(
@@ -560,7 +560,7 @@ def test_malformed_metadata_response_records_request_scoped_failure(
         _signal_metadata_stdout_event=MagicMock(),
     )
 
-    _NodeMetadataResponseRuntime(cast(Any, node)).handleMetadataResponse(packet)
+    _NodeMetadataResponseRuntime(cast(Any, node)).handle_metadata_response(packet)
 
     assert iface._acknowledgment.receivedNak is True
     assert iface._set_wait_error.call_args_list == [
@@ -753,7 +753,7 @@ def test_settings_response_missing_expected_field_records_scoped_failure() -> No
         }
     }
 
-    _NodeSettingsResponseRuntime(node).handleSettingsResponse(packet)  # type: ignore[arg-type]
+    _NodeSettingsResponseRuntime(node).handle_settings_response(packet)  # type: ignore[arg-type]
 
     assert iface._acknowledgment.receivedNak is True
     assert iface._set_wait_error.call_args_list == [

--- a/meshtastic/tests/test_content_runtime_additional.py
+++ b/meshtastic/tests/test_content_runtime_additional.py
@@ -298,10 +298,10 @@ class TestSelectWriteResponseHandler:
 
 
 class TestWriteCannedMessageChunking:
-    """Tests for writeCannedMessage chunking (lines 498-532)."""
+    """Tests for canned-message write chunking and cache behavior."""
 
     @pytest.mark.unit
-    def test_writeCannedMessage_single_chunk_short_message(
+    def test_write_canned_message_single_chunk_short_message(
         self, mock_node_for_read_gen: MagicMock
     ) -> None:
         """Test short message is sent as single chunk."""
@@ -315,13 +315,13 @@ class TestWriteCannedMessageChunking:
         # Message shorter than chunk size
         short_message = "x" * (CANNED_MESSAGE_CHUNK_SIZE - 1)
 
-        runtime.writeCannedMessage(short_message)
+        runtime.write_canned_message(short_message)
 
         # Should be sent as single message, not chunked
         assert mock_node_for_read_gen._send_admin.call_count == 1
 
     @pytest.mark.unit
-    def test_writeCannedMessage_multi_chunk_long_message(
+    def test_write_canned_message_multi_chunk_long_message(
         self, mock_node_for_read_gen: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Test long message is split into multiple chunks."""
@@ -336,7 +336,7 @@ class TestWriteCannedMessageChunking:
         long_message = "x" * (CANNED_MESSAGE_CHUNK_SIZE * 3 + 10)
 
         with caplog.at_level(logging.DEBUG):
-            runtime.writeCannedMessage(long_message)
+            runtime.write_canned_message(long_message)
 
         # Should be split into multiple sends
         assert (
@@ -345,7 +345,7 @@ class TestWriteCannedMessageChunking:
         assert "Setting canned message in 4 chunks" in caplog.text
 
     @pytest.mark.unit
-    def test_writeCannedMessage_chunk_send_failure_invalidation(
+    def test_write_canned_message_chunk_send_failure_invalidation(
         self, mock_node_for_read_gen: MagicMock
     ) -> None:
         """Test that cache is invalidated if chunk send fails after previous chunks sent."""
@@ -374,7 +374,7 @@ class TestWriteCannedMessageChunking:
         # Set up cache to verify invalidation
         mock_node_for_read_gen.cannedPluginMessage = "old_message"
 
-        result = runtime.writeCannedMessage(long_message)
+        result = runtime.write_canned_message(long_message)
 
         # Result should be None because second chunk failed
         assert result is None
@@ -382,7 +382,7 @@ class TestWriteCannedMessageChunking:
         assert mock_node_for_read_gen.cannedPluginMessage is None
 
     @pytest.mark.unit
-    def test_writeCannedMessage_first_chunk_failure_no_invalidation(
+    def test_write_canned_message_first_chunk_failure_no_invalidation(
         self, mock_node_for_read_gen: MagicMock
     ) -> None:
         """Test that cache is NOT invalidated if first chunk send fails."""
@@ -402,7 +402,7 @@ class TestWriteCannedMessageChunking:
         # Set up cache to verify it's NOT invalidated
         mock_node_for_read_gen.cannedPluginMessage = "old_message"
 
-        result = runtime.writeCannedMessage(long_message)
+        result = runtime.write_canned_message(long_message)
 
         # Result should be None because first chunk failed
         assert result is None
@@ -410,7 +410,7 @@ class TestWriteCannedMessageChunking:
         assert mock_node_for_read_gen.cannedPluginMessage == "old_message"
 
     @pytest.mark.unit
-    def test_writeCannedMessage_exception_during_chunks(
+    def test_write_canned_message_exception_during_chunks(
         self, mock_node_for_read_gen: MagicMock
     ) -> None:
         """Test that exception during chunking invalidates cache and re-raises."""
@@ -440,13 +440,13 @@ class TestWriteCannedMessageChunking:
         mock_node_for_read_gen.cannedPluginMessage = "old_message"
 
         with pytest.raises(RuntimeError, match="Send failed"):
-            runtime.writeCannedMessage(long_message)
+            runtime.write_canned_message(long_message)
 
         # Cache should be invalidated because at least one chunk was written
         assert mock_node_for_read_gen.cannedPluginMessage is None
 
     @pytest.mark.unit
-    def test_writeCannedMessage_success_returns_first_result(
+    def test_write_canned_message_success_returns_first_result(
         self, mock_node_for_read_gen: MagicMock
     ) -> None:
         """Test that successful multi-chunk write returns first chunk's result."""
@@ -473,13 +473,13 @@ class TestWriteCannedMessageChunking:
 
         mock_node_for_read_gen._send_admin.side_effect = send_admin_side_effect
 
-        result = runtime.writeCannedMessage(long_message)
+        result = runtime.write_canned_message(long_message)
 
         # Should return the first chunk's result
         assert result is first_result
 
     @pytest.mark.unit
-    def test_writeCannedMessage_invalidation_on_success(
+    def test_write_canned_message_invalidation_on_success(
         self, mock_node_for_read_gen: MagicMock
     ) -> None:
         """Test that cache is invalidated after successful multi-chunk write."""
@@ -500,7 +500,7 @@ class TestWriteCannedMessageChunking:
         mock_node_for_read_gen.cannedPluginMessage = "old_message"
         mock_node_for_read_gen.cannedPluginMessageMessages = "old_fragment"
 
-        runtime.writeCannedMessage(long_message)
+        runtime.write_canned_message(long_message)
 
         # Cache should be invalidated
         assert mock_node_for_read_gen.cannedPluginMessage is None

--- a/meshtastic/tests/test_node_runtime_channel_request.py
+++ b/meshtastic/tests/test_node_runtime_channel_request.py
@@ -57,7 +57,7 @@ def channel_request_runtime(
 
 
 @pytest.mark.unit
-def test_setChannels_with_valid_channels_copies_and_normalizes(
+def test_set_channels_with_valid_channels_copies_and_normalizes(
     channel_request_runtime: _NodeChannelRequestRuntime,
     channel_state: _NodeChannelState,
 ) -> None:
@@ -77,7 +77,7 @@ def test_setChannels_with_valid_channels_copies_and_normalizes(
 
     source_channels = [source_channel1, source_channel2]
 
-    channel_request_runtime.setChannels(source_channels)
+    channel_request_runtime.set_channels(source_channels)
 
     # Verify channels were copied (not the same objects)
     assert channel_state.channels is not None
@@ -96,17 +96,17 @@ def test_setChannels_with_valid_channels_copies_and_normalizes(
 
 
 @pytest.mark.unit
-def test_requestChannels_with_starting_index_zero_resets_channels(
+def test_request_channels_with_starting_index_zero_resets_channels(
     channel_request_runtime: _NodeChannelRequestRuntime,
     channel_state: _NodeChannelState,
     mock_node: MagicMock,
 ) -> None:
-    """RequestChannels with starting_index=0 should reset channels and partialChannels."""
+    """Starting at index zero should reset complete and partial channel state."""
     # Set up pre-existing channels
     channel_state.channels = [channel_pb2.Channel()]
     channel_state.partial_channels = [channel_pb2.Channel()]
 
-    channel_request_runtime.requestChannels(starting_index=0)
+    channel_request_runtime.request_channels(starting_index=0)
 
     # Verify channels were reset
     assert channel_state.channels is None
@@ -116,18 +116,18 @@ def test_requestChannels_with_starting_index_zero_resets_channels(
 
 
 @pytest.mark.unit
-def test_requestChannels_with_starting_index_nonzero_preserves_channels(
+def test_request_channels_with_starting_index_nonzero_preserves_channels(
     channel_request_runtime: _NodeChannelRequestRuntime,
     channel_state: _NodeChannelState,
     mock_node: MagicMock,
 ) -> None:
-    """RequestChannels with starting_index>0 should not reset channels or partialChannels."""
+    """Starting above zero should preserve complete and partial channel state."""
     # Set up pre-existing channels
     existing_channel = channel_pb2.Channel()
     channel_state.channels = [existing_channel]
     channel_state.partial_channels = [channel_pb2.Channel()]
 
-    channel_request_runtime.requestChannels(starting_index=2)
+    channel_request_runtime.request_channels(starting_index=2)
 
     # Verify channels were NOT reset
     assert channel_state.channels == [existing_channel]
@@ -137,21 +137,19 @@ def test_requestChannels_with_starting_index_nonzero_preserves_channels(
 
 
 @pytest.mark.unit
-def test_requestChannels_calls_canonical_request_channel_method(
+def test_request_channels_calls_request_channel(
     channel_request_runtime: _NodeChannelRequestRuntime,
 ) -> None:
-    """RequestChannels should call requestChannel directly, not deprecated alias."""
-    channel_request_runtime.requestChannel = MagicMock()  # type: ignore[method-assign]
+    """request_channels should delegate the initial request to request_channel."""
     channel_request_runtime.request_channel = MagicMock()  # type: ignore[method-assign]
 
-    channel_request_runtime.requestChannels(starting_index=3)
+    channel_request_runtime.request_channels(starting_index=3)
 
-    channel_request_runtime.requestChannel.assert_called_once_with(3)
-    channel_request_runtime.request_channel.assert_not_called()
+    channel_request_runtime.request_channel.assert_called_once_with(3)
 
 
 @pytest.mark.unit
-def test_waitForConfig_falls_back_to_node_attribute_without_response_runtime(
+def test_wait_for_config_falls_back_to_node_attribute_without_response_runtime(
     channel_request_runtime: _NodeChannelRequestRuntime,
     mock_node: MagicMock,
 ) -> None:
@@ -162,21 +160,21 @@ def test_waitForConfig_falls_back_to_node_attribute_without_response_runtime(
 
     assert not hasattr(mock_node, "_channel_response_runtime")
 
-    result = channel_request_runtime.waitForConfig(attribute="channels")
+    result = channel_request_runtime.wait_for_config(attribute="channels")
 
     assert result is True
     mock_timeout.waitForSet.assert_called_once_with(mock_node, attrs=("channels",))
 
 
 @pytest.mark.unit
-def test_waitForConfig_observes_channels_installed_during_response_wait(
+def test_wait_for_config_observes_channels_installed_during_response_wait(
     channel_request_runtime: _NodeChannelRequestRuntime,
     channel_state: _NodeChannelState,
     mock_node: MagicMock,
 ) -> None:
     """Channel completion should be observed through the shared state owner."""
     response_runtime = MagicMock()
-    response_runtime.hasChannelRequestFailed.return_value = False
+    response_runtime.has_channel_request_failed.return_value = False
     mock_node._channel_response_runtime = response_runtime
 
     def _install_channels(
@@ -191,12 +189,12 @@ def test_waitForConfig_observes_channels_installed_during_response_wait(
 
     mock_node._timeout.waitForSet.side_effect = _install_channels  # noqa: SLF001
 
-    assert channel_request_runtime.waitForConfig(attribute="channels") is True
-    response_runtime.hasChannelRequestFailed.assert_not_called()
+    assert channel_request_runtime.wait_for_config(attribute="channels") is True
+    response_runtime.has_channel_request_failed.assert_not_called()
 
 
 @pytest.mark.unit
-def test_waitForConfig_with_non_channels_attribute(
+def test_wait_for_config_with_non_channels_attribute(
     channel_request_runtime: _NodeChannelRequestRuntime,
     mock_node: MagicMock,
 ) -> None:
@@ -205,7 +203,7 @@ def test_waitForConfig_with_non_channels_attribute(
     mock_timeout.waitForSet.return_value = True
     mock_node._timeout = mock_timeout  # noqa: SLF001
 
-    result = channel_request_runtime.waitForConfig(attribute="lora")
+    result = channel_request_runtime.wait_for_config(attribute="lora")
 
     assert result is True
     call_args = mock_timeout.waitForSet.call_args
@@ -228,7 +226,7 @@ def test_request_channel_sends_admin_message_with_correct_channel_num(
 
     mock_node._send_admin.return_value = mesh_pb2.MeshPacket()  # noqa: SLF001
 
-    result = channel_request_runtime.requestChannel(channel_num=3)
+    result = channel_request_runtime.request_channel(channel_num=3)
 
     # Verify _send_admin was called with correct message
     mock_node._send_admin.assert_called_once()  # noqa: SLF001
@@ -261,7 +259,7 @@ def test_request_channel_for_remote_node_logs_info(
     mock_node.iface = mock_iface
 
     with caplog.at_level(logging.INFO):
-        channel_request_runtime.requestChannel(channel_num=5)
+        channel_request_runtime.request_channel(channel_num=5)
 
     # Verify info log was emitted for remote node
     assert "Requesting channel 5 info from remote node" in caplog.text
@@ -283,7 +281,7 @@ def test_request_channel_for_local_node_logs_debug(
     mock_node.iface = mock_iface
 
     with caplog.at_level(logging.DEBUG):
-        channel_request_runtime.requestChannel(channel_num=2)
+        channel_request_runtime.request_channel(channel_num=2)
 
     # Verify debug log was emitted for local node
     assert "Requesting channel 2" in caplog.text
@@ -306,10 +304,10 @@ def test_request_channel_send_exception_marks_request_failed(
     mock_node._send_admin.side_effect = RuntimeError("send failed")  # noqa: SLF001
 
     with pytest.raises(RuntimeError, match="send failed"):
-        channel_request_runtime.requestChannel(channel_num=1)
+        channel_request_runtime.request_channel(channel_num=1)
 
-    channel_response_runtime.markChannelRequestSent.assert_called_once_with(1)
-    channel_response_runtime.markChannelRequestSendFailed.assert_called_once_with(1)
+    channel_response_runtime.mark_channel_request_sent.assert_called_once_with(1)
+    channel_response_runtime.mark_channel_request_send_failed.assert_called_once_with(1)
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_node_runtime_content.py
+++ b/meshtastic/tests/test_node_runtime_content.py
@@ -659,7 +659,7 @@ class TestNodeAdminContentRuntime:
         assert "Module not present" in caplog.text
 
     @pytest.mark.unit
-    def test_readRingtone_returns_cached_value(
+    def test_read_ringtone_returns_cached_value(
         self,
         mock_node_for_admin: MagicMock,
         cache_store: _NodeContentCacheStore,
@@ -673,14 +673,14 @@ class TestNodeAdminContentRuntime:
             response_runtime=response_runtime,
         )
 
-        result = runtime.readRingtone()
+        result = runtime.read_ringtone()
 
         assert result == "RTTTL: cached:d=4,o=5,b=100:c"
         # Should not call _send_admin since cached
         mock_node_for_admin._send_admin.assert_not_called()
 
     @pytest.mark.unit
-    def test_readRingtone_module_unavailable_returns_none(
+    def test_read_ringtone_module_unavailable_returns_none(
         self,
         mock_node_for_admin: MagicMock,
         cache_store: _NodeContentCacheStore,
@@ -696,13 +696,13 @@ class TestNodeAdminContentRuntime:
         )
 
         with caplog.at_level(logging.WARNING):
-            result = runtime.readRingtone()
+            result = runtime.read_ringtone()
 
         assert result is None
         assert "External Notification module not present" in caplog.text
 
     @pytest.mark.unit
-    def test_readRingtone_ignores_late_callback_after_timeout(
+    def test_read_ringtone_ignores_late_callback_after_timeout(
         self,
         mock_node_for_admin: MagicMock,
         cache_store: _NodeContentCacheStore,
@@ -741,7 +741,7 @@ class TestNodeAdminContentRuntime:
             response_runtime=response_runtime,
         )
 
-        first_result = runtime.readRingtone()
+        first_result = runtime.read_ringtone()
         assert first_result is None
 
         late_raw = admin_pb2.AdminMessage()
@@ -749,12 +749,12 @@ class TestNodeAdminContentRuntime:
         callback_by_call[1]({"decoded": {"admin": {"raw": late_raw}}})
         assert mock_node_for_admin.ringtonePart is None
 
-        second_result = runtime.readRingtone()
+        second_result = runtime.read_ringtone()
         assert second_result is None
         assert mock_node_for_admin.ringtonePart is None
 
     @pytest.mark.unit
-    def test_writeRingtone_valid_ringtone_calls_send_admin(
+    def test_write_ringtone_valid_ringtone_calls_send_admin(
         self,
         mock_node_for_admin: MagicMock,
         cache_store: _NodeContentCacheStore,
@@ -770,7 +770,7 @@ class TestNodeAdminContentRuntime:
         ringtone = "RTTTL: test:d=4,o=5,b=100:c"
 
         with caplog.at_level(logging.DEBUG):
-            result = runtime.writeRingtone(ringtone)
+            result = runtime.write_ringtone(ringtone)
 
         assert result is not None
         mock_node_for_admin._send_admin.assert_called_once()
@@ -778,7 +778,7 @@ class TestNodeAdminContentRuntime:
         assert "Setting ringtone" in caplog.text
 
     @pytest.mark.unit
-    def test_writeRingtone_too_long_raises_error(
+    def test_write_ringtone_too_long_raises_error(
         self,
         mock_node_for_admin: MagicMock,
         cache_store: _NodeContentCacheStore,
@@ -795,14 +795,14 @@ class TestNodeAdminContentRuntime:
         with pytest.raises(
             MeshInterface.MeshInterfaceError, match="interface error raised"
         ):
-            runtime.writeRingtone(long_ringtone)
+            runtime.write_ringtone(long_ringtone)
 
         mock_node_for_admin._raise_interface_error.assert_called_once()
         error_msg = mock_node_for_admin._raise_interface_error.call_args[0][0]
         assert f"{MAX_RINGTONE_LENGTH} characters" in error_msg
 
     @pytest.mark.unit
-    def test_writeRingtone_module_unavailable_returns_none(
+    def test_write_ringtone_module_unavailable_returns_none(
         self,
         mock_node_for_admin: MagicMock,
         cache_store: _NodeContentCacheStore,
@@ -818,13 +818,13 @@ class TestNodeAdminContentRuntime:
         )
 
         with caplog.at_level(logging.WARNING):
-            result = runtime.writeRingtone("RTTTL: test:d=4,o=5,b=100:c")
+            result = runtime.write_ringtone("RTTTL: test:d=4,o=5,b=100:c")
 
         assert result is None
         assert "External Notification module not present" in caplog.text
 
     @pytest.mark.unit
-    def test_writeRingtone_invalidates_cache(
+    def test_write_ringtone_invalidates_cache(
         self,
         mock_node_for_admin: MagicMock,
         cache_store: _NodeContentCacheStore,
@@ -839,13 +839,13 @@ class TestNodeAdminContentRuntime:
             response_runtime=response_runtime,
         )
 
-        runtime.writeRingtone("RTTTL: new:d=4,o=5,b=100:c")
+        runtime.write_ringtone("RTTTL: new:d=4,o=5,b=100:c")
 
         assert mock_node_for_admin.ringtone is None
         assert mock_node_for_admin.ringtonePart is None
 
     @pytest.mark.unit
-    def test_writeRingtone_send_returns_none_skips_invalidation(
+    def test_write_ringtone_send_returns_none_skips_invalidation(
         self,
         mock_node_for_admin: MagicMock,
         cache_store: _NodeContentCacheStore,
@@ -860,13 +860,13 @@ class TestNodeAdminContentRuntime:
             response_runtime=response_runtime,
         )
 
-        runtime.writeRingtone("RTTTL: new:d=4,o=5,b=100:c")
+        runtime.write_ringtone("RTTTL: new:d=4,o=5,b=100:c")
 
         # Cache should not be invalidated
         assert mock_node_for_admin.ringtone == "old_ringtone"
 
     @pytest.mark.unit
-    def test_readCannedMessage_returns_cached_value(
+    def test_read_canned_message_returns_cached_value(
         self,
         mock_node_for_admin: MagicMock,
         cache_store: _NodeContentCacheStore,
@@ -880,14 +880,14 @@ class TestNodeAdminContentRuntime:
             response_runtime=response_runtime,
         )
 
-        result = runtime.readCannedMessage()
+        result = runtime.read_canned_message()
 
         assert result == "Hello\nWorld"
         # Should not call _send_admin since cached
         mock_node_for_admin._send_admin.assert_not_called()
 
     @pytest.mark.unit
-    def test_readCannedMessage_module_unavailable_returns_none(
+    def test_read_canned_message_module_unavailable_returns_none(
         self,
         mock_node_for_admin: MagicMock,
         cache_store: _NodeContentCacheStore,
@@ -903,13 +903,13 @@ class TestNodeAdminContentRuntime:
         )
 
         with caplog.at_level(logging.WARNING):
-            result = runtime.readCannedMessage()
+            result = runtime.read_canned_message()
 
         assert result is None
         assert "Canned Message module not present" in caplog.text
 
     @pytest.mark.unit
-    def test_writeCannedMessage_valid_message_calls_send_admin(
+    def test_write_canned_message_valid_message_calls_send_admin(
         self,
         mock_node_for_admin: MagicMock,
         cache_store: _NodeContentCacheStore,
@@ -925,7 +925,7 @@ class TestNodeAdminContentRuntime:
         message = "Hello\nWorld"
 
         with caplog.at_level(logging.DEBUG):
-            result = runtime.writeCannedMessage(message)
+            result = runtime.write_canned_message(message)
 
         assert result is not None
         mock_node_for_admin._send_admin.assert_called_once()
@@ -933,7 +933,7 @@ class TestNodeAdminContentRuntime:
         assert "Setting canned message" in caplog.text
 
     @pytest.mark.unit
-    def test_writeCannedMessage_too_long_raises_error(
+    def test_write_canned_message_too_long_raises_error(
         self,
         mock_node_for_admin: MagicMock,
         cache_store: _NodeContentCacheStore,
@@ -950,14 +950,14 @@ class TestNodeAdminContentRuntime:
         with pytest.raises(
             MeshInterface.MeshInterfaceError, match="interface error raised"
         ):
-            runtime.writeCannedMessage(long_message)
+            runtime.write_canned_message(long_message)
 
         mock_node_for_admin._raise_interface_error.assert_called_once()
         error_msg = mock_node_for_admin._raise_interface_error.call_args[0][0]
         assert f"{MAX_CANNED_MESSAGE_LENGTH} characters" in error_msg
 
     @pytest.mark.unit
-    def test_writeCannedMessage_module_unavailable_returns_none(
+    def test_write_canned_message_module_unavailable_returns_none(
         self,
         mock_node_for_admin: MagicMock,
         cache_store: _NodeContentCacheStore,
@@ -973,13 +973,13 @@ class TestNodeAdminContentRuntime:
         )
 
         with caplog.at_level(logging.WARNING):
-            result = runtime.writeCannedMessage("Hello\nWorld")
+            result = runtime.write_canned_message("Hello\nWorld")
 
         assert result is None
         assert "Canned Message module not present" in caplog.text
 
     @pytest.mark.unit
-    def test_writeCannedMessage_invalidates_cache(
+    def test_write_canned_message_invalidates_cache(
         self,
         mock_node_for_admin: MagicMock,
         cache_store: _NodeContentCacheStore,
@@ -994,13 +994,13 @@ class TestNodeAdminContentRuntime:
             response_runtime=response_runtime,
         )
 
-        runtime.writeCannedMessage("New message")
+        runtime.write_canned_message("New message")
 
         assert mock_node_for_admin.cannedPluginMessage is None
         assert mock_node_for_admin.cannedPluginMessageMessages is None
 
     @pytest.mark.unit
-    def test_writeCannedMessage_send_returns_none_skips_invalidation(
+    def test_write_canned_message_send_returns_none_skips_invalidation(
         self,
         mock_node_for_admin: MagicMock,
         cache_store: _NodeContentCacheStore,
@@ -1015,7 +1015,7 @@ class TestNodeAdminContentRuntime:
             response_runtime=response_runtime,
         )
 
-        runtime.writeCannedMessage("New message")
+        runtime.write_canned_message("New message")
 
         # Cache should not be invalidated
         assert mock_node_for_admin.cannedPluginMessage == "old_message"

--- a/meshtastic/tests/test_node_runtime_settings.py
+++ b/meshtastic/tests/test_node_runtime_settings.py
@@ -269,7 +269,7 @@ class TestNodeSettingsRuntime:
         builder = _NodeSettingsMessageBuilder(mock_local_node)
         runtime = _NodeSettingsRuntime(mock_local_node, message_builder=builder)
 
-        runtime.requestConfig(admin_pb2.AdminMessage.ConfigType.DEVICE_CONFIG)
+        runtime.request_config(admin_pb2.AdminMessage.ConfigType.DEVICE_CONFIG)
 
         mock_local_node._send_admin.assert_called_once()
         call_kwargs = mock_local_node._send_admin.call_args[1]
@@ -284,7 +284,7 @@ class TestNodeSettingsRuntime:
         builder = _NodeSettingsMessageBuilder(mock_remote_node)
         runtime = _NodeSettingsRuntime(mock_remote_node, message_builder=builder)
 
-        runtime.requestConfig(admin_pb2.AdminMessage.ConfigType.DEVICE_CONFIG)
+        runtime.request_config(admin_pb2.AdminMessage.ConfigType.DEVICE_CONFIG)
 
         mock_remote_node._send_admin.assert_called_once()
         call_kwargs = mock_remote_node._send_admin.call_args[1]
@@ -304,7 +304,7 @@ class TestNodeSettingsRuntime:
         with pytest.raises(
             _TestInterfaceError, match="requestConfig failed: admin message not started"
         ):
-            runtime.requestConfig(admin_pb2.AdminMessage.ConfigType.DEVICE_CONFIG)
+            runtime.request_config(admin_pb2.AdminMessage.ConfigType.DEVICE_CONFIG)
 
         mock_remote_node._send_admin.assert_called_once()
         mock_remote_node.iface.waitForAckNak.assert_not_called()
@@ -317,7 +317,7 @@ class TestNodeSettingsRuntime:
         builder = _NodeSettingsMessageBuilder(mock_local_node)
         runtime = _NodeSettingsRuntime(mock_local_node, message_builder=builder)
 
-        runtime.requestConfig(
+        runtime.request_config(
             admin_pb2.AdminMessage.ConfigType.DEVICE_CONFIG, admin_index=2
         )
 
@@ -394,7 +394,7 @@ class TestNodeSettingsRuntime:
         )
 
         with caplog.at_level(logging.DEBUG):
-            runtime.writeConfig("device")
+            runtime.write_config("device")
 
         assert "Config write completed: device" in caplog.text
         mock_local_node._send_admin.assert_called_once()
@@ -412,7 +412,7 @@ class TestNodeSettingsRuntime:
             config_pb2.Config.DeviceConfig.Role.CLIENT
         )
 
-        runtime.writeConfig("device")
+        runtime.write_config("device")
 
         mock_remote_node._send_admin.assert_called_once()
         call_kwargs = mock_remote_node._send_admin.call_args[1]
@@ -434,7 +434,7 @@ class TestNodeSettingsRuntime:
         with pytest.raises(
             _TestInterfaceError, match="writeConfig failed: admin message not started"
         ):
-            runtime.writeConfig("device")
+            runtime.write_config("device")
 
         mock_remote_node.iface.waitForAckNak.assert_not_called()
 
@@ -466,7 +466,7 @@ class TestNodeSettingsResponseRuntime:
         packet: dict[str, Any] = {}
 
         with caplog.at_level(logging.WARNING):
-            runtime.handleSettingsResponse(packet)
+            runtime.handle_settings_response(packet)
 
         assert "malformed settings response (missing decoded)" in caplog.text
         assert mock_node_for_response.iface._acknowledgment.receivedNak is True
@@ -484,7 +484,7 @@ class TestNodeSettingsResponseRuntime:
         }
 
         with caplog.at_level(logging.ERROR):
-            runtime.handleSettingsResponse(packet)
+            runtime.handle_settings_response(packet)
 
         assert "Error on response: NO_RESPONSE" in caplog.text
         assert mock_node_for_response.iface._acknowledgment.receivedNak is True
@@ -507,7 +507,7 @@ class TestNodeSettingsResponseRuntime:
             }
         }
 
-        runtime.handleSettingsResponse(packet)
+        runtime.handle_settings_response(packet)
 
         assert mock_node_for_response.iface._acknowledgment.receivedNak is False
         assert mock_node_for_response.iface._acknowledgment.receivedAck is True
@@ -521,7 +521,7 @@ class TestNodeSettingsResponseRuntime:
         packet: dict[str, Any] = {"decoded": {}}
 
         with caplog.at_level(logging.WARNING):
-            runtime.handleSettingsResponse(packet)
+            runtime.handle_settings_response(packet)
 
         assert "malformed settings response (missing admin)" in caplog.text
         assert mock_node_for_response.iface._acknowledgment.receivedNak is True
@@ -537,7 +537,7 @@ class TestNodeSettingsResponseRuntime:
         }
 
         with caplog.at_level(logging.WARNING):
-            runtime.handleSettingsResponse(packet)
+            runtime.handle_settings_response(packet)
 
         assert "Received empty config response from node" in caplog.text
         assert mock_node_for_response.iface._acknowledgment.receivedNak is True
@@ -553,7 +553,7 @@ class TestNodeSettingsResponseRuntime:
         }
 
         with caplog.at_level(logging.WARNING):
-            runtime.handleSettingsResponse(packet)
+            runtime.handle_settings_response(packet)
 
         assert "Received empty module config response from node" in caplog.text
         assert mock_node_for_response.iface._acknowledgment.receivedNak is True
@@ -644,7 +644,7 @@ class TestNodeSettingsResponseRuntime:
         }
 
         with caplog.at_level(logging.WARNING):
-            runtime.handleSettingsResponse(packet)
+            runtime.handle_settings_response(packet)
 
         assert "malformed settings response (invalid admin.raw)" in caplog.text
         assert mock_node_for_response.iface._acknowledgment.receivedNak is True
@@ -669,7 +669,7 @@ class TestNodeSettingsResponseRuntime:
         }
 
         with caplog.at_level(logging.INFO):
-            runtime.handleSettingsResponse(packet)
+            runtime.handle_settings_response(packet)
 
         assert mock_node_for_response.iface._acknowledgment.receivedAck is True
         assert "Received settings block: device" in caplog.text
@@ -736,7 +736,7 @@ class TestNodeAdminCommandRuntime:
         runtime = _NodeAdminCommandRuntime(mock_local_node_for_admin)
 
         with caplog.at_level(logging.INFO):
-            result = runtime.factoryReset(full=True)
+            result = runtime.factory_reset(full=True)
 
         assert result is not None
         assert "factory reset (full device reset)" in caplog.text
@@ -760,7 +760,7 @@ class TestNodeAdminCommandRuntime:
         runtime = _NodeAdminCommandRuntime(mock_local_node_for_admin)
 
         with caplog.at_level(logging.INFO):
-            result = runtime.factoryReset(full=False)
+            result = runtime.factory_reset(full=False)
 
         assert result is not None
         assert "factory reset (config reset)" in caplog.text
@@ -784,7 +784,7 @@ class TestNodeAdminCommandRuntime:
         runtime = _NodeAdminCommandRuntime(mock_local_node_for_admin)
 
         with caplog.at_level(logging.INFO):
-            result = runtime.beginSettingsTransaction()
+            result = runtime.begin_settings_transaction()
 
         assert result is not None
         assert "open a transaction to edit settings" in caplog.text
@@ -800,7 +800,7 @@ class TestNodeAdminCommandRuntime:
         runtime = _NodeAdminCommandRuntime(mock_local_node_for_admin)
 
         with caplog.at_level(logging.INFO):
-            result = runtime.commitSettingsTransaction()
+            result = runtime.commit_settings_transaction()
 
         assert result is not None
         assert "commit open transaction" in caplog.text
@@ -839,7 +839,7 @@ class TestNodeAdminCommandRuntime:
         runtime = _NodeAdminCommandRuntime(mock_node_for_admin)
 
         with caplog.at_level(logging.INFO):
-            result = runtime.beginSettingsTransaction()
+            result = runtime.begin_settings_transaction()
 
         assert result is not None
         mock_node_for_admin.ensureSessionKey.assert_called_once()
@@ -858,7 +858,7 @@ class TestNodeAdminCommandRuntime:
         runtime = _NodeAdminCommandRuntime(mock_node_for_admin)
 
         with caplog.at_level(logging.INFO):
-            result = runtime.commitSettingsTransaction()
+            result = runtime.commit_settings_transaction()
 
         assert result is not None
         mock_node_for_admin.ensureSessionKey.assert_called_once()
@@ -939,7 +939,7 @@ class TestNodeAdminCommandRuntime:
         with pytest.raises(
             _TestInterfaceError, match="startOTA only possible on local node"
         ):
-            runtime.startOta(
+            runtime.start_ota(
                 mode=admin_pb2.OTAMode.OTA_WIFI,
                 ota_file_hash=b"hash",
             )
@@ -952,7 +952,7 @@ class TestNodeAdminCommandRuntime:
         runtime = _NodeAdminCommandRuntime(mock_local_node_for_admin)
 
         with pytest.raises(TypeError, match=r"missing required argument.*mode"):
-            runtime.startOta(
+            runtime.start_ota(
                 mode=None,
                 ota_file_hash=b"hash",
             )
@@ -967,7 +967,7 @@ class TestNodeAdminCommandRuntime:
         with pytest.raises(
             TypeError, match=r"missing required argument.*ota_file_hash"
         ):
-            runtime.startOta(
+            runtime.start_ota(
                 mode=admin_pb2.OTAMode.OTA_WIFI,
                 ota_file_hash=None,
             )
@@ -980,7 +980,7 @@ class TestNodeAdminCommandRuntime:
         runtime = _NodeAdminCommandRuntime(mock_local_node_for_admin)
 
         with pytest.raises(ValueError, match="Conflicting OTA mode arguments"):
-            runtime.startOta(
+            runtime.start_ota(
                 mode=admin_pb2.OTAMode.OTA_WIFI,
                 ota_mode=admin_pb2.OTAMode.OTA_BLE,
                 ota_file_hash=b"hash",
@@ -994,7 +994,7 @@ class TestNodeAdminCommandRuntime:
         runtime = _NodeAdminCommandRuntime(mock_local_node_for_admin)
 
         with pytest.raises(TypeError, match="unexpected keyword argument"):
-            runtime.startOta(
+            runtime.start_ota(
                 mode=admin_pb2.OTAMode.OTA_WIFI,
                 ota_file_hash=b"hash",
                 unknown_arg="value",
@@ -1007,7 +1007,7 @@ class TestNodeAdminCommandRuntime:
         """start_OTA with valid mode and hash sends OTA request (lines 441-479)."""
         runtime = _NodeAdminCommandRuntime(mock_local_node_for_admin)
 
-        result = runtime.startOta(
+        result = runtime.start_ota(
             mode=admin_pb2.OTAMode.OTA_WIFI,
             ota_file_hash=b"test_hash_bytes",
         )
@@ -1027,7 +1027,7 @@ class TestNodeAdminCommandRuntime:
         """start_OTA uses legacy 'hash' kwarg from extra_kwargs."""
         runtime = _NodeAdminCommandRuntime(mock_local_node_for_admin)
 
-        result = runtime.startOta(
+        result = runtime.start_ota(
             mode=admin_pb2.OTAMode.OTA_WIFI,
             ota_file_hash=None,
             hash=b"legacy_hash",
@@ -1049,7 +1049,7 @@ class TestNodeAdminCommandRuntime:
             "meshtastic.node_runtime.settings_runtime.admin.toNodeNum",
             return_value=12345,
         ) as mock_to_node_num:
-            result = runtime.setIgnored(0x12345)
+            result = runtime.set_ignored(0x12345)
 
         mock_to_node_num.assert_called_once_with(0x12345)
         assert result is not None
@@ -1068,7 +1068,7 @@ class TestNodeAdminCommandRuntime:
             "meshtastic.node_runtime.settings_runtime.admin.toNodeNum",
             return_value=0x9388F81C,
         ) as mock_to_node_num:
-            result = runtime.setIgnored("!9388f81c")
+            result = runtime.set_ignored("!9388f81c")
 
         mock_to_node_num.assert_called_once_with("!9388f81c")
         assert result is not None
@@ -1155,7 +1155,7 @@ class TestNodeOwnerProfileRuntime:
     ) -> _NodeOwnerProfileRuntime:
         """Create a _NodeOwnerProfileRuntime with mocked admin_command_runtime."""
         admin_runtime = MagicMock()
-        admin_runtime.sendOwnerMessage = MagicMock(return_value=MagicMock())
+        admin_runtime.send_owner_message = MagicMock(return_value=MagicMock())
         return _NodeOwnerProfileRuntime(
             mock_node_for_owner,
             admin_command_runtime=admin_runtime,
@@ -1171,13 +1171,13 @@ class TestNodeOwnerProfileRuntime:
         long_name = "A" * 50  # Longer than MAX_LONG_NAME_LEN (40)
 
         with caplog.at_level(logging.WARNING):
-            mock_runtime_for_owner.setOwner(long_name=long_name)
+            mock_runtime_for_owner.set_owner(long_name=long_name)
 
         assert "Long name is longer than" in caplog.text
         assert "truncating" in caplog.text
         # Verify the message was sent with truncated name
         call_args = (
-            mock_runtime_for_owner._admin_command_runtime.sendOwnerMessage.call_args  # type: ignore[attr-defined]
+            mock_runtime_for_owner._admin_command_runtime.send_owner_message.call_args  # type: ignore[attr-defined]
         )
         message = call_args[0][0]
         assert len(message.set_owner.long_name) == MAX_LONG_NAME_LEN
@@ -1193,13 +1193,13 @@ class TestNodeOwnerProfileRuntime:
         short_name = "LongShort"  # Longer than MAX_SHORT_NAME_LEN (4)
 
         with caplog.at_level(logging.WARNING):
-            mock_runtime_for_owner.setOwner(short_name=short_name)
+            mock_runtime_for_owner.set_owner(short_name=short_name)
 
         assert "Short name is longer than" in caplog.text
         assert "truncating" in caplog.text
         # Verify the message was sent with truncated name
         call_args = (
-            mock_runtime_for_owner._admin_command_runtime.sendOwnerMessage.call_args  # type: ignore[attr-defined]
+            mock_runtime_for_owner._admin_command_runtime.send_owner_message.call_args  # type: ignore[attr-defined]
         )
         message = call_args[0][0]
         assert len(message.set_owner.short_name) == MAX_SHORT_NAME_LEN
@@ -1211,7 +1211,7 @@ class TestNodeOwnerProfileRuntime:
     ) -> None:
         """set_owner with empty long_name raises error."""
         with pytest.raises(_TestInterfaceError, match=EMPTY_LONG_NAME_MSG):
-            mock_runtime_for_owner.setOwner(long_name="")
+            mock_runtime_for_owner.set_owner(long_name="")
 
     @pytest.mark.unit
     def test_set_owner_whitespace_long_name_raises_error(
@@ -1219,7 +1219,7 @@ class TestNodeOwnerProfileRuntime:
     ) -> None:
         """set_owner with whitespace-only long_name raises error."""
         with pytest.raises(_TestInterfaceError, match=EMPTY_LONG_NAME_MSG):
-            mock_runtime_for_owner.setOwner(long_name="   ")
+            mock_runtime_for_owner.set_owner(long_name="   ")
 
     @pytest.mark.unit
     def test_set_owner_empty_short_name_raises_error(
@@ -1227,7 +1227,7 @@ class TestNodeOwnerProfileRuntime:
     ) -> None:
         """set_owner with empty short_name raises error."""
         with pytest.raises(_TestInterfaceError, match=EMPTY_SHORT_NAME_MSG):
-            mock_runtime_for_owner.setOwner(short_name="")
+            mock_runtime_for_owner.set_owner(short_name="")
 
     @pytest.mark.unit
     def test_set_owner_whitespace_short_name_raises_error(
@@ -1235,17 +1235,17 @@ class TestNodeOwnerProfileRuntime:
     ) -> None:
         """set_owner with whitespace-only short_name raises error."""
         with pytest.raises(_TestInterfaceError, match=EMPTY_SHORT_NAME_MSG):
-            mock_runtime_for_owner.setOwner(short_name="   ")
+            mock_runtime_for_owner.set_owner(short_name="   ")
 
     @pytest.mark.unit
     def test_set_owner_strips_whitespace(
         self, mock_runtime_for_owner: _NodeOwnerProfileRuntime
     ) -> None:
         """set_owner strips whitespace from names before validation."""
-        mock_runtime_for_owner.setOwner(long_name="  ValidName  ", short_name=" AB ")
+        mock_runtime_for_owner.set_owner(long_name="  ValidName  ", short_name=" AB ")
 
         call_args = (
-            mock_runtime_for_owner._admin_command_runtime.sendOwnerMessage.call_args  # type: ignore[attr-defined]
+            mock_runtime_for_owner._admin_command_runtime.send_owner_message.call_args  # type: ignore[attr-defined]
         )
         message = call_args[0][0]
         assert message.set_owner.long_name == "ValidName"
@@ -1256,10 +1256,10 @@ class TestNodeOwnerProfileRuntime:
         self, mock_runtime_for_owner: _NodeOwnerProfileRuntime
     ) -> None:
         """set_owner sets is_licensed flag."""
-        mock_runtime_for_owner.setOwner(long_name="Test", is_licensed=True)
+        mock_runtime_for_owner.set_owner(long_name="Test", is_licensed=True)
 
         call_args = (
-            mock_runtime_for_owner._admin_command_runtime.sendOwnerMessage.call_args  # type: ignore[attr-defined]
+            mock_runtime_for_owner._admin_command_runtime.send_owner_message.call_args  # type: ignore[attr-defined]
         )
         message = call_args[0][0]
         assert message.set_owner.is_licensed is True
@@ -1269,10 +1269,10 @@ class TestNodeOwnerProfileRuntime:
         self, mock_runtime_for_owner: _NodeOwnerProfileRuntime
     ) -> None:
         """set_owner sets is_unmessagable flag when provided."""
-        mock_runtime_for_owner.setOwner(long_name="Test", is_unmessagable=True)
+        mock_runtime_for_owner.set_owner(long_name="Test", is_unmessagable=True)
 
         call_args = (
-            mock_runtime_for_owner._admin_command_runtime.sendOwnerMessage.call_args  # type: ignore[attr-defined]
+            mock_runtime_for_owner._admin_command_runtime.send_owner_message.call_args  # type: ignore[attr-defined]
         )
         message = call_args[0][0]
         assert message.set_owner.is_unmessagable is True
@@ -1282,10 +1282,10 @@ class TestNodeOwnerProfileRuntime:
         self, mock_runtime_for_owner: _NodeOwnerProfileRuntime
     ) -> None:
         """set_owner does not set is_unmessagable when None."""
-        mock_runtime_for_owner.setOwner(long_name="Test", is_unmessagable=None)
+        mock_runtime_for_owner.set_owner(long_name="Test", is_unmessagable=None)
 
         call_args = (
-            mock_runtime_for_owner._admin_command_runtime.sendOwnerMessage.call_args  # type: ignore[attr-defined]
+            mock_runtime_for_owner._admin_command_runtime.send_owner_message.call_args  # type: ignore[attr-defined]
         )
         message = call_args[0][0]
         assert not message.set_owner.HasField("is_unmessagable")
@@ -1298,7 +1298,7 @@ class TestNodeOwnerProfileRuntime:
     ) -> None:
         """set_owner with all parameters sets all fields."""
         with caplog.at_level(logging.DEBUG):
-            mock_runtime_for_owner.setOwner(
+            mock_runtime_for_owner.set_owner(
                 long_name="TestUser",
                 short_name="TEST",
                 is_licensed=True,
@@ -1306,7 +1306,7 @@ class TestNodeOwnerProfileRuntime:
             )
 
         call_args = (
-            mock_runtime_for_owner._admin_command_runtime.sendOwnerMessage.call_args  # type: ignore[attr-defined]
+            mock_runtime_for_owner._admin_command_runtime.send_owner_message.call_args  # type: ignore[attr-defined]
         )
         message = call_args[0][0]
         assert message.set_owner.long_name == "TestUser"
@@ -1323,10 +1323,10 @@ class TestNodeOwnerProfileRuntime:
         self, mock_runtime_for_owner: _NodeOwnerProfileRuntime
     ) -> None:
         """set_owner with only long_name sets only that field."""
-        mock_runtime_for_owner.setOwner(long_name="OnlyLong")
+        mock_runtime_for_owner.set_owner(long_name="OnlyLong")
 
         call_args = (
-            mock_runtime_for_owner._admin_command_runtime.sendOwnerMessage.call_args  # type: ignore[attr-defined]
+            mock_runtime_for_owner._admin_command_runtime.send_owner_message.call_args  # type: ignore[attr-defined]
         )
         message = call_args[0][0]
         assert message.set_owner.long_name == "OnlyLong"
@@ -1338,10 +1338,10 @@ class TestNodeOwnerProfileRuntime:
         self, mock_runtime_for_owner: _NodeOwnerProfileRuntime
     ) -> None:
         """set_owner with only short_name sets only that field."""
-        mock_runtime_for_owner.setOwner(short_name="ABC")
+        mock_runtime_for_owner.set_owner(short_name="ABC")
 
         call_args = (
-            mock_runtime_for_owner._admin_command_runtime.sendOwnerMessage.call_args  # type: ignore[attr-defined]
+            mock_runtime_for_owner._admin_command_runtime.send_owner_message.call_args  # type: ignore[attr-defined]
         )
         message = call_args[0][0]
         assert message.set_owner.short_name == "ABC"


### PR DESCRIPTION
## Overview

This change normalizes implementation-only Node runtime and SetURL names to snake_case. Public `Node` methods keep their historical camelCase API, and the runtime compatibility export documented by the repository manifest remains available.

### Key changes

**Refactors**

* Normalize channel request/export/response, settings/admin/owner, content, and SetURL runtime methods to snake_case.
* Remove duplicate camelCase aliases from internal runtime classes and shared helpers that are not part of the compatibility manifest.
* Update Node's internal delegation and runtime tests to use the normalized names.

**Fixes**

* Preserve historical user-visible debug and log wording while changing only implementation identifiers.
* Keep response and channel-request behavior unchanged through the renamed internal paths.

**Compatibility**

* Keep the public `Node` camelCase API unchanged, including `startOTA()`, `removeNode()`, and the existing compatibility wrappers.
* Preserve the historical `startOTA()` keyword forms covered by the compatibility contract.
* Preserve `meshtastic.node_runtime.settings_runtime.toNodeNum`, the manifest-backed runtime compatibility export.
* Other `node_runtime` aliases removed by this PR are internal implementation details rather than supported public API.
