### PR TITLE
Manage remote hardware state independently from MeshInterface

### DIFF
--- a/meshtastic/remote_hardware.py
+++ b/meshtastic/remote_hardware.py
@@ -2,10 +2,13 @@
 
 import logging
 import threading
+import weakref
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable, Protocol, cast
 
 from pubsub import pub
 
+from meshtastic._interface_errors import MeshInterfaceError as _MeshInterfaceError
 from meshtastic.protobuf import mesh_pb2, portnums_pb2, remote_hardware_pb2
 
 if TYPE_CHECKING:
@@ -29,12 +32,6 @@ INVALID_GPIO_MASK_ERROR = "mask must be a non-negative int"
 INVALID_GPIO_VALS_ERROR = "vals must be a non-negative int"
 INVALID_GPIO_VALS_MASK_ERROR = "vals contains bits outside mask"
 WATCH_MASKS_ATTR = "_remote_hardware_watch_masks"
-WATCH_MASKS_LOCK_ATTR = "_remote_hardware_watch_masks_lock"
-WATCH_MASKS_INIT_LOCK = threading.Lock()
-REMOTE_HARDWARE_SUBSCRIBE_LOCK = threading.Lock()
-
-_MESH_INTERFACE_ERROR_LOCK = threading.Lock()
-_MESH_INTERFACE_ERROR: type[Exception] | None = None
 
 
 class LockLike(Protocol):
@@ -56,26 +53,6 @@ class LockLike(Protocol):
         tb: Any,
     ) -> None:
         """Exit context manager and release lock."""
-
-
-def _get_mesh_interface_error() -> type[Exception]:
-    """Resolve MeshInterfaceError lazily to avoid module-import cycles.
-
-    Returns
-    -------
-    MeshInterfaceError : type[Exception]
-        The cached MeshInterface.MeshInterfaceError exception class.
-    """
-    global _MESH_INTERFACE_ERROR  # pylint: disable=global-statement
-    if _MESH_INTERFACE_ERROR is None:
-        with _MESH_INTERFACE_ERROR_LOCK:
-            if _MESH_INTERFACE_ERROR is None:
-                from meshtastic.mesh_interface import (  # pylint: disable=import-outside-toplevel
-                    MeshInterface,
-                )
-
-                _MESH_INTERFACE_ERROR = MeshInterface.MeshInterfaceError
-    return _MESH_INTERFACE_ERROR
 
 
 def _normalize_node_key(nodeid: Any) -> str | None:
@@ -133,32 +110,89 @@ def _parse_node_number(text: str) -> int | None:
         return None
 
 
-def _get_watch_masks(interface: "MeshInterface") -> dict[str, int]:
-    """Return per-interface watch masks, creating storage if needed.
+@dataclass(slots=True)
+class _RemoteHardwareState:
+    """Per-interface remote-hardware watch state."""
 
-    This helper mutates ``WATCH_MASKS_ATTR`` on ``interface`` when missing and
-    is not thread-safe by itself. Callers of ``_get_watch_masks`` must hold the
-    lock returned by ``_get_watch_masks_lock(interface)`` when reading or
-    mutating the returned dictionary.
-    """
-    watch_masks = getattr(interface, WATCH_MASKS_ATTR, None)
-    if isinstance(watch_masks, dict):
-        return watch_masks
-    watch_masks = {}
-    setattr(interface, WATCH_MASKS_ATTR, watch_masks)
-    return watch_masks
+    lock: threading.RLock = field(default_factory=threading.RLock)
+    watch_masks: dict[str, int] = field(default_factory=dict)
+
+
+class _RemoteHardwareStateRegistry:
+    """Own per-interface watch state and process-level pubsub registration."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._states: weakref.WeakKeyDictionary[object, _RemoteHardwareState] = (
+            weakref.WeakKeyDictionary()
+        )
+
+    def state_for(self, interface: "MeshInterface") -> _RemoteHardwareState:
+        """Return stable state for one interface without mutating that interface.
+
+        Parameters
+        ----------
+        interface : MeshInterface
+            Interface whose remote-hardware state is requested.
+
+        Returns
+        -------
+        _RemoteHardwareState
+            Registry-owned state that disappears when the interface is collected.
+        """
+        with self._lock:
+            state = self._states.get(interface)
+            if state is not None:
+                return state
+            state = _RemoteHardwareState()
+            legacy_masks = getattr(interface, WATCH_MASKS_ATTR, None)
+            if isinstance(legacy_masks, dict):
+                state.watch_masks.update(
+                    {
+                        str(key): int(value)
+                        for key, value in legacy_masks.items()
+                        if isinstance(value, int) and not isinstance(value, bool)
+                    }
+                )
+            self._states[interface] = state
+            return state
+
+    def ensure_subscription(self) -> None:
+        """Ensure the process-level remote-hardware receive hook is subscribed."""
+        with self._lock:
+            already_subscribed = False
+            try:
+                already_subscribed = pub.isSubscribed(
+                    onGPIOReceive, REMOTE_HARDWARE_TOPIC
+                )
+            except pub.TopicNameError:
+                # Topic may not exist yet; subscribe below to create/register it.
+                already_subscribed = False
+            except (TypeError, ValueError) as ex:
+                logger.warning(
+                    "Unable to inspect remote hardware topic subscription: %s", ex
+                )
+                already_subscribed = False
+            if not already_subscribed:
+                pub.subscribe(onGPIOReceive, REMOTE_HARDWARE_TOPIC)
+
+
+_REMOTE_HARDWARE_STATE_REGISTRY = _RemoteHardwareStateRegistry()
+
+
+def _get_remote_hardware_state(interface: "MeshInterface") -> _RemoteHardwareState:
+    """Return registry-owned remote-hardware state for ``interface``."""
+    return _REMOTE_HARDWARE_STATE_REGISTRY.state_for(interface)
+
+
+def _get_watch_masks(interface: "MeshInterface") -> dict[str, int]:
+    """Compatibility helper returning registry-owned per-interface watch masks."""
+    return _get_remote_hardware_state(interface).watch_masks
 
 
 def _get_watch_masks_lock(interface: "MeshInterface") -> LockLike:
-    """Return the per-interface lock guarding watch-mask state."""
-    lock = getattr(interface, WATCH_MASKS_LOCK_ATTR, None)
-    if lock is None:
-        with WATCH_MASKS_INIT_LOCK:
-            lock = getattr(interface, WATCH_MASKS_LOCK_ATTR, None)
-            if lock is None:
-                lock = threading.Lock()
-                setattr(interface, WATCH_MASKS_LOCK_ATTR, lock)
-    return cast(LockLike, lock)
+    """Compatibility helper returning the registry-owned watch-state lock."""
+    return cast(LockLike, _get_remote_hardware_state(interface).lock)
 
 
 def onGPIOReceive(packet: Any, interface: "MeshInterface") -> None:
@@ -302,28 +336,10 @@ class RemoteHardwareClient:
         else:
             ch = iface.localNode.getChannelByName(GPIO_CHANNEL_NAME)
         if ch is None:
-            mesh_interface_error = _get_mesh_interface_error()
-            raise mesh_interface_error(NO_GPIO_CHANNEL_ERROR)
+            raise _MeshInterfaceError(NO_GPIO_CHANNEL_ERROR)
         self.channelIndex = ch.index
-        with _get_watch_masks_lock(self.iface):
-            _get_watch_masks(self.iface)
-
-        with REMOTE_HARDWARE_SUBSCRIBE_LOCK:
-            already_subscribed = False
-            try:
-                already_subscribed = pub.isSubscribed(
-                    onGPIOReceive, REMOTE_HARDWARE_TOPIC
-                )
-            except pub.TopicNameError:
-                # Topic may not exist yet; subscribe below to create/register it.
-                already_subscribed = False
-            except (TypeError, ValueError) as ex:
-                logger.warning(
-                    "Unable to inspect remote hardware topic subscription: %s", ex
-                )
-                already_subscribed = False
-            if not already_subscribed:
-                pub.subscribe(onGPIOReceive, REMOTE_HARDWARE_TOPIC)
+        self._state = _get_remote_hardware_state(self.iface)
+        _REMOTE_HARDWARE_STATE_REGISTRY.ensure_subscription()
 
     @staticmethod
     def _normalize_dest_nodeid(nodeid: int | str | None) -> int | str:
@@ -351,14 +367,12 @@ class RemoteHardwareClient:
             or is_special_alias
         )
         if has_invalid_dest_nodeid:
-            mesh_interface_error = _get_mesh_interface_error()
-            raise mesh_interface_error(MISSING_DEST_NODE_ID_ERROR)
+            raise _MeshInterfaceError(MISSING_DEST_NODE_ID_ERROR)
         if isinstance(nodeid, str):
             return nodeid.strip()
         if isinstance(nodeid, int):
             return nodeid
-        mesh_interface_error = _get_mesh_interface_error()
-        raise mesh_interface_error(
+        raise _MeshInterfaceError(
             f"{MISSING_DEST_NODE_ID_ERROR} (got {type(nodeid).__name__}: {nodeid!r})"
         )
 
@@ -407,8 +421,7 @@ class RemoteHardwareClient:
     def _validate_non_negative_int(value: Any, error_message: str) -> int:
         """Validate integer GPIO arguments and return normalized int."""
         if isinstance(value, bool) or not isinstance(value, int) or value < 0:
-            mesh_interface_error = _get_mesh_interface_error()
-            raise mesh_interface_error(error_message)
+            raise _MeshInterfaceError(error_message)
         return value
 
     def writeGPIOs(
@@ -433,8 +446,7 @@ class RemoteHardwareClient:
         mask = self._validate_non_negative_int(mask, INVALID_GPIO_MASK_ERROR)
         vals = self._validate_non_negative_int(vals, INVALID_GPIO_VALS_ERROR)
         if vals & ~mask:
-            mesh_interface_error = _get_mesh_interface_error()
-            raise mesh_interface_error(INVALID_GPIO_VALS_MASK_ERROR)
+            raise _MeshInterfaceError(INVALID_GPIO_VALS_MASK_ERROR)
         logger.debug("writeGPIOs nodeid:%s mask:%s vals:%s", nodeid, mask, vals)
         r = remote_hardware_pb2.HardwareMessage()
         r.type = remote_hardware_pb2.HardwareMessage.Type.WRITE_GPIOS
@@ -495,6 +507,6 @@ class RemoteHardwareClient:
         result = self._send_hardware(nodeid, r)
         node_key = _normalize_node_key(nodeid)
         if node_key is not None:
-            with _get_watch_masks_lock(self.iface):
-                _get_watch_masks(self.iface)[node_key] = int(mask)
+            with self._state.lock:
+                self._state.watch_masks[node_key] = int(mask)
         return result

--- a/meshtastic/tests/test_remote_hardware.py
+++ b/meshtastic/tests/test_remote_hardware.py
@@ -8,7 +8,12 @@ import pytest
 
 from ..mesh_interface import MeshInterface
 from ..protobuf import portnums_pb2, remote_hardware_pb2
-from ..remote_hardware import WATCH_MASKS_ATTR, RemoteHardwareClient, onGPIOreceive
+from ..remote_hardware import (
+    WATCH_MASKS_ATTR,
+    RemoteHardwareClient,
+    _get_remote_hardware_state,
+    onGPIOreceive,
+)
 from ..serial_interface import SerialInterface
 
 
@@ -56,7 +61,9 @@ def test_onGPIOreceive_uses_node_watch_mask(
 ) -> None:
     """Test onGPIOreceive falls back to tracked per-node watch mask when needed."""
     iface = mock_gpio_iface
-    setattr(iface, WATCH_MASKS_ATTR, {"num:16": 7})
+    state = _get_remote_hardware_state(iface)
+    with state.lock:
+        state.watch_masks["num:16"] = 7
     packet = {"from": 16, "decoded": {"remotehw": {"gpioValue": "7"}}}
     with caplog.at_level(logging.DEBUG):
         onGPIOreceive(packet, iface)
@@ -72,7 +79,9 @@ def test_onGPIOreceive_does_not_apply_single_mask_fallback_with_mismatched_sende
 ) -> None:
     """Sender-specific misses should not apply the legacy single-mask fallback."""
     iface = mock_gpio_iface
-    setattr(iface, WATCH_MASKS_ATTR, {"num:16": 7})
+    state = _get_remote_hardware_state(iface)
+    with state.lock:
+        state.watch_masks["num:16"] = 7
     packet = {"from": 17, "decoded": {"remotehw": {"gpioValue": "7"}}}
     with caplog.at_level(logging.DEBUG):
         onGPIOreceive(packet, iface)
@@ -87,7 +96,9 @@ def test_onGPIOreceive_applies_single_mask_fallback_with_blank_sender_fields(
 ) -> None:
     """Blank sender identity fields should be treated as missing for legacy fallback."""
     iface = mock_gpio_iface
-    setattr(iface, WATCH_MASKS_ATTR, {"num:16": 7})
+    state = _get_remote_hardware_state(iface)
+    with state.lock:
+        state.watch_masks["num:16"] = 7
     packet = {
         "from": "   ",
         "fromId": "",
@@ -133,6 +144,35 @@ def test_onGPIOreceive_marks_response_on_nondict_remotehw() -> None:
     onGPIOreceive(packet, iface)
 
     assert iface.gotResponse is True
+
+
+@pytest.mark.unit
+def test_remote_hardware_state_is_registry_owned_and_interface_scoped(
+    mock_gpio_iface: MagicMock,
+) -> None:
+    """Watch state should be isolated per interface without hidden injection."""
+    other_iface = MagicMock()
+    first = _get_remote_hardware_state(mock_gpio_iface)
+    second = _get_remote_hardware_state(other_iface)
+
+    with first.lock:
+        first.watch_masks["num:16"] = 7
+
+    assert second.watch_masks == {}
+    assert WATCH_MASKS_ATTR not in mock_gpio_iface.__dict__
+    assert WATCH_MASKS_ATTR not in other_iface.__dict__
+
+
+@pytest.mark.unit
+def test_remote_hardware_state_migrates_legacy_private_masks_once() -> None:
+    """Existing private mask dictionaries should seed registry state compatibly."""
+    iface = MagicMock()
+    iface.__dict__[WATCH_MASKS_ATTR] = {"num:16": 7}
+
+    state = _get_remote_hardware_state(iface)
+    iface.__dict__[WATCH_MASKS_ATTR]["num:16"] = 3
+
+    assert state.watch_masks == {"num:16": 7}
 
 
 @pytest.mark.unit
@@ -214,7 +254,9 @@ def test_watchGPIOs(
     assert kwargs["channelIndex"] == rhw.channelIndex
     assert kwargs["wantResponse"] is False
     assert kwargs["onResponse"] is None
-    assert getattr(mock_gpio_iface, WATCH_MASKS_ATTR)["num:16"] == 123
+    state = _get_remote_hardware_state(mock_gpio_iface)
+    assert state.watch_masks["num:16"] == 123
+    assert WATCH_MASKS_ATTR not in mock_gpio_iface.__dict__
 
 
 @pytest.mark.unit
@@ -225,7 +267,9 @@ def test_watchGPIOs_normalizes_leading_zero_decimal_nodeid(
     rhw = RemoteHardwareClient(mock_gpio_iface)
     rhw.watchGPIOs("0016", 123)
 
-    assert getattr(mock_gpio_iface, WATCH_MASKS_ATTR)["num:16"] == 123
+    state = _get_remote_hardware_state(mock_gpio_iface)
+    assert state.watch_masks["num:16"] == 123
+    assert WATCH_MASKS_ATTR not in mock_gpio_iface.__dict__
 
 
 @pytest.mark.unit
@@ -236,7 +280,9 @@ def test_watchGPIOs_treats_malformed_signed_nodeid_as_id(
     rhw = RemoteHardwareClient(mock_gpio_iface)
     rhw.watchGPIOs("+-1", 123)
 
-    assert getattr(mock_gpio_iface, WATCH_MASKS_ATTR)["id:+-1"] == 123
+    state = _get_remote_hardware_state(mock_gpio_iface)
+    assert state.watch_masks["id:+-1"] == 123
+    assert WATCH_MASKS_ATTR not in mock_gpio_iface.__dict__
 
 
 @pytest.mark.unit
@@ -250,8 +296,8 @@ def test_watchGPIOs_does_not_cache_mask_on_send_failure(
     with pytest.raises(RuntimeError, match="send failed"):
         rhw.watchGPIOs("0x10", 123)
 
-    watch_masks = getattr(mock_gpio_iface, WATCH_MASKS_ATTR, {})
-    assert "num:16" not in watch_masks
+    state = _get_remote_hardware_state(mock_gpio_iface)
+    assert "num:16" not in state.watch_masks
 
 
 @pytest.mark.unit

--- a/meshtastic/tests/test_remote_hardware.py
+++ b/meshtastic/tests/test_remote_hardware.py
@@ -348,3 +348,20 @@ def test_write_gpios_rejects_vals_outside_mask(mock_gpio_iface: MagicMock) -> No
         MeshInterface.MeshInterfaceError, match="vals contains bits outside mask"
     ):
         rhw.writeGPIOs("0x10", 0b0011, 0b0100)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("invalid_mask", [True, False, "7", 7.5, None])
+def test_remote_hardware_state_migration_filters_invalid_legacy_masks(
+    invalid_mask: object,
+) -> None:
+    """Legacy migration should retain only genuine integer watch masks."""
+    iface = MagicMock()
+    iface.__dict__[WATCH_MASKS_ATTR] = {
+        "num:16": 7,
+        "num:17": invalid_mask,
+    }
+
+    state = _get_remote_hardware_state(iface)
+
+    assert state.watch_masks == {"num:16": 7}


### PR DESCRIPTION
## Summary by Sourcery

Decouple remote hardware watch state and subscription management from MeshInterface instances and centralize them in a registry while simplifying error handling to use the shared MeshInterfaceError class directly.

Enhancements:
- Introduce a registry-owned per-interface remote hardware state object to track watch masks and synchronization independently of MeshInterface internals.
- Centralize process-level remote hardware pubsub subscription logic to avoid per-interface subscription races and side effects.
- Migrate existing per-interface watch mask dictionaries into the new registry-backed state for backward compatibility while keeping interfaces free of hidden attributes.

Tests:
- Extend remote hardware tests to cover the new registry-based state isolation, legacy mask migration behavior, and updated watch mask storage semantics.