### PR TITLE
Make BLE package facade lazy

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -76,7 +76,7 @@ from meshtastic.configure_verify import (  # noqa: F401 - legacy __main__ compat
     _verify_channel_url_against_state,
 )
 from meshtastic.host_port import parseHostAndPort
-from meshtastic.interfaces.ble import BLEInterface
+from meshtastic.interfaces.ble.interface import BLEInterface
 from meshtastic.lockdown import (
     build_lockdown_auth,
     read_lockdown_passphrase_file,

--- a/meshtastic/ble_interface.py
+++ b/meshtastic/ble_interface.py
@@ -35,6 +35,7 @@ except ModuleNotFoundError as exc:  # pragma: no cover - dependency guard
 # Public API re-export: import the canonical BLE facade once and mirror its
 # declared public surface from __all__ into this shim namespace.
 from meshtastic.interfaces import ble as _ble
+from meshtastic.interfaces.ble.interface import BLEInterface as _BLEInterface
 from meshtastic.interfaces.ble import (  # noqa: F401  # pylint: disable=unused-import
     BLECLIENT_ERROR_ASYNC_TIMEOUT,
     ERROR_CONNECTION_FAILED,
@@ -58,11 +59,12 @@ from meshtastic.interfaces.ble import (  # noqa: F401  # pylint: disable=unused-
     BLEDBusTransportError,
     BLEDeviceNotFoundError,
     BLEDiscoveryError,
-    BLEInterface,
     MeshtasticBLEError,
     logger,
     sanitize_address,
 )
+
+BLEInterface = _BLEInterface
 
 _BLE_PUBLIC_ALL = tuple(getattr(_ble, "__all__", ()))
 for _ble_public_symbol in _BLE_PUBLIC_ALL:

--- a/meshtastic/interfaces/ble/__init__.py
+++ b/meshtastic/interfaces/ble/__init__.py
@@ -8,6 +8,14 @@ managers/helpers live in submodules under
 """
 
 # ruff: noqa: RUF022, E402  # __all__ is intentionally grouped; import guard precedes exports
+# pylint: disable=wrong-import-position,ungrouped-imports  # dependency guard must run first
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # Static-only declaration keeps the public lazy export discoverable to type
+    # checkers without importing the heavyweight implementation at runtime.
+    from meshtastic.interfaces.ble.interface import BLEInterface
 
 try:
     import bleak as _bleak  # noqa: F401

--- a/meshtastic/interfaces/ble/__init__.py
+++ b/meshtastic/interfaces/ble/__init__.py
@@ -48,9 +48,46 @@ from meshtastic.interfaces.ble.errors import (
     BLEDiscoveryError,
     MeshtasticBLEError,
 )
-from meshtastic.interfaces.ble.interface import BLEInterface
 from meshtastic.interfaces.ble.utils import sanitize_address
 
+
+def __getattr__(name: str) -> object:
+    """Resolve heavyweight BLE facade exports lazily.
+
+    Parameters
+    ----------
+    name : str
+        Package attribute requested by import or attribute access.
+
+    Returns
+    -------
+    object
+        Resolved compatibility export.
+
+    Raises
+    ------
+    AttributeError
+        If ``name`` is not a supported lazy export.
+    """
+    if name == "BLEInterface":
+        # Import here intentionally so the public package facade remains lazy.
+        # pylint: disable=import-outside-toplevel
+        from meshtastic.interfaces.ble.interface import BLEInterface
+
+        # pylint: enable=import-outside-toplevel
+        globals()[name] = BLEInterface
+        return BLEInterface
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Return package attributes including unresolved lazy compatibility exports."""
+    return sorted(set(globals()) | set(__all__))
+
+
+# ``BLEInterface`` is provided through ``__getattr__`` so importing this package
+# does not eagerly load the heavyweight implementation module.
+# pylint: disable=undefined-all-variable
 __all__ = [
     # Main classes
     "BLEInterface",

--- a/meshtastic/interfaces/ble/interface.py
+++ b/meshtastic/interfaces/ble/interface.py
@@ -27,7 +27,6 @@ Threading model summary
 # BLEInterface is the public compatibility facade and composition root for extracted BLE runtimes.
 # pylint: disable=too-many-lines
 
-
 import atexit
 import contextlib
 import math
@@ -47,7 +46,7 @@ from bleak.backends.device import BLEDevice
 from bleak.exc import BleakDBusError, BleakError
 
 from meshtastic._publishing import publishing_thread as publishingThread
-from meshtastic.interfaces.ble import constants as _ble_constants
+import meshtastic.interfaces.ble.constants as _ble_constants
 from meshtastic.interfaces.ble.client import BLEClient
 from meshtastic.interfaces.ble.compat_adapter import (
     _get_declared_callable,
@@ -901,9 +900,7 @@ class BLEInterface(  # pylint: disable=too-many-instance-attributes
             except (BleakError, RuntimeError) as e:
                 logger.warning("Device scan failed: %s", e, exc_info=True)
                 return []
-            except (
-                Exception
-            ) as e:  # noqa: BLE001 # pragma: no cover - defensive last resort
+            except Exception as e:  # noqa: BLE001 # pragma: no cover - defensive last resort
                 logger.warning(
                     "Unexpected error during device scan: %s", e, exc_info=True
                 )
@@ -1255,8 +1252,8 @@ class BLEInterface(  # pylint: disable=too-many-instance-attributes
         """
         state_manager = self._state_manager
         lifecycle_owner_is_current: bool | None
-        canonical_locked_probe = (
-            _is_canonical_state_manager(state_manager, self._state_lock)
+        canonical_locked_probe = _is_canonical_state_manager(
+            state_manager, self._state_lock
         )
         with self._state_lock:
             if self._closed or self._connection_session_epoch != expected_session_epoch:
@@ -2440,17 +2437,13 @@ class BLEInterface(  # pylint: disable=too-many-instance-attributes
             """Best-effort rollback for notification session bookkeeping."""
             if notification_dispatcher is None or notification_session_snapshot is None:
                 return
-            with contextlib.suppress(
-                Exception
-            ):  # noqa: BLE001 - rollback cleanup is best effort
+            with contextlib.suppress(Exception):  # noqa: BLE001 - rollback cleanup is best effort
                 notification_dispatcher._registered_notification_session_epoch = (
                     notification_session_snapshot[
                         "_registered_notification_session_epoch"
                     ]
                 )
-            with contextlib.suppress(
-                Exception
-            ):  # noqa: BLE001 - rollback cleanup is best effort
+            with contextlib.suppress(Exception):  # noqa: BLE001 - rollback cleanup is best effort
                 started_notify_snapshot = _copy_started_notify_snapshot(
                     notification_session_snapshot["_started_notify_characteristics"]
                 )
@@ -2458,39 +2451,27 @@ class BLEInterface(  # pylint: disable=too-many-instance-attributes
                     notification_dispatcher._started_notify_characteristics = (
                         started_notify_snapshot
                     )
-            with contextlib.suppress(
-                Exception
-            ):  # noqa: BLE001 - rollback cleanup is best effort
+            with contextlib.suppress(Exception):  # noqa: BLE001 - rollback cleanup is best effort
                 notification_dispatcher.fromnum_notify_enabled = (
                     notification_session_snapshot["fromnum_notify_enabled"]
                 )
-            with contextlib.suppress(
-                Exception
-            ):  # noqa: BLE001 - rollback cleanup is best effort
+            with contextlib.suppress(Exception):  # noqa: BLE001 - rollback cleanup is best effort
                 notification_dispatcher.malformed_notification_count = (
                     notification_session_snapshot["malformed_notification_count"]
                 )
-            with contextlib.suppress(
-                Exception
-            ):  # noqa: BLE001 - rollback cleanup is best effort
+            with contextlib.suppress(Exception):  # noqa: BLE001 - rollback cleanup is best effort
                 notification_dispatcher._current_legacy_log_handler = (
                     notification_session_snapshot["_current_legacy_log_handler"]
                 )
-            with contextlib.suppress(
-                Exception
-            ):  # noqa: BLE001 - rollback cleanup is best effort
+            with contextlib.suppress(Exception):  # noqa: BLE001 - rollback cleanup is best effort
                 notification_dispatcher._current_log_handler = (
                     notification_session_snapshot["_current_log_handler"]
                 )
-            with contextlib.suppress(
-                Exception
-            ):  # noqa: BLE001 - rollback cleanup is best effort
+            with contextlib.suppress(Exception):  # noqa: BLE001 - rollback cleanup is best effort
                 notification_dispatcher._current_from_num_handler = (
                     notification_session_snapshot["_current_from_num_handler"]
                 )
-            with contextlib.suppress(
-                Exception
-            ):  # noqa: BLE001 - rollback cleanup is best effort
+            with contextlib.suppress(Exception):  # noqa: BLE001 - rollback cleanup is best effort
                 notification_manager = notification_dispatcher._notification_manager
                 manager_lock = getattr(notification_manager, "_lock", None)
                 active_subscriptions_snapshot = notification_session_snapshot[

--- a/meshtastic/tests/test_ble_init.py
+++ b/meshtastic/tests/test_ble_init.py
@@ -60,6 +60,27 @@ class TestBLEPackageInit:
         assert hasattr(ble, "BLEClient")
         assert hasattr(ble, "SERVICE_UUID")
 
+    def test_ble_package_defers_interface_import_until_attribute_access(self) -> None:
+        """Importing the BLE package alone should not import the interface facade."""
+        module_snapshot = _snapshot_modules(_BLE_IMPORT_TEST_MODULE_PREFIXES)
+        try:
+            for name in list(sys.modules):
+                if _module_matches_prefix(name, _BLE_IMPORT_TEST_MODULE_PREFIXES):
+                    del sys.modules[name]
+
+            ble = importlib.import_module("meshtastic.interfaces.ble")
+
+            assert "meshtastic.interfaces.ble.interface" not in sys.modules
+            assert "BLEInterface" in dir(ble)
+
+            resolved = ble.BLEInterface
+
+            assert resolved is not None
+            assert "meshtastic.interfaces.ble.interface" in sys.modules
+            assert ble.BLEInterface is resolved
+        finally:
+            _restore_modules(module_snapshot, _BLE_IMPORT_TEST_MODULE_PREFIXES)
+
     def test_ble_init_raises_import_error_when_bleak_missing(self) -> None:
         """Test that importing ble package raises helpful ImportError when bleak is missing.
 

--- a/meshtastic/tests/test_ble_init.py
+++ b/meshtastic/tests/test_ble_init.py
@@ -5,46 +5,26 @@ Tests the import guard and error handling when bleak is not available.
 
 from __future__ import annotations
 
-import builtins
-import importlib
+import subprocess
 import sys
-from types import ModuleType
-from unittest.mock import patch
+import textwrap
 
 import pytest
 
-# pylint: disable=import-outside-toplevel
 
-_BLE_IMPORT_TEST_MODULE_PREFIXES = (
-    "bleak",
-    "meshtastic.ble_interface",
-    "meshtastic.interfaces",
-    "meshtastic.interfaces.ble",
-)
+def _run_isolated_python(source: str) -> None:
+    """Run an import-state assertion in a fresh interpreter process.
 
-
-def _module_matches_prefix(name: str, prefixes: tuple[str, ...]) -> bool:
-    """Return True when a module name is in or under one of the prefixes."""
-    return any(name == prefix or name.startswith(f"{prefix}.") for prefix in prefixes)
-
-
-def _snapshot_modules(prefixes: tuple[str, ...]) -> dict[str, ModuleType]:
-    """Capture module objects for the provided prefixes."""
-    return {
-        name: module
-        for name, module in sys.modules.items()
-        if _module_matches_prefix(name, prefixes)
-    }
-
-
-def _restore_modules(
-    snapshot: dict[str, ModuleType], prefixes: tuple[str, ...]
-) -> None:
-    """Restore captured modules and remove any modules created during the test."""
-    for name in list(sys.modules.keys()):
-        if _module_matches_prefix(name, prefixes):
-            del sys.modules[name]
-    sys.modules.update(snapshot)
+    Parameters
+    ----------
+    source : str
+        Python source executed by a child interpreter.
+    """
+    subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(source)],
+        check=True,
+        text=True,
+    )
 
 
 @pytest.mark.unit
@@ -61,102 +41,79 @@ class TestBLEPackageInit:
         assert hasattr(ble, "SERVICE_UUID")
 
     def test_ble_package_defers_interface_import_until_attribute_access(self) -> None:
-        """Importing the BLE package alone should not import the interface facade."""
-        module_snapshot = _snapshot_modules(_BLE_IMPORT_TEST_MODULE_PREFIXES)
-        try:
-            for name in list(sys.modules):
-                if _module_matches_prefix(name, _BLE_IMPORT_TEST_MODULE_PREFIXES):
-                    del sys.modules[name]
+        """Importing the BLE package alone should not import the implementation module."""
+        _run_isolated_python(
+            """
+            import importlib
+            import sys
 
             ble = importlib.import_module("meshtastic.interfaces.ble")
-
             assert "meshtastic.interfaces.ble.interface" not in sys.modules
             assert "BLEInterface" in dir(ble)
-
             resolved = ble.BLEInterface
-
-            assert resolved is not None
             assert "meshtastic.interfaces.ble.interface" in sys.modules
             assert ble.BLEInterface is resolved
-        finally:
-            _restore_modules(module_snapshot, _BLE_IMPORT_TEST_MODULE_PREFIXES)
+            """
+        )
 
     def test_ble_init_raises_import_error_when_bleak_missing(self) -> None:
-        """Test that importing ble package raises helpful ImportError when bleak is missing.
+        """Missing bleak should produce the package's actionable import error."""
+        _run_isolated_python(
+            """
+            import builtins
+            import importlib
 
-        Covers lines 14-17 of meshtastic/interfaces/ble/__init__.py:
-        the ModuleNotFoundError handler that provides a helpful error message.
-        """
-        module_snapshot = _snapshot_modules(_BLE_IMPORT_TEST_MODULE_PREFIXES)
-        original_import = builtins.__import__
-
-        try:
-            if "bleak" in sys.modules:
-                del sys.modules["bleak"]
-            if "meshtastic.interfaces.ble" in sys.modules:
-                del sys.modules["meshtastic.interfaces.ble"]
-            for key in list(sys.modules.keys()):
-                if key.startswith("meshtastic.interfaces.ble"):
-                    del sys.modules[key]
-
-            def raise_bleak_not_found(
-                name: str,
-                _globals: dict[str, object] | None = None,
-                _locals: dict[str, object] | None = None,
-                fromlist: tuple[str, ...] | None = None,
-                level: int = 0,
-            ) -> ModuleType:
+            original_import = builtins.__import__
+            def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
                 if name == "bleak":
                     raise ModuleNotFoundError("No module named 'bleak'", name="bleak")
-                return original_import(name, _globals, _locals, fromlist, level)
+                return original_import(name, globals, locals, fromlist, level)
 
-            with patch("builtins.__import__", side_effect=raise_bleak_not_found):
-                with pytest.raises(ImportError) as exc_info:
-                    importlib.import_module("meshtastic.interfaces.ble")
-
-            assert "bleak" in str(exc_info.value).lower()
-            assert "poetry install" in str(exc_info.value).lower()
-
-        finally:
-            _restore_modules(module_snapshot, _BLE_IMPORT_TEST_MODULE_PREFIXES)
+            builtins.__import__ = guarded_import
+            try:
+                importlib.import_module("meshtastic.interfaces.ble")
+            except ImportError as exc:
+                message = str(exc).lower()
+                assert "bleak" in message
+                assert "poetry install" in message
+            else:
+                raise AssertionError("expected BLE package import to fail without bleak")
+            """
+        )
 
     def test_ble_init_reraises_non_bleak_module_not_found(self) -> None:
-        """Test that ModuleNotFoundError for non-bleak modules is re-raised.
+        """Non-bleak dependency failures must not be rewritten as bleak guidance."""
+        _run_isolated_python(
+            """
+            import builtins
+            import importlib
 
-        Covers line 15-16: the check that only catches ModuleNotFoundError
-        when the missing module is specifically 'bleak'.
-        """
-        module_snapshot = _snapshot_modules(_BLE_IMPORT_TEST_MODULE_PREFIXES)
-        original_import = builtins.__import__
-
-        try:
-            if "meshtastic.interfaces.ble" in sys.modules:
-                del sys.modules["meshtastic.interfaces.ble"]
-            for key in list(sys.modules.keys()):
-                if key.startswith("meshtastic.interfaces.ble"):
-                    del sys.modules[key]
-
-            def raise_other_not_found(
-                name: str,
-                _globals: dict[str, object] | None = None,
-                _locals: dict[str, object] | None = None,
-                fromlist: tuple[str, ...] | None = None,
-                level: int = 0,
-            ) -> ModuleType:
+            original_import = builtins.__import__
+            def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
                 if name == "bleak":
                     raise ModuleNotFoundError(
-                        "No module named 'some_other_module'", name="some_other_module"
+                        "No module named 'some_other_module'",
+                        name="some_other_module",
                     )
-                return original_import(name, _globals, _locals, fromlist, level)
+                return original_import(name, globals, locals, fromlist, level)
 
-            with patch("builtins.__import__", side_effect=raise_other_not_found):
-                with pytest.raises(ModuleNotFoundError) as exc_info:
-                    importlib.import_module("meshtastic.interfaces.ble")
+            builtins.__import__ = guarded_import
+            try:
+                importlib.import_module("meshtastic.interfaces.ble")
+            except ModuleNotFoundError as exc:
+                assert exc.name == "some_other_module"
+            else:
+                raise AssertionError("expected non-bleak ModuleNotFoundError")
+            """
+        )
 
-                assert exc_info.value.name == "some_other_module"
+    def test_ble_unknown_lazy_export_raises_attribute_error(self) -> None:
+        """Unknown package attributes should retain normal module semantics."""
+        from meshtastic.interfaces import ble
 
-        finally:
-            _restore_modules(module_snapshot, _BLE_IMPORT_TEST_MODULE_PREFIXES)
+        unknown_name = "NoSuchBLEExport"
+        with pytest.raises(AttributeError, match=unknown_name):
+            getattr(ble, unknown_name)
 
     def test_ble_all_exports(self) -> None:
         """Test that __all__ exports are accessible."""


### PR DESCRIPTION
## Summary by Sourcery

Make the BLE package expose the BLEInterface facade lazily to avoid eagerly importing the heavyweight interface module on package import.

New Features:
- Add lazy attribute resolution in the BLE package so BLEInterface is imported only on first access.

Enhancements:
- Adjust BLE constants import style in the interface module to work correctly with the lazy package facade.
- Simplify several broad exception handling and rollback contexts for readability and consistency.

Tests:
- Add tests ensuring the BLE package defers importing the interface module until BLEInterface is accessed and that lazy resolution behaves correctly.