### PR TITLE
Centralize lazy dependency resolution for BLE

### DIFF
--- a/meshtastic/interfaces/ble/compat_adapter.py
+++ b/meshtastic/interfaces/ble/compat_adapter.py
@@ -9,6 +9,8 @@ are represented.
 from __future__ import annotations
 
 import inspect
+from importlib import import_module
+from types import ModuleType
 from collections.abc import Callable, Iterator
 from typing import Any, TypeVar, cast
 
@@ -16,6 +18,15 @@ from meshtastic.interfaces.ble.ports import _LockPort
 
 T = TypeVar("T")
 _MISSING = object()
+
+
+def _load_runtime_module(module_name: str) -> ModuleType:
+    """Load a runtime dependency lazily to preserve circular-import boundaries.
+
+    Lazy resolution is intentional for BLE compatibility modules because tests and
+    downstream integrations may monkeypatch module-level shims after import.
+    """
+    return import_module(module_name)
 
 
 def _get_declared_member(

--- a/meshtastic/interfaces/ble/compatibility_service.py
+++ b/meshtastic/interfaces/ble/compatibility_service.py
@@ -5,6 +5,7 @@ from threading import Event, Thread
 from typing import TYPE_CHECKING, Any, Callable, cast
 
 from meshtastic.interfaces.ble.compat_adapter import (
+    _load_runtime_module,
     _get_declared_callable,
     _get_declared_member,
 )
@@ -111,8 +112,7 @@ class BLECompatibilityEventPublisher:
         if self._is_live_publishing_thread(self._last_publishing_thread):
             return self._last_publishing_thread
         self._last_publishing_thread = None
-        from meshtastic import mesh_interface as mesh_iface_module
-
+        mesh_iface_module = _load_runtime_module("meshtastic.mesh_interface")
         fallback_thread = getattr(mesh_iface_module, "publishingThread", None)
         if self._is_live_publishing_thread(fallback_thread):
             self._last_publishing_thread = fallback_thread
@@ -509,8 +509,7 @@ class BLECompatibilityEventService:
         None
             Publication is best-effort; failures are logged and suppressed.
         """
-        from meshtastic import mesh_interface as mesh_iface_module
-
+        mesh_iface_module = _load_runtime_module("meshtastic.mesh_interface")
         mesh_pub: Any = getattr(mesh_iface_module, "pub", None)
         if mesh_pub is None:
             logger.debug("Skipping connection status publish: mesh pub is unavailable")
@@ -649,16 +648,14 @@ class BLECompatibilityEventService:
                         exc_info=True,
                     )
             if resolved_publishing_thread is None:
-                from meshtastic import mesh_interface as mesh_iface_module
-
+                mesh_iface_module = _load_runtime_module("meshtastic.mesh_interface")
                 resolved_publishing_thread = getattr(
                     mesh_iface_module, "publishingThread", None
                 )
         if not BLECompatibilityEventPublisher._is_live_publishing_thread(
             resolved_publishing_thread
         ):
-            from meshtastic import mesh_interface as mesh_iface_module
-
+            mesh_iface_module = _load_runtime_module("meshtastic.mesh_interface")
             fallback_thread = getattr(mesh_iface_module, "publishingThread", None)
             resolved_publishing_thread = (
                 fallback_thread

--- a/meshtastic/interfaces/ble/lifecycle_compat_service.py
+++ b/meshtastic/interfaces/ble/lifecycle_compat_service.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, NoReturn, cast
 from bleak import BleakClient as BleakRootClient
 
 from meshtastic.interfaces.ble.compat_adapter import (
+    _load_runtime_module,
     _get_declared_callable,
     _resolve_declared_member,
 )
@@ -1137,8 +1138,9 @@ class BLELifecycleService:
         """
         # Support lifecycle_service module monkeypatches in compatibility tests;
         # fall back to the canonical gating import when no override is present.
-        from meshtastic.interfaces.ble import lifecycle_service as lifecycle_service_mod
-
+        lifecycle_service_mod = _load_runtime_module(
+            "meshtastic.interfaces.ble.lifecycle_service"
+        )
         connected_elsewhere = getattr(
             lifecycle_service_mod,
             "_is_currently_connected_elsewhere",

--- a/meshtastic/interfaces/ble/lifecycle_controller_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_controller_runtime.py
@@ -6,7 +6,10 @@ from typing import TYPE_CHECKING, TypeVar, cast
 
 from bleak import BleakClient as BleakRootClient
 
-from meshtastic.interfaces.ble.compat_adapter import _get_declared_callable
+from meshtastic.interfaces.ble.compat_adapter import (
+    _get_declared_callable,
+    _load_runtime_module,
+)
 from meshtastic.interfaces.ble.lifecycle_compat_service import (
     _ORIGINAL_FINALIZE_CONNECTION_GATES,
     _ORIGINAL_GET_CONNECTED_CLIENT_STATUS,
@@ -137,8 +140,8 @@ class BLELifecycleController:
     ) -> None:
         """Verify ownership and publish connected side effects."""
         if self._uses_compat_connection_status_overrides():
-            from meshtastic.interfaces.ble import (
-                lifecycle_service as lifecycle_service_mod,  # pylint: disable=import-outside-toplevel
+            lifecycle_service_mod = _load_runtime_module(
+                "meshtastic.interfaces.ble.lifecycle_service"
             )
 
             if (
@@ -196,8 +199,8 @@ class BLELifecycleController:
         restore_last_connection_request: str | None = None,
     ) -> None:
         """Discard stale connect result for the bound interface."""
-        from meshtastic.interfaces.ble import (
-            lifecycle_service as lifecycle_service_mod,  # pylint: disable=import-outside-toplevel
+        lifecycle_service_mod = _load_runtime_module(
+            "meshtastic.interfaces.ble.lifecycle_service"
         )
 
         iface = self._iface
@@ -289,8 +292,8 @@ class BLELifecycleController:
 
     def _uses_compat_connection_status_overrides(self) -> bool:
         """Return whether lifecycle service status helpers were monkeypatched."""
-        from meshtastic.interfaces.ble import (
-            lifecycle_service as lifecycle_service_mod,  # pylint: disable=import-outside-toplevel
+        lifecycle_service_mod = _load_runtime_module(
+            "meshtastic.interfaces.ble.lifecycle_service"
         )
 
         service_get_status = (
@@ -327,8 +330,8 @@ class BLELifecycleController:
     ) -> None:
         """Finalize gate ownership after successful connect."""
         if self._uses_compat_connection_status_overrides():
-            from meshtastic.interfaces.ble import (
-                lifecycle_service as lifecycle_service_mod,  # pylint: disable=import-outside-toplevel
+            lifecycle_service_mod = _load_runtime_module(
+                "meshtastic.interfaces.ble.lifecycle_service"
             )
 
             lifecycle_service_mod.BLELifecycleService._finalize_connection_gates(
@@ -347,8 +350,8 @@ class BLELifecycleController:
     def _is_owned_connected_client(self, client: "BLEClient") -> bool:
         """Return whether the bound interface still owns the provided client."""
         if self._uses_compat_connection_status_overrides():
-            from meshtastic.interfaces.ble import (
-                lifecycle_service as lifecycle_service_mod,  # pylint: disable=import-outside-toplevel
+            lifecycle_service_mod = _load_runtime_module(
+                "meshtastic.interfaces.ble.lifecycle_service"
             )
 
             return lifecycle_service_mod.BLELifecycleService._is_owned_connected_client(

--- a/meshtastic/interfaces/ble/management_runtime.py
+++ b/meshtastic/interfaces/ble/management_runtime.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, TypeVar, cast
 
 from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.compat_adapter import (
+    _load_runtime_module,
     _get_declared_callable,
     _get_declared_member,
 )
@@ -296,9 +297,13 @@ class BLEManagementCommandHandler:
             if isinstance(instance_dict, dict) and method_name in instance_dict:
                 return _invoke_override()
             try:
-                from meshtastic.interfaces.ble.interface import BLEInterface
-
-                base_method = inspect.getattr_static(BLEInterface, method_name, None)
+                interface_module = _load_runtime_module(
+                    "meshtastic.interfaces.ble.interface"
+                )
+                ble_interface_type = interface_module.BLEInterface
+                base_method = inspect.getattr_static(
+                    ble_interface_type, method_name, None
+                )
                 class_method = inspect.getattr_static(
                     type(self._iface), method_name, None
                 )

--- a/meshtastic/interfaces/ble/receive_compat_service.py
+++ b/meshtastic/interfaces/ble/receive_compat_service.py
@@ -9,6 +9,7 @@ from bleak.exc import BleakError
 
 from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.compat_adapter import (
+    _load_runtime_module,
     _get_declared_callable,
     _get_declared_lock,
     _get_declared_member,
@@ -26,12 +27,11 @@ class BLEReceiveRecoveryService:
 
     @staticmethod
     def _controller_class() -> type["BLEReceiveRecoveryController"]:
-        """Resolve the receive controller class with a local import."""
-        from meshtastic.interfaces.ble.receive_service import (
-            BLEReceiveRecoveryController,
+        """Resolve the receive controller class lazily across the compat cycle."""
+        receive_module = _load_runtime_module(
+            "meshtastic.interfaces.ble.receive_service"
         )
-
-        return BLEReceiveRecoveryController
+        return cast(type["BLEReceiveRecoveryController"], receive_module.BLEReceiveRecoveryController)
 
     @staticmethod
     def _is_controller_like(

--- a/meshtastic/interfaces/ble/receive_service.py
+++ b/meshtastic/interfaces/ble/receive_service.py
@@ -12,6 +12,7 @@ from bleak.exc import BleakDBusError, BleakError, BleakGATTProtocolError
 
 from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.compat_adapter import (
+    _load_runtime_module,
     _get_declared_callable,
     _get_declared_member,
     _iter_declared_members,
@@ -465,8 +466,9 @@ class BLEReceiveRecoveryController:
                 public_name="close",
             )
             if close_fn is not None:
-                from meshtastic.interfaces.ble import interface as interface_mod
-
+                interface_mod = _load_runtime_module(
+                    "meshtastic.interfaces.ble.interface"
+                )
                 close_fn(
                     management_shutdown_wait_timeout=(
                         interface_mod._MANAGEMENT_SHUTDOWN_WAIT_TIMEOUT_SECONDS
@@ -474,9 +476,10 @@ class BLEReceiveRecoveryController:
                     management_wait_poll_seconds=interface_mod._MANAGEMENT_CONNECT_WAIT_POLL_SECONDS,
                 )
                 return
-        from meshtastic.interfaces.ble import interface as interface_mod
-        from meshtastic.interfaces.ble import lifecycle_service as lifecycle_service_mod
-
+        interface_mod = _load_runtime_module("meshtastic.interfaces.ble.interface")
+        lifecycle_service_mod = _load_runtime_module(
+            "meshtastic.interfaces.ble.lifecycle_service"
+        )
         lifecycle_service_mod.BLELifecycleService._close(
             iface,
             management_shutdown_wait_timeout=(
@@ -1144,9 +1147,10 @@ class BLEReceiveRecoveryController:
 
 
 # COMPAT_STABLE_SHIM: Re-export legacy receive service name for compatibility.
-# Deferred import avoids circular dependency with `receive_compat_service`.
-from meshtastic.interfaces.ble.receive_compat_service import (  # noqa: E402
-    BLEReceiveRecoveryService,
-)
+# Lazy module resolution preserves the receive-service compatibility cycle without
+# a non-top-level import statement.
+BLEReceiveRecoveryService = _load_runtime_module(
+    "meshtastic.interfaces.ble.receive_compat_service"
+).BLEReceiveRecoveryService
 
 __all__ = ["BLEReceiveRecoveryController", "BLEReceiveRecoveryService"]


### PR DESCRIPTION
## Summary by Sourcery

Centralize lazy runtime module resolution for BLE compatibility paths to preserve circular-import boundaries and support monkeypatched shims.

Enhancements:
- Introduce a shared _load_runtime_module helper in the BLE compatibility adapter for lazy importing of runtime dependencies.
- Refactor BLE lifecycle, receive, management, and compatibility services to use centralized lazy module loading instead of scattered local imports, maintaining compatibility cycles and monkeypatching behavior.