### PR TITLE
Harden shutdown ownership for PowerLogger

### DIFF
--- a/meshtastic/slog/slog.py
+++ b/meshtastic/slog/slog.py
@@ -157,6 +157,11 @@ INTERVAL_REQUIRED_MESSAGE = "interval must be > 0 seconds"
 DIR_NAME_REQUIRED_MESSAGE = "dir_name must be a non-empty path when provided"
 SAMPLE_FAILURE_WARNING_COOLDOWN_SECONDS = 5.0
 SAMPLE_FAILURE_WARNING_BURST_COUNT = 3
+TOPIC_MESHTASTIC_LOG_LINE = "meshtastic.log.line"
+
+
+class _PowerLoggerShutdownError(RuntimeError):
+    """Raised when the sampler cannot stop before dependency teardown."""
 
 
 class PowerLogger:
@@ -242,6 +247,10 @@ class PowerLogger:
         self._stop_event = threading.Event()
         self._sample_warning_count = 0
         self._last_sample_warning_monotonic = 0.0
+        self._dependency_close_lock = threading.Lock()
+        self._dependencies_closed = False
+        self._deferred_dependency_close = False
+        self._background_close_error: Exception | None = None
         self.is_logging = True
         self.thread = threading.Thread(
             target=self._logging_thread, name="PowerLogger", daemon=True
@@ -381,70 +390,134 @@ class PowerLogger:
 
     def _logging_thread(self) -> None:
         """Background thread for logging periodic current readings."""
-        while not self._stop_event.is_set():
-            try:
-                self._store_current_reading()
-                self._sample_warning_count = 0
-                self._last_sample_warning_monotonic = 0.0
-            except Exception as exc:  # noqa: BLE001 - keep sampler alive
-                self._sample_warning_count += 1
-                now_monotonic = time.monotonic()
-                should_warn = (
-                    self._sample_warning_count <= SAMPLE_FAILURE_WARNING_BURST_COUNT
-                    or (
-                        now_monotonic - self._last_sample_warning_monotonic
-                        >= SAMPLE_FAILURE_WARNING_COOLDOWN_SECONDS
+        try:
+            while not self._stop_event.is_set():
+                try:
+                    self._store_current_reading()
+                    self._sample_warning_count = 0
+                    self._last_sample_warning_monotonic = 0.0
+                except Exception as exc:  # noqa: BLE001 - keep sampler alive
+                    self._sample_warning_count += 1
+                    now_monotonic = time.monotonic()
+                    should_warn = (
+                        self._sample_warning_count <= SAMPLE_FAILURE_WARNING_BURST_COUNT
+                        or (
+                            now_monotonic - self._last_sample_warning_monotonic
+                            >= SAMPLE_FAILURE_WARNING_COOLDOWN_SECONDS
+                        )
                     )
+                    if should_warn:
+                        logger.warning(
+                            "PowerLogger sample failed: %s", exc, exc_info=True
+                        )
+                        self._last_sample_warning_monotonic = now_monotonic
+                    else:
+                        logger.debug(
+                            "PowerLogger sample failed (suppressed warning #%d): %s",
+                            self._sample_warning_count,
+                            exc,
+                        )
+                self._stop_event.wait(self.interval)
+        finally:
+            if self._deferred_dependency_close:
+                self._close_dependencies_after_worker_exit()
+
+    def _close_dependencies_locked(self) -> None:
+        """Close dependencies while the caller holds ``_dependency_close_lock``."""
+        if self._dependencies_closed:
+            return
+
+        meter_close_exc: Exception | None = None
+        writer_close_exc: Exception | None = None
+        try:
+            self._p_meter.close()
+        except Exception as exc:  # noqa: BLE001 - preserve primary close failure
+            meter_close_exc = exc
+        try:
+            self.writer.close()
+        except Exception as exc:  # noqa: BLE001 - secondary cleanup
+            writer_close_exc = exc
+        finally:
+            self._dependencies_closed = True
+
+        if meter_close_exc is not None:
+            if writer_close_exc is not None:
+                logger.warning(
+                    "PowerLogger writer close failed after power meter close error: %s",
+                    writer_close_exc,
+                    exc_info=True,
                 )
-                if should_warn:
-                    logger.warning("PowerLogger sample failed: %s", exc, exc_info=True)
-                    self._last_sample_warning_monotonic = now_monotonic
-                else:
-                    logger.debug(
-                        "PowerLogger sample failed (suppressed warning #%d): %s",
-                        self._sample_warning_count,
-                        exc,
-                    )
-            self._stop_event.wait(self.interval)
+            raise meter_close_exc
+        if writer_close_exc is not None:
+            raise writer_close_exc
+
+    def _close_dependencies(self) -> None:
+        """Close meter and writer exactly once while preserving error priority."""
+        with self._dependency_close_lock:
+            self._close_dependencies_locked()
+
+    def _close_dependencies_after_worker_exit(self) -> None:
+        """Close dependencies and retain any error for the next ``close()`` caller."""
+        close_error: Exception | None = None
+        with self._dependency_close_lock:
+            try:
+                self._close_dependencies_locked()
+            except Exception as exc:  # noqa: BLE001 - cannot escape worker thread
+                self._background_close_error = exc
+                close_error = exc
+        if close_error is not None:
+            logger.warning(
+                "PowerLogger dependency cleanup failed on worker exit: %s",
+                close_error,
+                exc_info=close_error,
+            )
+
+    def _take_closed_dependency_error(self) -> tuple[bool, Exception | None]:
+        """Atomically report closed state and consume its deferred worker error."""
+        with self._dependency_close_lock:
+            if not self._dependencies_closed:
+                return False, None
+            close_error = self._background_close_error
+            self._background_close_error = None
+            return True, close_error
 
     def close(self) -> None:
-        """Close the PowerLogger and stop logging."""
-        if self.is_logging:
-            self.is_logging = False
-            self._stop_event.set()
-            if threading.current_thread() is not self.thread:
-                self.thread.join(timeout=POWER_LOGGER_JOIN_TIMEOUT)
-                if self.thread.is_alive():
-                    logger.warning(
-                        "PowerLogger background thread did not stop within %.1fs; continuing teardown.",
-                        POWER_LOGGER_JOIN_TIMEOUT,
-                    )
-            else:
-                logger.debug(
-                    "PowerLogger.close() called from logging thread; skipping self-join."
-                )
-            meter_close_exc: Exception | None = None
-            try:
-                self._p_meter.close()
-            except Exception as exc:  # noqa: BLE001 - preserve primary close failure
-                meter_close_exc = exc
-            try:
-                self.writer.close()
-            except Exception as writer_close_exc:  # noqa: BLE001 - secondary cleanup
-                if meter_close_exc is not None:
-                    logger.warning(
-                        "PowerLogger writer close failed after power meter close error: %s",
-                        writer_close_exc,
-                        exc_info=True,
-                    )
-                else:
-                    raise
-            if meter_close_exc is not None:
-                raise meter_close_exc
+        """Stop sampling before closing meter/writer dependencies.
 
+        A worker that outlives the bounded join retains ownership of dependency
+        cleanup and closes them in ``_logging_thread``'s ``finally`` block. The
+        caller receives an explicit shutdown error instead of racing the live
+        sampler by closing resources underneath it.
+        """
+        dependencies_closed, background_error = self._take_closed_dependency_error()
+        if dependencies_closed:
+            if background_error is not None:
+                raise background_error
+            return
 
-# FIXME move these defs somewhere else
-TOPIC_MESHTASTIC_LOG_LINE = "meshtastic.log.line"
+        self.is_logging = False
+        self._deferred_dependency_close = True
+        self._stop_event.set()
+        if threading.current_thread() is self.thread:
+            logger.debug(
+                "PowerLogger.close() called from logging thread; deferring dependency cleanup until thread exit."
+            )
+            return
+
+        self.thread.join(timeout=POWER_LOGGER_JOIN_TIMEOUT)
+        if self.thread.is_alive():
+            raise _PowerLoggerShutdownError(
+                "PowerLogger background thread did not stop within "
+                f"{POWER_LOGGER_JOIN_TIMEOUT:.1f}s; meter and writer remain open "
+                "until the worker exits."
+            )
+
+        # Fake/test threads may not execute _logging_thread's finally block, so
+        # the caller also finalizes once the thread is confirmed stopped.
+        self._close_dependencies()
+        _dependencies_closed, background_error = self._take_closed_dependency_error()
+        if background_error is not None:
+            raise background_error
 
 
 class StructuredLogger:

--- a/meshtastic/tests/test_slog_coverage.py
+++ b/meshtastic/tests/test_slog_coverage.py
@@ -585,21 +585,22 @@ def test_power_logger_very_small_interval(
 
 
 @pytest.mark.unit
-def test_power_logger_slow_thread_stop_warning(
-    caplog: pytest.LogCaptureFixture,
+def test_power_logger_hung_thread_leaves_dependencies_open(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """PowerLogger should warn when thread doesn't stop within timeout."""
-    monkeypatch.setattr(slog_module, "FeatherWriter", _FakeWriter)
+    """A hung sampler must leave its dependencies open and surface failure."""
+    writer = MagicMock()
+    monkeypatch.setattr(slog_module, "FeatherWriter", MagicMock(return_value=writer))
     monkeypatch.setattr("meshtastic.slog.slog.threading.Thread", _SlowStopThread)
 
     meter = _make_meter_with_voltage(3.3)
     logger = PowerLogger(meter, "unused-path")
 
-    with caplog.at_level(logging.WARNING):
+    with pytest.raises(RuntimeError, match="did not stop within"):
         logger.close()
 
-    assert "did not stop within" in caplog.text
+    meter.close.assert_not_called()
+    writer.close.assert_not_called()
 
 
 @pytest.mark.unit
@@ -607,19 +608,22 @@ def test_power_logger_close_from_logging_thread(
     caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """PowerLogger.close() called from logging thread should skip self-join."""
+    """A self-close request must defer cleanup until the sampler exits."""
     monkeypatch.setattr(slog_module, "FeatherWriter", _FakeWriter)
 
     meter = _make_meter_with_voltage(3.3)
     logger = PowerLogger(meter, "unused-path")
 
-    # Mock to make current thread look like the logging thread
-    monkeypatch.setattr(threading, "current_thread", lambda: logger.thread)
+    # Make the caller look like the logging thread only for the close decision.
+    with monkeypatch.context() as context:
+        context.setattr(threading, "current_thread", lambda: logger.thread)
+        with caplog.at_level(logging.DEBUG):
+            logger.close()
 
-    with caplog.at_level(logging.DEBUG):
-        logger.close()
-
-    assert "skipping self-join" in caplog.text
+    assert "deferring dependency cleanup until thread exit" in caplog.text
+    logger.thread.join(timeout=1.0)
+    assert not logger.thread.is_alive()
+    meter.close.assert_called_once_with()
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_slog_power_logger.py
+++ b/meshtastic/tests/test_slog_power_logger.py
@@ -479,3 +479,80 @@ def test_log_set_close_raises_power_close_error_when_slog_close_succeeds(
 
     assert log_set.slog_logger is None
     assert log_set.power_logger is None
+
+
+@pytest.mark.unit
+def test_power_logger_worker_finally_closes_dependencies_after_deferred_close() -> None:
+    """A worker-owned deferred close must release dependencies only after sampling exits."""
+    meter = MagicMock()
+    writer = MagicMock()
+    logger_obj = object.__new__(PowerLogger)
+    logger_obj._p_meter = meter
+    logger_obj.writer = writer
+    logger_obj.interval = 0.001
+    logger_obj._stop_event = threading.Event()
+    logger_obj._sample_warning_count = 0
+    logger_obj._last_sample_warning_monotonic = 0.0
+    logger_obj._dependency_close_lock = threading.Lock()
+    logger_obj._dependencies_closed = False
+    logger_obj._deferred_dependency_close = True
+    logger_obj._background_close_error = None
+    store_current_reading = MagicMock()
+    logger_obj._store_current_reading = (  # type: ignore[method-assign]
+        store_current_reading
+    )
+    logger_obj._stop_event.set()
+
+    logger_obj._logging_thread()
+
+    store_current_reading.assert_not_called()
+    meter.close.assert_called_once_with()
+    writer.close.assert_called_once_with()
+    assert logger_obj._dependencies_closed is True
+
+
+@pytest.mark.unit
+def test_power_logger_close_is_idempotent_after_dependencies_close() -> None:
+    """Repeated close calls must not repeat meter/writer teardown."""
+    meter = MagicMock()
+    writer = MagicMock()
+    logger_obj = object.__new__(PowerLogger)
+    logger_obj._p_meter = meter
+    logger_obj.writer = writer
+    logger_obj._stop_event = threading.Event()
+    logger_obj._dependency_close_lock = threading.Lock()
+    logger_obj._dependencies_closed = False
+    logger_obj._deferred_dependency_close = False
+    logger_obj._background_close_error = None
+    logger_obj.is_logging = True
+    logger_obj.thread = MagicMock()
+    logger_obj.thread.is_alive.return_value = False
+
+    logger_obj.close()
+    logger_obj.close()
+
+    meter.close.assert_called_once_with()
+    writer.close.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_power_logger_close_reports_deferred_worker_cleanup_error_once() -> None:
+    """A worker-side dependency failure must reach exactly one close caller."""
+    meter = MagicMock()
+    meter.close.side_effect = RuntimeError("meter close failed")
+    writer = MagicMock()
+    logger_obj = object.__new__(PowerLogger)
+    logger_obj._p_meter = meter
+    logger_obj.writer = writer
+    logger_obj._dependency_close_lock = threading.Lock()
+    logger_obj._dependencies_closed = False
+    logger_obj._background_close_error = None
+
+    logger_obj._close_dependencies_after_worker_exit()
+
+    with pytest.raises(RuntimeError, match="meter close failed"):
+        logger_obj.close()
+    logger_obj.close()
+
+    meter.close.assert_called_once_with()
+    writer.close.assert_called_once_with()


### PR DESCRIPTION
## Summary by Sourcery

Harden PowerLogger shutdown to avoid closing dependencies from a still-running sampler thread and surface shutdown failures deterministically.

Bug Fixes:
- Prevent PowerLogger from closing its meter and writer while the background sampling thread may still be running by deferring cleanup to a controlled point.
- Ensure that dependency close errors raised in the background thread are captured and re-raised to callers instead of being silently logged.
- Change handling of hung PowerLogger threads so that dependencies remain open and a dedicated shutdown error is raised instead of merely logging a warning.

Enhancements:
- Introduce an idempotent dependency close routine that closes the power meter and writer exactly once while preserving error priority between them.
- Refine PowerLogger.close() semantics to distinguish caller-initiated shutdowns, self-close from the logging thread, and post-shutdown calls, including a dedicated shutdown error type.

Tests:
- Add unit tests covering deferred dependency cleanup on worker exit, idempotent close behavior, hung thread behavior leaving dependencies open, and self-close deferring cleanup until sampler exit.