### PR TITLE
Harden power meter resource lifecycle management

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1790,21 +1790,98 @@ def exportConfig(interface: MeshInterface) -> str:
 export_config = exportConfig
 
 
+def _close_power_meter_quietly(candidate: Any) -> None:
+    """Best-effort close used while rolling back meter construction/configuration."""
+    close_method = getattr(candidate, "close", None)
+    if callable(close_method):
+        try:
+            close_method()
+        except Exception:
+            logger.debug("Power meter cleanup failed", exc_info=True)
+
+
+def _validated_power_voltage(args: argparse.Namespace) -> float:
+    """Validate power-related CLI arguments before opening hardware."""
+    voltage = 0.0
+    if args.power_voltage is not None:
+        if not any(
+            (
+                args.power_riden,
+                args.power_ppk2_meter,
+                args.power_ppk2_supply,
+                args.power_sim,
+            )
+        ):
+            _cli_exit(
+                "--power-voltage requires one of --power-riden, --power-ppk2-meter, --power-ppk2-supply, or --power-sim"
+            )
+        try:
+            voltage = float(args.power_voltage)
+        except ValueError:
+            _cli_exit("--power-voltage must be a number")
+        if not MIN_SUPPLY_VOLTAGE_V <= voltage <= MAX_SUPPLY_VOLTAGE_V:
+            _cli_exit(
+                f"Voltage must be between {MIN_SUPPLY_VOLTAGE_V}V and {MAX_SUPPLY_VOLTAGE_V}V"
+            )
+
+    if (args.power_ppk2_supply or args.power_ppk2_meter) and voltage <= 0:
+        _cli_exit("Voltage must be specified for PPK2")
+    return voltage
+
+
+def _build_power_meter(args: argparse.Namespace, voltage: float) -> Any:
+    """Construct and configure one power meter transactionally."""
+    candidate: Any = None
+    try:
+        if args.power_riden:
+            riden_factory = RidenPowerSupply
+            if riden_factory is None:
+                _cli_exit("The Riden power meter backend is unavailable")
+            candidate = riden_factory(args.power_riden)
+        elif args.power_ppk2_supply or args.power_ppk2_meter:
+            ppk2_factory = PPK2PowerSupply
+            if ppk2_factory is None:
+                _cli_exit("The PPK2 power meter backend is unavailable")
+            candidate = ppk2_factory()
+            candidate.setVoltage(voltage)
+            candidate.setIsSupply(args.power_ppk2_supply)
+        elif args.power_sim:
+            sim_factory = SimPowerSupply
+            if sim_factory is None:
+                _cli_exit("The simulated power meter backend is unavailable")
+            candidate = sim_factory()
+
+        if candidate is None:
+            _cli_exit("A power meter backend must be selected")
+
+        if voltage:
+            logger.info("Setting power supply to %s volts", voltage)
+            candidate.setVoltage(voltage)
+            candidate.powerOn()
+            if args.power_wait:
+                input("Powered on, press enter to continue...")
+            else:
+                logger.info("Powered-on, waiting for device to boot")
+                time.sleep(POWER_ON_BOOT_DELAY_SECONDS)
+        return candidate
+    except BaseException:
+        if candidate is not None:
+            _close_power_meter_quietly(candidate)
+        raise
+
+
 def _create_power_meter() -> None:
     """Initialize and configure the global power meter from parsed CLI arguments.
 
-    Validates an optional voltage (must be between MIN_SUPPLY_VOLTAGE_V and MAX_SUPPLY_VOLTAGE_V), instantiates the
-    selected power meter implementation based on power-related CLI flags, assigns it to the
-    module-global `meter`, and, if a voltage is provided, sets the meter voltage and
-    powers it on. When powering on, optionally waits for user confirmation or sleeps
-    briefly depending on the CLI power-wait flag.
+    Validation is performed before opening hardware. A newly-created meter is
+    fully configured before replacing the historical module-global ``meter``;
+    failures close the partial meter and preserve the previous global instance.
 
     Raises
     ------
     RuntimeError
-        if mt_config.args is not initialized.
+        If ``mt_config.args`` is not initialized.
     """
-
     global meter  # pylint: disable=global-statement
     args = mt_config.args
     if args is None:
@@ -1818,53 +1895,12 @@ def _create_power_meter() -> None:
             "You may need to run `poetry install --with powermon`. "
             f"Import Error was: {powermon_exception}"
         )
-    if RidenPowerSupply is None or PPK2PowerSupply is None or SimPowerSupply is None:
-        _cli_exit(
-            "The powermon module loaded incompletely and required meter classes are "
-            "unavailable."
-        )
-
-    # If the user specified a voltage, make sure it is valid AND a backend is selected
-    v = 0.0
-    if args.power_voltage is not None:
-        if not any(
-            (
-                args.power_riden,
-                args.power_ppk2_meter,
-                args.power_ppk2_supply,
-                args.power_sim,
-            )
-        ):
-            _cli_exit(
-                "--power-voltage requires one of --power-riden, --power-ppk2-meter, --power-ppk2-supply, or --power-sim"
-            )
-        v = float(args.power_voltage)
-        if v < MIN_SUPPLY_VOLTAGE_V or v > MAX_SUPPLY_VOLTAGE_V:
-            _cli_exit(
-                f"Voltage must be between {MIN_SUPPLY_VOLTAGE_V}V and {MAX_SUPPLY_VOLTAGE_V}V"
-            )
-    if args.power_riden:
-        meter = RidenPowerSupply(args.power_riden)
-    elif args.power_ppk2_supply or args.power_ppk2_meter:
-        meter = PPK2PowerSupply()
-        if v <= 0:
-            _cli_exit("Voltage must be specified for PPK2")
-        meter.setVoltage(
-            v
-        )  # PPK2 requires setting voltage before selecting supply mode
-        meter.setIsSupply(args.power_ppk2_supply)
-    elif args.power_sim:
-        meter = SimPowerSupply()
-
-    if meter and v:
-        logger.info("Setting power supply to %s volts", v)
-        meter.setVoltage(v)
-        meter.powerOn()
-        if args.power_wait:
-            input("Powered on, press enter to continue...")
-        else:
-            logger.info("Powered-on, waiting for device to boot")
-            time.sleep(POWER_ON_BOOT_DELAY_SECONDS)
+    voltage = _validated_power_voltage(args)
+    replacement = _build_power_meter(args, voltage)
+    previous = meter
+    meter = replacement
+    if previous is not None and previous is not replacement:
+        _close_power_meter_quietly(previous)
 
 
 def _power_meter_requested(args: argparse.Namespace) -> bool:

--- a/meshtastic/cli/parser.py
+++ b/meshtastic/cli/parser.py
@@ -1030,7 +1030,7 @@ def parse_cli_args(
 
     power_group.add_argument(
         "--power-stress",
-        help="Perform power monitor stress testing, to capture a power consumption profile for the device (also requires --power-mon)",
+        help="Exercise device power states for power-consumption profiling",
         action="store_true",
     )
 

--- a/meshtastic/powermon/power_supply.py
+++ b/meshtastic/powermon/power_supply.py
@@ -54,9 +54,17 @@ class PowerMeter:
     def __init__(self) -> None:
         """Initialize the PowerMeter object."""
         self.prevPowerTime = time.monotonic()
+        self._closed: bool = False
 
     def close(self) -> None:
-        """Close the power meter."""
+        """Mark the power meter closed.
+
+        Concrete hardware backends should release transport resources before
+        delegating here. The base implementation remains intentionally light so
+        compatibility subclasses that do not own external resources continue to
+        work unchanged.
+        """
+        self._closed = True
 
     def getAverageCurrentMA(self) -> float:
         """Return average current of last measurement in mA (since last call to this method).

--- a/meshtastic/powermon/ppk2.py
+++ b/meshtastic/powermon/ppk2.py
@@ -20,6 +20,19 @@ STABILIZATION_DELAY_S: Final[float] = 0.2  # Delay to discard initial FIFO readi
 READ_ERROR_RETRY_DELAY_S: Final[float] = 0.05  # Backoff after transient read errors.
 
 
+def _close_ppk2_transport(api: object) -> None:
+    """Best-effort close of a PPK2 API object and its serial transport."""
+    close_method = getattr(api, "close", None)
+    if callable(close_method):
+        with suppress(Exception):
+            close_method()
+
+    serial_handle = getattr(api, "ser", None)
+    if serial_handle is not None:
+        with suppress(Exception):
+            serial_handle.close()
+
+
 class PPK2PowerSupply(PowerSupply):
     """Interface for talking with the NRF PPK2 high-resolution micro-power supply.
 
@@ -88,13 +101,16 @@ class PPK2PowerSupply(PowerSupply):
         self.r = r = ppk2_api.PPK2_API(
             portName
         )  # serial port will be different for you
-        r.get_modifiers()
-
-        self.measurement_thread = threading.Thread(
-            target=self._measurement_loop, daemon=True, name="ppk2 measurement"
-        )
-        logging.info("Connected to Power Profiler Kit II (PPK2)")
-        super().__init__()  # we call this late so that the serial port is already open
+        try:
+            r.get_modifiers()
+            self.measurement_thread = threading.Thread(
+                target=self._measurement_loop, daemon=True, name="ppk2 measurement"
+            )
+            logging.info("Connected to Power Profiler Kit II (PPK2)")
+            super().__init__()  # we call this late so that the serial port is already open
+        except BaseException:
+            _close_ppk2_transport(r)
+            raise
 
     def _measurement_loop(self) -> None:
         """Endless measurement loop that runs in a background thread.
@@ -236,8 +252,10 @@ class PPK2PowerSupply(PowerSupply):
         self.resetMeasurements()
 
     def close(self) -> None:
-        """Close the power meter and release resources."""
+        """Close the power meter and release resources idempotently."""
         with self._measurement_state_lock:
+            if getattr(self, "_closed", False):
+                return
             self.measuring = False
             with self._want_measurement:
                 self._want_measurement.notify_all()
@@ -250,16 +268,8 @@ class PPK2PowerSupply(PowerSupply):
                     logging.warning(
                         "PPK2 measurement thread did not stop within timeout; forcing transport cleanup."
                     )
-            close_method = getattr(self.r, "close", None)
-            if callable(close_method):
-                with suppress(Exception):
-                    close_method()  # pylint: disable=not-callable
-
-            serial_handle = getattr(self.r, "ser", None)
-            if serial_handle is not None:
-                with suppress(Exception):
-                    serial_handle.close()
-        super().close()
+            _close_ppk2_transport(self.r)
+            super().close()
 
     def setIsSupply(self, is_supply: bool) -> None:
         """Set the PPK2 mode to either power supply or amp meter.

--- a/meshtastic/powermon/riden.py
+++ b/meshtastic/powermon/riden.py
@@ -3,10 +3,12 @@
 import logging
 import math
 import time
+from contextlib import suppress
 from datetime import datetime
 from typing import Any, Final, cast
 
 import riden
+import serial  # type: ignore[import-untyped]
 
 from .constants import MILLIAMPS_PER_AMP, SECONDS_PER_HOUR
 from .power_supply import PowerError, PowerSupply
@@ -18,6 +20,20 @@ DEFAULT_RIDEN_BAUDRATE: Final[int] = 115200
 DEFAULT_RIDEN_ADDRESS: Final[int] = 1
 
 Riden = cast(type[Any], riden.Riden)  # type: ignore[attr-defined]
+
+
+def _close_riden_transport(device: object) -> None:
+    """Best-effort close of a Riden Modbus master and serial transport."""
+    master = getattr(device, "master", None)
+    close_master = getattr(master, "close", None)
+    if callable(close_master):
+        with suppress(Exception):
+            close_master()
+
+    serial_handle = getattr(device, "serial", None)
+    if serial_handle is not None:
+        with suppress(Exception):
+            serial_handle.close()
 
 
 class RidenPowerSupply(PowerSupply):
@@ -33,24 +49,45 @@ class RidenPowerSupply(PowerSupply):
         portName : str, optional
             The serial port path of the power supply. Defaults to ``"/dev/ttyUSB0"``.
         """
-        self.r = r = Riden(
-            port=portName,
-            baudrate=DEFAULT_RIDEN_BAUDRATE,
-            address=DEFAULT_RIDEN_ADDRESS,
+        serial_handle = serial.Serial(
+            port=portName, baudrate=DEFAULT_RIDEN_BAUDRATE
         )
-        logging.info(
-            "Connected to Riden power supply: model %s, sn %s, firmware %s. Date/time updated.",
-            r.type,
-            r.sn,
-            r.fw,
-        )
-        r.set_date_time(datetime.now())
-        # Keep base init after port open so timing/voltage state is available.
-        super().__init__()
-        self.prevWattHour = self._get_raw_watt_hour()
-        # COMPAT_STABLE_SHIM: retained for callers that inspect legacy running sample state.
-        self.nowWattHour = self.prevWattHour
-        self.prevPowerTime = time.monotonic()
+        try:
+            self.r = r = Riden(
+                port=portName,
+                baudrate=DEFAULT_RIDEN_BAUDRATE,
+                address=DEFAULT_RIDEN_ADDRESS,
+                serial=serial_handle,
+            )
+        except BaseException:
+            with suppress(Exception):
+                serial_handle.close()
+            raise
+
+        try:
+            logging.info(
+                "Connected to Riden power supply: model %s, sn %s, firmware %s. Date/time updated.",
+                r.type,
+                r.sn,
+                r.fw,
+            )
+            r.set_date_time(datetime.now())
+            # Keep base init after port open so timing/voltage state is available.
+            super().__init__()
+            self.prevWattHour = self._get_raw_watt_hour()
+            # COMPAT_STABLE_SHIM: retained for callers that inspect legacy running sample state.
+            self.nowWattHour = self.prevWattHour
+            self.prevPowerTime = time.monotonic()
+        except BaseException:
+            _close_riden_transport(r)
+            raise
+
+    def close(self) -> None:
+        """Close the Modbus/serial transport without changing output power state."""
+        if getattr(self, "_closed", False):
+            return
+        _close_riden_transport(self.r)
+        super().close()
 
     def setMaxCurrent(self, i: float) -> None:
         """Set the maximum current the supply will provide."""

--- a/meshtastic/tests/test_main_actions_power.py
+++ b/meshtastic/tests/test_main_actions_power.py
@@ -1839,3 +1839,116 @@ def test_stable_path_banner_shown_when_different(
             in out
         )
         assert err == ""
+
+
+@pytest.mark.unit
+def test_create_power_meter_validates_ppk2_voltage_before_construction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PPK2 voltage validation should fail before opening the hardware backend."""
+    args = SimpleNamespace(
+        power_voltage=None,
+        power_riden=None,
+        power_ppk2_supply=False,
+        power_ppk2_meter=True,
+        power_sim=False,
+        power_wait=False,
+    )
+    constructor = MagicMock()
+    monkeypatch.setattr(main_module, "meter", None)
+    monkeypatch.setattr(main_module, "have_powermon", True)
+    monkeypatch.setattr(main_module, "RidenPowerSupply", object)
+    monkeypatch.setattr(main_module, "PPK2PowerSupply", constructor)
+    monkeypatch.setattr(main_module, "SimPowerSupply", object)
+    monkeypatch.setattr(mt_config, "args", args)
+
+    with pytest.raises(SystemExit):
+        _create_power_meter()
+
+    constructor.assert_not_called()
+
+
+@pytest.mark.unit
+def test_create_power_meter_rejects_nan_voltage_before_construction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-finite voltage input must not reach a hardware backend."""
+    constructor = MagicMock()
+    args = SimpleNamespace(
+        power_voltage="nan",
+        power_riden="/dev/ttyUSB0",
+        power_ppk2_supply=False,
+        power_ppk2_meter=False,
+        power_sim=False,
+        power_wait=False,
+    )
+    monkeypatch.setattr(main_module, "meter", None)
+    monkeypatch.setattr(main_module, "have_powermon", True)
+    monkeypatch.setattr(main_module, "RidenPowerSupply", constructor)
+    monkeypatch.setattr(main_module, "PPK2PowerSupply", object)
+    monkeypatch.setattr(main_module, "SimPowerSupply", object)
+    monkeypatch.setattr(mt_config, "args", args)
+
+    with pytest.raises(SystemExit):
+        _create_power_meter()
+
+    constructor.assert_not_called()
+
+
+@pytest.mark.unit
+def test_create_power_meter_closes_partial_backend_and_preserves_previous_global(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Configuration failures should close the new meter without replacing the old one."""
+    previous = MagicMock()
+    candidate = MagicMock()
+    candidate.setVoltage.side_effect = RuntimeError("configure failed")
+    args = SimpleNamespace(
+        power_voltage="3.3",
+        power_riden=None,
+        power_ppk2_supply=False,
+        power_ppk2_meter=False,
+        power_sim=True,
+        power_wait=False,
+    )
+    monkeypatch.setattr(main_module, "meter", previous)
+    monkeypatch.setattr(main_module, "have_powermon", True)
+    monkeypatch.setattr(main_module, "RidenPowerSupply", object)
+    monkeypatch.setattr(main_module, "PPK2PowerSupply", object)
+    monkeypatch.setattr(main_module, "SimPowerSupply", MagicMock(return_value=candidate))
+    monkeypatch.setattr(mt_config, "args", args)
+
+    with pytest.raises(RuntimeError, match="configure failed"):
+        _create_power_meter()
+
+    candidate.close.assert_called_once_with()
+    previous.close.assert_not_called()
+    assert main_module.meter is previous
+
+
+@pytest.mark.unit
+def test_create_power_meter_replaces_and_closes_previous_meter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Successful meter replacement should release the previous backend transport."""
+    previous = MagicMock()
+    replacement = MagicMock()
+    args = SimpleNamespace(
+        power_voltage=None,
+        power_riden=None,
+        power_ppk2_supply=False,
+        power_ppk2_meter=False,
+        power_sim=True,
+        power_wait=False,
+    )
+    monkeypatch.setattr(main_module, "meter", previous)
+    monkeypatch.setattr(main_module, "have_powermon", True)
+    monkeypatch.setattr(main_module, "RidenPowerSupply", object)
+    monkeypatch.setattr(main_module, "PPK2PowerSupply", object)
+    monkeypatch.setattr(main_module, "SimPowerSupply", MagicMock(return_value=replacement))
+    monkeypatch.setattr(mt_config, "args", args)
+
+    _create_power_meter()
+
+    assert main_module.meter is replacement
+    previous.close.assert_called_once_with()

--- a/meshtastic/tests/test_powermon_ppk2.py
+++ b/meshtastic/tests/test_powermon_ppk2.py
@@ -285,3 +285,65 @@ def test_ppk2_constructor_initializes_measurement_thread_and_compatibility_wrapp
     assert PPK2PowerSupply.getMinCurrentmA is PowerSupply.getMinCurrentmA
     assert PPK2PowerSupply.getMaxCurrentmA is PowerSupply.getMaxCurrentmA
     assert PPK2PowerSupply.getAverageCurrentmA is PowerSupply.getAverageCurrentmA
+
+
+@pytest.mark.unit
+def test_constructor_closes_transport_when_modifier_initialization_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Constructor failures after opening PPK2 transport must release serial state."""
+    api = MagicMock()
+    api.ser = MagicMock()
+    api.get_modifiers.side_effect = RuntimeError("modifier failure")
+    monkeypatch.setattr(
+        "meshtastic.powermon.ppk2.ppk2_api.PPK2_API",
+        MagicMock(return_value=api),
+    )
+
+    with pytest.raises(RuntimeError, match="modifier failure"):
+        PPK2PowerSupply(portName="COM9")
+
+    api.close.assert_called_once_with()
+    api.ser.close.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_constructor_closes_transport_when_thread_setup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Post-open constructor failures must also release the PPK2 transport."""
+    api = MagicMock()
+    api.ser = MagicMock()
+    monkeypatch.setattr(
+        "meshtastic.powermon.ppk2.ppk2_api.PPK2_API",
+        MagicMock(return_value=api),
+    )
+    monkeypatch.setattr(
+        "meshtastic.powermon.ppk2.threading.Thread",
+        MagicMock(side_effect=RuntimeError("thread setup failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="thread setup failed"):
+        PPK2PowerSupply(portName="COM9")
+
+    api.get_modifiers.assert_called_once_with()
+    api.close.assert_called_once_with()
+    api.ser.close.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_close_is_idempotent(ppk2_stub: "PPK2PowerSupply") -> None:
+    """Repeated close calls must not repeat hardware teardown commands."""
+    ppk = ppk2_stub
+    ppk.r = MagicMock()
+    ppk.r.ser = MagicMock()
+    ppk.measurement_thread = MagicMock()
+    ppk.measurement_thread.is_alive.return_value = False
+    ppk._closed = False
+
+    ppk.close()
+    ppk.close()
+
+    ppk.r.stop_measuring.assert_called_once_with()
+    ppk.r.close.assert_called_once_with()
+    ppk.r.ser.close.assert_called_once_with()

--- a/meshtastic/tests/test_powermon_riden.py
+++ b/meshtastic/tests/test_powermon_riden.py
@@ -170,3 +170,68 @@ def test_get_raw_watt_hour_legacy_alias_delegates(
 
     assert pps._getRawWattHour() == pytest.approx(7.25)
     pps._get_raw_watt_hour.assert_called_once()
+
+
+@pytest.mark.unit
+def test_close_closes_modbus_master_and_serial_once(
+    riden_stub: RidenPowerSupply,
+) -> None:
+    """Close should release transport resources idempotently without powering off."""
+    pps = riden_stub
+    device = cast(MagicMock, pps.r)
+    device.master = MagicMock()
+    device.serial = MagicMock()
+    pps._closed = False
+
+    pps.close()
+    pps.close()
+
+    device.master.close.assert_called_once_with()
+    device.serial.close.assert_called_once_with()
+    device.set_output.assert_not_called()
+    assert pps._closed is True
+
+
+@pytest.mark.unit
+def test_constructor_closes_transport_when_post_open_initialization_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Constructor failures after opening Riden transport must release it."""
+    serial_handle = MagicMock()
+    device = MagicMock()
+    device.type = "RD6006"
+    device.sn = "1234"
+    device.fw = 1
+    device.master = MagicMock()
+    device.serial = serial_handle
+    device.set_date_time.side_effect = RuntimeError("clock failed")
+    monkeypatch.setattr(
+        "meshtastic.powermon.riden.serial.Serial", MagicMock(return_value=serial_handle)
+    )
+    monkeypatch.setattr("meshtastic.powermon.riden.Riden", MagicMock(return_value=device))
+
+    with pytest.raises(RuntimeError, match="clock failed"):
+        RidenPowerSupply("COM9")
+
+    device.master.close.assert_called_once_with()
+    serial_handle.close.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_constructor_closes_serial_when_riden_initialization_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Failures inside the third-party Riden constructor must not leak serial."""
+    serial_handle = MagicMock()
+    serial_factory = MagicMock(return_value=serial_handle)
+    monkeypatch.setattr("meshtastic.powermon.riden.serial.Serial", serial_factory)
+    monkeypatch.setattr(
+        "meshtastic.powermon.riden.Riden",
+        MagicMock(side_effect=RuntimeError("riden init failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="riden init failed"):
+        RidenPowerSupply("COM9")
+
+    serial_factory.assert_called_once_with(port="COM9", baudrate=115200)
+    serial_handle.close.assert_called_once_with()


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change improves power-meter resource lifecycle management. Power-meter creation now uses transactional setup and preserves the existing meter when a replacement fails. PPK2 and Riden transports now release resources during initialization failures and through idempotent `close()` methods.

### Key changes

- **Features**
  - Added `RidenPowerSupply.close()` for explicit resource cleanup.
  - Added closed-state tracking to `PowerMeter.close()`.

- **Fixes**
  - Validate voltage and backend requirements before hardware access.
  - Close partially initialized meters when setup fails.
  - Preserve the current global meter when replacement setup fails.
  - Close the previous global meter only after a replacement is ready.
  - Clean up PPK2 API and serial resources on initialization failure.
  - Clean up Riden Modbus and serial resources on initialization failure.
  - Make PPK2 and Riden cleanup idempotent.
  - Preserve power output state during Riden cleanup.

- **Refactors**
  - Split power-meter setup into validation and transactional construction.
  - Added shared best-effort transport cleanup helpers.
  - Added tests for validation, replacement behavior, initialization failures, and repeated cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->