### PR TITLE
Document intentional BLE structural lint boundaries

### DIFF
--- a/meshtastic/interfaces/ble/connection.py
+++ b/meshtastic/interfaces/ble/connection.py
@@ -1,5 +1,8 @@
 """BLE connection management and validation."""
 
+# Connection orchestration remains centralized to preserve compatibility probes and retry sequencing.
+# pylint: disable=too-many-lines
+
 import logging
 import math
 import numbers

--- a/meshtastic/interfaces/ble/errors.py
+++ b/meshtastic/interfaces/ble/errors.py
@@ -44,7 +44,7 @@ T = TypeVar("T")
 class MeshtasticBLEError(MeshInterface.MeshInterfaceError):
     """Base exception for structured Meshtastic BLE failures."""
 
-    def __init__(
+    def __init__(  # pylint: disable=super-init-not-called,non-parent-init-called
         self,
         message: str,
         *,
@@ -138,7 +138,7 @@ class BLEDBusTransportError(MeshtasticBLEError, BleakDBusError):
 
     _DEFAULT_DBUS_ERROR = "org.bluez.Error.Failed"
 
-    def __init__(
+    def __init__(  # pylint: disable=super-init-not-called
         self,
         message: str,
         *,

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -24,6 +24,10 @@ Threading model summary
   idempotent and synchronized through the shared state manager lock.
 """
 
+# BLEInterface is the public compatibility facade and composition root for extracted BLE runtimes.
+# pylint: disable=too-many-lines
+
+
 import atexit
 import contextlib
 import math
@@ -131,7 +135,11 @@ from meshtastic.interfaces.ble.session_state import (
     BLESessionState,
     _BLESessionStateCompatMixin,
 )
-from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
+from meshtastic.interfaces.ble.state import (
+    BLEStateManager,
+    ConnectionState,
+    _is_canonical_state_manager,
+)
 from meshtastic.interfaces.ble.utils import (
     _is_unexpected_keyword_error,
     _sleep,
@@ -199,7 +207,10 @@ ERROR_CLIENT_MANAGER_MISSING_UPDATE_CLIENT_REFERENCE: str = (
 )
 
 
-class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
+# The facade owns runtime collaborators; mutable session state itself lives in BLESessionState.
+class BLEInterface(  # pylint: disable=too-many-instance-attributes
+    _BLESessionStateCompatMixin, MeshInterface
+):
     """MeshInterface using BLE to connect to Meshtastic devices.
 
     This class provides a complete BLE interface for Meshtastic communication,
@@ -1245,9 +1256,7 @@ class BLEInterface(_BLESessionStateCompatMixin, MeshInterface):
         state_manager = self._state_manager
         lifecycle_owner_is_current: bool | None
         canonical_locked_probe = (
-            type(state_manager)
-            is BLEStateManager  # pylint: disable=unidiomatic-typecheck
-            and state_manager.lock is self._state_lock
+            _is_canonical_state_manager(state_manager, self._state_lock)
         )
         with self._state_lock:
             if self._closed or self._connection_session_epoch != expected_session_epoch:

--- a/meshtastic/interfaces/ble/lifecycle_compat_service.py
+++ b/meshtastic/interfaces/ble/lifecycle_compat_service.py
@@ -1,5 +1,8 @@
 """Lifecycle compatibility shim service for BLE."""
 
+# This module intentionally consolidates the historical lifecycle compatibility surface.
+# pylint: disable=too-many-lines
+
 from collections.abc import Callable
 from dataclasses import dataclass
 from inspect import Parameter, signature

--- a/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
@@ -26,7 +26,11 @@ from meshtastic.interfaces.ble.lifecycle_primitives import (
 )
 from meshtastic.interfaces.ble.ports import _BLESessionStatePort
 from meshtastic.interfaces.ble.session_state import _session_state_for
-from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
+from meshtastic.interfaces.ble.state import (
+    BLEStateManager,
+    ConnectionState,
+    _is_canonical_state_manager,
+)
 from meshtastic.interfaces.ble.utils import (
     _sleep,
     _thread_start_probe,
@@ -207,16 +211,14 @@ class BLEDisconnectLifecycleCoordinator:
         should_reconnect = False
 
         state_manager = _get_declared_member(iface, "_state_manager")
-        canonical_state_manager = (
-            state_manager
-            if type(state_manager)
-            is BLEStateManager  # pylint: disable=unidiomatic-typecheck
-            and state_manager.lock is self._session.lock
+        canonical_state_manager: BLEStateManager | None = None
+        if (
+            _is_canonical_state_manager(state_manager, self._session.lock)
             and current_state_getter is None
             and transition_to_disconnected is None
             and reset_to_disconnected is None
-            else None
-        )
+        ):
+            canonical_state_manager = state_manager
 
         # Compatibility closing probes may execute collaborator code. Shutdown
         # claims ``session.closed`` under this same lock, so combining the

--- a/meshtastic/interfaces/ble/lifecycle_ownership_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_ownership_runtime.py
@@ -20,7 +20,11 @@ from meshtastic.interfaces.ble.lifecycle_primitives import (
 )
 from meshtastic.interfaces.ble.ports import _BLESessionStatePort
 from meshtastic.interfaces.ble.session_state import _session_state_for
-from meshtastic.interfaces.ble.state import BLEStateManager, ConnectionState
+from meshtastic.interfaces.ble.state import (
+    BLEStateManager,
+    ConnectionState,
+    _is_canonical_state_manager,
+)
 from meshtastic.interfaces.ble.utils import (
     sanitize_address,
 )
@@ -86,9 +90,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         """
         state_manager = self._state_manager
         if (
-            type(state_manager)
-            is BLEStateManager  # pylint: disable=unidiomatic-typecheck
-            and state_manager.lock is self._session.lock
+            _is_canonical_state_manager(state_manager, self._session.lock)
         ):
             return BLEStateManager._current_state_unlocked(state_manager)
         return None
@@ -146,9 +148,7 @@ class BLEConnectionOwnershipLifecycleCoordinator:
         canonical_state_owned = (
             is_closing_getter is None
             and state_connected_getter is None
-            and type(state_manager)
-            is BLEStateManager  # pylint: disable=unidiomatic-typecheck
-            and state_manager.lock is self._session.lock
+            and _is_canonical_state_manager(state_manager, self._session.lock)
         )
         if is_closing_getter is not None:
             result = is_closing_getter()

--- a/meshtastic/interfaces/ble/runner.py
+++ b/meshtastic/interfaces/ble/runner.py
@@ -648,7 +648,8 @@ class BLECoroutineRunner:
             # Re-acquire lock to check result and update state
             with self._instance_lock:
                 if thread.is_alive():
-                    global _zombie_runner_count
+                    # Internal diagnostics/tests intentionally expose this module counter.
+                    global _zombie_runner_count  # pylint: disable=global-statement
                     with _zombie_lock:
                         _zombie_runner_count += 1
                         current_count = _zombie_runner_count

--- a/meshtastic/interfaces/ble/state.py
+++ b/meshtastic/interfaces/ble/state.py
@@ -16,7 +16,7 @@ Lock Ordering Note:
 
 from enum import Enum
 from threading import RLock
-from typing import ClassVar
+from typing import ClassVar, TypeGuard, cast
 
 from meshtastic.interfaces.ble.constants import logger
 
@@ -440,3 +440,16 @@ class BLEStateManager:
             ``True`` when DISCONNECTED is reached (including no-op).
         """
         return self._reset_to_disconnected()
+
+def _is_canonical_state_manager(
+    candidate: object,
+    lock: object,
+) -> TypeGuard[BLEStateManager]:
+    """Return whether ``candidate`` is the exact state owner for ``lock``.
+
+    Compatibility subclasses and test doubles intentionally take slower probe
+    paths; only the concrete manager may use lock-coupled unlocked access.
+    """
+    if type(candidate) is not BLEStateManager:  # pylint: disable=unidiomatic-typecheck
+        return False
+    return cast(BLEStateManager, candidate).lock is lock


### PR DESCRIPTION
## Summary by Sourcery

Clarify BLE runtime architecture and document intentional lint exceptions while centralizing canonical state-manager probing.

Enhancements:
- Introduce a shared helper to detect the canonical BLEStateManager for a given lock and reuse it across lifecycle and notification code paths.
- Add module- and class-level documentation describing BLE facades, lifecycle compatibility surfaces, and connection orchestration responsibilities.
- Annotate constructors and globals with explicit pylint suppressions to reflect intentional inheritance and diagnostic patterns.