### PR TITLE
Implement lazy publishing for worker

### DIFF
--- a/meshtastic/_publishing.py
+++ b/meshtastic/_publishing.py
@@ -8,5 +8,5 @@ consumers share one process-wide worker.
 
 from meshtastic.util import DeferredExecution
 
-publishing_thread = DeferredExecution("publishing")
-"""Process-wide worker that serializes deferred publication callbacks."""
+publishing_thread = DeferredExecution._create_lazy("publishing")
+"""Process-wide executor that starts its worker on the first queued callback."""

--- a/meshtastic/interfaces/ble/compatibility_service.py
+++ b/meshtastic/interfaces/ble/compatibility_service.py
@@ -287,9 +287,10 @@ class BLECompatibilityEventService:
         callback : Any
             Callable to enqueue for deferred execution.
         prefer_non_blocking : bool
-            When ``True``, only attempt ``queue.put_nowait``. If a non-blocking
-            enqueue path is unavailable or full, return ``False`` so callers
-            can apply an inline fallback.
+            When ``True``, use an executor's atomic non-blocking enqueue contract
+            when available, otherwise attempt ``queue.put_nowait``. If neither
+            path can accept the callback, return ``False`` so callers can apply
+            an inline fallback.
 
         Returns
         -------
@@ -297,12 +298,20 @@ class BLECompatibilityEventService:
             ``True`` when the callback was queued, otherwise ``False``.
         """
         queue_work = getattr(publishing_thread, "queueWork", None)
+        queue_work_non_blocking = _get_declared_callable(
+            publishing_thread, "_queue_work_non_blocking"
+        )
         queue = getattr(publishing_thread, "queue", None)
         put_nowait = getattr(queue, "put_nowait", None)
         can_queue_work = callable(queue_work)
         can_put_nowait = callable(put_nowait)
         queue_work_callback: Callable[[Any], object] | None = (
             cast(Callable[[Any], object], queue_work) if can_queue_work else None
+        )
+        queue_work_non_blocking_callback: Callable[[Any], bool] | None = (
+            cast(Callable[[Any], bool], queue_work_non_blocking)
+            if callable(queue_work_non_blocking)
+            else None
         )
         put_nowait_callback: Callable[[Any], object] | None = (
             cast(Callable[[Any], object], put_nowait) if can_put_nowait else None
@@ -321,7 +330,9 @@ class BLECompatibilityEventService:
 
         queued = False
         if prefer_non_blocking:
-            if put_nowait_callback is not None:
+            if queue_work_non_blocking_callback is not None:
+                queued = queue_work_non_blocking_callback(callback)
+            elif put_nowait_callback is not None:
                 try:
                     put_nowait_callback(callback)
                     queued = True

--- a/meshtastic/tests/conftest.py
+++ b/meshtastic/tests/conftest.py
@@ -654,9 +654,9 @@ def _platform_socket_mocks() -> Generator[tuple[MagicMock, MagicMock], None, Non
 def _shutdown_publishing_thread() -> Generator[None, None, None]:
     """Ensure the global publishing thread is shut down after all tests complete.
 
-    The publishingThread is a global DeferredExecution instance that creates a
-    daemon worker thread. While daemon threads should exit when the main thread
-    exits, pytest can hang waiting for them. This fixture ensures clean shutdown.
+    The publishingThread is a global DeferredExecution instance whose daemon
+    worker starts lazily on first use. If tests start it, this fixture guarantees
+    clean shutdown at the end of the session.
     """
     yield
     # After all tests complete, shut down the publishing thread

--- a/meshtastic/tests/test_core_runtime_primitives.py
+++ b/meshtastic/tests/test_core_runtime_primitives.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import ast
 import inspect
 import pickle
+import subprocess
+import sys
 import typing
 from pathlib import Path
 
@@ -183,6 +185,26 @@ def test_protocol_owner_module_does_not_import_package_root() -> None:
 def test_public_publishing_thread_is_internal_owner_identity() -> None:
     """Historical publishingThread should alias the internal singleton exactly."""
     assert meshtastic.publishingThread is _publishing.publishing_thread
+
+
+def test_importing_meshtastic_does_not_start_publishing_worker() -> None:
+    """Package import should not create the publishing daemon before work exists."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import meshtastic; "
+                "print(meshtastic.publishingThread.thread is None); "
+                "meshtastic.publishingThread.stop()"
+            ),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.splitlines()[-1].strip() == "True"
 
 
 def test_production_consumers_do_not_import_publishing_worker_from_package_root() -> (

--- a/meshtastic/tests/test_util.py
+++ b/meshtastic/tests/test_util.py
@@ -1620,6 +1620,62 @@ def test_deferred_execution_runs_closure() -> None:
 
 
 @pytest.mark.unit
+def test_deferred_execution_lazy_start_waits_for_first_work() -> None:
+    """A lazy executor should not create a worker until work is accepted."""
+    completed = threading.Event()
+    de = DeferredExecution._create_lazy("test_lazy_thread")
+
+    assert de.thread is None
+    de.queueWork(completed.set)
+
+    assert de.thread is not None
+    assert completed.wait(timeout=1.0)
+    de.stop()
+    assert de.join(timeout=1.0)
+
+
+@pytest.mark.unit
+def test_deferred_execution_lazy_start_failure_can_be_retried(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed lazy thread start must not leave the executor permanently poisoned."""
+    de = DeferredExecution._create_lazy("test_retry_lazy_thread")
+    real_thread = threading.Thread
+
+    class _FailingThread:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            _ = (args, kwargs)
+
+        def start(self) -> None:
+            raise RuntimeError("thread start failed")
+
+    monkeypatch.setattr(threading, "Thread", _FailingThread)
+    with pytest.raises(RuntimeError, match="thread start failed"):
+        de.queueWork(lambda: None)
+    assert de.thread is None
+
+    monkeypatch.setattr(threading, "Thread", real_thread)
+    completed = threading.Event()
+    de.queueWork(completed.set)
+    assert completed.wait(timeout=1.0)
+    de.stop()
+    assert de.join(timeout=1.0)
+
+
+@pytest.mark.unit
+def test_deferred_execution_lazy_stop_without_work_does_not_start_worker() -> None:
+    """Stopping an unused lazy executor must not create a shutdown-only thread."""
+    de = DeferredExecution._create_lazy("test_unused_lazy_thread")
+
+    de.stop()
+
+    assert de.thread is None
+    assert de.join(timeout=1.0)
+    de.queueWork(lambda: pytest.fail("work after stop must remain ignored"))
+    assert de.thread is None
+
+
+@pytest.mark.unit
 def test_deferred_execution_stop_drains_previously_queued_work() -> None:
     """stop() should drain work accepted before the shutdown sentinel."""
     first_started = threading.Event()

--- a/meshtastic/util.py
+++ b/meshtastic/util.py
@@ -13,7 +13,7 @@ import threading
 import time
 import warnings
 from collections.abc import Iterable
-from queue import Empty, Queue
+from queue import Empty, Full, Queue
 from typing import (
     Any,
     Callable,
@@ -655,7 +655,11 @@ class DeferredExecution:
 
     # Sentinel object to signal shutdown of the worker thread
     _SHUTDOWN = object()
+    queue: Queue[Any]
+    _shutdown: bool
     _stop_lock: threading.Lock
+    _thread_name: str
+    thread: threading.Thread | None
 
     def __init__(self, name: str) -> None:
         """Create a DeferredExecution instance and start its daemon worker thread.
@@ -668,14 +672,53 @@ class DeferredExecution:
         name : str
             Name assigned to the worker thread.
         """
+        self._initialize(name, start_worker=True)
+
+    @classmethod
+    def _create_lazy(cls, name: str) -> "DeferredExecution":
+        """Create an executor whose worker starts only when work is accepted.
+
+        This private constructor keeps the historical public ``__init__``
+        signature and eager-start behavior unchanged while allowing process-wide
+        owners to avoid import-time thread creation.
+        """
+        instance = cls.__new__(cls)
+        instance._initialize(name, start_worker=False)
+        return instance
+
+    def _initialize(self, name: str, *, start_worker: bool) -> None:
+        """Initialize queue/worker state with an explicit startup policy."""
         self.queue: Queue[Any] = Queue()
-        self._shutdown: bool = False
+        self._shutdown = False
         self._stop_lock = threading.Lock()
-        # this thread must be marked as daemon, otherwise it will prevent clients from exiting
-        self.thread = threading.Thread(
-            target=self._run, args=(), name=name, daemon=True
+        self._thread_name = name
+        self.thread = None
+        if start_worker:
+            with self._stop_lock:
+                self._ensure_started_locked()
+
+    def _ensure_started_locked(self) -> None:
+        """Start the daemon worker exactly once while ``_stop_lock`` is held."""
+        if self.thread is not None or self._shutdown:
+            return
+        # This thread must be daemonized, otherwise it prevents clients from exiting.
+        thread = threading.Thread(
+            target=self._run, args=(), name=self._thread_name, daemon=True
         )
-        self.thread.start()
+        thread.start()
+        self.thread = thread
+
+    def _queue_work_non_blocking(self, runnable: Callable[[], Any]) -> bool:
+        """Atomically start the worker and enqueue work without blocking."""
+        with self._stop_lock:
+            if self._shutdown:
+                return False
+            self._ensure_started_locked()
+            try:
+                self.queue.put_nowait(runnable)
+            except Full:
+                return False
+            return True
 
     def queueWork(self, runnable: Callable[[], Any]) -> None:
         """Enqueue a callable to be executed by the background worker thread.
@@ -693,6 +736,7 @@ class DeferredExecution:
         with self._stop_lock:
             if self._shutdown:
                 return
+            self._ensure_started_locked()
             self.queue.put(runnable)
 
     def stop(self) -> None:
@@ -704,8 +748,10 @@ class DeferredExecution:
         shutdown has already started.
         """
         with self._stop_lock:
-            if not self._shutdown:
-                self._shutdown = True
+            if self._shutdown:
+                return
+            self._shutdown = True
+            if self.thread is not None:
                 self.queue.put(self._SHUTDOWN)
 
     def join(self, timeout: float | None = None) -> bool:

--- a/tests/test_ble_utils_service_targets.py
+++ b/tests/test_ble_utils_service_targets.py
@@ -36,6 +36,7 @@ from meshtastic.interfaces.ble.reconnection import (
     ThreadCoordinatorMissingMethodError,
 )
 from meshtastic.interfaces.ble.state import BLEStateManager
+from meshtastic.util import DeferredExecution
 from tests.test_ble_interface_fixtures import DummyClient, _build_interface
 
 pytestmark = pytest.mark.unit
@@ -255,6 +256,25 @@ def test_compatibility_event_service_enqueue_paths() -> None:
         is True
     )
     assert queued_nowait == [callback]
+
+
+def test_nonblocking_enqueue_starts_lazy_publishing_worker() -> None:
+    """The first BLE status callback must activate a lazy publishing executor."""
+    completed = Event()
+    publishing_thread = DeferredExecution._create_lazy("test-ble-publishing")
+
+    try:
+        assert publishing_thread.thread is None
+        assert BLECompatibilityEventService._enqueue_publish_callback(
+            publishing_thread,
+            completed.set,
+            prefer_non_blocking=True,
+        )
+        assert publishing_thread.thread is not None
+        assert completed.wait(timeout=1.0)
+    finally:
+        publishing_thread.stop()
+        publishing_thread.join(timeout=1.0)
 
 
 def test_wait_for_disconnect_notifications_handles_timeout_and_dead_publisher(


### PR DESCRIPTION
## Summary by Sourcery

Make the global publishing executor lazily start its worker thread only when work is queued, avoiding thread creation at import time, and ensure it shuts down cleanly.

New Features:
- Introduce a lazy-start variant of DeferredExecution that defers worker thread creation until the first unit of work is enqueued.

Bug Fixes:
- Prevent failed worker thread startup from permanently disabling a lazy DeferredExecution instance.
- Ensure stopping a never-used lazy executor does not create or start a worker thread.

Enhancements:
- Refactor DeferredExecution initialization to separate construction from worker startup and guard thread creation with a lock for single-start semantics.

Tests:
- Add unit tests covering lazy-start behavior, retry after thread-start failure, and stopping a lazy executor without ever starting its worker.
- Add an integration-style test verifying that importing the meshtastic package does not start the publishing worker thread.