### PR TITLE
Resolve MeshInterface error import cycle

### DIFF
--- a/meshtastic/_interface_errors.py
+++ b/meshtastic/_interface_errors.py
@@ -1,0 +1,23 @@
+"""Leaf exception definitions shared across interface-adjacent runtimes."""
+
+
+class MeshInterfaceError(Exception):
+    """General MeshInterface operation error with a human-readable message."""
+
+    def __init__(self, message: str) -> None:
+        """Create an interface error with its historical ``message`` attribute.
+
+        Parameters
+        ----------
+        message : str
+            Human-readable description of the interface failure.
+        """
+        self.message = message
+        super().__init__(self.message)
+
+
+# Preserve the historical nested-class metadata as well as identity through the
+# MeshInterface compatibility alias. This keeps repr/pickle/introspection stable
+# while allowing internal modules to depend on a leaf exception module.
+MeshInterfaceError.__module__ = "meshtastic.mesh_interface"
+MeshInterfaceError.__qualname__ = "MeshInterface.MeshInterfaceError"

--- a/meshtastic/interfaces/ble/errors.py
+++ b/meshtastic/interfaces/ble/errors.py
@@ -5,8 +5,8 @@ from typing import Any, Callable, TypeVar
 
 from bleak.exc import BleakDBusError, BleakDeviceNotFoundError, BleakError
 
+from meshtastic._interface_errors import MeshInterfaceError as _MeshInterfaceError
 from meshtastic.interfaces.ble.constants import logger
-from meshtastic.mesh_interface import MeshInterface
 
 # Import DecodeError from protobuf, or create a fallback if not available
 DecodeError: type[Exception]
@@ -41,7 +41,7 @@ __all__ = [
 T = TypeVar("T")
 
 
-class MeshtasticBLEError(MeshInterface.MeshInterfaceError):
+class MeshtasticBLEError(_MeshInterfaceError):
     """Base exception for structured Meshtastic BLE failures."""
 
     def __init__(  # pylint: disable=super-init-not-called,non-parent-init-called

--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -21,6 +21,7 @@ except ImportError:
 from pubsub import pub
 
 import meshtastic.node
+from meshtastic._interface_errors import MeshInterfaceError as _MeshInterfaceError
 from meshtastic._core_constants import (
     BROADCAST_ADDR,
     LAST_DISCONNECT_SOURCE_TYPE_ERROR,
@@ -96,9 +97,7 @@ NODE_NOT_FOUND_DB_UNAVAILABLE_ERROR_TEMPLATE = (
     "NodeId {destination_id} not found and node DB is unavailable"
 )
 HEX_NODE_ID_TAIL_CHARS = frozenset("0123456789abcdefABCDEF")
-NO_RESPONSE_FIRMWARE_ERROR: str = (
-    "No response from node. At least firmware 2.1.22 is required on the destination node."
-)
+NO_RESPONSE_FIRMWARE_ERROR: str = "No response from node. At least firmware 2.1.22 is required on the destination node."
 
 JSONValue: TypeAlias = (
     None | bool | int | float | str | list["JSONValue"] | dict[str, "JSONValue"]
@@ -283,19 +282,8 @@ class MeshInterface:  # pylint: disable=R0902
     _connect_wait_timeout_seconds: float
     _suppress_connect_failure_logging: bool
 
-    class MeshInterfaceError(Exception):
-        """An exception class for general mesh interface errors."""
-
-        def __init__(self, message: str) -> None:
-            """Create a MeshInterfaceError with a human-readable message.
-
-            Parameters
-            ----------
-            message : str
-                The error message describing the failure.
-            """
-            self.message = message
-            super().__init__(self.message)
+    MeshInterfaceError = _MeshInterfaceError
+    """Historical nested exception alias preserved for public compatibility."""
 
     def __init__(
         self,
@@ -361,9 +349,9 @@ class MeshInterface:  # pylint: disable=R0902
         # _handle_packet_from_radio (receive thread). Use this lock to serialize
         # responseHandlers access across those call sites.
         self._response_handlers_lock = threading.RLock()
-        self.responseHandlers: dict[int, ResponseHandler] = (
-            {}
-        )  # A map from request ID to the handler
+        self.responseHandlers: dict[
+            int, ResponseHandler
+        ] = {}  # A map from request ID to the handler
         self._response_wait_errors: dict[tuple[str, int], str] = {}
         self._response_wait_acks: set[tuple[str, int]] = set()
         self._active_wait_request_ids: dict[str, set[int]] = {}
@@ -1635,8 +1623,7 @@ class MeshInterface:  # pylint: disable=R0902
                 next_packet_id & PACKET_ID_COUNTER_MASK
             )  # Keep only low 10-bit counter (clear upper 22 bits)
             random_part = (
-                random.randint(0, PACKET_ID_RANDOM_MAX)
-                << PACKET_ID_RANDOM_SHIFT_BITS  # noqa: S311
+                random.randint(0, PACKET_ID_RANDOM_MAX) << PACKET_ID_RANDOM_SHIFT_BITS  # noqa: S311
             ) & PACKET_ID_MASK  # generate number with 10 zeros at end
             self.currentPacketId = next_packet_id | random_part  # combine
             return self.currentPacketId
@@ -1754,9 +1741,7 @@ class MeshInterface:  # pylint: disable=R0902
             self.myInfo = None
             self.nodes = {}  # nodes keyed by ID
             self.nodesByNum = {}  # nodes keyed by nodenum
-            self._localChannels = (
-                []
-            )  # empty until we start getting channels pushed from the device (during config)
+            self._localChannels = []  # empty until we start getting channels pushed from the device (during config)
             config_id = self.configId
             if config_id is None or not self.noNodes:
                 # Keep config_complete_id zero reserved as an unset sentinel.

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -21,6 +21,7 @@ from typing import (
 
 from google.protobuf.descriptor import FieldDescriptor
 
+from meshtastic._interface_errors import MeshInterfaceError as _MeshInterfaceError
 from meshtastic.node_runtime import contact_runtime
 from meshtastic.node_runtime.admin_wait import (
     _send_admin_with_ack_scope,
@@ -675,11 +676,7 @@ class Node:  # pylint: disable=too-many-instance-attributes
         MeshInterface.MeshInterfaceError
             Always raised with the provided message.
         """
-        from meshtastic.mesh_interface import (  # pylint: disable=import-outside-toplevel
-            MeshInterface,
-        )
-
-        raise MeshInterface.MeshInterfaceError(message)
+        raise _MeshInterfaceError(message)
 
     def writeConfig(self, config_name: str) -> None:
         """Write a single named subsection of the node's edited configuration to the device.

--- a/meshtastic/stream_interface.py
+++ b/meshtastic/stream_interface.py
@@ -12,6 +12,7 @@ from typing import IO, Any, BinaryIO, Callable
 import serial  # type: ignore[import-untyped]
 from google.protobuf.message import DecodeError
 
+from meshtastic._interface_errors import MeshInterfaceError as _MeshInterfaceError
 from meshtastic.mesh_interface import MeshInterface
 from meshtastic.protobuf import mesh_pb2
 from meshtastic.util import is_windows11, stripnl
@@ -92,7 +93,7 @@ class StreamInterface(MeshInterface):
     ``connect()`` should be called even when ``self.stream`` is ``None``.
     """
 
-    class StreamInterfaceError(MeshInterface.MeshInterfaceError):
+    class StreamInterfaceError(_MeshInterfaceError):
         """Raised when StreamInterface is instantiated without a concrete stream."""
 
         DEFAULT_MSG = "StreamInterface is now abstract (to update existing code create SerialInterface instead)"
@@ -110,7 +111,7 @@ class StreamInterface(MeshInterface):
             """
             super().__init__(message)
 
-    class PayloadTooLargeError(MeshInterface.MeshInterfaceError, ValueError):
+    class PayloadTooLargeError(_MeshInterfaceError, ValueError):
         """Raised when a serialized ToRadio payload exceeds MAX_TO_FROM_RADIO_SIZE."""
 
         def __init__(self, payload_size: int, max_size: int) -> None:

--- a/meshtastic/tests/test_interface_error_boundary.py
+++ b/meshtastic/tests/test_interface_error_boundary.py
@@ -1,0 +1,41 @@
+"""Compatibility tests for the shared MeshInterface error boundary."""
+
+import pickle
+
+import pytest
+
+from meshtastic._interface_errors import MeshInterfaceError as _MeshInterfaceError
+from meshtastic.mesh_interface import MeshInterface
+from meshtastic.node import Node
+
+
+@pytest.mark.unit
+def test_mesh_interface_error_preserves_nested_public_identity() -> None:
+    """The leaf definition must remain the exact historical nested class object."""
+    error_type = MeshInterface.MeshInterfaceError
+
+    assert error_type is _MeshInterfaceError
+    assert error_type.__name__ == "MeshInterfaceError"
+    assert error_type.__module__ == "meshtastic.mesh_interface"
+    assert error_type.__qualname__ == "MeshInterface.MeshInterfaceError"
+
+
+@pytest.mark.unit
+def test_mesh_interface_error_preserves_message_and_pickle_contract() -> None:
+    """Moved exception definitions should preserve construction and pickling."""
+    original = MeshInterface.MeshInterfaceError("boundary failure")
+
+    restored = pickle.loads(pickle.dumps(original))  # noqa: S301 - trusted local test object
+
+    assert type(restored) is MeshInterface.MeshInterfaceError
+    assert restored.message == "boundary failure"
+    assert str(restored) == "boundary failure"
+
+
+@pytest.mark.unit
+def test_node_raises_shared_interface_error_without_facade_import() -> None:
+    """Node's internal error seam should raise the shared public exception type."""
+    node = object.__new__(Node)
+
+    with pytest.raises(MeshInterface.MeshInterfaceError, match="node failure"):
+        node._raise_interface_error("node failure")  # noqa: SLF001

--- a/meshtastic/tests/test_interface_error_boundary.py
+++ b/meshtastic/tests/test_interface_error_boundary.py
@@ -39,3 +39,13 @@ def test_node_raises_shared_interface_error_without_facade_import() -> None:
 
     with pytest.raises(MeshInterface.MeshInterfaceError, match="node failure"):
         node._raise_interface_error("node failure")  # noqa: SLF001
+
+@pytest.mark.unit
+def test_internal_exception_subclasses_preserve_public_mesh_interface_base() -> None:
+    """Internal subclasses should use the leaf class without changing public ancestry."""
+    from meshtastic.interfaces.ble.errors import MeshtasticBLEError
+    from meshtastic.stream_interface import StreamInterface
+
+    assert issubclass(StreamInterface.StreamInterfaceError, MeshInterface.MeshInterfaceError)
+    assert issubclass(StreamInterface.PayloadTooLargeError, MeshInterface.MeshInterfaceError)
+    assert issubclass(MeshtasticBLEError, MeshInterface.MeshInterfaceError)


### PR DESCRIPTION
## Summary by Sourcery

Extract MeshInterfaceError into a shared leaf module to break the import cycle between mesh_interface and node while preserving the public nested exception API.

Enhancements:
- Introduce a dedicated _interface_errors module that defines MeshInterfaceError for reuse across interface-adjacent runtimes.
- Alias the shared MeshInterfaceError back onto MeshInterface.MeshInterfaceError to maintain historical public identity and metadata.
- Clean up minor formatting in mesh_interface around constants, random ID generation, and channel initialization for consistency.

Tests:
- Add unit tests verifying MeshInterfaceError identity, pickling behavior, and that Node raises the shared interface error without importing MeshInterface directly.