### PR TITLE
Manage CLI session resources deterministically

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -44,6 +44,7 @@ from meshtastic._core_constants import (
     BROADCAST_ADDR,
 )
 from meshtastic.cli.context import ActionOutcome, CliContext
+from meshtastic.cli.session_resources import CliSessionResources
 
 # COMPAT_STABLE_SHIM: Preserve legacy imports from meshtastic.cli.parser.
 # pylint: disable=unused-import
@@ -1948,6 +1949,28 @@ def _parse_host_port(host_str: str, default_port: int) -> tuple[str, int]:
         _cli_exit(f"Error: {exc}", 1)
 
 
+def _release_session_power_meter(active_meter: Any) -> None:
+    """Close an invocation-owned meter and clear the legacy global reference."""
+    global meter  # pylint: disable=global-statement
+    _close_power_meter_quietly(active_meter)
+    if meter is active_meter:
+        meter = None
+
+
+def _clear_session_logfile(active_logfile: Any) -> None:
+    """Clear the legacy logfile reference when its owning invocation ends."""
+    if mt_config.logfile is active_logfile:
+        mt_config.logfile = None
+
+
+def _unsubscribe_cli_receive() -> None:
+    """Best-effort removal of the invocation-level receive subscription."""
+    try:
+        pub.unsubscribe(onReceive, "meshtastic.receive")
+    except Exception:
+        logger.debug("Unable to remove CLI receive subscription", exc_info=True)
+
+
 def common() -> None:
     """Configure logging, validate CLI arguments, establish the selected transport.
 
@@ -2040,9 +2063,6 @@ def common() -> None:
         if args.ota_update is not None and not os.path.isfile(args.ota_update):
             _cli_exit(f"Error: OTA firmware file not found: {args.ota_update}")
 
-        if _power_meter_requested(args):
-            _create_power_meter()
-
         if args.ch_index is not None:
             channelIndex = int(args.ch_index)
             mt_config.channel_index = channelIndex
@@ -2074,8 +2094,21 @@ def common() -> None:
                 else:
                     _cli_exit("Test was a success.", 0)
         else:
-            # Use ExitStack to guarantee cleanup on early exits or exceptions
+            # Use one invocation stack to own transports, files, meters, and
+            # long-running services through success, failure, or interruption.
             with contextlib.ExitStack() as stack:
+                session_resources = CliSessionResources(stack)
+                session_resources.activate()
+
+                if _power_meter_requested(args):
+                    _create_power_meter()
+                    active_meter = meter
+                    if active_meter is not None:
+                        session_resources.register_cleanup(
+                            lambda: _release_session_power_meter(active_meter)
+                        )
+
+                mt_config.logfile = None
                 if args.seriallog == "stdout":
                     logfile = sys.stdout
                 elif args.seriallog == "none":
@@ -2085,12 +2118,20 @@ def common() -> None:
                 else:
                     logger.info("Logging serial output to %s", args.seriallog)
                     # Note: using line buffering.
-                    logfile = stack.enter_context(
-                        open(args.seriallog, "w+", buffering=1, encoding="utf8")
+                    logfile = session_resources.enter_context(
+                        # The invocation ExitStack owns this file; Pylint cannot
+                        # infer that ownership transfer through enter_context().
+                        open(  # pylint: disable=consider-using-with
+                            args.seriallog, "w+", buffering=1, encoding="utf8"
+                        )
                     )
                     mt_config.logfile = logfile
+                    session_resources.register_cleanup(
+                        lambda: _clear_session_logfile(logfile)
+                    )
 
                 subscribe()
+                session_resources.register_cleanup(_unsubscribe_cli_receive)
                 if args.ble_scan:
                     logger.debug("BLE scan starting")
                     for x in BLEInterface.scan():
@@ -2100,7 +2141,7 @@ def common() -> None:
                 client: MeshInterface | None = None
                 if args.ble:
                     try:
-                        client = stack.enter_context(
+                        client = session_resources.enter_context(
                             BLEInterface(
                                 args.ble if args.ble != "any" else None,
                                 debugOut=logfile,
@@ -2122,7 +2163,7 @@ def common() -> None:
                             args.host,
                             meshtastic.tcp_interface.DEFAULT_TCP_PORT,
                         )
-                        client = stack.enter_context(
+                        client = session_resources.enter_context(
                             meshtastic.tcp_interface.TCPInterface(
                                 tcp_hostname,
                                 portNumber=tcp_port,
@@ -2142,7 +2183,7 @@ def common() -> None:
                         )
                 else:
                     try:
-                        client = stack.enter_context(
+                        client = session_resources.enter_context(
                             meshtastic.serial_interface.SerialInterface(
                                 args.port,
                                 debugOut=logfile,
@@ -2188,7 +2229,7 @@ def common() -> None:
                             "Serial device unavailable after initialization; falling back to localhost TCP interface."
                         )
                         try:
-                            client = stack.enter_context(
+                            client = session_resources.enter_context(
                                 meshtastic.tcp_interface.TCPInterface(
                                     "localhost",
                                     debugOut=logfile,

--- a/meshtastic/cli/context.py
+++ b/meshtastic/cli/context.py
@@ -12,6 +12,12 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, NoReturn, Protocol
 
+from meshtastic.cli.session_resources import (
+    CliSessionResources,
+    SessionCleanup,
+    get_current_session_resources,
+)
+
 if TYPE_CHECKING:
     from meshtastic.mesh_interface import MeshInterface
 
@@ -94,12 +100,32 @@ class CliContext:
         Keyword arguments historically forwarded to ``MeshInterface.getNode``.
     outcome : ActionOutcome
         Mutable lifecycle outcome accumulated across compatible actions.
+    session_resources : CliSessionResources | None
+        Invocation owner for resources that must survive successful action dispatch.
     """
 
     interface: MeshInterface
     args: argparse.Namespace
     get_node_kwargs: dict[str, Any]
     outcome: ActionOutcome = field(default_factory=ActionOutcome)
+    session_resources: CliSessionResources | None = field(
+        default_factory=get_current_session_resources
+    )
+
+    def retain_failure_cleanup(
+        self, cleanup: Callable[[], None]
+    ) -> SessionCleanup | None:
+        """Transfer one armed rollback cleanup to invocation ownership.
+
+        When no invocation resource owner is active, the callback stays in the
+        historical failure-cleanup list so direct ``onConnected()`` callers keep
+        their existing lifecycle behavior.
+        """
+        if self.session_resources is None:
+            return None
+        lease = self.session_resources.register_cleanup(cleanup)
+        self.outcome.failure_cleanup_callbacks.remove(cleanup)
+        return lease
 
     @property
     def destination(self) -> str:

--- a/meshtastic/cli/messaging_service_actions.py
+++ b/meshtastic/cli/messaging_service_actions.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from meshtastic._core_constants import BROADCAST_ADDR
 from meshtastic.cli.context import CliContext, CliExit, _terminate_cli
+from meshtastic.cli.session_resources import SessionCleanup
 from meshtastic.protobuf import portnums_pb2
 
 logger = logging.getLogger(__name__)
@@ -397,6 +398,7 @@ def _start_tunnel(context: CliContext, hooks: MessagingServiceHooks) -> None:
         tunnel_instance = tunnel.Tunnel(context.interface)
     context.outcome.close_now = False
     context.outcome.failure_cleanup_callbacks.append(tunnel_instance.close)
+    context.retain_failure_cleanup(tunnel_instance.close)
 
 
 def _handle_long_running_services(
@@ -407,6 +409,7 @@ def _handle_long_running_services(
     interface = context.interface
 
     log_set_close: Callable[[], None] | None = None
+    log_set_session_cleanup: SessionCleanup | None = None
     if args.slog or args.power_stress:
         if not hooks.powermon_available():
             _terminate_cli(
@@ -431,6 +434,7 @@ def _handle_long_running_services(
             )
             log_set_close = log_set.close
             context.outcome.failure_cleanup_callbacks.append(log_set_close)
+            log_set_session_cleanup = context.retain_failure_cleanup(log_set_close)
             context.outcome.close_now = False
 
         if args.power_stress:
@@ -443,8 +447,11 @@ def _handle_long_running_services(
                 )
             power_stress_factory(interface).run()
             if log_set_close is not None:
-                log_set_close()
-                context.outcome.failure_cleanup_callbacks.remove(log_set_close)
+                if log_set_session_cleanup is not None:
+                    log_set_session_cleanup.run()
+                else:
+                    log_set_close()
+                    context.outcome.failure_cleanup_callbacks.remove(log_set_close)
             context.outcome.close_now = True
 
     if args.listen:

--- a/meshtastic/cli/session_resources.py
+++ b/meshtastic/cli/session_resources.py
@@ -1,0 +1,66 @@
+"""Invocation-scoped ownership for CLI resources and long-running services."""
+
+from __future__ import annotations
+
+import contextvars
+from collections.abc import Callable
+from contextlib import AbstractContextManager, ExitStack
+from dataclasses import dataclass, field
+from typing import TypeVar
+
+_T = TypeVar("_T")
+_CURRENT_SESSION_RESOURCES: contextvars.ContextVar[CliSessionResources | None] = (
+    contextvars.ContextVar("cli_session_resources", default=None)
+)
+
+
+@dataclass(slots=True)
+class SessionCleanup:
+    """One idempotent cleanup registered with an invocation resource stack."""
+
+    callback: Callable[[], None]
+    _armed: bool = field(default=True, init=False)
+
+    def run(self) -> None:
+        """Run the cleanup at most once."""
+        if not self._armed:
+            return
+        self._armed = False
+        self.callback()
+
+
+class CliSessionResources:
+    """Register resources against the ``common()`` invocation ``ExitStack``."""
+
+    def __init__(self, stack: ExitStack) -> None:
+        """Bind session ownership to an existing invocation stack."""
+        self._stack = stack
+        self._activated = False
+
+    def activate(self) -> None:
+        """Expose this owner to connected action contexts until stack unwind."""
+        if self._activated:
+            return
+        token = _CURRENT_SESSION_RESOURCES.set(self)
+        self._activated = True
+
+        def _reset_context() -> None:
+            _CURRENT_SESSION_RESOURCES.reset(token)
+            self._activated = False
+
+        self._stack.callback(_reset_context)
+
+    def enter_context(self, resource: AbstractContextManager[_T]) -> _T:
+        """Enter a context-managed resource under invocation ownership."""
+        return self._stack.enter_context(resource)
+
+    def register_cleanup(self, callback: Callable[[], None]) -> SessionCleanup:
+        """Register an idempotent cleanup and return its execution lease."""
+        cleanup = SessionCleanup(callback)
+        self._stack.callback(cleanup.run)
+        return cleanup
+
+
+def get_current_session_resources() -> CliSessionResources | None:
+    """Return the active invocation resource owner, if one exists."""
+    return _CURRENT_SESSION_RESOURCES.get()

--- a/meshtastic/tests/test_cli_messaging_service_actions.py
+++ b/meshtastic/tests/test_cli_messaging_service_actions.py
@@ -701,3 +701,81 @@ def test_missing_channel_selection_defaults_to_primary_channel() -> None:
     _handle_messaging_actions(context, hooks)
 
     interface.sendTraceRoute.assert_called_once_with("!00000003", 5, channelIndex=0)
+
+
+@pytest.mark.unit
+def test_slog_transfers_cleanup_to_active_cli_session() -> None:
+    """Successful slog startup should survive dispatch and close with the invocation."""
+    import contextlib
+
+    from meshtastic.cli.session_resources import CliSessionResources
+
+    interface = _interface_double()
+    log_set = MagicMock()
+    with contextlib.ExitStack() as stack:
+        session = CliSessionResources(stack)
+        session.activate()
+        context = _context(interface, slog="default")
+        hooks = _hooks(log_set_factory=MagicMock(return_value=log_set))
+
+        _handle_long_running_services(context, hooks)
+
+        assert context.outcome.failure_cleanup_callbacks == []
+        log_set.close.assert_not_called()
+
+    log_set.close.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_tunnel_transfers_cleanup_to_active_cli_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Successful tunnel startup should be owned until the invocation ends."""
+    import contextlib
+
+    from meshtastic import tunnel
+    from meshtastic.cli.session_resources import CliSessionResources
+
+    interface = _interface_double()
+    interface.noProto = False
+    tunnel_instance = MagicMock()
+    monkeypatch.setattr(tunnel, "Tunnel", MagicMock(return_value=tunnel_instance))
+
+    with contextlib.ExitStack() as stack:
+        session = CliSessionResources(stack)
+        session.activate()
+        context = _context(interface, tunnel=True, dest="^all")
+
+        actions._start_tunnel(context, _hooks())
+
+        assert context.outcome.failure_cleanup_callbacks == []
+        tunnel_instance.close.assert_not_called()
+
+    tunnel_instance.close.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_power_stress_closes_retained_slog_only_once() -> None:
+    """Eager slog shutdown for power stress should disarm later session cleanup."""
+    import contextlib
+
+    from meshtastic.cli.session_resources import CliSessionResources
+
+    interface = _interface_double()
+    log_set = MagicMock()
+    stress = MagicMock()
+    with contextlib.ExitStack() as stack:
+        session = CliSessionResources(stack)
+        session.activate()
+        context = _context(interface, slog="default", power_stress=True)
+        hooks = _hooks(
+            log_set_factory=MagicMock(return_value=log_set),
+            power_stress_factory=MagicMock(return_value=stress),
+        )
+
+        _handle_long_running_services(context, hooks)
+
+        log_set.close.assert_called_once_with()
+        assert context.outcome.failure_cleanup_callbacks == []
+
+    log_set.close.assert_called_once_with()

--- a/meshtastic/tests/test_cli_session_resources.py
+++ b/meshtastic/tests/test_cli_session_resources.py
@@ -1,0 +1,72 @@
+"""Tests for invocation-owned CLI resource cleanup and transfer semantics."""
+
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import MagicMock, create_autospec
+
+import pytest
+
+from meshtastic.cli.context import CliContext
+from meshtastic.cli.session_resources import (
+    CliSessionResources,
+    get_current_session_resources,
+)
+from meshtastic.mesh_interface import MeshInterface
+
+
+@pytest.mark.unit
+def test_session_cleanup_runs_once_and_context_resets() -> None:
+    """Registered cleanup should run once and invocation context must not leak."""
+    cleanup = MagicMock()
+    assert get_current_session_resources() is None
+
+    with contextlib.ExitStack() as stack:
+        session = CliSessionResources(stack)
+        session.activate()
+        lease = session.register_cleanup(cleanup)
+        assert get_current_session_resources() is session
+        lease.run()
+        lease.run()
+
+    cleanup.assert_called_once_with()
+    assert get_current_session_resources() is None
+
+
+@pytest.mark.unit
+def test_cli_context_transfers_failure_cleanup_to_active_session() -> None:
+    """Connected resources should move from rollback to invocation ownership."""
+    cleanup = MagicMock()
+    with contextlib.ExitStack() as stack:
+        session = CliSessionResources(stack)
+        session.activate()
+        context = CliContext(
+            interface=create_autospec(MeshInterface, instance=True),
+            args=MagicMock(),
+            get_node_kwargs={},
+        )
+        context.outcome.failure_cleanup_callbacks.append(cleanup)
+
+        lease = context.retain_failure_cleanup(cleanup)
+
+        assert lease is not None
+        assert context.outcome.failure_cleanup_callbacks == []
+        cleanup.assert_not_called()
+
+    cleanup.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_cli_context_without_session_preserves_failure_cleanup() -> None:
+    """Direct connected-action callers should retain historical rollback behavior."""
+    cleanup = MagicMock()
+    context = CliContext(
+        interface=create_autospec(MeshInterface, instance=True),
+        args=MagicMock(),
+        get_node_kwargs={},
+        session_resources=None,
+    )
+    context.outcome.failure_cleanup_callbacks.append(cleanup)
+
+    assert context.retain_failure_cleanup(cleanup) is None
+    assert context.outcome.failure_cleanup_callbacks == [cleanup]

--- a/meshtastic/tests/test_main_actions_power.py
+++ b/meshtastic/tests/test_main_actions_power.py
@@ -1952,3 +1952,32 @@ def test_create_power_meter_replaces_and_closes_previous_meter(
 
     assert main_module.meter is replacement
     previous.close.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_release_session_power_meter_closes_and_clears_matching_global(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invocation meter cleanup should release hardware and clear the legacy alias."""
+    active_meter = MagicMock()
+    monkeypatch.setattr(main_module, "meter", active_meter)
+
+    main_module._release_session_power_meter(active_meter)
+
+    active_meter.close.assert_called_once_with()
+    assert main_module.meter is None
+
+
+@pytest.mark.unit
+def test_release_session_power_meter_does_not_clear_replacement_global(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Late cleanup must not erase a meter installed by a newer invocation."""
+    old_meter = MagicMock()
+    replacement = MagicMock()
+    monkeypatch.setattr(main_module, "meter", replacement)
+
+    main_module._release_session_power_meter(old_meter)
+
+    old_meter.close.assert_called_once_with()
+    assert main_module.meter is replacement


### PR DESCRIPTION
## Summary by Sourcery

Introduce invocation-scoped CLI session resource ownership so transports, log files, meters, and long-running services are cleaned up deterministically across successful and failed runs.

New Features:
- Add CliSessionResources and SessionCleanup to own invocation-scoped CLI resources and expose the active session via a context variable.
- Allow CliContext to transfer failure-only cleanup callbacks into invocation-scoped ownership for long-running services like tunnels and slog.

Bug Fixes:
- Ensure slog and tunnel resources are cleaned up on normal CLI exit rather than only on failure, avoiding leaked sessions and double-closures.
- Guarantee CLI power meter instances are closed and their global alias cleared only when the owning invocation ends, without affecting newer meters.
- Ensure serial log files and receive subscriptions are properly released at the end of a CLI invocation, preventing stale global state.

Enhancements:
- Refactor main CLI entrypoint to centralize resource management through a single ExitStack and session owner, simplifying lifecycle handling of transports and logging.
- Make power stress tests disarm later session cleanup when slog is shut down eagerly, ensuring idempotent cleanup flows.

Tests:
- Add unit tests covering CliSessionResources lifecycle, cleanup transfer semantics in CliContext, and idempotent SessionCleanup behavior.
- Extend CLI messaging and power tests to verify cleanup ownership for slog, tunnels, and power meters under normal and stress scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This change adds invocation-scoped ownership for CLI resources. The CLI now releases transports, serial logs, power meters, subscriptions, tunnels, and structured logging services at the end of each invocation. Cleanup also runs for errors, early exits, and interruptions.

## Key changes

### Features

- Added `CliSessionResources` to manage resources with an `ExitStack`.
- Added `SessionCleanup` for idempotent cleanup callbacks.
- Added `get_current_session_resources()` for access to the active session.
- Registered transports, serial log files, receive subscriptions, and power meters with the active session.
- Added cleanup ownership for tunnels and structured logging services.
- Added `CliContext.retain_failure_cleanup()` to transfer rollback callbacks to the active session.

### Fixes

- Prevented duplicate cleanup.
- Cleared global power-meter references only when they refer to the released meter.
- Preserved replacement power meters during late cleanup.
- Preserved local failure cleanup when no session is active.
- Ensured cleanup runs after successful and unsuccessful CLI invocations.

### Refactors

- Centralized CLI resource lifecycle management in `CliSessionResources`.
- Migrated transport and serial logfile ownership from direct handling to session management.
- Updated power-stress cleanup to use retained session cleanup when available.
- Added tests for session lifecycle, cleanup transfer, service cleanup, power-meter ownership, and replacement-resource handling.

## Breaking changes and migration

No breaking changes or migration steps are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->