### PR TITLE
Apply repo-wide trunk lint and format autofixes

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -3,7 +3,7 @@
 This document is the canonical human-readable policy for compatibility aliases,
 deprecations, and legacy compatibility behaviors in this repository. Runtime
 import guarantees are additionally defined by the machine-readable
-``meshtastic/_runtime_compatibility.json`` manifest consumed by API-baseline tooling.
+`meshtastic/_runtime_compatibility.json` manifest consumed by API-baseline tooling.
 
 If a compatibility symbol is not listed here, or a runtime import guarantee is
 not present in that manifest, do not add or keep it by default.
@@ -59,7 +59,7 @@ implementation details that are NOT part of the public stable API.
 
 ### Documented Runtime Compatibility Exports
 
-The machine-readable manifest ``meshtastic/_runtime_compatibility.json`` is the
+The machine-readable manifest `meshtastic/_runtime_compatibility.json` is the
 source of truth consumed by API-baseline tooling for runtime import guarantees.
 It currently guarantees only:
 

--- a/bin/extract_api_surface.py
+++ b/bin/extract_api_surface.py
@@ -80,7 +80,6 @@ def _load_runtime_compatibility_import_paths(pkg_dir: Path) -> list[str]:
     return sorted(paths)
 
 
-
 def _annotation_to_str(node: ast.AST | None) -> str:
     if node is None:
         return ""

--- a/meshtastic/__init__.py
+++ b/meshtastic/__init__.py
@@ -81,21 +81,15 @@ from meshtastic.util import (
     stripnl,
 )
 
-from . import util
-from ._core_constants import (
-    BROADCAST_ADDR as _BROADCAST_ADDR,
-    BROADCAST_NUM as _BROADCAST_NUM,
-    DECODE_ERROR_KEY as _DECODE_ERROR_KEY,
-    LOCAL_ADDR as _LOCAL_ADDR,
-    NODELESS_WANT_CONFIG_ID as _NODELESS_WANT_CONFIG_ID,
-    OUR_APP_VERSION as _OUR_APP_VERSION,
-)
-from ._response_types import (
-    ResponseCallback as _ResponseCallback,
-    ResponseHandler as _ResponseHandler,
-)
-from . import _protocol_runtime
-from . import _publishing
+from . import _protocol_runtime, _publishing, util
+from ._core_constants import BROADCAST_ADDR as _BROADCAST_ADDR
+from ._core_constants import BROADCAST_NUM as _BROADCAST_NUM
+from ._core_constants import DECODE_ERROR_KEY as _DECODE_ERROR_KEY
+from ._core_constants import LOCAL_ADDR as _LOCAL_ADDR
+from ._core_constants import NODELESS_WANT_CONFIG_ID as _NODELESS_WANT_CONFIG_ID
+from ._core_constants import OUR_APP_VERSION as _OUR_APP_VERSION
+from ._response_types import ResponseCallback as _ResponseCallback
+from ._response_types import ResponseHandler as _ResponseHandler
 from .protobuf import (
     admin_pb2,
     apponly_pb2,

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -24,26 +24,26 @@ from google.protobuf.descriptor import FieldDescriptor
 from google.protobuf.json_format import MessageToDict
 from pubsub import pub
 
-import meshtastic.cli.config_io as cli_config_io
 import meshtastic.cli.channel_contact_actions as cli_channel_contact_actions
+import meshtastic.cli.config_io as cli_config_io
 import meshtastic.cli.configure_actions as cli_configure_actions
 import meshtastic.cli.device_actions as cli_device_actions
 import meshtastic.cli.dispatch as cli_dispatch
 import meshtastic.cli.messaging_service_actions as cli_messaging_service_actions
 import meshtastic.cli.runtime as cli_runtime
-from meshtastic.cli.context import ActionOutcome, CliContext
 import meshtastic.ota
 import meshtastic.serial_interface
 import meshtastic.tcp_interface
 import meshtastic.util
 from meshtastic import mt_config, remote_hardware
+
 # COMPAT_STABLE_SHIM: LOCAL_ADDR remains importable from meshtastic.__main__.
 # pylint: disable=unused-import
+from meshtastic._core_constants import LOCAL_ADDR  # noqa: F401
 from meshtastic._core_constants import (
     BROADCAST_ADDR,
-    LOCAL_ADDR,  # noqa: F401
 )
-# pylint: enable=unused-import
+from meshtastic.cli.context import ActionOutcome, CliContext
 
 # COMPAT_STABLE_SHIM: Preserve legacy imports from meshtastic.cli.parser.
 # pylint: disable=unused-import
@@ -71,8 +71,8 @@ from meshtastic.cli.values import (  # noqa: F401,W0611 - legacy __main__ compat
 from meshtastic.cli.values import (  # noqa: F401,W0611 - legacy __main__ compatibility export
     parse_modem_preset_name as _parse_modem_preset_name,
 )
-from meshtastic.configure_verify import (
-    _verify_channel_url_against_state,  # noqa: F401 - legacy __main__ compatibility export
+from meshtastic.configure_verify import (  # noqa: F401 - legacy __main__ compatibility export
+    _verify_channel_url_against_state,
 )
 from meshtastic.host_port import parseHostAndPort
 from meshtastic.interfaces.ble import BLEInterface
@@ -84,8 +84,8 @@ from meshtastic.lockdown import (
 )
 from meshtastic.mesh_interface import MeshInterface
 from meshtastic.mesh_interface_runtime import node_data
-from meshtastic.protobuf import (
-    admin_pb2,  # noqa: F401 - legacy __main__ compatibility export
+from meshtastic.protobuf import (  # noqa: F401 - legacy __main__ compatibility export
+    admin_pb2,
     channel_pb2,
     config_pb2,
     localonly_pb2,
@@ -97,6 +97,9 @@ from meshtastic.version import (
     PROJECT_DISPLAY_NAME,
     get_active_version,
 )
+
+# pylint: enable=unused-import
+
 
 # COMPAT_STABLE_SHIM: Preserve legacy private imports while runtime owns behavior.
 MAIN_LOOP_IDLE_SLEEP_SECONDS = cli_runtime.MAIN_LOOP_IDLE_SLEEP_SECONDS

--- a/meshtastic/cli/channel_contact_actions.py
+++ b/meshtastic/cli/channel_contact_actions.py
@@ -11,7 +11,6 @@ import meshtastic.util
 from meshtastic.cli.context import CliContext, CliExit, _terminate_cli
 from meshtastic.protobuf import channel_pb2, config_pb2
 
-
 MAX_CHANNEL_NAME_LENGTH: int = 10
 
 

--- a/meshtastic/cli/configure_actions.py
+++ b/meshtastic/cli/configure_actions.py
@@ -1130,9 +1130,7 @@ def _apply_settings_transaction(
     module_config_sections : dict[str, dict[str, Any]]
         Validated LocalModuleConfig sections.
     """
-    hooks.cli_print(
-        "Applying configuration transaction (may trigger device reboot)..."
-    )
+    hooks.cli_print("Applying configuration transaction (may trigger device reboot)...")
     target_node.beginSettingsTransaction()
     remaining_writes = len(config_sections) + len(module_config_sections)
     commit_attempted = False

--- a/meshtastic/cli/device_actions.py
+++ b/meshtastic/cli/device_actions.py
@@ -694,9 +694,7 @@ def _handle_position_fields(context: CliContext, hooks: DeviceActionHooks) -> No
             )
         else:
             hooks.cli_print(f"Setting position fields to {all_fields}")
-            if not hooks.set_pref(
-                position_config, "position_flags", f"{all_fields:d}"
-            ):
+            if not hooks.set_pref(position_config, "position_flags", f"{all_fields:d}"):
                 _terminate_cli(
                     hooks.cli_exit,
                     "ERROR: Failed to set position_flags preference.",

--- a/meshtastic/interfaces/ble/compatibility_service.py
+++ b/meshtastic/interfaces/ble/compatibility_service.py
@@ -8,16 +8,16 @@ from meshtastic.interfaces.ble.compat_adapter import (
     _get_declared_callable,
     _get_declared_member,
 )
-from meshtastic.interfaces.ble.lifecycle_primitives import _LifecycleStateAccess
-from meshtastic.interfaces.ble.failure_policy import (
-    _BLEFailureDisposition,
-    _log_ble_failure,
-)
 from meshtastic.interfaces.ble.constants import (
     DISCONNECT_TIMEOUT_SECONDS,
     MAX_DRAIN_ITERATIONS,
     logger,
 )
+from meshtastic.interfaces.ble.failure_policy import (
+    _BLEFailureDisposition,
+    _log_ble_failure,
+)
+from meshtastic.interfaces.ble.lifecycle_primitives import _LifecycleStateAccess
 from meshtastic.interfaces.ble.utils import (
     _resolve_safe_execute as _resolve_safe_execute_hook,
 )
@@ -457,10 +457,7 @@ class BLECompatibilityEventService:
 
         queue = getattr(publishing_thread, "queue", None)
         get_nowait = getattr(queue, "get_nowait", None)
-        if (
-            queue is None
-            or not callable(get_nowait)
-        ):
+        if queue is None or not callable(get_nowait):
             return
         iterations = 0
         while not flush_event.is_set():

--- a/meshtastic/interfaces/ble/discovery.py
+++ b/meshtastic/interfaces/ble/discovery.py
@@ -13,11 +13,11 @@ from typing import Any, Callable, Protocol, cast, runtime_checkable
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakDBusError, BleakError
 
+from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.compat_adapter import (
     _get_declared_member,
     _resolve_declared_callable,
 )
-from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.constants import (
     SERVICE_UUID,
     BLEConfig,

--- a/meshtastic/interfaces/ble/gating.py
+++ b/meshtastic/interfaces/ble/gating.py
@@ -38,6 +38,7 @@ from meshtastic.interfaces.ble.utils import sanitize_address
 
 logger = logging.getLogger("meshtastic.ble")
 
+
 class _BLEAddressRegistry:
     """Own process-wide BLE address claims and per-address lock bookkeeping.
 

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -1237,7 +1237,8 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
         state_manager = self._state_manager
         lifecycle_owner_is_current: bool | None
         canonical_locked_probe = (
-            type(state_manager) is BLEStateManager  # pylint: disable=unidiomatic-typecheck
+            type(state_manager)
+            is BLEStateManager  # pylint: disable=unidiomatic-typecheck
             and state_manager.lock is self._state_lock
         )
         with self._state_lock:
@@ -2777,7 +2778,9 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
         """
         lifecycle_controller = self._get_lifecycle_controller()
         finalize_connection_gates = _resolve_declared_callable(
-            lifecycle_controller, "_finalize_connection_gates", "finalize_connection_gates"
+            lifecycle_controller,
+            "_finalize_connection_gates",
+            "finalize_connection_gates",
         )
         if finalize_connection_gates is not None:
             finalize_connection_gates(
@@ -2802,7 +2805,9 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
         """
         lifecycle_controller = self._get_lifecycle_controller()
         is_owned_connected_client = _resolve_declared_callable(
-            lifecycle_controller, "_is_owned_connected_client", "is_owned_connected_client"
+            lifecycle_controller,
+            "_is_owned_connected_client",
+            "is_owned_connected_client",
         )
         if is_owned_connected_client is not None:
             result = is_owned_connected_client(client)

--- a/meshtastic/interfaces/ble/lifecycle_compat_service.py
+++ b/meshtastic/interfaces/ble/lifecycle_compat_service.py
@@ -39,7 +39,6 @@ from meshtastic.interfaces.ble.lifecycle_shutdown_runtime import (
 )
 from meshtastic.interfaces.ble.state import ConnectionState
 
-
 if TYPE_CHECKING:
     from meshtastic.interfaces.ble.client import BLEClient
     from meshtastic.interfaces.ble.interface import BLEInterface
@@ -137,7 +136,9 @@ class BLELifecycleService:
                 )
             )
 
-        get_lifecycle_controller = _get_declared_callable(iface, "_get_lifecycle_controller")
+        get_lifecycle_controller = _get_declared_callable(
+            iface, "_get_lifecycle_controller"
+        )
         if get_lifecycle_controller is not None:
             try:
                 lifecycle_controller = get_lifecycle_controller()
@@ -154,9 +155,8 @@ class BLELifecycleService:
                     "receive_lifecycle_coordinator",
                     "_receive_lifecycle_coordinator",
                 )
-                if (
-                    receive_coordinator is not None
-                    and _matches_receive_candidate(receive_coordinator)
+                if receive_coordinator is not None and _matches_receive_candidate(
+                    receive_coordinator
                 ):
                     return cast(BLEReceiveLifecycleCoordinator, receive_coordinator)
                 if _matches_receive_candidate(lifecycle_controller):
@@ -177,10 +177,7 @@ class BLELifecycleService:
                     "_ble_receive_lifecycle_coordinator",
                     lambda: BLEReceiveLifecycleCoordinator(iface),
                 )
-                if (
-                    coordinator is not None
-                    and _matches_receive_candidate(coordinator)
-                ):
+                if coordinator is not None and _matches_receive_candidate(coordinator):
                     return cast(BLEReceiveLifecycleCoordinator, coordinator)
         return BLEReceiveLifecycleCoordinator(iface)
 

--- a/meshtastic/interfaces/ble/lifecycle_controller_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_controller_runtime.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, TypeVar, cast
 
 from bleak import BleakClient as BleakRootClient
 
-from meshtastic.interfaces.ble.compat_adapter import (_get_declared_callable)
+from meshtastic.interfaces.ble.compat_adapter import _get_declared_callable
 from meshtastic.interfaces.ble.lifecycle_compat_service import (
     _ORIGINAL_FINALIZE_CONNECTION_GATES,
     _ORIGINAL_GET_CONNECTED_CLIENT_STATUS,
@@ -75,7 +75,9 @@ class BLELifecycleController:
         self._iface = iface
         session = _session_state_for(iface)
         self._receive = BLEReceiveLifecycleCoordinator(iface, session_state=session)
-        self._disconnect = BLEDisconnectLifecycleCoordinator(iface, session_state=session)
+        self._disconnect = BLEDisconnectLifecycleCoordinator(
+            iface, session_state=session
+        )
         self._connection_ownership = BLEConnectionOwnershipLifecycleCoordinator(
             iface, session_state=session
         )

--- a/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
@@ -10,8 +10,6 @@ from meshtastic.interfaces.ble.compat_adapter import (
     _get_declared_member,
     _resolve_declared_callable,
 )
-from meshtastic.interfaces.ble.ports import _BLESessionStatePort
-from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.constants import (
     READ_TRIGGER_EVENT,
     RECONNECTED_EVENT,
@@ -26,6 +24,8 @@ from meshtastic.interfaces.ble.lifecycle_primitives import (
     _LifecycleStateAccess,
     _LifecycleThreadAccess,
 )
+from meshtastic.interfaces.ble.ports import _BLESessionStatePort
+from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
 from meshtastic.interfaces.ble.utils import (
     _sleep,
@@ -43,7 +43,10 @@ class BLEDisconnectLifecycleCoordinator:
     """Own disconnect orchestration and reconnect scheduling behavior."""
 
     def __init__(
-        self, iface: "BLEInterface", *, session_state: _BLESessionStatePort | None = None
+        self,
+        iface: "BLEInterface",
+        *,
+        session_state: _BLESessionStatePort | None = None,
     ) -> None:
         """Bind disconnect orchestration ownership to a specific interface.
 
@@ -204,7 +207,8 @@ class BLEDisconnectLifecycleCoordinator:
         state_manager = _get_declared_member(iface, "_state_manager")
         canonical_state_manager = (
             state_manager
-            if type(state_manager) is BLEStateManager  # pylint: disable=unidiomatic-typecheck
+            if type(state_manager)
+            is BLEStateManager  # pylint: disable=unidiomatic-typecheck
             and state_manager.lock is self._session.lock
             and current_state_getter is None
             and transition_to_disconnected is None
@@ -228,9 +232,11 @@ class BLEDisconnectLifecycleCoordinator:
             # lock-owned primitive instead.
             current_state = cast(
                 ConnectionState,
-                BLEStateManager._current_state_unlocked(canonical_state_manager)
-                if canonical_state_manager is not None
-                else compatibility_current_state,
+                (
+                    BLEStateManager._current_state_unlocked(canonical_state_manager)
+                    if canonical_state_manager is not None
+                    else compatibility_current_state
+                ),
             )
             current_client = iface.client
             is_closing = compatibility_is_closing or self._session.closed
@@ -355,7 +361,9 @@ class BLEDisconnectLifecycleCoordinator:
                 or getattr(target_client, "address", None)
             )
         elif bleak_client is not None:
-            address = _normalize_disconnect_address(getattr(bleak_client, "address", None))
+            address = _normalize_disconnect_address(
+                getattr(bleak_client, "address", None)
+            )
         elif previous_client is not None:
             address = _normalize_disconnect_address(
                 iface._extract_client_address(previous_client)

--- a/meshtastic/interfaces/ble/lifecycle_ownership_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_ownership_runtime.py
@@ -86,7 +86,8 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         """
         state_manager = self._state_manager
         if (
-            type(state_manager) is BLEStateManager  # pylint: disable=unidiomatic-typecheck
+            type(state_manager)
+            is BLEStateManager  # pylint: disable=unidiomatic-typecheck
             and state_manager.lock is self._session.lock
         ):
             return BLEStateManager._current_state_unlocked(state_manager)
@@ -145,7 +146,8 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         canonical_state_owned = (
             is_closing_getter is None
             and state_connected_getter is None
-            and type(state_manager) is BLEStateManager  # pylint: disable=unidiomatic-typecheck
+            and type(state_manager)
+            is BLEStateManager  # pylint: disable=unidiomatic-typecheck
             and state_manager.lock is self._session.lock
         )
         if is_closing_getter is not None:
@@ -226,8 +228,10 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                 if enforce_canonical_state
                 else None
             )
-            is_closing = probed_is_closing or self._session.closed or (
-                canonical_state == ConnectionState.DISCONNECTING
+            is_closing = (
+                probed_is_closing
+                or self._session.closed
+                or (canonical_state == ConnectionState.DISCONNECTING)
             )
             return False, is_closing
         if not enforce_canonical_state:
@@ -300,8 +304,10 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         with self._session.lock:
             if self._session.connection_session_epoch != baseline_epoch:
                 canonical_state = self._canonical_connection_state_locked()
-                is_closing = probed_is_closing or self._session.closed or (
-                    canonical_state == ConnectionState.DISCONNECTING
+                is_closing = (
+                    probed_is_closing
+                    or self._session.closed
+                    or (canonical_state == ConnectionState.DISCONNECTING)
                 )
                 return False, is_closing
             return self._revalidate_connected_client_status_locked(
@@ -601,9 +607,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         # Compatibility probes can execute caller-owned code. Run the probe
         # outside the shared session lock, and avoid it entirely after the
         # terminal closed flag is already authoritative.
-        compatibility_is_closing = (
-            True if session_already_closed else get_is_closing()
-        )
+        compatibility_is_closing = True if session_already_closed else get_is_closing()
         with self._session.lock:
             disconnect_session_epoch = self._session.connection_session_epoch
             inflight_client = self._session.connected_publish_inflight_client
@@ -786,8 +790,10 @@ class BLEConnectionOwnershipLifecycleCoordinator:
             _raise_invalidated(snapshot)
         publish_committed = False
         if should_publish_connected:
-            probed_owned, probed_is_closing, expected_epoch = self._probe_status_provider(
-                connected_client, get_connected_status_locked
+            probed_owned, probed_is_closing, expected_epoch = (
+                self._probe_status_provider(
+                    connected_client, get_connected_status_locked
+                )
             )
             with self._session.lock:
                 still_owned, is_closing = self._revalidate_status_probe_locked(
@@ -953,8 +959,10 @@ class BLEConnectionOwnershipLifecycleCoordinator:
                     self._session.client_publish_pending = False
                     if publish_completed:
                         self._session.client_replacement_pending = False
-            probed_owned, probed_is_closing, expected_epoch = self._probe_status_provider(
-                connected_client, get_connected_status_locked
+            probed_owned, probed_is_closing, expected_epoch = (
+                self._probe_status_provider(
+                    connected_client, get_connected_status_locked
+                )
             )
             with self._session.lock:
                 still_owned_after, is_closing_after = (
@@ -1027,8 +1035,8 @@ class BLEConnectionOwnershipLifecycleCoordinator:
 
         if still_active:
             should_clear_gate_keys = False
-            probed_owned, probed_is_closing, expected_epoch = self._probe_status_provider(
-                connected_client, get_status_locked
+            probed_owned, probed_is_closing, expected_epoch = (
+                self._probe_status_provider(connected_client, get_status_locked)
             )
             with self._session.lock:
                 still_active, is_closing = self._revalidate_status_probe_locked(
@@ -1063,8 +1071,8 @@ class BLEConnectionOwnershipLifecycleCoordinator:
             )
             needs_cleanup = False
             should_clear_gate_keys = False
-            probed_owned, probed_is_closing, expected_epoch = self._probe_status_provider(
-                connected_client, get_status_locked
+            probed_owned, probed_is_closing, expected_epoch = (
+                self._probe_status_provider(connected_client, get_status_locked)
             )
             with self._session.lock:
                 still_active, is_closing = self._revalidate_status_probe_locked(

--- a/meshtastic/interfaces/ble/lifecycle_receive_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_receive_runtime.py
@@ -418,7 +418,9 @@ class BLEReceiveLifecycleCoordinator:
                         elif not start_failure_confirmed:
                             pending_since = existing_pending_since
                             if not isinstance(pending_since, (float, int)):
-                                self._session.receive_start_pending_since = time.monotonic()
+                                self._session.receive_start_pending_since = (
+                                    time.monotonic()
+                                )
                             self._session.receive_start_pending = True
                             inconclusive_probe_thread = existing
                             logger.debug(
@@ -430,7 +432,10 @@ class BLEReceiveLifecycleCoordinator:
                             self._session.receive_start_pending = False
                             self._session.receive_start_pending_since = None
 
-                if deferred_current_thread is None and inconclusive_probe_thread is None:
+                if (
+                    deferred_current_thread is None
+                    and inconclusive_probe_thread is None
+                ):
                     expected_existing = existing
                     recovery_attempts_before_start = (
                         self._session.receive_recovery_attempts

--- a/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
@@ -13,8 +13,6 @@ from meshtastic.interfaces.ble.compat_adapter import (
     _get_declared_callable,
     _get_declared_member,
 )
-from meshtastic.interfaces.ble.ports import _BLESessionStatePort
-from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.constants import (
     DISCONNECT_TIMEOUT_SECONDS,
     NOTIFICATION_START_TIMEOUT,
@@ -33,6 +31,8 @@ from meshtastic.interfaces.ble.lifecycle_primitives import (
     _LifecycleStateAccess,
     _LifecycleThreadAccess,
 )
+from meshtastic.interfaces.ble.ports import _BLESessionStatePort
+from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.state import ConnectionState
 from meshtastic.interfaces.ble.utils import (
     _is_unexpected_keyword_error,
@@ -61,7 +61,10 @@ class BLEShutdownLifecycleCoordinator:
     """
 
     def __init__(
-        self, iface: "BLEInterface", *, session_state: _BLESessionStatePort | None = None
+        self,
+        iface: "BLEInterface",
+        *,
+        session_state: _BLESessionStatePort | None = None,
     ) -> None:
         """Bind shutdown ownership to a specific interface.
 

--- a/meshtastic/interfaces/ble/management_compat_service.py
+++ b/meshtastic/interfaces/ble/management_compat_service.py
@@ -7,8 +7,11 @@ import sys as sys_stdlib
 from collections.abc import Callable
 from typing import TYPE_CHECKING, cast
 
-from meshtastic.interfaces.ble.compat_adapter import (_get_declared_callable, _get_declared_member)
 from meshtastic.interfaces.ble.client import BLEClient
+from meshtastic.interfaces.ble.compat_adapter import (
+    _get_declared_callable,
+    _get_declared_member,
+)
 from meshtastic.interfaces.ble.constants import logger
 from meshtastic.interfaces.ble.gating import _is_currently_connected_elsewhere
 from meshtastic.interfaces.ble.management_runtime import (
@@ -119,30 +122,24 @@ class BLEManagementCommandsService:
                         exc_info=True,
                     )
                 else:
-                    if (
-                        resolved is not None
-                        and (
-                            BLEManagementCommandsService._is_handler_like(resolved)
-                            # COMPAT_STABLE_SHIM: preserve iface-owned partial
-                            # handler/proxy doubles used by historical shim paths.
-                            or BLEManagementCommandsService._has_required_handler_entrypoint(
-                                resolved,
-                                expected_method,
-                            )
+                    if resolved is not None and (
+                        BLEManagementCommandsService._is_handler_like(resolved)
+                        # COMPAT_STABLE_SHIM: preserve iface-owned partial
+                        # handler/proxy doubles used by historical shim paths.
+                        or BLEManagementCommandsService._has_required_handler_entrypoint(
+                            resolved,
+                            expected_method,
                         )
                     ):
                         return cast(BLEManagementCommandHandler, resolved)
             direct_handler = _get_declared_member(iface, "_management_command_handler")
-            if (
-                direct_handler is not None
-                and (
-                    BLEManagementCommandsService._is_handler_like(direct_handler)
-                    # COMPAT_STABLE_SHIM: preserve iface-owned partial
-                    # handler/proxy doubles used by historical shim paths.
-                    or BLEManagementCommandsService._has_required_handler_entrypoint(
-                        direct_handler,
-                        expected_method,
-                    )
+            if direct_handler is not None and (
+                BLEManagementCommandsService._is_handler_like(direct_handler)
+                # COMPAT_STABLE_SHIM: preserve iface-owned partial
+                # handler/proxy doubles used by historical shim paths.
+                or BLEManagementCommandsService._has_required_handler_entrypoint(
+                    direct_handler,
+                    expected_method,
                 )
             ):
                 return cast(BLEManagementCommandHandler, direct_handler)

--- a/meshtastic/interfaces/ble/receive_compat_service.py
+++ b/meshtastic/interfaces/ble/receive_compat_service.py
@@ -7,12 +7,12 @@ from typing import TYPE_CHECKING, Any, cast
 
 from bleak.exc import BleakError
 
+from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.compat_adapter import (
     _get_declared_callable,
     _get_declared_lock,
     _get_declared_member,
 )
-from meshtastic.interfaces.ble.client import BLEClient
 
 if TYPE_CHECKING:
     from meshtastic.interfaces.ble.coordination import ThreadCoordinator
@@ -90,13 +90,10 @@ class BLEReceiveRecoveryService:
         if candidate is None:
             return None
         resolved = candidate
-        should_invoke_factory = (
-            callable(resolved)
-            and (
-                inspect.isclass(resolved)
-                or not BLEReceiveRecoveryService._is_controller_like(
-                    resolved, required_method
-                )
+        should_invoke_factory = callable(resolved) and (
+            inspect.isclass(resolved)
+            or not BLEReceiveRecoveryService._is_controller_like(
+                resolved, required_method
             )
         )
         if should_invoke_factory:
@@ -113,9 +110,8 @@ class BLEReceiveRecoveryService:
                     resolved = cast(Callable[..., Any], resolved)()
         if inspect.isclass(resolved):
             return None
-        if (
-            resolved is not None
-            and BLEReceiveRecoveryService._is_controller_like(resolved, required_method)
+        if resolved is not None and BLEReceiveRecoveryService._is_controller_like(
+            resolved, required_method
         ):
             return cast("BLEReceiveRecoveryController", resolved)
         return None
@@ -139,7 +135,9 @@ class BLEReceiveRecoveryService:
             Controller bound to ``iface``.
         """
         controller_cls = BLEReceiveRecoveryService._controller_class()
-        get_controller = _get_declared_callable(iface, "_get_receive_recovery_controller")
+        get_controller = _get_declared_callable(
+            iface, "_get_receive_recovery_controller"
+        )
         if get_controller is not None:
             with contextlib.suppress(
                 Exception

--- a/meshtastic/interfaces/ble/session_state.py
+++ b/meshtastic/interfaces/ble/session_state.py
@@ -224,9 +224,7 @@ class _BLESessionStateCompatMixin:
     def _last_disconnect_source(self, value: str | None) -> None:
         if value is not None and not isinstance(value, str):
             raise TypeError(
-                LAST_DISCONNECT_SOURCE_TYPE_ERROR.format(
-                    type_name=type(value).__name__
-                )
+                LAST_DISCONNECT_SOURCE_TYPE_ERROR.format(type_name=type(value).__name__)
             )
         self._get_session_state().last_disconnect_source = value
 
@@ -437,9 +435,7 @@ class _LegacyBLESessionStateAdapter:
 
     def __init__(self, iface: object) -> None:
         object.__setattr__(self, "_iface", iface)
-        object.__setattr__(
-            self, "_fallback_lock", cast(_LockPort, threading.RLock())
-        )
+        object.__setattr__(self, "_fallback_lock", cast(_LockPort, threading.RLock()))
 
     def _resolve_lock(self, mapped: str) -> _LockPort:
         """Return the synchronization owner currently governing legacy state."""

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -21,12 +21,12 @@ except ImportError:
 from pubsub import pub
 
 import meshtastic.node
-from meshtastic._publishing import publishing_thread as publishingThread
 from meshtastic._core_constants import (
     BROADCAST_ADDR,
     LAST_DISCONNECT_SOURCE_TYPE_ERROR,
     NODELESS_WANT_CONFIG_ID,
 )
+from meshtastic._publishing import publishing_thread as publishingThread
 from meshtastic._response_types import ResponseHandler
 from meshtastic.mesh_interface_runtime.flows import (
     DEFAULT_TELEMETRY_TYPE,
@@ -275,9 +275,7 @@ class MeshInterface:  # pylint: disable=R0902
     def _last_disconnect_source(self, value: str | None) -> None:
         if value is not None and not isinstance(value, str):
             raise TypeError(
-                LAST_DISCONNECT_SOURCE_TYPE_ERROR.format(
-                    type_name=type(value).__name__
-                )
+                LAST_DISCONNECT_SOURCE_TYPE_ERROR.format(type_name=type(value).__name__)
             )
         self.__dict__["_last_disconnect_source"] = value
 

--- a/meshtastic/mesh_interface_runtime/node_view.py
+++ b/meshtastic/mesh_interface_runtime/node_view.py
@@ -331,7 +331,9 @@ class NodeView:
 
         # Get node data under lock
         with self._node_db_lock:
-            nodes_snapshot = list(self.nodes_by_num.values()) if self.nodes_by_num else []
+            nodes_snapshot = (
+                list(self.nodes_by_num.values()) if self.nodes_by_num else []
+            )
             local_node_num = self.local_node.nodeNum
 
         if nodes_snapshot:

--- a/meshtastic/mesh_interface_runtime/receive_pipeline.py
+++ b/meshtastic/mesh_interface_runtime/receive_pipeline.py
@@ -12,9 +12,9 @@ import google.protobuf.json_format
 from google.protobuf import message as protobuf_message
 from pubsub import pub
 
-from meshtastic._publishing import publishing_thread as publishingThread
 from meshtastic._core_constants import BROADCAST_ADDR, BROADCAST_NUM, DECODE_ERROR_KEY
 from meshtastic._protocol_runtime import protocols
+from meshtastic._publishing import publishing_thread as publishingThread
 from meshtastic._topics import LOCKDOWN_STATUS_TOPIC
 from meshtastic.protobuf import (
     channel_pb2,
@@ -29,7 +29,6 @@ from meshtastic.util import stripnl
 from .ports import _ReceivePipelinePort
 from .queue_send import _QueueSendRuntime
 from .request_wait import _RequestWaitRuntime
-
 
 if TYPE_CHECKING:
     from meshtastic.node import Node
@@ -548,9 +547,7 @@ class ReceivePipeline:
 
         with self._node_db_lock:
             if self.nodes_by_num is None:
-                raise self._port.error_type(
-                    "Node database not initialized"
-                )
+                raise self._port.error_type("Node database not initialized")
 
             if nodeNum in self.nodes_by_num:
                 return self.nodes_by_num[nodeNum]

--- a/meshtastic/mesh_interface_runtime/request_wait.py
+++ b/meshtastic/mesh_interface_runtime/request_wait.py
@@ -166,7 +166,9 @@ class _RequestWaitRuntime:
     def _prune_stale_response_handlers_locked(self, *, now: float) -> list[int]:
         """Prune expired managed callbacks while the response-state lock is held."""
         response_handlers = self._get_response_handlers()
-        for request_id, managed_handler in list(self._managed_response_handlers.items()):
+        for request_id, managed_handler in list(
+            self._managed_response_handlers.items()
+        ):
             if response_handlers.get(request_id) is not managed_handler:
                 self._clear_managed_response_metadata_locked(request_id)
 
@@ -584,8 +586,11 @@ class _RequestWaitRuntime:
                 managed_handler = self._managed_response_handlers.get(request_id)
                 if managed_handler is not None and candidate is not managed_handler:
                     self._clear_managed_response_metadata_locked(request_id)
-                elif managed_handler is candidate and self._response_handler_is_stale_locked(
-                    request_id, now=time.monotonic()
+                elif (
+                    managed_handler is candidate
+                    and self._response_handler_is_stale_locked(
+                        request_id, now=time.monotonic()
+                    )
                 ):
                     self._remove_response_handler_locked(request_id)
                     return None, False

--- a/meshtastic/mesh_interface_runtime/send_pipeline.py
+++ b/meshtastic/mesh_interface_runtime/send_pipeline.py
@@ -38,7 +38,6 @@ from meshtastic.protobuf import mesh_pb2, portnums_pb2
 from meshtastic.traceroute import TraceRouteResult
 from meshtastic.util import Acknowledgment, Timeout, stripnl
 
-
 if TYPE_CHECKING:
     from meshtastic.node import Node
 

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -8,9 +8,24 @@ in the mesh, including methods for localConfig, moduleConfig, and channels manag
 import logging
 import sys
 import threading
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, NoReturn, Sequence, TypeVar, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    ClassVar,
+    NoReturn,
+    Sequence,
+    TypeVar,
+    cast,
+)
+
 from google.protobuf.descriptor import FieldDescriptor
 
+from meshtastic.node_runtime import contact_runtime
+from meshtastic.node_runtime.admin_wait import (
+    _send_admin_with_ack_scope,
+    _wait_for_admin_ack,
+)
 from meshtastic.node_runtime.channel_export_runtime import _NodeChannelExportRuntime
 from meshtastic.node_runtime.channel_lookup_runtime import _NodeChannelLookupRuntime
 from meshtastic.node_runtime.channel_normalization_runtime import (
@@ -21,11 +36,6 @@ from meshtastic.node_runtime.channel_presentation_runtime import (
 )
 from meshtastic.node_runtime.channel_request_runtime import _NodeChannelRequestRuntime
 from meshtastic.node_runtime.channel_state import _ChannelLock, _NodeChannelState
-from meshtastic.node_runtime.admin_wait import (
-    _send_admin_with_ack_scope,
-    _wait_for_admin_ack,
-)
-from meshtastic.node_runtime import contact_runtime
 from meshtastic.node_runtime.settings_runtime import (
     _NodeAdminCommandRuntime,
     _NodeOwnerProfileRuntime,

--- a/meshtastic/node_runtime/admin_wait.py
+++ b/meshtastic/node_runtime/admin_wait.py
@@ -132,9 +132,7 @@ def _send_admin_with_ack_scope(
     return send_admin(message, **kwargs)
 
 
-def _get_bound_interface_helper(
-    node: "Node", name: str
-) -> Callable[..., Any] | None:
+def _get_bound_interface_helper(node: "Node", name: str) -> Callable[..., Any] | None:
     """Return a real bound interface helper, excluding loose mock attributes."""
     helper = getattr(node.iface, name, None)
     if callable(helper) and getattr(helper, "__self__", None) is node.iface:
@@ -142,9 +140,7 @@ def _get_bound_interface_helper(
     return None
 
 
-def _wait_for_admin_ack(
-    node: "Node", request: mesh_pb2.MeshPacket | None
-) -> None:
+def _wait_for_admin_ack(node: "Node", request: mesh_pb2.MeshPacket | None) -> None:
     """Wait for the ACK/NAK that belongs to one remote admin request.
 
     The modern MeshInterface exposes a private request-scoped wait helper. The

--- a/meshtastic/node_runtime/response_runtime.py
+++ b/meshtastic/node_runtime/response_runtime.py
@@ -53,7 +53,9 @@ class _NodeMetadataResponseRuntime:
             self._node.iface._acknowledgment.receivedNak = True
             if packet is not None:
                 _record_admin_wait_error_for_packet(
-                    self._node, packet, "Received malformed metadata response (missing routing)."
+                    self._node,
+                    packet,
+                    "Received malformed metadata response (missing routing).",
                 )
             self._node._signal_metadata_stdout_event()
             return True
@@ -171,7 +173,9 @@ class _NodeMetadataResponseRuntime:
             )
             self._node.iface._acknowledgment.receivedNak = True
             _record_admin_wait_error_for_packet(
-                self._node, packet, "Received malformed metadata response (missing decoded)."
+                self._node,
+                packet,
+                "Received malformed metadata response (missing decoded).",
             )
             self._node._signal_metadata_stdout_event()
             return
@@ -188,7 +192,9 @@ class _NodeMetadataResponseRuntime:
             )
             self._node.iface._acknowledgment.receivedNak = True
             _record_admin_wait_error_for_packet(
-                self._node, packet, "Received malformed metadata response (missing admin)."
+                self._node,
+                packet,
+                "Received malformed metadata response (missing admin).",
             )
             self._node._signal_metadata_stdout_event()
             return
@@ -202,7 +208,9 @@ class _NodeMetadataResponseRuntime:
             )
             self._node.iface._acknowledgment.receivedNak = True
             _record_admin_wait_error_for_packet(
-                self._node, packet, "Received malformed metadata response (missing admin.raw)."
+                self._node,
+                packet,
+                "Received malformed metadata response (missing admin.raw).",
             )
             self._node._signal_metadata_stdout_event()
             return

--- a/meshtastic/node_runtime/settings_runtime/admin.py
+++ b/meshtastic/node_runtime/settings_runtime/admin.py
@@ -189,7 +189,6 @@ class _NodeAdminCommandRuntime:
             use_remote_ack_callback=False,
         )
 
-
     def enter_dfu_mode(self) -> mesh_pb2.MeshPacket | None:
         """Send enter-DFU-mode command."""
         message = admin_pb2.AdminMessage()
@@ -200,7 +199,6 @@ class _NodeAdminCommandRuntime:
             ensure_session_key=True,
             use_remote_ack_callback=True,
         )
-
 
     def shutdown(self, secs: int) -> mesh_pb2.MeshPacket | None:
         """Send shutdown command with delayed shutdown seconds."""
@@ -245,7 +243,6 @@ class _NodeAdminCommandRuntime:
             use_remote_ack_callback=True,
         )
 
-
     def _send_node_id_command(
         self,
         *,
@@ -271,7 +268,6 @@ class _NodeAdminCommandRuntime:
             ),
         )
 
-
     def set_favorite(self, node_id: int | str) -> mesh_pb2.MeshPacket | None:
         """Send set-favorite command."""
         return self._send_node_id_command(
@@ -280,7 +276,6 @@ class _NodeAdminCommandRuntime:
                 message, "set_favorite_node", node_num
             ),
         )
-
 
     def remove_favorite(self, node_id: int | str) -> mesh_pb2.MeshPacket | None:
         """Send remove-favorite command."""
@@ -291,7 +286,6 @@ class _NodeAdminCommandRuntime:
             ),
         )
 
-
     def set_ignored(self, node_id: int | str) -> mesh_pb2.MeshPacket | None:
         """Send set-ignored command."""
         return self._send_node_id_command(
@@ -301,7 +295,6 @@ class _NodeAdminCommandRuntime:
             ),
         )
 
-
     def remove_ignored(self, node_id: int | str) -> mesh_pb2.MeshPacket | None:
         """Send remove-ignored command."""
         return self._send_node_id_command(
@@ -310,7 +303,6 @@ class _NodeAdminCommandRuntime:
                 message, "remove_ignored_node", node_num
             ),
         )
-
 
     def reset_node_db(self) -> mesh_pb2.MeshPacket | None:
         """Send NodeDB reset command."""

--- a/meshtastic/node_runtime/seturl/coordinator.py
+++ b/meshtastic/node_runtime/seturl/coordinator.py
@@ -100,7 +100,9 @@ class _SetUrlTransactionCoordinator:
             self._node._raise_interface_error(  # noqa: SLF001
                 "Interface localNode not initialized"
             )
-        admin_index_for_write = admin_write_node._get_admin_channel_index()  # noqa: SLF001
+        admin_index_for_write = (
+            admin_write_node._get_admin_channel_index()
+        )  # noqa: SLF001
         named_admin_index_for_write = (
             admin_write_node._get_named_admin_channel_index()  # noqa: SLF001
         )

--- a/meshtastic/node_runtime/transport_runtime/channel.py
+++ b/meshtastic/node_runtime/transport_runtime/channel.py
@@ -11,8 +11,8 @@ from meshtastic.node_runtime.admin_wait import (
 from meshtastic.node_runtime.channel_state import _NodeChannelState
 from meshtastic.node_runtime.shared import (
     MAX_CHANNELS,
+    _is_named_admin_channel_name,
 )
-from meshtastic.node_runtime.shared import _is_named_admin_channel_name
 from meshtastic.protobuf import admin_pb2, channel_pb2
 
 if TYPE_CHECKING:

--- a/meshtastic/tests/_main_legacy_support.py
+++ b/meshtastic/tests/_main_legacy_support.py
@@ -11,10 +11,9 @@ from typing import Any, cast
 from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
-
-import meshtastic.__main__ as main_module
 from google.protobuf import descriptor_pb2, descriptor_pool, message_factory
 
+import meshtastic.__main__ as main_module
 from meshtastic import mt_config
 from meshtastic.__main__ import main
 from meshtastic.node import Node
@@ -190,6 +189,7 @@ def _make_fake_tcp_interface(
     on_close: Callable[[], None] | None = None,
 ) -> type[object]:
     """Return a configurable TCPInterface test double with context-manager behavior."""
+
     class _FakeTCPInterface:
         def __init__(self, *_args: object, **_kwargs: object) -> None:
             self.hostname = "localhost"
@@ -216,7 +216,8 @@ def _build_nested_bytes_test_message() -> Any:
     )
     child = file_proto.message_type.add(name="Child")
     child.field.add(
-        name="payload", number=1,
+        name="payload",
+        number=1,
         label=descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL,
         type=descriptor_pb2.FieldDescriptorProto.TYPE_BYTES,
     )
@@ -224,41 +225,48 @@ def _build_nested_bytes_test_message() -> Any:
     child_map_entry = container.nested_type.add(name="ChildMapEntry")
     child_map_entry.options.map_entry = True
     child_map_entry.field.add(
-        name="key", number=1,
+        name="key",
+        number=1,
         label=descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL,
         type=descriptor_pb2.FieldDescriptorProto.TYPE_STRING,
     )
     child_map_entry.field.add(
-        name="value", number=2,
+        name="value",
+        number=2,
         label=descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL,
         type=descriptor_pb2.FieldDescriptorProto.TYPE_MESSAGE,
         type_name=".mtjk.tests.nested.Child",
     )
     container.field.add(
-        name="child_map", number=1,
+        name="child_map",
+        number=1,
         label=descriptor_pb2.FieldDescriptorProto.LABEL_REPEATED,
         type=descriptor_pb2.FieldDescriptorProto.TYPE_MESSAGE,
         type_name=".mtjk.tests.nested.Container.ChildMapEntry",
     )
     container.field.add(
-        name="children", number=2,
+        name="children",
+        number=2,
         label=descriptor_pb2.FieldDescriptorProto.LABEL_REPEATED,
         type=descriptor_pb2.FieldDescriptorProto.TYPE_MESSAGE,
         type_name=".mtjk.tests.nested.Child",
     )
     container.field.add(
-        name="child", number=3,
+        name="child",
+        number=3,
         label=descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL,
         type=descriptor_pb2.FieldDescriptorProto.TYPE_MESSAGE,
         type_name=".mtjk.tests.nested.Child",
     )
     container.field.add(
-        name="blobs", number=4,
+        name="blobs",
+        number=4,
         label=descriptor_pb2.FieldDescriptorProto.LABEL_REPEATED,
         type=descriptor_pb2.FieldDescriptorProto.TYPE_BYTES,
     )
     container.field.add(
-        name="scalar_blob", number=5,
+        name="scalar_blob",
+        number=5,
         label=descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL,
         type=descriptor_pb2.FieldDescriptorProto.TYPE_BYTES,
     )

--- a/meshtastic/tests/_mesh_interface_legacy_support.py
+++ b/meshtastic/tests/_mesh_interface_legacy_support.py
@@ -13,7 +13,9 @@ from google.protobuf.message import Message
 
 import meshtastic.mesh_interface as mesh_interface_module
 from meshtastic.mesh_interface import MeshInterface
-from meshtastic.mesh_interface_runtime import receive_pipeline as receive_pipeline_module
+from meshtastic.mesh_interface_runtime import (
+    receive_pipeline as receive_pipeline_module,
+)
 from meshtastic.protobuf import mesh_pb2, portnums_pb2
 
 from .. import ResponseHandler

--- a/meshtastic/tests/_node_channel_state_test_support.py
+++ b/meshtastic/tests/_node_channel_state_test_support.py
@@ -13,17 +13,13 @@ def _attach_channel_state(node: MagicMock) -> _NodeChannelState:
     def _get_channels(_node: object) -> list[channel_pb2.Channel] | None:
         return state.channels
 
-    def _set_channels(
-        _node: object, value: list[channel_pb2.Channel] | None
-    ) -> None:
+    def _set_channels(_node: object, value: list[channel_pb2.Channel] | None) -> None:
         state.channels = value
 
     def _get_partial_channels(_node: object) -> list[channel_pb2.Channel]:
         return state.partial_channels
 
-    def _set_partial_channels(
-        _node: object, value: list[channel_pb2.Channel]
-    ) -> None:
+    def _set_partial_channels(_node: object, value: list[channel_pb2.Channel]) -> None:
         state.partial_channels = value
 
     def _get_channels_lock(_node: object) -> _ChannelLock:

--- a/meshtastic/tests/conftest.py
+++ b/meshtastic/tests/conftest.py
@@ -20,9 +20,9 @@ from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 
+import meshtastic.util as util_module
 from meshtastic import mt_config, publishingThread
 from meshtastic.powermon import power_supply as power_supply_module
-import meshtastic.util as util_module
 from meshtastic.util import DeferredExecution
 
 from ..mesh_interface import MeshInterface

--- a/meshtastic/tests/seturl/conftest.py
+++ b/meshtastic/tests/seturl/conftest.py
@@ -10,7 +10,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from meshtastic.tests._node_channel_state_test_support import _attach_channel_state
 from meshtastic.node_runtime.seturl_runtime import (
     _SetUrlCacheManager,
     _SetUrlExecutionEngine,
@@ -20,6 +19,7 @@ from meshtastic.protobuf import (
     channel_pb2,
     localonly_pb2,
 )
+from meshtastic.tests._node_channel_state_test_support import _attach_channel_state
 
 
 class _LockProbe:

--- a/meshtastic/tests/test_admin_ack_wait_scoping.py
+++ b/meshtastic/tests/test_admin_ack_wait_scoping.py
@@ -231,7 +231,9 @@ def test_active_wait_scope_query_tracks_registration_and_retirement() -> None:
         assert iface._has_active_wait_request(WAIT_ATTR_NAK, request_id)  # noqa: SLF001
 
         iface._retire_wait_request(WAIT_ATTR_NAK, request_id=request_id)  # noqa: SLF001
-        assert not iface._has_active_wait_request(WAIT_ATTR_NAK, request_id)  # noqa: SLF001
+        assert not iface._has_active_wait_request(
+            WAIT_ATTR_NAK, request_id
+        )  # noqa: SLF001
 
 
 @pytest.mark.unit
@@ -275,12 +277,16 @@ def test_request_scoped_admin_waits_do_not_crosstalk() -> None:
         assert thread_a.is_alive()
         assert thread_b.is_alive()
 
-        iface._mark_wait_acknowledged(WAIT_ATTR_NAK, request_id=request_a)  # noqa: SLF001
+        iface._mark_wait_acknowledged(
+            WAIT_ATTR_NAK, request_id=request_a
+        )  # noqa: SLF001
         _wait_until(lambda: request_a in completed)
         assert request_b not in completed
         assert thread_b.is_alive()
 
-        iface._mark_wait_acknowledged(WAIT_ATTR_NAK, request_id=request_b)  # noqa: SLF001
+        iface._mark_wait_acknowledged(
+            WAIT_ATTR_NAK, request_id=request_b
+        )  # noqa: SLF001
         thread_a.join(timeout=1.0)
         thread_b.join(timeout=1.0)
 
@@ -337,7 +343,9 @@ def test_scoped_admin_nak_only_fails_matching_request() -> None:
         assert not ok_complete.is_set()
         assert ok_thread.is_alive()
 
-        iface._mark_wait_acknowledged(WAIT_ATTR_NAK, request_id=request_ok)  # noqa: SLF001
+        iface._mark_wait_acknowledged(
+            WAIT_ATTR_NAK, request_id=request_ok
+        )  # noqa: SLF001
         ok_thread.join(timeout=1.0)
         assert not ok_thread.is_alive()
         assert ok_complete.is_set()
@@ -435,7 +443,9 @@ def test_fast_admin_ack_is_not_lost_between_send_and_wait(
         ) -> mesh_pb2.MeshPacket:
             observed_active_scope.append(
                 packet.id
-                in iface._active_wait_request_ids.get(WAIT_ATTR_NAK, set())  # noqa: SLF001
+                in iface._active_wait_request_ids.get(
+                    WAIT_ATTR_NAK, set()
+                )  # noqa: SLF001
             )
             remote.onAckNak(
                 {
@@ -459,7 +469,9 @@ def test_fast_admin_ack_is_not_lost_between_send_and_wait(
         assert request is not None
         assert observed_active_scope == [True]
         assert iface._active_wait_request_ids.get(WAIT_ATTR_NAK) is None  # noqa: SLF001
-        assert request.id in iface._retired_wait_request_ids[WAIT_ATTR_NAK]  # noqa: SLF001
+        assert (
+            request.id in iface._retired_wait_request_ids[WAIT_ATTR_NAK]
+        )  # noqa: SLF001
 
 
 @pytest.mark.unit
@@ -564,7 +576,9 @@ def test_malformed_metadata_response_records_request_scoped_failure(
 
     assert iface._acknowledgment.receivedNak is True
     assert iface._set_wait_error.call_args_list == [
-        call(WAIT_ATTR_NAK, f"Received malformed metadata response ({error_fragment})."),
+        call(
+            WAIT_ATTR_NAK, f"Received malformed metadata response ({error_fragment})."
+        ),
         call(
             WAIT_ATTR_NAK,
             f"Received malformed metadata response ({error_fragment}).",
@@ -707,6 +721,7 @@ def test_admin_wait_error_noops_without_wait_error_hook() -> None:
 @pytest.mark.unit
 def test_admin_sender_signature_probe_handles_uninspectable_callable() -> None:
     """Compatibility send callables with invalid signatures should disable private scoping."""
+
     class _UninspectableCallable:
         @property
         def __signature__(self) -> object:
@@ -736,7 +751,9 @@ def test_request_scoped_admin_wait_timeout_retires_request() -> None:
         assert request_id not in iface._active_wait_request_ids.get(  # noqa: SLF001
             WAIT_ATTR_NAK, set()
         )
-        assert request_id in iface._retired_wait_request_ids[WAIT_ATTR_NAK]  # noqa: SLF001
+        assert (
+            request_id in iface._retired_wait_request_ids[WAIT_ATTR_NAK]
+        )  # noqa: SLF001
 
 
 @pytest.mark.unit
@@ -757,7 +774,9 @@ def test_settings_response_missing_expected_field_records_scoped_failure() -> No
 
     assert iface._acknowledgment.receivedNak is True
     assert iface._set_wait_error.call_args_list == [
-        call(WAIT_ATTR_NAK, "Received settings response without expected field 'device'."),
+        call(
+            WAIT_ATTR_NAK, "Received settings response without expected field 'device'."
+        ),
         call(
             WAIT_ATTR_NAK,
             "Received settings response without expected field 'device'.",

--- a/meshtastic/tests/test_ble_compat_services_coverage.py
+++ b/meshtastic/tests/test_ble_compat_services_coverage.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 
 import logging
 import re
-from types import SimpleNamespace
 from collections.abc import Callable
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
@@ -177,7 +177,6 @@ class TestBLEManagementCommandsServiceHandlerDetection:
 
         result = BLEManagementCommandsService._is_handler_like(handler)
         assert result is False
-
 
 
 class TestBLEManagementCommandsServiceHandlerResolution:

--- a/meshtastic/tests/test_ble_connection_runtime.py
+++ b/meshtastic/tests/test_ble_connection_runtime.py
@@ -12,11 +12,11 @@ import pytest
 from bleak.exc import BleakDBusError
 
 from meshtastic.interfaces.ble.client import BLEClient
-from meshtastic.interfaces.ble.constants import DISCONNECT_TIMEOUT_SECONDS
 from meshtastic.interfaces.ble.connection import (
     ClientManager,
     ConnectionOrchestrator,
 )
+from meshtastic.interfaces.ble.constants import DISCONNECT_TIMEOUT_SECONDS
 from meshtastic.interfaces.ble.errors import BLEDBusTransportError, BLEErrorHandler
 from meshtastic.interfaces.ble.runner import BLECoroutineRunner
 

--- a/meshtastic/tests/test_ble_failure_policy.py
+++ b/meshtastic/tests/test_ble_failure_policy.py
@@ -101,7 +101,9 @@ def test_receive_closing_probe_failure_logs_compatibility_fallback(
     )
 
     with caplog.at_level(logging.DEBUG, logger=logger.name):
-        compatibility_is_closing = controller._probe_connection_closing_compat()  # noqa: SLF001
+        compatibility_is_closing = (
+            controller._probe_connection_closing_compat()
+        )  # noqa: SLF001
         with session.lock:
             assert (
                 controller._is_connection_closing_locked(  # noqa: SLF001

--- a/meshtastic/tests/test_ble_reconnection_coverage.py
+++ b/meshtastic/tests/test_ble_reconnection_coverage.py
@@ -429,6 +429,7 @@ class TestReconnectWorkerCallPolicy:
         with pytest.raises(ReconnectPolicyMissingMethodError):
             worker._call_policy("nonexistent_method")
 
+
 class TestReconnectWorkerShouldAbortReconnect:
     """Tests for abort reconnect decision logic."""
 

--- a/meshtastic/tests/test_cli_channel_contact_edge_cases.py
+++ b/meshtastic/tests/test_cli_channel_contact_edge_cases.py
@@ -108,9 +108,7 @@ def test_channel_add_rejects_name_over_protocol_limit() -> None:
     """Channel names longer than the firmware field limit must fail before lookup."""
     interface = _interface_double()
     hooks = _hooks(get_channel_index=MagicMock(return_value=None))
-    context = _context(
-        interface, ch_add="x" * (actions.MAX_CHANNEL_NAME_LENGTH + 1)
-    )
+    context = _context(interface, ch_add="x" * (actions.MAX_CHANNEL_NAME_LENGTH + 1))
 
     with pytest.raises(SystemExit):
         actions._handle_channel_add(context, hooks)
@@ -196,9 +194,7 @@ def test_add_channel_url_uses_add_only_mode(monkeypatch: pytest.MonkeyPatch) -> 
 
     actions._handle_channel_mutations(context, _hooks())
 
-    node.setURL.assert_called_once_with(
-        "https://example.invalid/#abc", addOnly=True
-    )
+    node.setURL.assert_called_once_with("https://example.invalid/#abc", addOnly=True)
     assert context.outcome.close_now is True
 
 

--- a/meshtastic/tests/test_cli_configure_edge_cases.py
+++ b/meshtastic/tests/test_cli_configure_edge_cases.py
@@ -285,9 +285,7 @@ def test_seturl_stability_detects_drop_during_window(
         sleep=lambda _seconds: None,
     )
 
-    assert (
-        configure_actions._post_seturl_stability_check(iface, timeout=100.0) is False
-    )
+    assert configure_actions._post_seturl_stability_check(iface, timeout=100.0) is False
     iface.waitForConfig.assert_not_called()
     assert caplog.text.count("Transport dropped during stability window") == (
         configure_actions.SETURL_STABILITY_MAX_ATTEMPTS
@@ -789,7 +787,9 @@ def test_configure_export_restricts_existing_file_permissions(tmp_path: Path) ->
     hooks = ConfigureActionHooks(
         handle_set_command=MagicMock(),
         handle_configure_command=MagicMock(return_value=(False, False)),
-        export_config=MagicMock(return_value="config:\n  security:\n    privateKey: secret\n"),
+        export_config=MagicMock(
+            return_value="config:\n  security:\n    privateKey: secret\n"
+        ),
         cli_exit=cast(CliExit, _cli_exit),
         cli_print=MagicMock(),
         is_local_destination=MagicMock(return_value=True),
@@ -903,9 +903,7 @@ def test_configure_result_reporting_handles_future_verification_result() -> None
 @pytest.mark.unit
 def test_configure_command_result_preserves_two_item_tuple_contract() -> None:
     """Internal ACK metadata must not change the historical two-item result shape."""
-    result = configure_actions._ConfigureCommandResult(
-        False, False, request_sent=False
-    )
+    result = configure_actions._ConfigureCommandResult(False, False, request_sent=False)
 
     assert isinstance(result, tuple)
     assert result == (False, False)
@@ -919,9 +917,7 @@ def test_configure_command_result_preserves_two_item_tuple_contract() -> None:
 def test_configure_noop_does_not_arm_shared_ack_wait() -> None:
     """A confirmed configure no-op must not wait for an acknowledgment never sent."""
     interface = _interface()
-    result = configure_actions._ConfigureCommandResult(
-        False, False, request_sent=False
-    )
+    result = configure_actions._ConfigureCommandResult(False, False, request_sent=False)
     hooks = ConfigureActionHooks(
         handle_set_command=MagicMock(),
         handle_configure_command=MagicMock(return_value=result),
@@ -950,9 +946,7 @@ def test_configure_noop_does_not_arm_shared_ack_wait() -> None:
 def test_set_ack_wait_survives_later_configure_noop() -> None:
     """A configure no-op must not disarm an ACK wait requested by ``--set``."""
     interface = _interface()
-    result = configure_actions._ConfigureCommandResult(
-        False, False, request_sent=False
-    )
+    result = configure_actions._ConfigureCommandResult(False, False, request_sent=False)
     set_command = MagicMock()
     hooks = ConfigureActionHooks(
         handle_set_command=set_command,

--- a/meshtastic/tests/test_cli_device_actions.py
+++ b/meshtastic/tests/test_cli_device_actions.py
@@ -687,8 +687,10 @@ def test_factory_reset_scoped_wait_checks_error_before_return_and_retires_reques
     wait_for_request_ack.assert_called_once()
     wait_args = wait_for_request_ack.call_args
     assert wait_args.args[:2] == ("receivedNak", 73)
-    assert 0 < wait_args.kwargs["timeout_seconds"] <= (
-        device_actions.FACTORY_RESET_ACCEPTANCE_POLL_SECONDS
+    assert (
+        0
+        < wait_args.kwargs["timeout_seconds"]
+        <= (device_actions.FACTORY_RESET_ACCEPTANCE_POLL_SECONDS)
     )
     raise_wait_error.assert_called_once_with("receivedNak", request_id=73)
     retire_wait.assert_called_once_with("receivedNak", request_id=73)

--- a/meshtastic/tests/test_cli_messaging_service_actions.py
+++ b/meshtastic/tests/test_cli_messaging_service_actions.py
@@ -636,6 +636,7 @@ def test_tunnel_starts_with_optional_subnet(
 ) -> None:
     """Eligible tunnel requests should keep the connection open and forward subnet."""
     from meshtastic import tunnel
+
     interface = _interface_double()
     interface.noProto = False
     context = _context(interface, tunnel=True, dest="^all", tunnel_net=subnet)

--- a/meshtastic/tests/test_core_runtime_primitives.py
+++ b/meshtastic/tests/test_core_runtime_primitives.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 import ast
 import inspect
 import pickle
-from pathlib import Path
 import typing
+from pathlib import Path
 
 import pytest
 
 import meshtastic
 from meshtastic import _core_constants, _protocol_runtime, _publishing, _response_types
-
 
 ROOT = Path(__file__).resolve().parents[2]
 pytestmark = pytest.mark.unit
@@ -79,7 +78,9 @@ def test_public_response_types_are_leaf_module_identities() -> None:
         assert getattr(meshtastic, name) is getattr(_response_types, name), name
 
 
-def test_production_consumers_do_not_reference_moved_primitives_from_package_root() -> None:
+def test_production_consumers_do_not_reference_moved_primitives_from_package_root() -> (
+    None
+):
     """Production internals should consume leaf-owned primitives directly."""
     moved_names = (
         set(_core_constants.__all__)
@@ -184,7 +185,9 @@ def test_public_publishing_thread_is_internal_owner_identity() -> None:
     assert meshtastic.publishingThread is _publishing.publishing_thread
 
 
-def test_production_consumers_do_not_import_publishing_worker_from_package_root() -> None:
+def test_production_consumers_do_not_import_publishing_worker_from_package_root() -> (
+    None
+):
     """Production modules should depend on the internal publishing owner directly."""
     for path in _production_python_modules():
         assert "publishingThread" not in _meshtastic_root_references(path), path

--- a/meshtastic/tests/test_import_compatibility.py
+++ b/meshtastic/tests/test_import_compatibility.py
@@ -18,7 +18,6 @@ from types import ModuleType
 import pytest
 
 
-
 @pytest.mark.unit
 class TestCoreModuleImports:
     """Test core Meshtastic module imports that should remain stable."""

--- a/meshtastic/tests/test_init.py
+++ b/meshtastic/tests/test_init.py
@@ -1,9 +1,9 @@
 """Meshtastic unit tests for __init__.py."""
 
-from collections.abc import Callable
 import copy
 import logging
 import re
+from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, create_autospec
@@ -12,7 +12,6 @@ import pytest
 import serial as pyserial  # type: ignore[import-untyped]
 
 import meshtastic
-from meshtastic import _protocol_runtime
 from meshtastic import (
     DECODE_ERROR_KEY,
     _on_admin_receive,
@@ -20,6 +19,7 @@ from meshtastic import (
     _on_position_receive,
     _on_telemetry_receive,
     _on_text_receive,
+    _protocol_runtime,
     _receive_info_update,
     mt_config,
 )

--- a/meshtastic/tests/test_main_actions_power.py
+++ b/meshtastic/tests/test_main_actions_power.py
@@ -32,7 +32,6 @@ from ..ota import OTAError, OTATransportError
 from ..protobuf.channel_pb2 import Channel  # pylint: disable=E0611
 from ..serial_interface import SerialInterface
 from ..tcp_interface import TCPInterface
-
 from ._main_legacy_support import (
     _build_configure_interface,
     _make_fake_tcp_interface,
@@ -44,6 +43,7 @@ from ._main_legacy_support import (
 
 MAIN_LOCAL_ADDR: str = cast(str, main_module.__dict__["LOCAL_ADDR"])
 
+
 @pytest.fixture(autouse=True)
 def _mock_newer_version_check(monkeypatch: pytest.MonkeyPatch) -> None:
     """Prevent external network calls during unit tests in this module.
@@ -54,6 +54,7 @@ def _mock_newer_version_check(monkeypatch: pytest.MonkeyPatch) -> None:
         Pytest monkeypatching fixture.
     """
     monkeypatch.setattr("meshtastic.util.check_if_newer_version", lambda: None)
+
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
@@ -1200,8 +1201,6 @@ def test_main_ota_update_requires_tcp_interface(
     assert excinfo.value.code == 1
 
 
-
-
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_main_ota_update_retries_then_exits(
@@ -1555,7 +1554,9 @@ def test_create_power_meter_sleeps_after_power_on_when_not_waiting(
     sleep_mock = MagicMock()
     time_attrs = vars(main_module.time).copy()
     time_attrs["sleep"] = sleep_mock
-    monkeypatch.setattr(main_module, "time", SimpleNamespace(**time_attrs), raising=True)
+    monkeypatch.setattr(
+        main_module, "time", SimpleNamespace(**time_attrs), raising=True
+    )
 
     _create_power_meter()
 

--- a/meshtastic/tests/test_main_cli_core.py
+++ b/meshtastic/tests/test_main_cli_core.py
@@ -23,19 +23,20 @@ from meshtastic.__main__ import (
     support_info,
 )
 
-# from ..ble_interface import BLEInterface
-
 # from ..radioconfig_pb2 import UserPreferences
 # import meshtastic.config_pb2
 from ..protobuf import localonly_pb2
 from ..serial_interface import SerialInterface
 from ..tcp_interface import TCPInterface
 
+# from ..ble_interface import BLEInterface
+
 
 # from ..remote_hardware import onGPIOreceive
 # from ..config_pb2 import Config
 
 MAIN_LOCAL_ADDR: str = cast(str, main_module.__dict__["LOCAL_ADDR"])
+
 
 @pytest.fixture(autouse=True)
 def _mock_newer_version_check(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -47,6 +48,7 @@ def _mock_newer_version_check(monkeypatch: pytest.MonkeyPatch) -> None:
         Pytest monkeypatching fixture.
     """
     monkeypatch.setattr("meshtastic.util.check_if_newer_version", lambda: None)
+
 
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")

--- a/meshtastic/tests/test_main_preferences_export.py
+++ b/meshtastic/tests/test_main_preferences_export.py
@@ -23,12 +23,9 @@ from meshtastic.__main__ import (
     traverseConfig,
 )
 
-# from ..ble_interface import BLEInterface
-
 # from ..radioconfig_pb2 import UserPreferences
 # import meshtastic.config_pb2
 from ..protobuf import config_pb2, localonly_pb2
-
 from ._main_legacy_support import (
     _build_configure_interface,
     _build_export_interface,
@@ -36,6 +33,9 @@ from ._main_legacy_support import (
     _get_config_field,
     _run_main_configure_file,
 )
+
+# from ..ble_interface import BLEInterface
+
 
 # from ..remote_hardware import onGPIOreceive
 # from ..config_pb2 import Config
@@ -51,6 +51,7 @@ def _mock_newer_version_check(monkeypatch: pytest.MonkeyPatch) -> None:
         Pytest monkeypatching fixture.
     """
     monkeypatch.setattr("meshtastic.util.check_if_newer_version", lambda: None)
+
 
 @pytest.mark.unit
 def test_flatten_leaf_paths_flat_dict() -> None:
@@ -576,8 +577,6 @@ def test_prefix_base64_bytes_fields_rejects_invalid_repeated_values() -> None:
 
     with pytest.raises(TypeError, match="repeated bytes field security.admin_key"):
         _prefix_base64_bytes_fields(message, values)
-
-
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_mesh_interface_core.py
+++ b/meshtastic/tests/test_mesh_interface_core.py
@@ -384,7 +384,9 @@ def test_sendPosition_default_path_delegates_empty_position_payload() -> None:
     sent_packet = mesh_pb2.MeshPacket(id=123)
     with (
         MeshInterface(noProto=True) as iface,
-        patch.object(iface, "_send_data_with_wait", return_value=sent_packet) as send_mock,
+        patch.object(
+            iface, "_send_data_with_wait", return_value=sent_packet
+        ) as send_mock,
     ):
         result = iface.sendPosition()
 
@@ -686,7 +688,6 @@ def test_disconnected_publishes_lost_once_per_connection(
         iface.isConnected.set()
         iface._disconnected()
         assert len(queued_callbacks) == 2
-
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_mesh_interface_runtime_ports.py
+++ b/meshtastic/tests/test_mesh_interface_runtime_ports.py
@@ -6,10 +6,10 @@ import pytest
 
 from meshtastic.mesh_interface import MeshInterface
 from meshtastic.mesh_interface_runtime.ports import (
+    _interface_error_type,
     _NodeViewPort,
     _ReceivePipelinePort,
     _SendPipelinePort,
-    _interface_error_type,
 )
 from meshtastic.protobuf import mesh_pb2
 

--- a/meshtastic/tests/test_mesh_interface_send_concurrency.py
+++ b/meshtastic/tests/test_mesh_interface_send_concurrency.py
@@ -32,14 +32,13 @@ from ..protobuf import (
     portnums_pb2,
     telemetry_pb2,
 )
-
-# TODO
-# from ..config import Config
-
 from ._mesh_interface_legacy_support import (
     _start_wait_thread,
     _wait_for_scoped_wait_registration,
 )
+
+# TODO
+# from ..config import Config
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_mesh_interface_wait_receive.py
+++ b/meshtastic/tests/test_mesh_interface_wait_receive.py
@@ -39,7 +39,6 @@ from ..protobuf import (
 # TODO
 # from ..config import Config
 from ..util import Acknowledgment, Timeout
-
 from ._mesh_interface_legacy_support import (
     _inline_queue_work,
     _install_protocol_stub,
@@ -60,7 +59,6 @@ def _decode_failure_iface_fixture(
     _inline_queue_work(monkeypatch)
     with MeshInterface(noProto=True) as iface:
         yield iface
-
 
 
 @pytest.mark.unit
@@ -1603,7 +1601,6 @@ class TestUnscopedWaitForAckNakOverlappingCommands:
                 "This is unpredictable behavior from unscoped waits."
             )
 
-
     @pytest.mark.unit
     @pytest.mark.usefixtures("reset_mt_config")
     def test_overlapping_admin_commands_nak_race_condition(self) -> None:
@@ -2035,9 +2032,12 @@ def test_response_handler_pruning_preserves_active_scoped_wait() -> None:
         )
         iface._clear_wait_error(WAIT_ATTR_NAK, request_id=502)
         registered_at = iface._request_wait_runtime._response_handler_registered_at[502]
-        assert iface._request_wait_runtime.prune_stale_response_handlers(
-            now=registered_at + RESPONSE_HANDLER_TTL_SECONDS + 1.0
-        ) == []
+        assert (
+            iface._request_wait_runtime.prune_stale_response_handlers(
+                now=registered_at + RESPONSE_HANDLER_TTL_SECONDS + 1.0
+            )
+            == []
+        )
         assert 502 in iface.responseHandlers
 
 
@@ -2070,9 +2070,12 @@ def test_response_handler_pruning_preserves_legacy_unmanaged_entry() -> None:
             callback=MagicMock(), ackPermitted=True
         )
 
-        assert iface._request_wait_runtime.prune_stale_response_handlers(
-            now=time.monotonic() + 10_000.0
-        ) == []
+        assert (
+            iface._request_wait_runtime.prune_stale_response_handlers(
+                now=time.monotonic() + 10_000.0
+            )
+            == []
+        )
         assert 504 in iface.responseHandlers
         assert 504 not in iface._request_wait_runtime._response_handler_registered_at
         assert 504 not in iface._request_wait_runtime._managed_response_handlers
@@ -2130,6 +2133,7 @@ def test_inbound_response_expires_only_its_correlated_stale_handler() -> None:
         assert 509 in iface.responseHandlers
         assert 509 in runtime._response_handler_registered_at
 
+
 @pytest.mark.unit
 @pytest.mark.usefixtures("reset_mt_config")
 def test_response_handler_pruning_preserves_legacy_replacement() -> None:
@@ -2141,9 +2145,12 @@ def test_response_handler_pruning_preserves_legacy_replacement() -> None:
         legacy_handler = ResponseHandler(callback=MagicMock(), ackPermitted=True)
         iface.responseHandlers[508] = legacy_handler
 
-        assert runtime.prune_stale_response_handlers(
-            now=registered_at + RESPONSE_HANDLER_TTL_SECONDS + 1.0
-        ) == []
+        assert (
+            runtime.prune_stale_response_handlers(
+                now=registered_at + RESPONSE_HANDLER_TTL_SECONDS + 1.0
+            )
+            == []
+        )
         assert iface.responseHandlers[508] is legacy_handler
         assert 508 not in runtime._response_handler_registered_at
         assert 508 not in runtime._response_matchers

--- a/meshtastic/tests/test_node_contact_runtime_compat.py
+++ b/meshtastic/tests/test_node_contact_runtime_compat.py
@@ -49,7 +49,9 @@ def test_add_contact_url_preserves_node_module_payload_limit_monkeypatch() -> No
     target = _node_with_contact(0x87654321)
 
     with patch.object(node_module, "_MAX_CONTACT_URL_PAYLOAD", 1):
-        with pytest.raises(MeshInterface.MeshInterfaceError, match="Contact URL fragment too large"):
+        with pytest.raises(
+            MeshInterface.MeshInterfaceError, match="Contact URL fragment too large"
+        ):
             target.addContactURL(url)
 
 

--- a/meshtastic/tests/test_node_content_admin.py
+++ b/meshtastic/tests/test_node_content_admin.py
@@ -20,11 +20,10 @@ from ..protobuf import (
 )
 from ..protobuf.channel_pb2 import Channel  # pylint: disable=E0611
 from ..util import Acknowledgment
-
 from ._node_legacy_support import (
-    _TrackingLock,
     _get_mock_call_arg,
     _make_fake_send_admin,
+    _TrackingLock,
 )
 
 CHANNEL_LIMIT = MAX_CHANNELS
@@ -416,6 +415,7 @@ def test_get_canned_message_times_out_without_response(
         r"Timed out waiting for canned message response", caplog.text, re.MULTILINE
     )
 
+
 @pytest.mark.unit
 @pytest.mark.parametrize(
     ("packet", "expected_flags"),
@@ -472,6 +472,7 @@ def test_onAckNak_classifies_ack_nak_variants(
         acknowledgment.receivedImplAck,
     ) == expected_flags
 
+
 @pytest.mark.unit
 def test_send_admin_no_proto_returns_none(
     autospec_local_node_iface: Callable[[type[Any]], MagicMock],
@@ -481,6 +482,7 @@ def test_send_admin_no_proto_returns_none(
     msg = admin_pb2.AdminMessage()
 
     assert anode._send_admin(msg) is None
+
 
 @pytest.mark.unit
 def test_send_admin_uses_session_passkey_and_selected_admin_index(
@@ -506,6 +508,7 @@ def test_send_admin_uses_session_passkey_and_selected_admin_index(
     assert iface.sendData.call_args.kwargs["channelIndex"] == 3
     assert iface.sendData.call_args.kwargs["pkiEncrypted"] is True
 
+
 @pytest.mark.unit
 def test_send_admin_respects_explicit_channel_zero(
     autospec_local_node_iface: Callable[[type[Any]], MagicMock],
@@ -523,6 +526,7 @@ def test_send_admin_respects_explicit_channel_zero(
 
     assert result is packet
     assert iface.sendData.call_args.kwargs["channelIndex"] == 0
+
 
 @pytest.mark.unit
 def test_ensureSessionKey_requests_only_when_missing(

--- a/meshtastic/tests/test_node_metadata.py
+++ b/meshtastic/tests/test_node_metadata.py
@@ -18,7 +18,6 @@ from ..protobuf import (
     mesh_pb2,
 )
 from ..util import Acknowledgment
-
 from ._node_legacy_support import (
     _MetadataLockProbeIface,
     _TrackingLock,

--- a/meshtastic/tests/test_node_runtime_channel_normalization.py
+++ b/meshtastic/tests/test_node_runtime_channel_normalization.py
@@ -101,7 +101,9 @@ class TestFixupChannels:
     """Tests for _NodeChannelNormalizationRuntime._fixup_channels()."""
 
     def test_fixup_channels_delegates_to_state_owner(
-        self, channel_state: _NodeChannelState, runtime: _NodeChannelNormalizationRuntime
+        self,
+        channel_state: _NodeChannelState,
+        runtime: _NodeChannelNormalizationRuntime,
     ) -> None:
         """_fixup_channels should let the state owner manage normalization locking."""
         channel_state.normalize = MagicMock()  # type: ignore[method-assign]
@@ -214,7 +216,9 @@ class TestFillChannels:
     """Tests for _NodeChannelNormalizationRuntime._fill_channels()."""
 
     def test_fill_channels_delegates_to_state_owner(
-        self, channel_state: _NodeChannelState, runtime: _NodeChannelNormalizationRuntime
+        self,
+        channel_state: _NodeChannelState,
+        runtime: _NodeChannelNormalizationRuntime,
     ) -> None:
         """_fill_channels should let the state owner manage fill locking."""
         channel_state.fill = MagicMock()  # type: ignore[method-assign]
@@ -258,7 +262,9 @@ class TestIntegration:
             "Truncating channel list" in record.message for record in caplog.records
         )
 
-    def test_fixup_channels_with_partial_list(self, channel_state: _NodeChannelState) -> None:
+    def test_fixup_channels_with_partial_list(
+        self, channel_state: _NodeChannelState
+    ) -> None:
         """Partial channel list should be reindexed and filled."""
         initial_count = 2
         channel_state.channels = []

--- a/meshtastic/tests/test_node_runtime_response.py
+++ b/meshtastic/tests/test_node_runtime_response.py
@@ -10,13 +10,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from ._node_channel_state_test_support import _attach_channel_state
 from ..node_runtime.response_runtime import (
     _NodeChannelResponseRuntime,
     _NodeMetadataResponseRuntime,
 )
 from ..protobuf import admin_pb2, channel_pb2, config_pb2, mesh_pb2, portnums_pb2
 from ..util import Acknowledgment
+from ._node_channel_state_test_support import _attach_channel_state
 
 
 @pytest.fixture
@@ -430,7 +430,8 @@ class TestNodeChannelResponseRuntime:
     ) -> None:
         """Handle channel response with missing decoded should return early."""
         runtime = _NodeChannelResponseRuntime(
-            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+            mock_node_for_channel,
+            channel_state=mock_node_for_channel._test_channel_state,
         )
         packet: dict[str, Any] = {"decoded": None}
 
@@ -445,7 +446,8 @@ class TestNodeChannelResponseRuntime:
     ) -> None:
         """Handle channel response with routing error should retry in-flight request."""
         runtime = _NodeChannelResponseRuntime(
-            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+            mock_node_for_channel,
+            channel_state=mock_node_for_channel._test_channel_state,
         )
         runtime.mark_channel_request_sent(3)
         packet: dict[str, Any] = {
@@ -469,7 +471,8 @@ class TestNodeChannelResponseRuntime:
     ) -> None:
         """Handle channel response with routing success should wait for ADMIN_APP payload."""
         runtime = _NodeChannelResponseRuntime(
-            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+            mock_node_for_channel,
+            channel_state=mock_node_for_channel._test_channel_state,
         )
 
         packet: dict[str, Any] = {
@@ -494,7 +497,8 @@ class TestNodeChannelResponseRuntime:
     ) -> None:
         """Handle channel response with admin message should append to partialChannels."""
         runtime = _NodeChannelResponseRuntime(
-            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+            mock_node_for_channel,
+            channel_state=mock_node_for_channel._test_channel_state,
         )
         runtime.mark_channel_request_sent(0)
 
@@ -524,7 +528,8 @@ class TestNodeChannelResponseRuntime:
     ) -> None:
         """Handle channel response with last channel index should finalize channels."""
         runtime = _NodeChannelResponseRuntime(
-            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+            mock_node_for_channel,
+            channel_state=mock_node_for_channel._test_channel_state,
         )
         runtime.mark_channel_request_sent(7)
 
@@ -561,7 +566,8 @@ class TestNodeChannelResponseRuntime:
     ) -> None:
         """Handle channel response with non-last channel should request next channel."""
         runtime = _NodeChannelResponseRuntime(
-            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+            mock_node_for_channel,
+            channel_state=mock_node_for_channel._test_channel_state,
         )
         runtime.mark_channel_request_sent(3)
 
@@ -589,7 +595,8 @@ class TestNodeChannelResponseRuntime:
     ) -> None:
         """Late duplicate channel response after successful retry should not restart installation."""
         runtime = _NodeChannelResponseRuntime(
-            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+            mock_node_for_channel,
+            channel_state=mock_node_for_channel._test_channel_state,
         )
         runtime.mark_channel_request_sent(0)
 
@@ -626,7 +633,8 @@ class TestNodeChannelResponseRuntime:
     ) -> None:
         """Handle channel response with missing admin should log warning."""
         runtime = _NodeChannelResponseRuntime(
-            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+            mock_node_for_channel,
+            channel_state=mock_node_for_channel._test_channel_state,
         )
         packet: dict[str, Any] = {
             "decoded": {
@@ -645,7 +653,8 @@ class TestNodeChannelResponseRuntime:
     ) -> None:
         """Handle channel response with missing admin.raw should log warning."""
         runtime = _NodeChannelResponseRuntime(
-            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+            mock_node_for_channel,
+            channel_state=mock_node_for_channel._test_channel_state,
         )
         packet: dict[str, Any] = {
             "decoded": {
@@ -665,7 +674,8 @@ class TestNodeChannelResponseRuntime:
     ) -> None:
         """_handle_routing_response should return False for non-ROUTING_APP portnum."""
         runtime = _NodeChannelResponseRuntime(
-            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+            mock_node_for_channel,
+            channel_state=mock_node_for_channel._test_channel_state,
         )
         decoded: dict[str, Any] = {
             "portnum": "ADMIN_APP",
@@ -682,7 +692,8 @@ class TestNodeChannelResponseRuntime:
     ) -> None:
         """_handle_routing_response should guard malformed routing payloads."""
         runtime = _NodeChannelResponseRuntime(
-            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+            mock_node_for_channel,
+            channel_state=mock_node_for_channel._test_channel_state,
         )
         decoded: dict[str, Any] = {
             "portnum": portnums_pb2.PortNum.Name(portnums_pb2.PortNum.ROUTING_APP),
@@ -702,7 +713,8 @@ class TestNodeChannelResponseRuntime:
     ) -> None:
         """_handle_routing_response should wait for ADMIN_APP payload on routing success."""
         runtime = _NodeChannelResponseRuntime(
-            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+            mock_node_for_channel,
+            channel_state=mock_node_for_channel._test_channel_state,
         )
 
         decoded: dict[str, Any] = {
@@ -726,7 +738,8 @@ class TestNodeChannelResponseRuntime:
     ) -> None:
         """Routing errors without a pending index should set terminal channel-failure state."""
         runtime = _NodeChannelResponseRuntime(
-            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+            mock_node_for_channel,
+            channel_state=mock_node_for_channel._test_channel_state,
         )
         decoded: dict[str, Any] = {
             "portnum": portnums_pb2.PortNum.Name(portnums_pb2.PortNum.ROUTING_APP),
@@ -747,7 +760,8 @@ class TestNodeChannelResponseRuntime:
     ) -> None:
         """Routing retry should mark failure if the retry send is skipped."""
         runtime = _NodeChannelResponseRuntime(
-            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+            mock_node_for_channel,
+            channel_state=mock_node_for_channel._test_channel_state,
         )
         runtime.mark_channel_request_sent(4)
         mock_node_for_channel._request_channel.return_value = None
@@ -769,7 +783,8 @@ class TestNodeChannelResponseRuntime:
     ) -> None:
         """Persistent routing failures should stop retrying after the configured retry limit."""
         runtime = _NodeChannelResponseRuntime(
-            mock_node_for_channel, channel_state=mock_node_for_channel._test_channel_state
+            mock_node_for_channel,
+            channel_state=mock_node_for_channel._test_channel_state,
         )
         runtime.mark_channel_request_sent(2)
         decoded: dict[str, Any] = {

--- a/meshtastic/tests/test_node_runtime_transport.py
+++ b/meshtastic/tests/test_node_runtime_transport.py
@@ -729,9 +729,9 @@ class TestNodeDeleteChannelRuntime:
             -1,
         )
         assert pre_delete_idx >= 0, "pre_delete_admin write should exist"
-        assert post_delete_idx > pre_delete_idx, (
-            "post_delete_admin should appear after pre_delete_admin"
-        )
+        assert (
+            post_delete_idx > pre_delete_idx
+        ), "post_delete_admin should appear after pre_delete_admin"
 
     @pytest.mark.unit
     def test_delete_channel_releases_state_lock_before_device_writes(
@@ -747,9 +747,11 @@ class TestNodeDeleteChannelRuntime:
                 role=(
                     channel_pb2.Channel.Role.PRIMARY
                     if index == 0
-                    else channel_pb2.Channel.Role.SECONDARY
-                    if index == 1
-                    else channel_pb2.Channel.Role.DISABLED
+                    else (
+                        channel_pb2.Channel.Role.SECONDARY
+                        if index == 1
+                        else channel_pb2.Channel.Role.DISABLED
+                    )
                 ),
             )
             for index in range(MAX_CHANNELS)
@@ -891,9 +893,11 @@ class TestNodeDeleteChannelRuntime:
             channel.role = (
                 channel_pb2.Channel.Role.PRIMARY
                 if index == 0
-                else channel_pb2.Channel.Role.SECONDARY
-                if index == 1
-                else channel_pb2.Channel.Role.DISABLED
+                else (
+                    channel_pb2.Channel.Role.SECONDARY
+                    if index == 1
+                    else channel_pb2.Channel.Role.DISABLED
+                )
             )
             channels.append(channel)
         mock_local_node.channels = channels

--- a/meshtastic/tests/test_node_seturl.py
+++ b/meshtastic/tests/test_node_seturl.py
@@ -20,9 +20,9 @@ from ..protobuf import (
 from ..protobuf.channel_pb2 import Channel  # pylint: disable=E0611
 from ._node_legacy_support import (
     _DropChannelsOnEnterCountLock,
-    _make_recording_send_admin,
     _encode_channel_set_to_url,
     _get_mock_call_arg,
+    _make_recording_send_admin,
 )
 
 CHANNEL_LIMIT = MAX_CHANNELS

--- a/meshtastic/tests/test_node_view.py
+++ b/meshtastic/tests/test_node_view.py
@@ -11,12 +11,12 @@ import pytest
 
 from meshtastic import BROADCAST_ADDR, BROADCAST_NUM, LOCAL_ADDR
 from meshtastic.mesh_interface import MeshInterface
-from meshtastic.mesh_interface_runtime.ports import _NodeViewPort
 from meshtastic.mesh_interface_runtime.node_view import (
     NodeView,
     _normalize_json_serializable,
     _timeago,
 )
+from meshtastic.mesh_interface_runtime.ports import _NodeViewPort
 from meshtastic.protobuf import mesh_pb2
 
 

--- a/meshtastic/tests/test_send_pipeline.py
+++ b/meshtastic/tests/test_send_pipeline.py
@@ -451,7 +451,9 @@ class TestSendDataWithWait:
                 """Serialize the protobuf message."""
                 return b"serialized protobuf"
 
-        with patch.object(send_pipeline._port.facade, "_send_packet") as mock_send_packet:
+        with patch.object(
+            send_pipeline._port.facade, "_send_packet"
+        ) as mock_send_packet:
             mock_send_packet.return_value = MagicMock()
             send_pipeline._send_data_with_wait(
                 MockProtobuf(),
@@ -496,7 +498,9 @@ class TestSendDataWithWait:
         """Test that _send_data_with_wait registers response handler."""
         callback = MagicMock()
 
-        with patch.object(send_pipeline._port.facade, "_send_packet") as mock_send_packet:
+        with patch.object(
+            send_pipeline._port.facade, "_send_packet"
+        ) as mock_send_packet:
             with patch.object(
                 send_pipeline, "_add_response_handler"
             ) as mock_add_handler:
@@ -1075,7 +1079,6 @@ class TestSendPacket:
 
         mock_send_to_radio.assert_not_called()
         assert "noProto" in caplog.text
-
 
 
 class TestWaitForConfig:

--- a/tests/_ble_interface_core_support.py
+++ b/tests/_ble_interface_core_support.py
@@ -37,10 +37,7 @@ SAFE_EXECUTE_CALLABLE_ONLY_ERROR_MSG = "callable-only failed"
 SAFE_EXECUTE_LEGACY_POSITIONAL_MISMATCH_ERROR_MSG = "legacy positional mismatch"
 
 
-
-def _pin_interface_platform(
-    monkeypatch: pytest.MonkeyPatch, platform: str
-) -> None:
+def _pin_interface_platform(monkeypatch: pytest.MonkeyPatch, platform: str) -> None:
     """Replace the BLE interface module's ``sys`` reference with a local platform fake.
 
     Parameters
@@ -114,6 +111,7 @@ def _pin_interface_subprocess_run(
         raising=True,
     )
 
+
 def _pin_trust_environment(
     monkeypatch: pytest.MonkeyPatch,
     *,
@@ -130,9 +128,7 @@ def _pin_trust_environment(
         callable raises if the subprocess path is unexpectedly reached.
     """
     _pin_interface_platform(monkeypatch, "linux")
-    _pin_interface_shutil_which(
-        monkeypatch, lambda _name: "/usr/bin/bluetoothctl"
-    )
+    _pin_interface_shutil_which(monkeypatch, lambda _name: "/usr/bin/bluetoothctl")
     if run is None:
 
         def _unexpected_run(*_args: object, **_kwargs: object) -> None:
@@ -192,8 +188,9 @@ def _make_establish_stub(
     device_key: str | None = None,
     alias_key: str | None = None,
     connection_alias_key: str | None = None,
-    on_call: Callable[[str | None, str | None, str | None, bool, float | None], None]
-    | None = None,
+    on_call: (
+        Callable[[str | None, str | None, str | None, bool, float | None], None] | None
+    ) = None,
 ) -> Callable[..., tuple[Any, str | None, str | None]]:
     """Build an ``_establish_and_update_client`` test stub.
 

--- a/tests/test_ble_connection_edge_cases.py
+++ b/tests/test_ble_connection_edge_cases.py
@@ -43,9 +43,9 @@ def _refresh_connection_symbols() -> None:
     globals()["ClientManager"] = connection_module.ClientManager
     globals()["ConnectionOrchestrator"] = connection_module.ConnectionOrchestrator
     globals()["ConnectionValidator"] = connection_module.ConnectionValidator
-    globals()["_is_device_not_found_error"] = (
-        connection_module._is_device_not_found_error
-    )
+    globals()[
+        "_is_device_not_found_error"
+    ] = connection_module._is_device_not_found_error
 
 
 class MockBLEError(Exception):

--- a/tests/test_ble_interface_connect_concurrency.py
+++ b/tests/test_ble_interface_connect_concurrency.py
@@ -22,8 +22,6 @@ from meshtastic.interfaces.ble.constants import (
     ERROR_INTERFACE_CLOSING,
 )
 from meshtastic.interfaces.ble.state import ConnectionState
-
-
 from tests._ble_interface_core_support import (
     _build_minimal_connect_test_interface,
     _make_establish_stub,
@@ -209,9 +207,9 @@ def test_concurrent_connect_and_disconnect_do_not_deadlock(
         connect_thread.join(timeout=12.0)
         disconnect_thread.join(timeout=12.0)
 
-        assert establish_called.is_set(), (
-            "connect() did not run connection establishment"
-        )
+        assert (
+            establish_called.is_set()
+        ), "connect() did not run connection establishment"
         assert not connect_thread.is_alive(), "connect() thread appears deadlocked"
         assert not disconnect_thread.is_alive(), "disconnect thread appears deadlocked"
 

--- a/tests/test_ble_interface_connect_lifecycle.py
+++ b/tests/test_ble_interface_connect_lifecycle.py
@@ -19,8 +19,6 @@ from meshtastic.interfaces.ble.constants import (
     ERROR_MANAGEMENT_CONNECTING,
 )
 from meshtastic.interfaces.ble.state import ConnectionState
-
-
 from tests._ble_interface_core_support import (
     _MAX_SPURIOUS_CONNECT_WAIT_CALLS_BEFORE_FAIL,
     _build_minimal_connect_test_interface,

--- a/tests/test_ble_interface_coverage.py
+++ b/tests/test_ble_interface_coverage.py
@@ -1161,7 +1161,9 @@ def test_get_or_create_collaborator_uses_double_checked_locking() -> None:
     assert result1 is result2
 
 
-def test_get_or_create_collaborator_lockless_fallback_converges_racing_callers() -> None:
+def test_get_or_create_collaborator_lockless_fallback_converges_racing_callers() -> (
+    None
+):
     """Partial lockless interfaces must still return one collaborator owner."""
 
     class _PartialInterface:
@@ -1200,7 +1202,9 @@ def test_get_or_create_collaborator_lockless_fallback_converges_racing_callers()
     assert iface._test_collaborator is results[0]
 
 
-def test_notification_registration_compat_state_probe_revalidates_outside_lock() -> None:
+def test_notification_registration_compat_state_probe_revalidates_outside_lock() -> (
+    None
+):
     """Fallback registration probes must release and then revalidate state ownership."""
 
     class _TrackingLock:

--- a/tests/test_ble_interface_discovery_compat.py
+++ b/tests/test_ble_interface_discovery_compat.py
@@ -33,8 +33,6 @@ from meshtastic.interfaces.ble.notifications import (
     NotificationManager,
 )
 from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
-
-
 from tests._ble_interface_core_support import (
     SAFE_EXECUTE_CALLABLE_ONLY_ERROR_MSG,
     SAFE_EXECUTE_DIFFERENT_TYPE_ERROR_MSG,
@@ -42,9 +40,9 @@ from tests._ble_interface_core_support import (
     SAFE_EXECUTE_KEYWORD_CALL_FAILED_MSG,
     SAFE_EXECUTE_POSITIONAL_MISMATCH_ERROR_MSG,
     SAFE_EXECUTE_UNEXPECTED_ERROR_MSG,
+    _create_ble_device,
     _FakeDiscoveryClient,
     _ImmediateThread,
-    _create_ble_device,
     _make_send_message_recorder,
 )
 

--- a/tests/test_ble_interface_management_core.py
+++ b/tests/test_ble_interface_management_core.py
@@ -27,8 +27,6 @@ from meshtastic.interfaces.ble.constants import (
     ERROR_MANAGEMENT_TARGET_CHANGED,
 )
 from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
-
-
 from tests._ble_interface_core_support import (
     _capture_management_wait_event,
     _clear_management_handler,
@@ -501,7 +499,9 @@ def test_ble_interface_close_waits_for_temporary_pair_operation(
     def _run_pair() -> None:
         try:
             iface.pair("mesh-node", confirm=True, await_timeout=7.0)
-        except Exception as exc:  # pragma: no cover - failure captured below  # noqa: BLE001 - test captures thread errors
+        except (
+            Exception
+        ) as exc:  # pragma: no cover - failure captured below  # noqa: BLE001 - test captures thread errors
             pair_errors.append(exc)
 
     close_done = threading.Event()
@@ -509,7 +509,9 @@ def test_ble_interface_close_waits_for_temporary_pair_operation(
     def _run_close() -> None:
         try:
             iface.close()
-        except Exception as exc:  # pragma: no cover - failure captured below  # noqa: BLE001 - test captures thread errors
+        except (
+            Exception
+        ) as exc:  # pragma: no cover - failure captured below  # noqa: BLE001 - test captures thread errors
             close_errors.append(exc)
         finally:
             close_done.set()

--- a/tests/test_ble_interface_receive_runtime.py
+++ b/tests/test_ble_interface_receive_runtime.py
@@ -17,8 +17,6 @@ from bleak.exc import BleakError
 from meshtastic.interfaces.ble import (
     BLEInterface,
 )
-
-
 from tests._ble_interface_core_support import (
     START_FAILED_MSG,
 )

--- a/tests/test_ble_interface_shutdown_notifications.py
+++ b/tests/test_ble_interface_shutdown_notifications.py
@@ -22,14 +22,12 @@ from meshtastic.interfaces.ble import (
 )
 from meshtastic.interfaces.ble.reconnection import ReconnectScheduler, ReconnectWorker
 from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
-
-
 from tests._ble_interface_core_support import (
     SAFE_EXECUTE_LEGACY_POSITIONAL_MISMATCH_ERROR_MSG,
     SAFE_EXECUTE_UNEXPECTED_ERROR_MSG,
+    _attach_close_monitor,
     _ReconnectTestNotificationManager,
     _ReconnectTestScheduler,
-    _attach_close_monitor,
     pub,
 )
 
@@ -233,9 +231,9 @@ def test_close_clears_ble_threads(monkeypatch: pytest.MonkeyPatch) -> None:
 
         time.sleep(poll_interval)
 
-    assert not lingering, (
-        f"Found lingering BLE threads after {max_wait_time}s: {lingering}"
-    )
+    assert (
+        not lingering
+    ), f"Found lingering BLE threads after {max_wait_time}s: {lingering}"
 
 
 @pytest.mark.parametrize("exc_type", [RuntimeError, OSError])
@@ -293,9 +291,9 @@ def test_receive_thread_specific_exceptions(
     iface._receive_from_radio_impl()
 
     assert "Fatal error in BLE receive thread" in caplog.text
-    assert close_called.is_set(), (
-        f"Expected close() to be called for {exc_type.__name__}"
-    )
+    assert (
+        close_called.is_set()
+    ), f"Expected close() to be called for {exc_type.__name__}"
 
     # Clean up
     iface._want_receive = False
@@ -430,12 +428,12 @@ def test_log_notification_registration(
     registered_uuids = [call[0] for call in client.start_notify_calls]
 
     # Should have registered both log notifications and the critical FROMNUM notification
-    assert LEGACY_LOGRADIO_UUID in registered_uuids, (
-        "Legacy log notification should be registered"
-    )
-    assert LOGRADIO_UUID in registered_uuids, (
-        "Current log notification should be registered"
-    )
+    assert (
+        LEGACY_LOGRADIO_UUID in registered_uuids
+    ), "Legacy log notification should be registered"
+    assert (
+        LOGRADIO_UUID in registered_uuids
+    ), "Current log notification should be registered"
     assert FROMNUM_UUID in registered_uuids, "FROMNUM notification should be registered"
 
     # Verify handlers are correctly associated
@@ -449,15 +447,15 @@ def test_log_notification_registration(
         call for call in client.start_notify_calls if call[0] == FROMNUM_UUID
     )
 
-    assert callable(legacy_call[1]), (
-        "Legacy log notification should register a callable handler"
-    )
-    assert callable(current_call[1]), (
-        "Current log notification should register a callable handler"
-    )
-    assert callable(fromnum_call[1]), (
-        "FROMNUM notification should register a callable handler"
-    )
+    assert callable(
+        legacy_call[1]
+    ), "Legacy log notification should register a callable handler"
+    assert callable(
+        current_call[1]
+    ), "Current log notification should register a callable handler"
+    assert callable(
+        fromnum_call[1]
+    ), "FROMNUM notification should register a callable handler"
 
     iface.close()
 
@@ -774,7 +772,10 @@ def test_register_notifications_keeps_fromnum_during_provisional_connect(
         assert client.stop_notify_calls == []
         assert iface._fromnum_notify_enabled is True
         assert iface._receive_recovery_controller._should_poll_without_notify() is False
-        assert FROMNUM_UUID in iface._notification_dispatcher._started_notify_characteristics
+        assert (
+            FROMNUM_UUID
+            in iface._notification_dispatcher._started_notify_characteristics
+        )
     finally:
         with iface._state_lock:
             iface.client = client
@@ -984,6 +985,7 @@ def test_register_notifications_rolls_back_if_client_disconnects_during_start(
         with iface._state_lock:
             iface.client = client
         iface.close()
+
 
 def test_register_notifications_retries_fromnum_notify_acquired_once(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_ble_interface_trust_management.py
+++ b/tests/test_ble_interface_trust_management.py
@@ -31,8 +31,6 @@ from meshtastic.interfaces.ble.constants import (
     ERROR_TRUST_INVALID_TIMEOUT,
 )
 from meshtastic.interfaces.ble.state import ConnectionState
-
-
 from tests._ble_interface_core_support import (
     _MAX_SPURIOUS_CLOSE_WAIT_CALLS_BEFORE_FAIL,
     _capture_management_wait_event,
@@ -326,9 +324,7 @@ def test_ble_interface_trust_includes_stdout_and_stderr_in_failure_details(
         lambda _address: _create_ble_device("AA:BB:CC:DD:EE:FF", "Meshtastic"),
     )
     _pin_interface_platform(monkeypatch, "linux")
-    _pin_interface_shutil_which(
-        monkeypatch, lambda _name: "/usr/bin/bluetoothctl"
-    )
+    _pin_interface_shutil_which(monkeypatch, lambda _name: "/usr/bin/bluetoothctl")
     _pin_interface_subprocess_run(
         monkeypatch,
         lambda *_args, **_kwargs: SimpleNamespace(
@@ -362,9 +358,7 @@ def test_ble_interface_trust_truncates_long_subprocess_output(
         lambda _address: _create_ble_device("AA:BB:CC:DD:EE:FF", "Meshtastic"),
     )
     _pin_interface_platform(monkeypatch, "linux")
-    _pin_interface_shutil_which(
-        monkeypatch, lambda _name: "/usr/bin/bluetoothctl"
-    )
+    _pin_interface_shutil_which(monkeypatch, lambda _name: "/usr/bin/bluetoothctl")
     long_output = "long-output-segment " * 200
     _pin_interface_subprocess_run(
         monkeypatch,
@@ -399,9 +393,7 @@ def test_ble_interface_trust_runs_bluetoothctl(
         lambda _address: _create_ble_device("aa bb cc dd ee ff", "Meshtastic"),
     )
     _pin_interface_platform(monkeypatch, "linux")
-    _pin_interface_shutil_which(
-        monkeypatch, lambda _name: "/usr/bin/bluetoothctl"
-    )
+    _pin_interface_shutil_which(monkeypatch, lambda _name: "/usr/bin/bluetoothctl")
 
     run_calls: list[tuple[list[str], float]] = []
 
@@ -485,9 +477,7 @@ def test_ble_interface_trust_translates_subprocess_timeout(
     """trust() should translate bluetoothctl timeouts into BLEError."""
     iface = _build_interface(monkeypatch, DummyClient(), start_receive_thread=False)
     _pin_interface_platform(monkeypatch, "linux")
-    _pin_interface_shutil_which(
-        monkeypatch, lambda _name: "/usr/bin/bluetoothctl"
-    )
+    _pin_interface_shutil_which(monkeypatch, lambda _name: "/usr/bin/bluetoothctl")
 
     def _raise_timeout(*_args: object, **_kwargs: object) -> SimpleNamespace:
         raise subprocess.TimeoutExpired(
@@ -514,9 +504,7 @@ def test_ble_interface_trust_translates_spawn_failure(
     """trust() should translate subprocess spawn failures into BLEError."""
     iface = _build_interface(monkeypatch, DummyClient(), start_receive_thread=False)
     _pin_interface_platform(monkeypatch, "linux")
-    _pin_interface_shutil_which(
-        monkeypatch, lambda _name: "/usr/bin/bluetoothctl"
-    )
+    _pin_interface_shutil_which(monkeypatch, lambda _name: "/usr/bin/bluetoothctl")
 
     def _raise_os_error(*_args: object, **_kwargs: object) -> SimpleNamespace:
         raise OSError("permission denied")
@@ -561,9 +549,7 @@ def test_ble_interface_trust_rejects_closing_interface(
 
     monkeypatch.setattr(iface, "findDevice", _unexpected_find_device)
     _pin_interface_platform(monkeypatch, "linux")
-    _pin_interface_shutil_which(
-        monkeypatch, lambda _name: "/usr/bin/bluetoothctl"
-    )
+    _pin_interface_shutil_which(monkeypatch, lambda _name: "/usr/bin/bluetoothctl")
     _pin_interface_subprocess_run(monkeypatch, _unexpected_run)
 
     try:
@@ -608,14 +594,18 @@ def test_ble_interface_trust_does_not_hold_interface_locks_during_subprocess(
     def _run_trust() -> None:
         try:
             iface.trust(trust_target, timeout=7.0)
-        except Exception as exc:  # pragma: no cover - failure captured below  # noqa: BLE001 - test captures thread errors
+        except (
+            Exception
+        ) as exc:  # pragma: no cover - failure captured below  # noqa: BLE001 - test captures thread errors
             trust_errors.append(exc)
 
     def _close_iface() -> None:
         try:
             close_started.set()
             iface.close()
-        except Exception as exc:  # pragma: no cover - failure captured below  # noqa: BLE001 - test captures thread errors
+        except (
+            Exception
+        ) as exc:  # pragma: no cover - failure captured below  # noqa: BLE001 - test captures thread errors
             close_errors.append(exc)
         finally:
             close_done.set()
@@ -672,13 +662,17 @@ def test_ble_interface_close_waits_for_explicit_trust_without_active_client(
     def _run_trust() -> None:
         try:
             iface.trust("AA:BB:CC:DD:EE:FF", timeout=7.0)
-        except Exception as exc:  # pragma: no cover - failure captured below  # noqa: BLE001 - test captures thread errors
+        except (
+            Exception
+        ) as exc:  # pragma: no cover - failure captured below  # noqa: BLE001 - test captures thread errors
             trust_errors.append(exc)
 
     def _run_close() -> None:
         try:
             iface.close()
-        except Exception as exc:  # pragma: no cover - failure captured below  # noqa: BLE001 - test captures thread errors
+        except (
+            Exception
+        ) as exc:  # pragma: no cover - failure captured below  # noqa: BLE001 - test captures thread errors
             close_errors.append(exc)
         finally:
             close_done.set()
@@ -1000,7 +994,9 @@ def test_ble_interface_implicit_trust_releases_connect_lock_before_subprocess(
     def _run_trust() -> None:
         try:
             iface.trust(timeout=7.0)
-        except Exception as exc:  # pragma: no cover - failure captured below  # noqa: BLE001 - test captures thread errors
+        except (
+            Exception
+        ) as exc:  # pragma: no cover - failure captured below  # noqa: BLE001 - test captures thread errors
             trust_errors.append(exc)
 
     trust_thread = threading.Thread(target=_run_trust, daemon=True)
@@ -1036,7 +1032,9 @@ def test_ble_interface_close_serializes_with_management_lock(
         try:
             close_started.set()
             iface.close()
-        except Exception as exc:  # pragma: no cover - failure captured below  # noqa: BLE001 - test captures thread errors
+        except (
+            Exception
+        ) as exc:  # pragma: no cover - failure captured below  # noqa: BLE001 - test captures thread errors
             close_errors.append(exc)
         finally:
             close_done.set()
@@ -1065,7 +1063,9 @@ def test_ble_interface_close_does_not_wait_for_connect_lock(
     def _close_iface() -> None:
         try:
             iface.close()
-        except Exception as exc:  # pragma: no cover - failure captured below  # noqa: BLE001 - test captures thread errors
+        except (
+            Exception
+        ) as exc:  # pragma: no cover - failure captured below  # noqa: BLE001 - test captures thread errors
             close_errors.append(exc)
         finally:
             close_done.set()

--- a/tests/test_ble_session_state.py
+++ b/tests/test_ble_session_state.py
@@ -13,8 +13,8 @@ from meshtastic.interfaces.ble.lifecycle_controller_runtime import (
 )
 from meshtastic.interfaces.ble.ports import _BLESessionStatePort
 from meshtastic.interfaces.ble.session_state import (
-    BLESessionState,
     LEGACY_SESSION_STATE_CACHE_ERROR,
+    BLESessionState,
     _LegacyBLESessionStateAdapter,
     _session_state_for,
 )
@@ -202,7 +202,9 @@ def test_legacy_adapter_field_map_matches_session_state_protocol() -> None:
         for field_name in getattr(protocol_base, "__annotations__", {})
     }
 
-    assert set(_LegacyBLESessionStateAdapter._FIELD_MAP) == protocol_fields  # noqa: SLF001
+    assert (
+        set(_LegacyBLESessionStateAdapter._FIELD_MAP) == protocol_fields
+    )  # noqa: SLF001
     assert set(_LegacyBLESessionStateAdapter._FIELD_DEFAULTS) == (  # noqa: SLF001
         protocol_fields - {"lock"}
     )
@@ -445,10 +447,12 @@ def test_receive_lifecycle_uses_explicit_session_pending_markers() -> None:
     def _unexpected_create(**_kwargs: object) -> object:
         raise AssertionError("pending session state should suppress thread creation")
 
-    created, recovery_attempts = coordinator._check_receive_start_conditions(  # noqa: SLF001
-        name="PendingReceive",
-        reset_recovery=False,
-        create_runtime_thread=_unexpected_create,  # type: ignore[arg-type]
+    created, recovery_attempts = (
+        coordinator._check_receive_start_conditions(  # noqa: SLF001
+            name="PendingReceive",
+            reset_recovery=False,
+            create_runtime_thread=_unexpected_create,  # type: ignore[arg-type]
+        )
     )
 
     assert created is None
@@ -566,12 +570,14 @@ def test_receive_lifecycle_schedules_inconclusive_restart_outside_session_lock()
         _capture_schedule
     )
 
-    created, recovery_attempts = coordinator._check_receive_start_conditions(  # noqa: SLF001
-        name="InconclusiveReceive",
-        reset_recovery=False,
-        create_runtime_thread=lambda **_kwargs: (_ for _ in ()).throw(
-            AssertionError("inconclusive liveness must defer thread creation")
-        ),
+    created, recovery_attempts = (
+        coordinator._check_receive_start_conditions(  # noqa: SLF001
+            name="InconclusiveReceive",
+            reset_recovery=False,
+            create_runtime_thread=lambda **_kwargs: (_ for _ in ()).throw(
+                AssertionError("inconclusive liveness must defer thread creation")
+            ),
+        )
     )
 
     assert created is None
@@ -610,10 +616,12 @@ def test_receive_lifecycle_thread_probes_run_outside_session_lock() -> None:
         name="ReplacementReceive", ident=None, is_alive=lambda: False
     )
 
-    created, recovery_attempts = coordinator._check_receive_start_conditions(  # noqa: SLF001
-        name="ReplacementReceive",
-        reset_recovery=False,
-        create_runtime_thread=lambda **_kwargs: staged,  # type: ignore[return-value]
+    created, recovery_attempts = (
+        coordinator._check_receive_start_conditions(  # noqa: SLF001
+            name="ReplacementReceive",
+            reset_recovery=False,
+            create_runtime_thread=lambda **_kwargs: staged,  # type: ignore[return-value]
+        )
     )
 
     assert created is staged
@@ -1032,7 +1040,12 @@ def test_receive_snapshot_compatibility_probes_run_outside_session_lock() -> Non
         session_state=state,  # type: ignore[arg-type]
     )
 
-    assert controller._snapshot_client_state() == (None, True, False, False)  # noqa: SLF001
+    assert controller._snapshot_client_state() == (
+        None,
+        True,
+        False,
+        False,
+    )  # noqa: SLF001
     assert probe_lock_states == [("connecting", False), ("closing", False)]
 
 

--- a/tests/test_ble_utils_service_targets.py
+++ b/tests/test_ble_utils_service_targets.py
@@ -452,6 +452,8 @@ def test_status_publish_ignores_synthesized_closing_probe(
     )
 
     assert sent == [("meshtastic.connection.status", iface, True)]
+
+
 def test_status_publish_closing_probe_failure_is_best_effort(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -524,6 +526,7 @@ def test_legacy_status_publish_ignores_synthesized_thread_provider(
 
         def __getattr__(self, name: str) -> object:
             if name == "_get_publishing_thread":
+
                 def _synthesized_provider() -> object:
                     self.synthesized_provider_calls += 1
                     raise AssertionError("synthesized provider must be ignored")
@@ -1087,9 +1090,7 @@ def test_utils_remaining_optional_kwarg_and_safe_execute_branches() -> None:
         )
 
     iface_no_hooks = SimpleNamespace(
-        error_handler=SimpleNamespace(
-            safe_execute=None, _safe_execute=None
-        )
+        error_handler=SimpleNamespace(safe_execute=None, _safe_execute=None)
     )
     assert ble_utils._resolve_safe_execute(iface_no_hooks) is None
 


### PR DESCRIPTION
Straighten linting out project-wide after #384 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This change applies repository-wide lint and format fixes after PR `#384`. It updates 76 files with Black, Prettier, isort, Ruff, and markdownlint corrections. The changes do not alter intended behavior or public APIs. The unit suite passes with 4,539 tests.

## Key changes

### Features

- No new features were added.

### Fixes

- Applied lint and formatting corrections across Python, Markdown, imports, whitespace, and line wrapping.
- Preserved the existing node database snapshot behavior in `show_nodes`.
- Updated inline-code formatting in `COMPATIBILITY.md`.

### Refactors

- Reordered and grouped imports across production and test modules.
- Reformatted function calls, signatures, assertions, conditional expressions, and exception clauses.
- Removed unnecessary blank lines.
- Updated lint annotations and re-enabled an unused-import check in `meshtastic.__main__`.

## Breaking changes and migration

- No breaking changes.
- No migration steps are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->