### PR TITLE
Centralize BLE Management State and Lifecycle Synchronization

### DIFF
--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -27,7 +27,6 @@ Threading model summary
 # BLEInterface is the public compatibility facade and composition root for extracted BLE runtimes.
 # pylint: disable=too-many-lines
 
-
 import atexit
 import contextlib
 import math
@@ -124,6 +123,11 @@ from meshtastic.interfaces.ble.management_service import (
 from meshtastic.interfaces.ble.management_service import (
     BLEManagementCommandHandler,
 )
+from meshtastic.interfaces.ble.management_state import (
+    BLEManagementState,
+    _ManagementConditionPort,
+)
+from meshtastic.interfaces.ble.ports import _LockPort
 from meshtastic.interfaces.ble.notifications import (
     BLENotificationDispatcher,
     NotificationManager,
@@ -315,11 +319,7 @@ class BLEInterface(  # pylint: disable=too-many-instance-attributes
         state_lock = self._state_manager.lock
         self._session_state = BLESessionState(lock=state_lock)
         self._connect_lock = threading.RLock()  # Serializes connection attempts
-        self._management_lock = (
-            threading.RLock()
-        )  # Serializes pair/unpair/trust vs. close()
-        self._management_idle_condition = threading.Condition(self._management_lock)
-        self._management_inflight = 0  # Tracks end-to-end management operations.
+        self._management_state = BLEManagementState()
         self._disconnect_lock = threading.Lock()  # Serializes disconnect handling
         self._exit_handler: Any | None = None
         self.address = address
@@ -361,7 +361,11 @@ class BLEInterface(  # pylint: disable=too-many-instance-attributes
             self.thread_coordinator,
             self,
         )
-        self._lifecycle_controller = BLELifecycleController(self)
+        self._lifecycle_controller = BLELifecycleController(
+            self,
+            client_closer=self._client_manager_safe_close_client,
+            management_state=self._get_management_state(),
+        )
         self._receive_recovery_controller = BLEReceiveRecoveryController(
             self, session_state=self._session_state
         )
@@ -374,6 +378,10 @@ class BLEInterface(  # pylint: disable=too-many-instance-attributes
             self,
             ble_client_factory=BLEClient,
             connected_elsewhere=self._connected_elsewhere_late_bound,
+            session_state=self._session_state,
+            management_state=self._get_management_state(),
+            connect_lock=self._connect_lock,
+            client_closer=self._client_manager_safe_close_client,
         )
 
         # Event coordination for reconnection and read operations
@@ -901,9 +909,7 @@ class BLEInterface(  # pylint: disable=too-many-instance-attributes
             except (BleakError, RuntimeError) as e:
                 logger.warning("Device scan failed: %s", e, exc_info=True)
                 return []
-            except (
-                Exception
-            ) as e:  # noqa: BLE001 # pragma: no cover - defensive last resort
+            except Exception as e:  # noqa: BLE001 # pragma: no cover - defensive last resort
                 logger.warning(
                     "Unexpected error during device scan: %s", e, exc_info=True
                 )
@@ -1255,8 +1261,8 @@ class BLEInterface(  # pylint: disable=too-many-instance-attributes
         """
         state_manager = self._state_manager
         lifecycle_owner_is_current: bool | None
-        canonical_locked_probe = (
-            _is_canonical_state_manager(state_manager, self._state_lock)
+        canonical_locked_probe = _is_canonical_state_manager(
+            state_manager, self._state_lock
         )
         with self._state_lock:
             if self._closed or self._connection_session_epoch != expected_session_epoch:
@@ -1330,7 +1336,12 @@ class BLEInterface(  # pylint: disable=too-many-instance-attributes
     def _get_lifecycle_controller(self) -> BLELifecycleController:
         """Return lifecycle collaborator, creating one lazily when needed."""
         return self._get_or_create_collaborator(
-            "_lifecycle_controller", lambda: BLELifecycleController(self)
+            "_lifecycle_controller",
+            lambda: BLELifecycleController(
+                self,
+                client_closer=self._client_manager_safe_close_client,
+                management_state=self._get_management_state(),
+            ),
         )
 
     def _get_receive_recovery_controller(self) -> BLEReceiveRecoveryController:
@@ -1349,6 +1360,45 @@ class BLEInterface(  # pylint: disable=too-many-instance-attributes
             ),
         )
 
+    def _get_management_state(self) -> BLEManagementState:
+        """Return the owned management state, creating it for partial objects."""
+        state = self.__dict__.get("_management_state")
+        if isinstance(state, BLEManagementState):
+            return state
+        candidate = BLEManagementState()
+        winner = self.__dict__.setdefault("_management_state", candidate)
+        if isinstance(winner, BLEManagementState):
+            return winner
+        self.__dict__["_management_state"] = candidate
+        return candidate
+
+    @property
+    def _management_lock(self) -> _LockPort:
+        """Compatibility view of the owned management lock."""
+        return self._get_management_state().lock
+
+    @_management_lock.setter
+    def _management_lock(self, value: _LockPort) -> None:
+        self._get_management_state().replace_lock(value)
+
+    @property
+    def _management_idle_condition(self) -> _ManagementConditionPort:
+        """Compatibility view of the owned management idle condition."""
+        return self._get_management_state().condition
+
+    @_management_idle_condition.setter
+    def _management_idle_condition(self, value: _ManagementConditionPort) -> None:
+        self._get_management_state().replace_condition(value)
+
+    @property
+    def _management_inflight(self) -> int:
+        """Compatibility view of in-flight management-operation count."""
+        return self._get_management_state().inflight
+
+    @_management_inflight.setter
+    def _management_inflight(self, value: int) -> None:
+        self._get_management_state().inflight = value
+
     def _get_management_command_handler(self) -> BLEManagementCommandHandler:
         """Return the bound management-command collaborator.
 
@@ -1363,6 +1413,10 @@ class BLEInterface(  # pylint: disable=too-many-instance-attributes
                 self,
                 ble_client_factory=BLEClient,
                 connected_elsewhere=self._connected_elsewhere_late_bound,
+                session_state=self._session_state,
+                management_state=self._get_management_state(),
+                connect_lock=self._connect_lock,
+                client_closer=self._client_manager_safe_close_client,
             ),
         )
 
@@ -2440,17 +2494,13 @@ class BLEInterface(  # pylint: disable=too-many-instance-attributes
             """Best-effort rollback for notification session bookkeeping."""
             if notification_dispatcher is None or notification_session_snapshot is None:
                 return
-            with contextlib.suppress(
-                Exception
-            ):  # noqa: BLE001 - rollback cleanup is best effort
+            with contextlib.suppress(Exception):  # noqa: BLE001 - rollback cleanup is best effort
                 notification_dispatcher._registered_notification_session_epoch = (
                     notification_session_snapshot[
                         "_registered_notification_session_epoch"
                     ]
                 )
-            with contextlib.suppress(
-                Exception
-            ):  # noqa: BLE001 - rollback cleanup is best effort
+            with contextlib.suppress(Exception):  # noqa: BLE001 - rollback cleanup is best effort
                 started_notify_snapshot = _copy_started_notify_snapshot(
                     notification_session_snapshot["_started_notify_characteristics"]
                 )
@@ -2458,39 +2508,27 @@ class BLEInterface(  # pylint: disable=too-many-instance-attributes
                     notification_dispatcher._started_notify_characteristics = (
                         started_notify_snapshot
                     )
-            with contextlib.suppress(
-                Exception
-            ):  # noqa: BLE001 - rollback cleanup is best effort
+            with contextlib.suppress(Exception):  # noqa: BLE001 - rollback cleanup is best effort
                 notification_dispatcher.fromnum_notify_enabled = (
                     notification_session_snapshot["fromnum_notify_enabled"]
                 )
-            with contextlib.suppress(
-                Exception
-            ):  # noqa: BLE001 - rollback cleanup is best effort
+            with contextlib.suppress(Exception):  # noqa: BLE001 - rollback cleanup is best effort
                 notification_dispatcher.malformed_notification_count = (
                     notification_session_snapshot["malformed_notification_count"]
                 )
-            with contextlib.suppress(
-                Exception
-            ):  # noqa: BLE001 - rollback cleanup is best effort
+            with contextlib.suppress(Exception):  # noqa: BLE001 - rollback cleanup is best effort
                 notification_dispatcher._current_legacy_log_handler = (
                     notification_session_snapshot["_current_legacy_log_handler"]
                 )
-            with contextlib.suppress(
-                Exception
-            ):  # noqa: BLE001 - rollback cleanup is best effort
+            with contextlib.suppress(Exception):  # noqa: BLE001 - rollback cleanup is best effort
                 notification_dispatcher._current_log_handler = (
                     notification_session_snapshot["_current_log_handler"]
                 )
-            with contextlib.suppress(
-                Exception
-            ):  # noqa: BLE001 - rollback cleanup is best effort
+            with contextlib.suppress(Exception):  # noqa: BLE001 - rollback cleanup is best effort
                 notification_dispatcher._current_from_num_handler = (
                     notification_session_snapshot["_current_from_num_handler"]
                 )
-            with contextlib.suppress(
-                Exception
-            ):  # noqa: BLE001 - rollback cleanup is best effort
+            with contextlib.suppress(Exception):  # noqa: BLE001 - rollback cleanup is best effort
                 notification_manager = notification_dispatcher._notification_manager
                 manager_lock = getattr(notification_manager, "_lock", None)
                 active_subscriptions_snapshot = notification_session_snapshot[

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -1379,7 +1379,7 @@ class BLEInterface(  # pylint: disable=too-many-instance-attributes
 
     @_management_lock.setter
     def _management_lock(self, value: _LockPort) -> None:
-        self._get_management_state().replace_lock(value)
+        self._get_management_state()._replace_lock(value)
 
     @property
     def _management_idle_condition(self) -> _ManagementConditionPort:
@@ -1388,7 +1388,7 @@ class BLEInterface(  # pylint: disable=too-many-instance-attributes
 
     @_management_idle_condition.setter
     def _management_idle_condition(self, value: _ManagementConditionPort) -> None:
-        self._get_management_state().replace_condition(value)
+        self._get_management_state()._replace_condition(value)
 
     @property
     def _management_inflight(self) -> int:

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -1361,16 +1361,26 @@ class BLEInterface(  # pylint: disable=too-many-instance-attributes
         )
 
     def _get_management_state(self) -> BLEManagementState:
-        """Return the owned management state, creating it for partial objects."""
+        """Return owned management state, repairing partial-object state safely."""
         state = self.__dict__.get("_management_state")
         if isinstance(state, BLEManagementState):
             return state
-        candidate = BLEManagementState()
-        winner = self.__dict__.setdefault("_management_state", candidate)
-        if isinstance(winner, BLEManagementState):
-            return winner
-        self.__dict__["_management_state"] = candidate
-        return candidate
+
+        repair_lock = cast(
+            _LockPort,
+            BLEInterface._get_or_create_collaborator(
+                self,
+                "_ble_management_state_init_lock",
+                threading.RLock,
+            ),
+        )
+        with repair_lock:
+            state = self.__dict__.get("_management_state")
+            if isinstance(state, BLEManagementState):
+                return state
+            state = BLEManagementState()
+            self.__dict__["_management_state"] = state
+            return state
 
     @property
     def _management_lock(self) -> _LockPort:

--- a/meshtastic/interfaces/ble/lifecycle_controller_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_controller_runtime.py
@@ -30,6 +30,10 @@ from meshtastic.interfaces.ble.lifecycle_receive_runtime import (
 from meshtastic.interfaces.ble.lifecycle_shutdown_runtime import (
     BLEShutdownLifecycleCoordinator,
 )
+from meshtastic.interfaces.ble.management_state import (
+    _BLEManagementStatePort,
+    _management_state_for,
+)
 from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.state import ConnectionState
 
@@ -61,7 +65,13 @@ def _callable_accepts_timeout_kwarg(func: Callable[..., object]) -> bool:
 class BLELifecycleController:
     """Instance-bound collaborator for BLE lifecycle responsibilities."""
 
-    def __init__(self, iface: "BLEInterface") -> None:
+    def __init__(
+        self,
+        iface: "BLEInterface",
+        *,
+        client_closer: Callable[..., None] | None = None,
+        management_state: _BLEManagementStatePort | None = None,
+    ) -> None:
         """Bind lifecycle orchestration helpers to a specific interface.
 
         Parameters
@@ -69,6 +79,13 @@ class BLELifecycleController:
         iface : BLEInterface
             Interface instance whose lifecycle collaborators are owned by this
             controller.
+        client_closer : Callable[..., None] | None, optional
+            Explicit client-close capability used by the disconnect coordinator.
+            When omitted, compatibility resolution falls back to the bound
+            interface.
+        management_state : _BLEManagementStatePort | None, optional
+            Shared management-operation state. When omitted, resolve the
+            interface-owned state or use the legacy adapter.
 
         Returns
         -------
@@ -77,14 +94,21 @@ class BLELifecycleController:
         """
         self._iface = iface
         session = _session_state_for(iface)
+        management = _management_state_for(iface, management_state)
         self._receive = BLEReceiveLifecycleCoordinator(iface, session_state=session)
         self._disconnect = BLEDisconnectLifecycleCoordinator(
-            iface, session_state=session
+            iface,
+            session_state=session,
+            client_closer=client_closer,
         )
         self._connection_ownership = BLEConnectionOwnershipLifecycleCoordinator(
             iface, session_state=session
         )
-        self._shutdown = BLEShutdownLifecycleCoordinator(iface, session_state=session)
+        self._shutdown = BLEShutdownLifecycleCoordinator(
+            iface,
+            session_state=session,
+            management_state=management,
+        )
 
     def _set_receive_wanted(self, *, want_receive: bool) -> None:
         """Request or clear the receive loop on the bound interface."""
@@ -299,9 +323,7 @@ class BLELifecycleController:
         service_get_status = (
             lifecycle_service_mod.BLELifecycleService._get_connected_client_status
         )
-        service_get_status_locked = (
-            lifecycle_service_mod.BLELifecycleService._get_connected_client_status_locked
-        )
+        service_get_status_locked = lifecycle_service_mod.BLELifecycleService._get_connected_client_status_locked
         service_verify_snapshot = (
             lifecycle_service_mod.BLELifecycleService._verify_ownership_snapshot
         )

--- a/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
@@ -51,6 +51,7 @@ class BLEDisconnectLifecycleCoordinator:
         iface: "BLEInterface",
         *,
         session_state: _BLESessionStatePort | None = None,
+        client_closer: Callable[..., None] | None = None,
     ) -> None:
         """Bind disconnect orchestration ownership to a specific interface.
 
@@ -61,6 +62,9 @@ class BLEDisconnectLifecycleCoordinator:
         session_state : _BLESessionStatePort | None
             Optional shared lifecycle state. When ``None``, resolve the
             interface-owned state or use the legacy adapter.
+        client_closer : Callable[..., None] | None, optional
+            Explicit client-close capability. When omitted, compatibility
+            resolution falls back to the bound interface.
 
         Returns
         -------
@@ -69,6 +73,7 @@ class BLEDisconnectLifecycleCoordinator:
         """
         self._iface = iface
         self._session = _session_state_for(iface, session_state)
+        self._client_closer = client_closer
         self._state_access = _LifecycleStateAccess(iface)
         self._thread_access = _LifecycleThreadAccess(iface)
         self._error_access = _LifecycleErrorAccess(iface)
@@ -124,10 +129,15 @@ class BLEDisconnectLifecycleCoordinator:
         timeout : float | None, optional
             Optional maximum seconds to wait for client disconnect/close.
         """
-        self._iface._client_manager_safe_close_client(
-            client,
-            disconnect_timeout=timeout,
+        closer = self._client_closer or _resolve_declared_callable(
+            self._iface,
+            "_client_manager_safe_close_client",
         )
+        if closer is None:
+            raise AttributeError(
+                "BLE disconnect collaborator is missing client cleanup capability"
+            )
+        closer(client, disconnect_timeout=timeout)
 
     def on_ble_disconnect(self, client: BleakRootClient) -> None:
         """Handle a Bleak disconnect callback from the active transport client."""
@@ -186,7 +196,6 @@ class BLEDisconnectLifecycleCoordinator:
 
     # Early exits preserve ownership checks before any disconnect side effects occur.
     def _resolve_disconnect_target(  # pylint: disable=too-many-return-statements
-
         self,
         source: str,
         client: "BLEClient | None",
@@ -402,7 +411,6 @@ class BLEDisconnectLifecycleCoordinator:
         safe_cleanup: Callable[[Callable[[], object], str], None] | None = None,
     ) -> None:
         """Close a disconnected previous client asynchronously."""
-        iface = self._iface
         create_runtime_thread = create_thread or self._thread_access.create_thread
         start_runtime_thread = start_thread or self._thread_access.start_thread
         run_safe_cleanup = safe_cleanup or self._error_access.safe_cleanup
@@ -411,7 +419,7 @@ class BLEDisconnectLifecycleCoordinator:
 
         def _close_inline() -> None:
             run_safe_cleanup(
-                lambda: iface._client_manager_safe_close_client(previous_client),
+                lambda: self.disconnect_and_close_client(previous_client),
                 "BLE client close during disconnect",
             )
 

--- a/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_disconnect_runtime.py
@@ -32,6 +32,7 @@ from meshtastic.interfaces.ble.state import (
     _is_canonical_state_manager,
 )
 from meshtastic.interfaces.ble.utils import (
+    _is_unexpected_keyword_error,
     _sleep,
     _thread_start_probe,
 )
@@ -137,7 +138,12 @@ class BLEDisconnectLifecycleCoordinator:
             raise AttributeError(
                 "BLE disconnect collaborator is missing client cleanup capability"
             )
-        closer(client, disconnect_timeout=timeout)
+        try:
+            closer(client, disconnect_timeout=timeout)
+        except TypeError as exc:
+            if not _is_unexpected_keyword_error(exc, "disconnect_timeout"):
+                raise
+            closer(client)
 
     def on_ble_disconnect(self, client: BleakRootClient) -> None:
         """Handle a Bleak disconnect callback from the active transport client."""

--- a/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
+++ b/meshtastic/interfaces/ble/lifecycle_shutdown_runtime.py
@@ -31,6 +31,10 @@ from meshtastic.interfaces.ble.lifecycle_primitives import (
     _LifecycleStateAccess,
     _LifecycleThreadAccess,
 )
+from meshtastic.interfaces.ble.management_state import (
+    _BLEManagementStatePort,
+    _management_state_for,
+)
 from meshtastic.interfaces.ble.ports import _BLESessionStatePort
 from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.state import ConnectionState
@@ -65,6 +69,7 @@ class BLEShutdownLifecycleCoordinator:
         iface: "BLEInterface",
         *,
         session_state: _BLESessionStatePort | None = None,
+        management_state: _BLEManagementStatePort | None = None,
     ) -> None:
         """Bind shutdown ownership to a specific interface.
 
@@ -75,6 +80,9 @@ class BLEShutdownLifecycleCoordinator:
         session_state : _BLESessionStatePort | None
             Optional shared lifecycle state. When ``None``, resolve the
             interface-owned state or use the legacy adapter.
+        management_state : _BLEManagementStatePort | None, optional
+            Shared management-operation state. When omitted, resolve the
+            interface-owned state or use the legacy adapter.
 
         Returns
         -------
@@ -83,6 +91,7 @@ class BLEShutdownLifecycleCoordinator:
         """
         self._iface = iface
         self._session = _session_state_for(iface, session_state)
+        self._management = _management_state_for(iface, management_state)
         self._state_access = _LifecycleStateAccess(iface)
         self._thread_access = _LifecycleThreadAccess(iface)
         self._error_access = _LifecycleErrorAccess(iface)
@@ -238,7 +247,6 @@ class BLEShutdownLifecycleCoordinator:
             ``None`` when already closed; otherwise ``True`` when management wait
             timed out, ``False`` when inflight management reached idle.
         """
-        iface = self._iface
         get_current_state = current_state_getter or self._state_access.current_state
         get_is_closing = is_closing_getter or self._state_access.is_closing
         do_transition_to = transition_to_state or self._state_access.transition_to
@@ -258,7 +266,7 @@ class BLEShutdownLifecycleCoordinator:
         # closing state without interface/session locks, then revalidate closed
         # state after acquiring the normal shutdown lock order.
         was_closing = get_is_closing()
-        with iface._management_lock:
+        with self._management.lock:
             with self._session.lock:
                 if self._session.closed:
                     logger.debug(SHUTDOWN_ALREADY_CLOSED_MSG)
@@ -298,18 +306,18 @@ class BLEShutdownLifecycleCoordinator:
                         disconnect_alias_key,
                         getattr(fallback_state, "value", fallback_state),
                     )
-            while iface._management_inflight > 0:
+            while self._management.inflight > 0:
                 elapsed = time.monotonic() - management_wait_started
                 if elapsed >= management_shutdown_wait_timeout:
                     management_wait_timed_out = True
                     logger.warning(
                         "Timed out waiting %.1fs for %d inflight management operation(s) during shutdown",
                         elapsed,
-                        iface._management_inflight,
+                        self._management.inflight,
                     )
                     break
                 remaining = management_shutdown_wait_timeout - elapsed
-                iface._management_idle_condition.wait(
+                self._management.condition.wait(
                     timeout=min(management_wait_poll_seconds, remaining)
                 )
         return management_wait_timed_out

--- a/meshtastic/interfaces/ble/management_runtime.py
+++ b/meshtastic/interfaces/ble/management_runtime.py
@@ -525,7 +525,7 @@ class BLEManagementCommandHandler:
 
     def begin_management_operation_locked(self) -> None:
         """Record a management operation while holding ``_management_lock``."""
-        self._management.begin_locked()
+        self._management._begin_locked()
 
     def finish_management_operation(self) -> None:
         """Mark completion of an in-flight management operation."""

--- a/meshtastic/interfaces/ble/management_runtime.py
+++ b/meshtastic/interfaces/ble/management_runtime.py
@@ -15,6 +15,7 @@ from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.compat_adapter import (
     _load_runtime_module,
     _get_declared_callable,
+    _get_declared_lock,
     _get_declared_member,
 )
 from meshtastic.interfaces.ble.connection import ConnectionOrchestrator
@@ -38,6 +39,12 @@ from meshtastic.interfaces.ble.gating import (
     _addr_lock_context,
 )
 from meshtastic.interfaces.ble.lifecycle_primitives import _client_is_connected_compat
+from meshtastic.interfaces.ble.management_state import (
+    _BLEManagementStatePort,
+    _management_state_for,
+)
+from meshtastic.interfaces.ble.ports import _BLESessionStatePort, _LockPort
+from meshtastic.interfaces.ble.session_state import _session_state_for
 from meshtastic.interfaces.ble.utils import (
     _call_factory_with_optional_kwarg,
     sanitize_address,
@@ -239,6 +246,10 @@ class BLEManagementCommandHandler:
         *,
         ble_client_factory: Callable[..., BLEClient],
         connected_elsewhere: Callable[[str | None, object | None], bool],
+        session_state: _BLESessionStatePort | None = None,
+        management_state: _BLEManagementStatePort | None = None,
+        connect_lock: _LockPort | None = None,
+        client_closer: Callable[..., None] | None = None,
     ) -> None:
         """Create a bound management collaborator.
 
@@ -250,11 +261,42 @@ class BLEManagementCommandHandler:
             Factory for temporary management clients.
         connected_elsewhere : Callable[[str | None, object | None], bool]
             Cross-interface ownership probe.
+        session_state : _BLESessionStatePort | None, optional
+            Shared BLE lifecycle state. When omitted, resolve the interface-owned
+            state or use the legacy adapter.
+        management_state : _BLEManagementStatePort | None, optional
+            Shared management-operation accounting state. When omitted, resolve
+            the interface-owned state or use the legacy adapter.
+        connect_lock : _LockPort | None, optional
+            Explicit connect-serialization lock. Compatibility resolution falls
+            back to a declared interface lock or an isolated reentrant lock.
+        client_closer : Callable[..., None] | None, optional
+            Explicit client-close capability for temporary management clients.
+            When omitted, compatibility resolution falls back to the interface.
         """
         self._iface = iface
         self._ble_client_factory = ble_client_factory
         self._connected_elsewhere = connected_elsewhere
+        self._session = _session_state_for(iface, session_state)
+        self._management = _management_state_for(iface, management_state)
+        self._connect_lock = (
+            connect_lock
+            or _get_declared_lock(iface, "_connect_lock")
+            or cast(_LockPort, threading.RLock())
+        )
+        self._client_closer = client_closer
         self._iface_override_dispatch_guard = threading.local()
+
+    def _close_client(self, client: BLEClient) -> None:
+        """Close a management client through the injected/fallback capability."""
+        closer = self._client_closer or _get_declared_callable(
+            self._iface, "_client_manager_safe_close_client"
+        )
+        if closer is None:
+            raise AttributeError(
+                "BLE management collaborator is missing client cleanup capability"
+            )
+        closer(client)
 
     def _active_iface_override_dispatches(self) -> set[str]:
         """Return per-thread set of in-flight iface override dispatch names."""
@@ -330,7 +372,7 @@ class BLEManagementCommandHandler:
         ):
             raise iface.BLEError(ERROR_MANAGEMENT_ADDRESS_EMPTY)
         if address is None:
-            with iface._state_lock:
+            with self._session.lock:
                 current_client = iface.client
             if self._is_client_connected(current_client):
                 current_address = iface._extract_client_address(current_client)
@@ -370,7 +412,7 @@ class BLEManagementCommandHandler:
         self, address: str | None
     ) -> BLEClient | None:
         """Return active/reusable management client when available."""
-        with self._iface._state_lock:
+        with self._session.lock:
             return self.get_management_client_if_available_locked(address)
 
     def get_management_client_if_available_locked(
@@ -398,7 +440,7 @@ class BLEManagementCommandHandler:
         prefer_current_client: bool,
     ) -> BLEClient | None:
         """Return reusable management client matching ``target_address``."""
-        with self._iface._state_lock:
+        with self._session.lock:
             return self.get_management_client_for_target_locked(
                 target_address,
                 prefer_current_client=prefer_current_client,
@@ -461,7 +503,7 @@ class BLEManagementCommandHandler:
     ) -> None:
         """Abort when implicit management target changed while waiting on gate."""
         iface = self._iface
-        with iface._state_lock:
+        with self._session.lock:
             current_binding = self.get_current_implicit_management_binding_locked()
         if current_binding is None:
             raise iface.BLEError(ERROR_MANAGEMENT_TARGET_CHANGED)
@@ -483,22 +525,14 @@ class BLEManagementCommandHandler:
 
     def begin_management_operation_locked(self) -> None:
         """Record a management operation while holding ``_management_lock``."""
-        self._iface._management_inflight += 1
+        self._management.begin_locked()
 
     def finish_management_operation(self) -> None:
         """Mark completion of an in-flight management operation."""
-        iface = self._iface
-        with iface._management_lock:
-            if iface._management_inflight <= 0:
-                logger.warning(
-                    "Management operation accounting underflow detected during finish(); resetting inflight count to zero."
-                )
-                iface._management_inflight = 0
-                iface._management_idle_condition.notify_all()
-                return
-            iface._management_inflight -= 1
-            if iface._management_inflight == 0:
-                iface._management_idle_condition.notify_all()
+        if not self._management.finish():
+            logger.warning(
+                "Management operation accounting underflow detected during finish(); resetting inflight count to zero."
+            )
 
     def start_management_phase(self, address: str | None) -> _ManagementStartContext:
         """Begin management operation and capture startup context."""
@@ -508,7 +542,7 @@ class BLEManagementCommandHandler:
         use_existing_client_without_resolved_address = False
         operation_started = False
         try:
-            with iface._connect_lock, iface._management_lock, iface._state_lock:
+            with self._connect_lock, self._management.lock, self._session.lock:
                 iface._validate_management_preconditions()
                 if address is None:
                     expected_implicit_binding = (
@@ -553,7 +587,7 @@ class BLEManagementCommandHandler:
         use_refreshed_existing_client = True
 
         if address is None:
-            with iface._connect_lock, iface._management_lock, iface._state_lock:
+            with self._connect_lock, self._management.lock, self._session.lock:
                 iface._validate_management_preconditions()
                 refreshed_existing_client = self._call_iface_override(
                     "_get_management_client_if_available_locked",
@@ -576,7 +610,7 @@ class BLEManagementCommandHandler:
                 else:
                     use_refreshed_existing_client = False
         else:
-            with iface._connect_lock, iface._management_lock, iface._state_lock:
+            with self._connect_lock, self._management.lock, self._session.lock:
                 iface._validate_management_preconditions()
                 refreshed_existing_client = self._call_iface_override(
                     "_get_management_client_if_available_locked",
@@ -665,7 +699,7 @@ class BLEManagementCommandHandler:
         target_key: str | None = None
         temporary_client: BLEClient | None = None
 
-        with iface._connect_lock, iface._management_lock, iface._state_lock:
+        with self._connect_lock, self._management.lock, self._session.lock:
             iface._validate_management_preconditions()
             if address is None:
                 self._call_iface_override(
@@ -716,16 +750,13 @@ class BLEManagementCommandHandler:
         command: Callable[[BLEClient], T],
     ) -> T:
         """Execute management command and close temporary client on exit."""
-        iface = self._iface
         try:
             return command(client_to_use)
         finally:
             if temporary_client is not None:
                 try:
-                    iface._client_manager_safe_close_client(temporary_client)
-                except (
-                    Exception
-                ):  # noqa: BLE001 - best-effort cleanup must not mask command outcome
+                    self._close_client(temporary_client)
+                except Exception:  # noqa: BLE001 - best-effort cleanup must not mask command outcome
                     logger.debug(
                         "Failed to close temporary management client.",
                         exc_info=True,
@@ -781,7 +812,7 @@ class BLEManagementCommandHandler:
 
             if target_address is None:
                 if refreshed_existing_client is not None:
-                    with iface._connect_lock, iface._management_lock, iface._state_lock:
+                    with self._connect_lock, self._management.lock, self._session.lock:
                         iface._validate_management_preconditions()
                         if (
                             address is None
@@ -809,14 +840,22 @@ class BLEManagementCommandHandler:
                             gate_target = _synthetic_gate_address_for_client(
                                 refreshed_existing_client
                             )
-                        with iface._management_target_gate(gate_target):
+                        with self._call_iface_override(
+                            "_management_target_gate",
+                            self.management_target_gate,
+                            gate_target,
+                        ):
                             return command(refreshed_existing_client)
                     raise iface.BLEError(ERROR_MANAGEMENT_TARGET_CHANGED)
                 raise iface.BLEError(ERROR_MANAGEMENT_ADDRESS_REQUIRED)
 
-            with iface._management_target_gate(target_address):
+            with self._call_iface_override(
+                "_management_target_gate",
+                self.management_target_gate,
+                target_address,
+            ):
                 if refreshed_existing_client is not None:
-                    with iface._connect_lock, iface._management_lock, iface._state_lock:
+                    with self._connect_lock, self._management.lock, self._session.lock:
                         iface._validate_management_preconditions()
                         if address is None:
                             self._call_iface_override(
@@ -978,9 +1017,7 @@ class BLEManagementCommandHandler:
                 check=False,
                 timeout=command_timeout,
             )
-        except (
-            Exception
-        ) as exc:  # noqa: BLE001 - preserve injected module compatibility
+        except Exception as exc:  # noqa: BLE001 - preserve injected module compatibility
             if isinstance(exc, timeout_exc_type):
                 raise iface.BLEError(
                     ERROR_TRUST_COMMAND_TIMEOUT.format(
@@ -1061,8 +1098,12 @@ class BLEManagementCommandHandler:
                 if target_address is None:
                     raise iface.BLEError(ERROR_MANAGEMENT_ADDRESS_REQUIRED)
             canonical_address = iface._format_bluetoothctl_address(target_address)
-            with iface._management_target_gate(target_address):
-                with iface._connect_lock, iface._management_lock, iface._state_lock:
+            with self._call_iface_override(
+                "_management_target_gate",
+                self.management_target_gate,
+                target_address,
+            ):
+                with self._connect_lock, self._management.lock, self._session.lock:
                     iface._validate_management_preconditions()
                     if address is None:
                         self._call_iface_override(

--- a/meshtastic/interfaces/ble/management_state.py
+++ b/meshtastic/interfaces/ble/management_state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+import weakref
 from collections.abc import Callable
 from typing import Any, Protocol, cast
 
@@ -65,7 +66,14 @@ class _ContextLockCondition:
         self._exit_lock: Callable[..., Any] = exit_lock
 
     def wait(self, timeout: float | None = None) -> bool:
-        """Release the compatibility lock while waiting, then reacquire it."""
+        """Release the compatibility lock while waiting, then reacquire it.
+
+        Notes
+        -----
+        The compatibility lock is released exactly once. Callers must hold it
+        exactly once while waiting; nested acquisition would leave the lock
+        owned and prevent another thread from reaching the notifier.
+        """
         waiter = threading.Event()
         with self._waiters_lock:
             self._waiters.append(waiter)
@@ -103,22 +111,30 @@ def _condition_for_lock(lock: _LockPort) -> _ManagementConditionPort:
 
 _LEGACY_ADAPTER_ATTR = "_ble_management_state_adapter"
 _LEGACY_ADAPTER_CACHE_LOCK = threading.RLock()
+# Values, rather than targets, are weak: each adapter intentionally owns a strong
+# target reference, so a WeakKeyDictionary[target, adapter] would indirectly pin
+# its supposedly weak key. Identity keys also support slotted/non-weakrefable
+# compatibility targets; a live adapter keeps its target alive, preventing id reuse.
+_LEGACY_ADAPTER_FALLBACK_CACHE: weakref.WeakValueDictionary[
+    int, _LegacyBLEManagementStateAdapter
+] = weakref.WeakValueDictionary()
+_LEGACY_MEMBER_MISSING = object()
+_CONDITION_LOCK_MISSING = object()
 
 
-def _persist_legacy_member(target: object, name: str, value: object) -> None:
-    """Persist a compatibility synchronization member when the target allows it."""
+def _persist_legacy_member(target: object, name: str, value: object) -> bool:
+    """Persist a compatibility member and report whether the write succeeded."""
     try:
         vars(target)[name] = value
-        return
+        return True
     except TypeError:
         pass
     try:
         setattr(target, name, value)
     except (AttributeError, TypeError):
         # Some legacy test doubles/proxies intentionally reject new attributes.
-        # The adapter still works for that single resolution; callers with writable
-        # compatibility members converge on one shared synchronization primitive.
-        pass
+        return False
+    return True
 
 
 class BLEManagementState:
@@ -207,13 +223,26 @@ class _LegacyBLEManagementStateAdapter:
 
     def __init__(self, target: object) -> None:
         self._target = target
+        self._fallback_inflight = 0
+        self._fallback_inflight_authoritative = False
         declared_lock = _get_declared_lock(target, "_management_lock")
         self._lock = declared_lock or cast(_LockPort, threading.RLock())
         if declared_lock is None:
             _persist_legacy_member(target, "_management_lock", self._lock)
 
         declared_condition = _get_declared_member(target, "_management_idle_condition")
-        if declared_condition is not None:
+        condition_lock = (
+            _get_declared_member(
+                declared_condition,
+                "_lock",
+                _CONDITION_LOCK_MISSING,
+            )
+            if declared_condition is not None
+            else _CONDITION_LOCK_MISSING
+        )
+        if declared_condition is not None and (
+            condition_lock is _CONDITION_LOCK_MISSING or condition_lock is self._lock
+        ):
             self._condition = cast(_ManagementConditionPort, declared_condition)
         else:
             self._condition = _condition_for_lock(self._lock)
@@ -236,12 +265,27 @@ class _LegacyBLEManagementStateAdapter:
     @property
     def inflight(self) -> int:
         """Return the legacy target's current management-operation count."""
-        value = _get_declared_member(self._target, "_management_inflight", 0)
-        return int(value) if isinstance(value, int) else 0
+        if self._fallback_inflight_authoritative:
+            return self._fallback_inflight
+        value = _get_declared_member(
+            self._target,
+            "_management_inflight",
+            _LEGACY_MEMBER_MISSING,
+        )
+        if value is _LEGACY_MEMBER_MISSING:
+            return self._fallback_inflight
+        if isinstance(value, bool) or not isinstance(value, int):
+            return 0
+        self._fallback_inflight = value
+        return value
 
     @inflight.setter
     def inflight(self, value: int) -> None:
-        cast(Any, self._target)._management_inflight = int(value)
+        normalized = int(value)
+        self._fallback_inflight = normalized
+        self._fallback_inflight_authoritative = not _persist_legacy_member(
+            self._target, "_management_inflight", normalized
+        )
 
     def _begin_locked(self) -> None:
         """Increment legacy inflight accounting while the caller owns ``lock``."""
@@ -289,7 +333,13 @@ def _management_state_for(
         cached = _get_declared_member(target, _LEGACY_ADAPTER_ATTR)
         if isinstance(cached, _LegacyBLEManagementStateAdapter):
             return cached
+
+        fallback_cached = _LEGACY_ADAPTER_FALLBACK_CACHE.get(id(target))
+        if fallback_cached is not None and fallback_cached._target is target:
+            return fallback_cached
+
         adapter = _LegacyBLEManagementStateAdapter(target)
+        _LEGACY_ADAPTER_FALLBACK_CACHE[id(target)] = adapter
         try:
             namespace = vars(target)
         except TypeError:

--- a/meshtastic/interfaces/ble/management_state.py
+++ b/meshtastic/interfaces/ble/management_state.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import threading
+from collections.abc import Callable
 from typing import Any, Protocol, cast
 
 from meshtastic.interfaces.ble.compat_adapter import (
+    _get_declared_callable,
     _get_declared_lock,
     _get_declared_member,
 )
@@ -41,11 +43,82 @@ class _BLEManagementStatePort(Protocol):
     def inflight(self, value: int) -> None:
         """Replace the in-flight count for compatibility/testing seams."""
 
-    def begin_locked(self) -> None:
+    def _begin_locked(self) -> None:
         """Increment the in-flight count while the caller holds ``lock``."""
 
     def finish(self) -> bool:
         """Finish one operation and return whether accounting remained valid."""
+
+
+class _ContextLockCondition:
+    """Condition adapter for locks that expose only context-manager semantics."""
+
+    def __init__(self, lock: _LockPort) -> None:
+        self._lock = lock
+        self._waiters_lock = threading.Lock()
+        self._waiters: list[threading.Event] = []
+        enter_lock = _get_declared_callable(lock, "__enter__")
+        exit_lock = _get_declared_callable(lock, "__exit__")
+        if enter_lock is None or exit_lock is None:
+            raise TypeError("compatibility lock must implement context-manager methods")
+        self._enter_lock: Callable[..., Any] = enter_lock
+        self._exit_lock: Callable[..., Any] = exit_lock
+
+    def wait(self, timeout: float | None = None) -> bool:
+        """Release the compatibility lock while waiting, then reacquire it."""
+        waiter = threading.Event()
+        with self._waiters_lock:
+            self._waiters.append(waiter)
+
+        self._exit_lock(None, None, None)  # pylint: disable=not-callable
+        try:
+            return waiter.wait(timeout)
+        finally:
+            with self._waiters_lock:
+                if waiter in self._waiters:
+                    self._waiters.remove(waiter)
+            self._enter_lock()  # pylint: disable=not-callable
+
+    def notify_all(self) -> None:
+        """Wake every waiter registered before this notification."""
+        with self._waiters_lock:
+            waiters = tuple(self._waiters)
+            self._waiters.clear()
+        for waiter in waiters:
+            waiter.set()
+
+
+def _condition_for_lock(lock: _LockPort) -> _ManagementConditionPort:
+    """Create a condition compatible with either full or context-only locks."""
+    if (
+        _get_declared_callable(lock, "acquire") is not None
+        and _get_declared_callable(lock, "release") is not None
+    ):
+        return cast(
+            _ManagementConditionPort,
+            threading.Condition(cast(Any, lock)),
+        )
+    return _ContextLockCondition(lock)
+
+
+_LEGACY_ADAPTER_ATTR = "_ble_management_state_adapter"
+_LEGACY_ADAPTER_CACHE_LOCK = threading.RLock()
+
+
+def _persist_legacy_member(target: object, name: str, value: object) -> None:
+    """Persist a compatibility synchronization member when the target allows it."""
+    try:
+        vars(target)[name] = value
+        return
+    except TypeError:
+        pass
+    try:
+        setattr(target, name, value)
+    except (AttributeError, TypeError):
+        # Some legacy test doubles/proxies intentionally reject new attributes.
+        # The adapter still works for that single resolution; callers with writable
+        # compatibility members converge on one shared synchronization primitive.
+        pass
 
 
 class BLEManagementState:
@@ -61,10 +134,7 @@ class BLEManagementState:
             created when omitted.
         """
         self._lock = lock or cast(_LockPort, threading.RLock())
-        self._condition: _ManagementConditionPort = cast(
-            _ManagementConditionPort,
-            threading.Condition(cast(Any, self._lock)),
-        )
+        self._condition = _condition_for_lock(self._lock)
         self._inflight = 0
 
     @property
@@ -87,7 +157,7 @@ class BLEManagementState:
         """Replace the current in-flight operation count."""
         self._inflight = int(value)
 
-    def replace_lock(self, lock: _LockPort) -> None:
+    def _replace_lock(self, lock: _LockPort) -> None:
         """Replace the compatibility lock and rebuild its default condition.
 
         Parameters
@@ -96,12 +166,9 @@ class BLEManagementState:
             Replacement synchronization lock.
         """
         self._lock = lock
-        self._condition = cast(
-            _ManagementConditionPort,
-            threading.Condition(cast(Any, lock)),
-        )
+        self._condition = _condition_for_lock(lock)
 
-    def replace_condition(self, condition: _ManagementConditionPort) -> None:
+    def _replace_condition(self, condition: _ManagementConditionPort) -> None:
         """Replace the compatibility condition object.
 
         Parameters
@@ -111,7 +178,7 @@ class BLEManagementState:
         """
         self._condition = condition
 
-    def begin_locked(self) -> None:
+    def _begin_locked(self) -> None:
         """Increment in-flight accounting while the caller holds ``lock``."""
         self._inflight += 1
 
@@ -142,15 +209,19 @@ class _LegacyBLEManagementStateAdapter:
         self._target = target
         declared_lock = _get_declared_lock(target, "_management_lock")
         self._lock = declared_lock or cast(_LockPort, threading.RLock())
+        if declared_lock is None:
+            _persist_legacy_member(target, "_management_lock", self._lock)
+
         declared_condition = _get_declared_member(target, "_management_idle_condition")
-        self._condition = (
-            cast(_ManagementConditionPort, declared_condition)
-            if declared_condition is not None
-            else cast(
-                _ManagementConditionPort,
-                threading.Condition(cast(Any, self._lock)),
+        if declared_condition is not None:
+            self._condition = cast(_ManagementConditionPort, declared_condition)
+        else:
+            self._condition = _condition_for_lock(self._lock)
+            _persist_legacy_member(
+                target,
+                "_management_idle_condition",
+                self._condition,
             )
-        )
 
     @property
     def lock(self) -> _LockPort:
@@ -172,7 +243,7 @@ class _LegacyBLEManagementStateAdapter:
     def inflight(self, value: int) -> None:
         cast(Any, self._target)._management_inflight = int(value)
 
-    def begin_locked(self) -> None:
+    def _begin_locked(self) -> None:
         """Increment legacy inflight accounting while the caller owns ``lock``."""
         self.inflight = self.inflight + 1
 
@@ -214,4 +285,14 @@ def _management_state_for(
     declared = _get_declared_member(target, "_management_state")
     if isinstance(declared, BLEManagementState):
         return declared
-    return _LegacyBLEManagementStateAdapter(target)
+    with _LEGACY_ADAPTER_CACHE_LOCK:
+        cached = _get_declared_member(target, _LEGACY_ADAPTER_ATTR)
+        if isinstance(cached, _LegacyBLEManagementStateAdapter):
+            return cached
+        adapter = _LegacyBLEManagementStateAdapter(target)
+        try:
+            namespace = vars(target)
+        except TypeError:
+            return adapter
+        namespace[_LEGACY_ADAPTER_ATTR] = adapter
+        return adapter

--- a/meshtastic/interfaces/ble/management_state.py
+++ b/meshtastic/interfaces/ble/management_state.py
@@ -1,0 +1,217 @@
+"""Owned synchronization and accounting state for BLE management operations."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Protocol, cast
+
+from meshtastic.interfaces.ble.compat_adapter import (
+    _get_declared_lock,
+    _get_declared_member,
+)
+from meshtastic.interfaces.ble.ports import _LockPort
+
+
+class _ManagementConditionPort(Protocol):
+    """Condition operations required by management coordination."""
+
+    def wait(self, timeout: float | None = None) -> bool:
+        """Wait for a management-state change."""
+
+    def notify_all(self) -> None:
+        """Wake all waiters observing management-state changes."""
+
+
+class _BLEManagementStatePort(Protocol):
+    """State operations required by BLE management command coordination."""
+
+    @property
+    def lock(self) -> _LockPort:
+        """Return the management coordination lock."""
+
+    @property
+    def condition(self) -> _ManagementConditionPort:
+        """Return the condition notified when management work becomes idle."""
+
+    @property
+    def inflight(self) -> int:
+        """Return the number of in-flight management operations."""
+
+    @inflight.setter
+    def inflight(self, value: int) -> None:
+        """Replace the in-flight count for compatibility/testing seams."""
+
+    def begin_locked(self) -> None:
+        """Increment the in-flight count while the caller holds ``lock``."""
+
+    def finish(self) -> bool:
+        """Finish one operation and return whether accounting remained valid."""
+
+
+class BLEManagementState:
+    """Own management-operation lock, condition, and in-flight accounting."""
+
+    def __init__(self, lock: _LockPort | None = None) -> None:
+        """Create management state around one stable re-entrant lock.
+
+        Parameters
+        ----------
+        lock : _LockPort | None, optional
+            Lock used to serialize management accounting. A new ``RLock`` is
+            created when omitted.
+        """
+        self._lock = lock or cast(_LockPort, threading.RLock())
+        self._condition: _ManagementConditionPort = cast(
+            _ManagementConditionPort,
+            threading.Condition(cast(Any, self._lock)),
+        )
+        self._inflight = 0
+
+    @property
+    def lock(self) -> _LockPort:
+        """Return the owned management lock."""
+        return self._lock
+
+    @property
+    def condition(self) -> _ManagementConditionPort:
+        """Return the condition associated with the management lock."""
+        return self._condition
+
+    @property
+    def inflight(self) -> int:
+        """Return the current in-flight operation count."""
+        return self._inflight
+
+    @inflight.setter
+    def inflight(self, value: int) -> None:
+        """Replace the current in-flight operation count."""
+        self._inflight = int(value)
+
+    def replace_lock(self, lock: _LockPort) -> None:
+        """Replace the compatibility lock and rebuild its default condition.
+
+        Parameters
+        ----------
+        lock : _LockPort
+            Replacement synchronization lock.
+        """
+        self._lock = lock
+        self._condition = cast(
+            _ManagementConditionPort,
+            threading.Condition(cast(Any, lock)),
+        )
+
+    def replace_condition(self, condition: _ManagementConditionPort) -> None:
+        """Replace the compatibility condition object.
+
+        Parameters
+        ----------
+        condition : _ManagementConditionPort
+            Condition associated with the currently configured management lock.
+        """
+        self._condition = condition
+
+    def begin_locked(self) -> None:
+        """Increment in-flight accounting while the caller holds ``lock``."""
+        self._inflight += 1
+
+    def finish(self) -> bool:
+        """Finish one operation and notify idle waiters.
+
+        Returns
+        -------
+        bool
+            ``True`` when a positive in-flight count was decremented normally;
+            ``False`` when an underflow was detected and normalized to zero.
+        """
+        with self._lock:
+            if self._inflight <= 0:
+                self._inflight = 0
+                self._condition.notify_all()
+                return False
+            self._inflight -= 1
+            if self._inflight == 0:
+                self._condition.notify_all()
+            return True
+
+
+class _LegacyBLEManagementStateAdapter:
+    """Compatibility adapter for partial collaborators without owned state."""
+
+    def __init__(self, target: object) -> None:
+        self._target = target
+        declared_lock = _get_declared_lock(target, "_management_lock")
+        self._lock = declared_lock or cast(_LockPort, threading.RLock())
+        declared_condition = _get_declared_member(target, "_management_idle_condition")
+        self._condition = (
+            cast(_ManagementConditionPort, declared_condition)
+            if declared_condition is not None
+            else cast(
+                _ManagementConditionPort,
+                threading.Condition(cast(Any, self._lock)),
+            )
+        )
+
+    @property
+    def lock(self) -> _LockPort:
+        """Return the management lock exposed by the legacy target."""
+        return self._lock
+
+    @property
+    def condition(self) -> _ManagementConditionPort:
+        """Return the management-idle condition exposed by the legacy target."""
+        return self._condition
+
+    @property
+    def inflight(self) -> int:
+        """Return the legacy target's current management-operation count."""
+        value = _get_declared_member(self._target, "_management_inflight", 0)
+        return int(value) if isinstance(value, int) else 0
+
+    @inflight.setter
+    def inflight(self, value: int) -> None:
+        cast(Any, self._target)._management_inflight = int(value)
+
+    def begin_locked(self) -> None:
+        """Increment legacy inflight accounting while the caller owns ``lock``."""
+        self.inflight = self.inflight + 1
+
+    def finish(self) -> bool:
+        """Retire one legacy inflight operation and signal idle at zero."""
+        with self.lock:
+            current = self.inflight
+            if current <= 0:
+                self.inflight = 0
+                self.condition.notify_all()
+                return False
+            self.inflight = current - 1
+            if self.inflight == 0:
+                self.condition.notify_all()
+            return True
+
+
+def _management_state_for(
+    target: object,
+    state: _BLEManagementStatePort | None = None,
+) -> _BLEManagementStatePort:
+    """Return explicit/owned management state or a legacy compatibility adapter.
+
+    Parameters
+    ----------
+    target : object
+        Interface-like object that may expose ``_management_state`` or legacy
+        management lock/count members.
+    state : _BLEManagementStatePort | None, optional
+        Explicit state supplied by the composition root.
+
+    Returns
+    -------
+    _BLEManagementStatePort
+        State owner used by management collaborators.
+    """
+    if state is not None:
+        return state
+    declared = _get_declared_member(target, "_management_state")
+    if isinstance(declared, BLEManagementState):
+        return declared
+    return _LegacyBLEManagementStateAdapter(target)

--- a/meshtastic/tests/test_ble_management_state.py
+++ b/meshtastic/tests/test_ble_management_state.py
@@ -1,7 +1,7 @@
 """Tests for owned BLE management synchronization state."""
 
 import threading
-from types import SimpleNamespace
+from types import SimpleNamespace, TracebackType
 from unittest.mock import MagicMock
 
 import pytest
@@ -18,11 +18,11 @@ def test_management_state_tracks_and_notifies_idle_waiters() -> None:
     state = BLEManagementState()
     notify_all = MagicMock(wraps=state.condition.notify_all)
     condition = SimpleNamespace(wait=state.condition.wait, notify_all=notify_all)
-    state.replace_condition(condition)  # type: ignore[arg-type]
+    state._replace_condition(condition)  # type: ignore[arg-type]
 
     with state.lock:
-        state.begin_locked()
-        state.begin_locked()
+        state._begin_locked()
+        state._begin_locked()
     assert state.inflight == 2
 
     assert state.finish() is True
@@ -43,7 +43,7 @@ def test_management_state_normalizes_underflow_and_notifies() -> None:
         wait=lambda *_args, **_kwargs: True,
         notify_all=notify_all,
     )
-    state.replace_condition(condition)  # type: ignore[arg-type]
+    state._replace_condition(condition)  # type: ignore[arg-type]
     state.inflight = -3
 
     assert state.finish() is False
@@ -57,11 +57,11 @@ def test_management_state_lock_replacement_rebuilds_default_condition() -> None:
     state = BLEManagementState()
     replacement = threading.RLock()
 
-    state.replace_lock(replacement)  # type: ignore[arg-type]
+    state._replace_lock(replacement)  # type: ignore[arg-type]
 
     assert state.lock is replacement
     with state.lock:
-        state.begin_locked()
+        state._begin_locked()
     assert state.inflight == 1
     assert state.finish() is True
 
@@ -79,7 +79,105 @@ def test_management_state_for_preserves_legacy_collaborator_members() -> None:
     state = _management_state_for(target)
 
     with state.lock:
-        state.begin_locked()
+        state._begin_locked()
     assert target._management_inflight == 1
     assert state.finish() is True
     assert target._management_inflight == 0
+
+
+class _ContextOnlyLock:
+    """Expose only the lock operations promised by ``_LockPort``."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+
+    def __enter__(self) -> object:
+        return self._lock.__enter__()
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        return self._lock.__exit__(exc_type, exc_value, traceback)
+
+
+@pytest.mark.unit
+def test_management_state_condition_supports_context_only_lock() -> None:
+    """A compatibility lock without acquire/release should still support waiters."""
+    state = BLEManagementState(_ContextOnlyLock())
+    released = threading.Event()
+
+    with state.lock:
+        state._begin_locked()
+
+    def _wait_for_idle() -> None:
+        with state.lock:
+            while state.inflight:
+                state.condition.wait(timeout=1.0)
+        released.set()
+
+    waiter = threading.Thread(target=_wait_for_idle)
+    waiter.start()
+    assert state.finish() is True
+    waiter.join(timeout=1.0)
+
+    assert not waiter.is_alive()
+    assert released.is_set()
+
+
+@pytest.mark.unit
+def test_legacy_management_state_adapter_is_cached_per_target() -> None:
+    """Legacy collaborators should resolve one shared lock/condition adapter."""
+    target = SimpleNamespace(_management_inflight=0)
+
+    first = _management_state_for(target)
+    second = _management_state_for(target)
+
+    assert first is second
+    assert first.lock is second.lock
+    assert first.condition is second.condition
+
+
+class _SlottedLegacyTarget:
+    """Legacy target that stores synchronization members but no adapter cache."""
+
+    __slots__ = (
+        "_management_idle_condition",
+        "_management_inflight",
+        "_management_lock",
+    )
+
+    def __init__(self) -> None:
+        self._management_inflight = 0
+
+
+@pytest.mark.unit
+def test_legacy_management_state_persists_fallback_primitives_on_slotted_target() -> None:
+    """Independent adapters should share fallback synchronization and wakeups."""
+    target = _SlottedLegacyTarget()
+    first = _management_state_for(target)
+    second = _management_state_for(target)
+    released = threading.Event()
+
+    assert first is not second
+    assert first.lock is second.lock
+    assert first.condition is second.condition
+
+    with first.lock:
+        first._begin_locked()
+
+    def _wait_with_second_adapter() -> None:
+        with second.lock:
+            while second.inflight:
+                second.condition.wait(timeout=1.0)
+        released.set()
+
+    waiter = threading.Thread(target=_wait_with_second_adapter)
+    waiter.start()
+    assert first.finish() is True
+    waiter.join(timeout=1.0)
+
+    assert not waiter.is_alive()
+    assert released.is_set()

--- a/meshtastic/tests/test_ble_management_state.py
+++ b/meshtastic/tests/test_ble_management_state.py
@@ -1,0 +1,85 @@
+"""Tests for owned BLE management synchronization state."""
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from meshtastic.interfaces.ble.management_state import (
+    BLEManagementState,
+    _management_state_for,
+)
+
+
+@pytest.mark.unit
+def test_management_state_tracks_and_notifies_idle_waiters() -> None:
+    """Management state should own inflight accounting and idle notification."""
+    state = BLEManagementState()
+    notify_all = MagicMock(wraps=state.condition.notify_all)
+    condition = SimpleNamespace(wait=state.condition.wait, notify_all=notify_all)
+    state.replace_condition(condition)  # type: ignore[arg-type]
+
+    with state.lock:
+        state.begin_locked()
+        state.begin_locked()
+    assert state.inflight == 2
+
+    assert state.finish() is True
+    assert state.inflight == 1
+    notify_all.assert_not_called()
+
+    assert state.finish() is True
+    assert state.inflight == 0
+    notify_all.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_management_state_normalizes_underflow_and_notifies() -> None:
+    """Finishing without active work should reset to idle and signal waiters."""
+    state = BLEManagementState()
+    notify_all = MagicMock()
+    condition = SimpleNamespace(
+        wait=lambda *_args, **_kwargs: True,
+        notify_all=notify_all,
+    )
+    state.replace_condition(condition)  # type: ignore[arg-type]
+    state.inflight = -3
+
+    assert state.finish() is False
+    assert state.inflight == 0
+    notify_all.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_management_state_lock_replacement_rebuilds_default_condition() -> None:
+    """Compatibility lock replacement should keep condition ownership coherent."""
+    state = BLEManagementState()
+    replacement = threading.RLock()
+
+    state.replace_lock(replacement)  # type: ignore[arg-type]
+
+    assert state.lock is replacement
+    with state.lock:
+        state.begin_locked()
+    assert state.inflight == 1
+    assert state.finish() is True
+
+
+@pytest.mark.unit
+def test_management_state_for_preserves_legacy_collaborator_members() -> None:
+    """Legacy partial collaborators should remain usable through an adapter."""
+    lock = threading.RLock()
+    condition = threading.Condition(lock)
+    target = SimpleNamespace(
+        _management_lock=lock,
+        _management_idle_condition=condition,
+        _management_inflight=0,
+    )
+    state = _management_state_for(target)
+
+    with state.lock:
+        state.begin_locked()
+    assert target._management_inflight == 1
+    assert state.finish() is True
+    assert target._management_inflight == 0

--- a/meshtastic/tests/test_ble_management_state.py
+++ b/meshtastic/tests/test_ble_management_state.py
@@ -99,8 +99,8 @@ class _ContextOnlyLock:
         exc_type: type[BaseException] | None,
         exc_value: BaseException | None,
         traceback: TracebackType | None,
-    ) -> bool | None:
-        return self._lock.__exit__(exc_type, exc_value, traceback)
+    ) -> None:
+        self._lock.__exit__(exc_type, exc_value, traceback)
 
 
 @pytest.mark.unit
@@ -108,6 +108,19 @@ def test_management_state_condition_supports_context_only_lock() -> None:
     """A compatibility lock without acquire/release should still support waiters."""
     state = BLEManagementState(_ContextOnlyLock())
     released = threading.Event()
+    waiting = threading.Event()
+    original_condition = state.condition
+
+    def _tracked_wait(timeout: float | None = None) -> bool:
+        waiting.set()
+        return original_condition.wait(timeout)
+
+    state._replace_condition(
+        SimpleNamespace(
+            wait=_tracked_wait,
+            notify_all=original_condition.notify_all,
+        )
+    )  # type: ignore[arg-type]
 
     with state.lock:
         state._begin_locked()
@@ -120,11 +133,40 @@ def test_management_state_condition_supports_context_only_lock() -> None:
 
     waiter = threading.Thread(target=_wait_for_idle)
     waiter.start()
+    assert waiting.wait(timeout=1.0)
     assert state.finish() is True
     waiter.join(timeout=1.0)
 
     assert not waiter.is_alive()
     assert released.is_set()
+
+
+@pytest.mark.unit
+def test_context_only_condition_timeout_unregisters_waiter() -> None:
+    """A timed-out compatibility wait should unregister itself before returning."""
+    state = BLEManagementState(_ContextOnlyLock())
+
+    with state.lock:
+        assert state.condition.wait(timeout=0.0) is False
+
+    # A later notification must remain safe after the timed-out waiter is gone.
+    with state.lock:
+        state.condition.notify_all()
+
+
+@pytest.mark.unit
+def test_legacy_management_state_normalizes_underflow() -> None:
+    """Legacy accounting underflow should normalize to idle without raising."""
+    lock = threading.RLock()
+    target = SimpleNamespace(
+        _management_lock=lock,
+        _management_idle_condition=threading.Condition(lock),
+        _management_inflight=0,
+    )
+    state = _management_state_for(target)
+
+    assert state.finish() is False
+    assert target._management_inflight == 0
 
 
 @pytest.mark.unit
@@ -161,7 +203,7 @@ def test_legacy_management_state_persists_fallback_primitives_on_slotted_target(
     second = _management_state_for(target)
     released = threading.Event()
 
-    assert first is not second
+    assert first is second
     assert first.lock is second.lock
     assert first.condition is second.condition
 
@@ -181,3 +223,59 @@ def test_legacy_management_state_persists_fallback_primitives_on_slotted_target(
 
     assert not waiter.is_alive()
     assert released.is_set()
+
+
+class _UnwritableLegacyTarget:
+    """Legacy target that cannot persist any compatibility members."""
+
+    __slots__ = ()
+
+
+@pytest.mark.unit
+def test_legacy_management_state_caches_unwritable_target_and_tracks_inflight() -> None:
+    """Unwritable targets should still share adapter state across collaborators."""
+    target = _UnwritableLegacyTarget()
+
+    first = _management_state_for(target)
+    second = _management_state_for(target)
+
+    assert first is second
+    with first.lock:
+        first._begin_locked()
+    assert first.inflight == 1
+    assert second.inflight == 1
+    assert second.finish() is True
+    assert first.inflight == 0
+
+
+@pytest.mark.unit
+def test_legacy_management_state_treats_boolean_inflight_as_invalid() -> None:
+    """Boolean legacy counters should not masquerade as active operations."""
+    target = SimpleNamespace(_management_inflight=True)
+    state = _management_state_for(target)
+
+    assert state.inflight == 0
+    with state.lock:
+        state._begin_locked()
+    assert target._management_inflight == 1
+    assert state.finish() is True
+
+
+@pytest.mark.unit
+def test_legacy_management_state_replaces_condition_bound_to_other_lock() -> None:
+    """A declared condition must not be reused with a different management lock."""
+    lock = threading.RLock()
+    mismatched = threading.Condition(threading.RLock())
+    target = SimpleNamespace(
+        _management_lock=lock,
+        _management_idle_condition=mismatched,
+        _management_inflight=1,
+    )
+
+    state = _management_state_for(target)
+
+    assert state.condition is not mismatched
+    assert target._management_idle_condition is state.condition
+    with state.lock:
+        assert state.condition.wait(timeout=0.0) is False
+    assert state.finish() is True

--- a/tests/test_ble_interface_management_core.py
+++ b/tests/test_ble_interface_management_core.py
@@ -13,6 +13,7 @@ import pytest
 
 # Import meshtastic modules for use in tests
 import meshtastic.interfaces.ble as ble_mod
+import meshtastic.interfaces.ble.interface as ble_interface_mod
 from meshtastic.interfaces.ble import (
     BLEClient,
     BLEInterface,
@@ -37,6 +38,76 @@ from tests._ble_interface_core_support import (
 from tests.test_ble_interface_fixtures import DummyClient, _build_interface
 
 pytestmark = pytest.mark.unit
+
+
+def test_get_management_state_replaces_invalid_partial_object_state() -> None:
+    """Partial objects should normalize foreign private state to the owned state type."""
+    iface = object.__new__(BLEInterface)
+    foreign_state = SimpleNamespace(inflight=7)
+    iface.__dict__["_management_state"] = foreign_state
+
+    resolved = iface._get_management_state()
+
+    assert resolved is iface.__dict__["_management_state"]
+    assert resolved is not foreign_state
+    assert resolved.inflight == 0
+
+
+def test_get_management_state_repairs_invalid_state_once_under_concurrency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent partial-object repair should converge on one management state."""
+    iface = object.__new__(BLEInterface)
+    iface.__dict__["_management_state"] = object()
+    real_state_type = ble_interface_mod.BLEManagementState
+    first_constructor_entered = threading.Event()
+    second_constructor_entered = threading.Event()
+    release_first_constructor = threading.Event()
+    constructor_count = 0
+    constructor_count_lock = threading.Lock()
+
+    class _BlockingManagementState(real_state_type):
+        def __init__(self) -> None:
+            nonlocal constructor_count
+            with constructor_count_lock:
+                constructor_count += 1
+                invocation = constructor_count
+            if invocation == 1:
+                first_constructor_entered.set()
+                assert release_first_constructor.wait(timeout=1.0)
+            else:
+                second_constructor_entered.set()
+            super().__init__()
+
+    monkeypatch.setattr(
+        ble_interface_mod,
+        "BLEManagementState",
+        _BlockingManagementState,
+    )
+    resolved: list[object] = []
+
+    def _resolve() -> None:
+        resolved.append(iface._get_management_state())
+
+    first = threading.Thread(target=_resolve)
+    second = threading.Thread(target=_resolve)
+    first.start()
+    assert first_constructor_entered.wait(timeout=1.0)
+    second.start()
+
+    # The second resolver must block on the shared partial-object init lock,
+    # rather than constructing a competing state while the first is in flight.
+    assert not second_constructor_entered.wait(timeout=0.05)
+    release_first_constructor.set()
+    first.join(timeout=1.0)
+    second.join(timeout=1.0)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert constructor_count == 1
+    assert len(resolved) == 2
+    assert resolved[0] is resolved[1]
+    assert resolved[0] is iface.__dict__["_management_state"]
 
 
 def test_find_device_returns_single_scan_result() -> None:

--- a/tests/test_ble_session_state.py
+++ b/tests/test_ble_session_state.py
@@ -1294,3 +1294,44 @@ def test_shutdown_start_does_not_probe_closing_after_terminal_close() -> None:
     )
 
     assert result is None
+
+
+def test_disconnect_client_closer_falls_back_when_timeout_keyword_is_unsupported() -> None:
+    """Legacy injected closers should still be called without timeout keywords."""
+    from meshtastic.interfaces.ble.lifecycle_disconnect_runtime import (
+        BLEDisconnectLifecycleCoordinator,
+    )
+
+    calls: list[object] = []
+
+    def _legacy_closer(client: object) -> None:
+        calls.append(client)
+
+    client = object()
+    coordinator = BLEDisconnectLifecycleCoordinator(  # type: ignore[arg-type]
+        SimpleNamespace(),
+        client_closer=_legacy_closer,
+    )
+
+    coordinator.disconnect_and_close_client(client, timeout=2.0)  # type: ignore[arg-type]
+
+    assert calls == [client]
+
+
+def test_disconnect_client_closer_propagates_internal_type_error() -> None:
+    """Timeout compatibility fallback must not hide errors raised inside a closer."""
+    from meshtastic.interfaces.ble.lifecycle_disconnect_runtime import (
+        BLEDisconnectLifecycleCoordinator,
+    )
+
+    def _broken_closer(_client: object, *, disconnect_timeout: float | None = None) -> None:
+        _ = disconnect_timeout
+        raise TypeError("closer implementation failed")
+
+    coordinator = BLEDisconnectLifecycleCoordinator(  # type: ignore[arg-type]
+        SimpleNamespace(),
+        client_closer=_broken_closer,
+    )
+
+    with pytest.raises(TypeError, match="closer implementation failed"):
+        coordinator.disconnect_and_close_client(object(), timeout=2.0)  # type: ignore[arg-type]

--- a/tests/test_ble_session_state.py
+++ b/tests/test_ble_session_state.py
@@ -1335,3 +1335,17 @@ def test_disconnect_client_closer_propagates_internal_type_error() -> None:
 
     with pytest.raises(TypeError, match="closer implementation failed"):
         coordinator.disconnect_and_close_client(object(), timeout=2.0)  # type: ignore[arg-type]
+
+
+def test_disconnect_client_closer_requires_cleanup_capability() -> None:
+    """A coordinator without any closer should report the missing capability."""
+    from meshtastic.interfaces.ble.lifecycle_disconnect_runtime import (
+        BLEDisconnectLifecycleCoordinator,
+    )
+
+    coordinator = BLEDisconnectLifecycleCoordinator(  # type: ignore[arg-type]
+        SimpleNamespace(),
+    )
+
+    with pytest.raises(AttributeError, match="client cleanup capability"):
+        coordinator.disconnect_and_close_client(object())  # type: ignore[arg-type]

--- a/tests/test_ble_utils_service_targets.py
+++ b/tests/test_ble_utils_service_targets.py
@@ -29,6 +29,8 @@ from meshtastic.interfaces.ble.management_service import (
     BLEManagementCommandHandler,
     BLEManagementCommandsService,
 )
+from meshtastic.interfaces.ble.management_state import BLEManagementState
+from meshtastic.interfaces.ble.session_state import BLESessionState
 from meshtastic.interfaces.ble.reconnection import (
     ReconnectPolicyMissingMethodError,
     ReconnectScheduler,
@@ -735,6 +737,95 @@ def test_management_shim_handler_resolution_preserves_minimal_iface_double(
             BLEManagementCommandsService._has_required_handler_entrypoint(object())
             is False
         )
+    finally:
+        iface.close()
+
+
+def _minimal_management_handler(
+    *, client_closer: Any = None
+) -> BLEManagementCommandHandler:
+    """Build a handler with explicit synchronization state and no iface fallbacks."""
+    iface = SimpleNamespace()
+    return BLEManagementCommandHandler(
+        iface,  # type: ignore[arg-type]
+        ble_client_factory=DummyClient,
+        connected_elsewhere=lambda *_args, **_kwargs: False,
+        session_state=BLESessionState(RLock()),
+        management_state=BLEManagementState(),
+        connect_lock=RLock(),
+        client_closer=client_closer,
+    )
+
+
+def test_management_handler_requires_client_cleanup_capability() -> None:
+    """A handler without any closer should report the missing cleanup capability."""
+    handler = _minimal_management_handler()
+
+    with pytest.raises(AttributeError, match="client cleanup capability"):
+        handler._close_client(DummyClient())
+
+
+def test_management_handler_close_failure_does_not_mask_command_result() -> None:
+    """Best-effort temporary cleanup must not replace a successful command result."""
+
+    def _failing_close(_client: object) -> None:
+        raise RuntimeError("close failed")
+
+    handler = _minimal_management_handler(client_closer=_failing_close)
+
+    result = handler.execute_with_client(
+        client_to_use=DummyClient(),
+        temporary_client=DummyClient(),
+        command=lambda _client: "ok",
+    )
+
+    assert result == "ok"
+
+
+def test_management_handler_revalidates_refreshed_client_under_shared_locks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A refreshed client should be revalidated while all coordination locks are held."""
+    iface = _build_interface(monkeypatch, DummyClient(), start_receive_thread=False)
+    try:
+        handler = BLEManagementCommandHandler(
+            iface,
+            ble_client_factory=DummyClient,
+            connected_elsewhere=lambda *_args, **_kwargs: False,
+            session_state=iface._session_state,
+            management_state=iface._management_state,
+            connect_lock=iface._connect_lock,
+            client_closer=iface._client_manager_safe_close_client,
+        )
+        refreshed_client = DummyClient()
+        start_context = SimpleNamespace(
+            expected_implicit_binding=None,
+            target_address="AA:BB:CC:DD:EE:FF",
+            use_existing_client_without_resolved_address=False,
+        )
+        preconditions = MagicMock()
+        monkeypatch.setattr(iface, "_validate_management_preconditions", preconditions)
+        monkeypatch.setattr(handler, "_start_management_phase", lambda _address: start_context)
+        monkeypatch.setattr(
+            handler,
+            "_resolve_management_target",
+            lambda _address, _context: ("AA:BB:CC:DD:EE:FF", refreshed_client),
+        )
+        monkeypatch.setattr(handler, "_is_client_connected", lambda _client: True)
+        monkeypatch.setattr(
+            iface,
+            "_management_target_gate",
+            lambda _target: contextlib.nullcontext(),
+        )
+        monkeypatch.setattr(handler, "finish_management_operation", lambda: None)
+
+        result = handler.execute_management_command(
+            "AA:BB:CC:DD:EE:FF",
+            lambda client: client,
+        )
+
+        assert result is refreshed_client
+        preconditions.assert_called_once_with()
     finally:
         iface.close()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This change completes the BLE collaborator state-boundary work. BLE lifecycle and management components now share injected management state, session state, connection locks, and client cleanup callbacks.

## Key changes

### Features
- Added `BLEManagementState` for shared lock, condition, and in-flight operation tracking.
- Added compatibility support through `_management_state_for` and a legacy state adapter.
- Added tests for state tracking, idle notifications, lock replacement, underflow handling, and legacy members.

### Refactors
- Updated `BLEInterface` to create and pass shared management dependencies.
- Updated lifecycle and management constructors to accept injected collaborators.
- Routed client cleanup through the configured `client_closer`.
- Updated management operations to use shared state and locks.
- Preserved compatibility properties for existing management lock, condition, and in-flight counter access.

### Fixes
- Management shutdown now uses shared synchronization state.
- Disconnect cleanup consistently uses the configured client closer.
- Temporary management clients use the shared cleanup path.
- In-flight operation underflow is normalized and reported through the existing warning behavior.

## Breaking changes and migration

- `BLELifecycleController`, `BLEDisconnectLifecycleCoordinator`, `BLEShutdownLifecycleCoordinator`, and `BLEManagementCommandHandler` constructor signatures now support additional keyword-only dependencies.
- Existing callers can continue to use the previous arguments because the new dependencies are optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->